### PR TITLE
return an error when both -key and -kms are used

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -93,9 +93,21 @@ func Sign() *ffcli.Command {
 	}
 }
 
+// KeyParseError is an error returned when an incorrect set of key flags
+// are parsed by the CLI
+type KeyParseError struct{}
+
+func (e *KeyParseError) Error() string {
+	return "either local key path (-key) or KMS path (-kms) must be provided, not both"
+}
+
 func SignCmd(ctx context.Context, keyPath string,
 	imageRef string, upload bool, payloadPath string,
 	annotations map[string]string, kmsVal string, pf cosign.PassFunc, force bool) error {
+
+	if keyPath != "" && kmsVal != "" {
+		return &KeyParseError{}
+	}
 
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {

--- a/cmd/cosign/cli/sign_test.go
+++ b/cmd/cosign/cli/sign_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright The Sigstore Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestSignCmdLocalKeyAndKms verifies the SignCmd returns an error
+// if both a local key path and a KMS key path are specified
+func TestSignCmdLocalKeyAndKms(t *testing.T) {
+	ctx := context.Background()
+
+	// specify both local and KMS keys
+	keyPath := "testLocalPath"
+	kmsVal := "testKmsVal"
+
+	err := SignCmd(ctx, keyPath, "", false, "", map[string]string{}, kmsVal, getPass, false)
+
+	if (errors.Is(err, &KeyParseError{}) == false) {
+		t.Fatal("expected KeyParseError")
+	}
+}


### PR DESCRIPTION
Closes #78. I also added a test around the functionality.