### PR TITLE
Separate out the root/chain from the cert we get.

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -135,7 +135,7 @@ func SignCmd(ctx context.Context, keyPath string,
 
 	var signature []byte
 	var publicKey *ecdsa.PublicKey
-	var cert string
+	var cert, chain string
 	switch {
 	case kmsVal != "":
 		k, err := kms.Get(ctx, kmsVal)
@@ -162,7 +162,7 @@ func SignCmd(ctx context.Context, keyPath string,
 			return errors.Wrap(err, "generating cert")
 		}
 		fmt.Fprintln(os.Stderr, "Retrieving signed certificate...")
-		cert, err = fulcio.GetCert(ctx, priv)
+		cert, chain, err = fulcio.GetCert(ctx, priv) // TODO, use the chain.
 		if err != nil {
 			return errors.Wrap(err, "retrieving cert")
 		}
@@ -184,7 +184,7 @@ func SignCmd(ctx context.Context, keyPath string,
 
 	fmt.Fprintln(os.Stderr, "Pushing signature to:", dstTag.String())
 
-	if err := cosign.Upload(signature, payload, dstTag, cert); err != nil {
+	if err := cosign.Upload(signature, payload, dstTag, cert, chain); err != nil {
 		return err
 	}
 

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -105,7 +105,7 @@ func SignBlobCmd(ctx context.Context, keyPath, kmsVal, payloadPath string, b64 b
 			return nil, errors.Wrap(err, "generating cert")
 		}
 		fmt.Fprintln(os.Stderr, "Retrieving signed certificate...")
-		cert, err := fulcio.GetCert(ctx, priv)
+		cert, _, err := fulcio.GetCert(ctx, priv) // TODO: use the chain
 		if err != nil {
 			return nil, errors.Wrap(err, "retrieving cert")
 		}

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -90,7 +90,7 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 	if err != nil {
 		return err
 	}
-	return cosign.Upload(sigBytes, payload, dstTag, "")
+	return cosign.Upload(sigBytes, payload, dstTag, "", "")
 }
 
 type SignatureArgType uint8

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/x509"
 	"encoding/pem"
-	"fmt"
 	"io/ioutil"
 	"runtime"
 	"strings"
@@ -113,9 +112,6 @@ func FetchSignatures(ctx context.Context, ref name.Reference) ([]SignedPayload, 
 				certs, err := LoadCerts(certPem)
 				if err != nil {
 					return err
-				}
-				if len(certs) != 1 {
-					return fmt.Errorf("expected 1 certificate, found %d", len(certs))
 				}
 				sp.Cert = certs[0]
 			}

--- a/pkg/cosign/remote.go
+++ b/pkg/cosign/remote.go
@@ -30,7 +30,7 @@ func Descriptors(ref name.Reference) ([]v1.Descriptor, error) {
 	return m.Layers, nil
 }
 
-func Upload(signature, payload []byte, dstTag name.Reference, cert string) error {
+func Upload(signature, payload []byte, dstTag name.Reference, cert, chain string) error {
 	l := &staticLayer{
 		b:  payload,
 		mt: "application/vnd.dev.cosign.simplesigning.v1+json",
@@ -52,6 +52,7 @@ func Upload(signature, payload []byte, dstTag name.Reference, cert string) error
 	}
 	if cert != "" {
 		annotations[certkey] = cert
+		annotations[chainkey] = chain
 	}
 	img, err := mutate.Append(base, mutate.Addendum{
 		Layer:       l,


### PR DESCRIPTION
This is the last change to fix up the next version of the fulcio API.

Signed-off-by: Dan Lorenc <dlorenc@google.com>