### PR TITLE
Rekor stores full x509 certs if they are uploaded with signatures.

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -206,7 +206,17 @@ func SignCmd(ctx context.Context, keyPath string,
 			}
 		}
 	}
-	index, err := cosign.UploadTLog(signature, payload, publicKey)
+	thingToUpload := []byte{}
+	// Upload the full cert if we have it!
+	if cert != "" {
+		thingToUpload = []byte(cert)
+	} else {
+		thingToUpload, err = cosign.MarshalPublicKey(publicKey)
+		if err != nil {
+			return err
+		}
+	}
+	index, err := cosign.UploadTLog(signature, payload, thingToUpload)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -206,7 +206,7 @@ func SignCmd(ctx context.Context, keyPath string,
 			}
 		}
 	}
-	thingToUpload := []byte{}
+	var thingToUpload []byte
 	// Upload the full cert if we have it!
 	if cert != "" {
 		thingToUpload = []byte(cert)

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -111,7 +111,16 @@ func SignBlobCmd(ctx context.Context, keyPath, payloadPath string, b64 bool, pf 
 	}
 
 	if cosign.Experimental() {
-		index, err := cosign.UploadTLog(signature, payload, &priv.PublicKey)
+		thingToUpload := []byte{}
+		if cert != "" {
+			thingToUpload = []byte(cert)
+		} else {
+			thingToUpload, err = cosign.MarshalPublicKey(&priv.PublicKey)
+			if err != nil {
+				return nil, err
+			}
+		}
+		index, err := cosign.UploadTLog(signature, payload, thingToUpload)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -111,7 +111,7 @@ func SignBlobCmd(ctx context.Context, keyPath, payloadPath string, b64 bool, pf 
 	}
 
 	if cosign.Experimental() {
-		thingToUpload := []byte{}
+		var thingToUpload []byte
 		if cert != "" {
 			thingToUpload = []byte(cert)
 		} else {

--- a/pkg/cosign/upload.go
+++ b/pkg/cosign/upload.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cosign
 
 import (
-	"crypto/ecdsa"
 	"encoding/base64"
 	"fmt"
 	"os"
@@ -44,17 +43,13 @@ func Experimental() bool {
 }
 
 // Upload will upload the signature, public key and payload to the tlog
-func UploadTLog(signature, payload []byte, publicKey *ecdsa.PublicKey) (string, error) {
+func UploadTLog(signature, payload []byte, key []byte) (string, error) {
 	rekorClient, err := app.GetRekorClient(TlogServer())
 	if err != nil {
 		return "", err
 	}
-	wrappedKey, err := MarshalPublicKey(publicKey)
-	if err != nil {
-		return "", err
-	}
 
-	re := rekorEntry(payload, signature, wrappedKey)
+	re := rekorEntry(payload, signature, key)
 	returnVal := models.Rekord{
 		APIVersion: swag.String(re.APIVersion()),
 		Spec:       re.RekordObj,
@@ -72,7 +67,7 @@ func UploadTLog(signature, payload []byte, publicKey *ecdsa.PublicKey) (string, 
 			}
 			fmt.Println("Signature already exists. Displaying proof")
 
-			return FindTlogEntry(rekorClient, cs.Base64Signature, cs.Payload, wrappedKey)
+			return FindTlogEntry(rekorClient, cs.Base64Signature, cs.Payload, key)
 
 		}
 		return "", err


### PR DESCRIPTION
If we send the whole thing, we can find it in the log and verify it
later!

For fun, this commit was signed magically! The "Signed-off-by" email address below can be verified in rekor!

Take the commit ID here and search it in Rekor:

```shell
$ rekor-cli search --artifact <(echo 57781484d237fdd6ac7063b20b51ac0f92362ea1)
Found matching entries (listed by UUID):
2c57fc01f37f82c7b35da90f3fdcd262debb65725947f7da43cac4ce8dfaccd4
```

Grab that UUID and get the full entry:

```shell
$ rekor-cli get --uuid 2c57fc01f37f82c7b35da90f3fdcd262debb65725947f7da43cac4ce8dfaccd4 --format=json | jq -r .Body.RekordObj.signature.publicKey.content | base64 -D
-----BEGIN CERTIFICATE-----
MIICrTCCAjSgAwIBAgIUAJP5HGVp5LCZLBUVGZucoqhS30owCgYIKoZIzj0EAwMw
KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
MTAzMTcwMDEwMzJaFw0yMTAzMTcwMDMwMjRaMDoxGzAZBgNVBAoMEmRsb3JlbmNA
Z29vZ2xlLmNvbTEbMBkGA1UEAwwSZGxvcmVuY0Bnb29nbGUuY29tMFkwEwYHKoZI
zj0CAQYIKoZIzj0DAQcDQgAEPFo7/Z3bZZSqRGLGvLHzVObteoKQN/EuZ4JEvpSD
X0hxT+vKFJtmUvwrrysdMnhyPe72/L8+wvM36WuzZPKznaOCASYwggEiMA4GA1Ud
DwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAMBgNVHRMBAf8EAjAAMB0G
A1UdDgQWBBRwNqrkKN6tSnh4kqgZZU8Alg7YQDAfBgNVHSMEGDAWgBTIxR0AQZok
KTJRJOsNrkrtSgbT7DCBjQYIKwYBBQUHAQEEgYAwfjB8BggrBgEFBQcwAoZwaHR0
cDovL3ByaXZhdGVjYS1jb250ZW50LTYwM2ZlN2U3LTAwMDAtMjIyNy1iZjc1LWY0
ZjVlODBkMjk1NC5zdG9yYWdlLmdvb2dsZWFwaXMuY29tL2NhMzZhMWU5NjI0MmI5
ZmNiMTQ2L2NhLmNydDAdBgNVHREEFjAUgRJkbG9yZW5jQGdvb2dsZS5jb20wCgYI
KoZIzj0EAwMDZwAwZAIwIv6J9UfepsUx0wcFsL2CNsrZ3xyVpQijYRq2e3B+G/Hf
HBXyKW//CS/nqOqjtK+KAjBum9sOiAhqMU61Wii3y/MKhP+Wso3Gih5YJ9DlmXPP
Zk216DijvpVWmQY2qPFNmQo=
-----END CERTIFICATE-----
```

Now do that again but run it through openssl:

```shell
$ rekor-cli get --uuid 2c57fc01f37f82c7b35da90f3fdcd262debb65725947f7da43cac4ce8dfaccd4 --format=json | jq -r .Body.RekordObj.signature.publicKey.content | base64 -D | openssl x509  -noout -subject
subject= /O=dlorenc@google.com/CN=dlorenc@google.com
```
***subject= /O=dlorenc@google.com/CN=dlorenc@google.com***

There it is! Git commits, signed by an email address, verified with an OIDC flow, with no keys and nothing stored in git!




Signed-off-by: Dan Lorenc <dlorenc@google.com>