### PR TITLE
Do not prompt for password if ENOENT

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -169,11 +169,11 @@ func SignCmd(ctx context.Context, keyPath string,
 }
 
 func sign(ctx context.Context, img *remote.Descriptor, keyPath string, payload []byte, pf cosign.PassFunc) (signature []byte, publicKey *ecdsa.PublicKey, err error) {
-	pass, err := pf(false)
+	kb, err := ioutil.ReadFile(keyPath)
 	if err != nil {
 		return
 	}
-	kb, err := ioutil.ReadFile(keyPath)
+	pass, err := pf(false)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Right now we ask for password even if -key file doesn't exist.