### PR TITLE
Include algorithm in Docker-manifest-digest

### DIFF
--- a/pkg/cosign/payload.go
+++ b/pkg/cosign/payload.go
@@ -26,7 +26,7 @@ func Payload(img v1.Descriptor, a map[string]string) ([]byte, error) {
 	simpleSigning := SimpleSigning{
 		Critical: Critical{
 			Image: Image{
-				DockerManifestDigest: img.Digest.Hex,
+				DockerManifestDigest: img.Digest.String(),
 			},
 			Type: "cosign container signature",
 		},

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -104,7 +104,7 @@ func Verify(ref name.Reference, pubKey ed25519.PublicKey, checkClaims bool, anno
 	}
 
 	// Now we have to actually parse the payloads and make sure the digest (and other claims) are correct
-	verified, err := verifyClaims(desc.Digest.Hex, annotations, valid)
+	verified, err := verifyClaims(desc.Digest.String(), annotations, valid)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -119,7 +119,7 @@ func TestGenerate(t *testing.T) {
 	ss := cosign.SimpleSigning{}
 	must(json.Unmarshal(b.Bytes(), &ss), t)
 
-	equals(desc.Digest.Hex, ss.Critical.Image.DockerManifestDigest, t)
+	equals(desc.Digest.String(), ss.Critical.Image.DockerManifestDigest, t)
 
 	// Now try with some annotations.
 	b.Reset()
@@ -127,7 +127,7 @@ func TestGenerate(t *testing.T) {
 	must(cli.GenerateCmd(context.Background(), imgName, a, &b), t)
 	must(json.Unmarshal(b.Bytes(), &ss), t)
 
-	equals(desc.Digest.Hex, ss.Critical.Image.DockerManifestDigest, t)
+	equals(desc.Digest.String(), ss.Critical.Image.DockerManifestDigest, t)
 	equals(ss.Optional["foo"], "bar", t)
 }
 


### PR DESCRIPTION
Using `Digest.Hex` drops the algorithm, but `Docker-manifest-digest` is supposed to include the algorithm.