### PR TITLE
CI: lock Go version and run unit tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,6 +15,23 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - uses: actions/checkout@v2
+
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+      - uses: actions/cache@v2
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
       
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
-        timeout-minutes: 7
+        timeout-minutes: 5
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,6 +50,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
+        timeout-minutes: 7
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,8 +15,17 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - uses: actions/checkout@v2
+      
       - uses: actions/setup-go@v2
-      - run: ./test/e2e_test.sh
+        with:
+          go-version: '1.15.10'
+
+      - name: Run Go tests
+        run: go test ./...
+
+      - name: Run end-to-end tests
+        run: ./test/e2e_test.sh
+
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,4 +53,3 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29
-          timeout: 5m


### PR DESCRIPTION
Locks the Go version to 1.15.10 (the latest 1.15 release at the time of commit), which is consistent with `go.mod`.

Also runs go tests as part of the pipeline.