### PR TITLE
Add version subcommand and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
+ifeq (,$(shell go env GOBIN))
+GOBIN=$(shell go env GOPATH)/bin
+else
+GOBIN=$(shell go env GOBIN)
+endif
+
+# Set version variables for LDFLAGS
+GIT_VERSION ?= $(shell git describe --tags --always --dirty)
+GIT_HASH ?= $(shell git rev-parse HEAD)
+BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+GIT_TREESTATE = "clean"
+DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(DIFF), 1)
+    GIT_TREESTATE = "dirty"
+endif
+
+LDFLAGS = "-X github.com/sigstore/cosign/cmd/cosign/cli.gitVersion=$(GIT_VERSION) \
+             -X github.com/sigstore/cosign/cmd/cosign/cli.gitCommit=$(GIT_HASH) \
+             -X github.com/sigstore/cosign/cmd/cosign/cli.gitTreeState=$(GIT_TREESTATE) \
+             -X github.com/sigstore/cosign/cmd/cosign/cli.buildDate=$(BUILDDATE)"
+
+.PHONY: all lint test clean
+
+all: cosign
+
+SRCS = $(shell find cmd -iname "*.go") $(shell find pkg -iname "*.go")
+
+cosign: $(SRCS)
+	go build -ldflags $(LDFLAGS) -o $@ ./cmd/cosign
+
+lint:
+	$(GOBIN)/golangci-lint run -v ./...
+
+test:
+	go test ./...
+
+clean:
+	rm -rf cosign

--- a/cmd/cosign/cli/version.go
+++ b/cmd/cosign/cli/version.go
@@ -1,0 +1,82 @@
+/*
+Copyright The Rekor Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"runtime"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags (e.g. via Makefile).
+var (
+	// Output of "git describe". The prerequisite is that the branch should be
+	// tagged using the correct versioning strategy.
+	gitVersion = "unknown"
+	// SHA1 from git, output of $(git rev-parse HEAD)
+	gitCommit = "unknown"
+	// State of git tree, either "clean" or "dirty"
+	gitTreeState = "unknown"
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	buildDate = "unknown"
+)
+
+func Version() *ffcli.Command {
+	var (
+		flagset = flag.NewFlagSet("cosign version", flag.ExitOnError)
+	)
+	return &ffcli.Command{
+		Name:       "version",
+		ShortUsage: "cosign version",
+		ShortHelp:  "Prints the cosign version",
+		FlagSet:    flagset,
+		Exec: func(ctx context.Context, args []string) error {
+			fmt.Printf("%#v\n", versionInfo())
+			return nil
+		},
+	}
+}
+
+type VersionInfo struct {
+	GitVersion   string
+	GitCommit    string
+	GitTreeState string
+	BuildDate    string
+	GoVersion    string
+	Compiler     string
+	Platform     string
+}
+
+func versionInfo() VersionInfo {
+	// These variables typically come from -ldflags settings and in
+	// their absence fallback to the global defaults set above.
+	return VersionInfo{
+		GitVersion:   gitVersion,
+		GitCommit:    gitCommit,
+		GitTreeState: gitTreeState,
+		BuildDate:    buildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -38,7 +38,7 @@ func main() {
 		ShortUsage: "cosign [flags] <subcommand>",
 		FlagSet:    rootFlagSet,
 		Subcommands: []*ffcli.Command{
-			cli.Verify(), cli.Sign(), cli.Upload(), cli.Generate(), cli.Download(), cli.GenerateKeyPair(), cli.SignBlob(), cli.VerifyBlob(), cli.Triangulate()},
+			cli.Verify(), cli.Sign(), cli.Upload(), cli.Generate(), cli.Download(), cli.GenerateKeyPair(), cli.SignBlob(), cli.VerifyBlob(), cli.Triangulate(), cli.Version()},
 		Exec: func(context.Context, []string) error {
 			return flag.ErrHelp
 		},


### PR DESCRIPTION
Sample output:
```shell
→ cosign version
cli.VersionInfo{GitVersion:"ddeddcb", GitCommit:"ddeddcb405f9967d9816a93177a2a2f078f17fbc", GitTreeState:"clean", BuildDate:"2021-03-19T00:35:00Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}
```

Closes #96.