### PR TITLE
`cosign validate`: return an error when kms and key arguments are both provided

### DIFF
--- a/cmd/cosign/cli/errors.go
+++ b/cmd/cosign/cli/errors.go
@@ -1,0 +1,9 @@
+package cli
+
+// KeyParseError is an error returned when an incorrect set of key flags
+// are parsed by the CLI
+type KeyParseError struct{}
+
+func (e *KeyParseError) Error() string {
+	return "either local key path (-key) or KMS path (-kms) must be provided, not both"
+}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -97,14 +97,6 @@ func Sign() *ffcli.Command {
 	}
 }
 
-// KeyParseError is an error returned when an incorrect set of key flags
-// are parsed by the CLI
-type KeyParseError struct{}
-
-func (e *KeyParseError) Error() string {
-	return "either local key path (-key) or KMS path (-kms) must be provided, not both"
-}
-
 func SignCmd(ctx context.Context, keyPath string,
 	imageRef string, upload bool, payloadPath string,
 	annotations map[string]string, kmsVal string, pf cosign.PassFunc, force bool) error {

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -29,89 +29,107 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign/fulcio"
 )
 
+// VerifyCommand verifies a signature on a supplied container image
+type VerifyCommand struct {
+	KmsVal      string
+	Key         string
+	CheckClaims bool
+	Annotations map[string]string
+}
+
+// Verify builds and returns an ffcli command
 func Verify() *ffcli.Command {
-	var (
-		flagset     = flag.NewFlagSet("cosign verify", flag.ExitOnError)
-		kmsVal      = flagset.String("kms", "", "verify via a public key stored in a KMS")
-		key         = flagset.String("key", "", "path to the public key")
-		checkClaims = flagset.Bool("check-claims", true, "whether to check the claims found")
-		annotations = annotationsMap{}
-	)
+	cmd := VerifyCommand{}
+	flagset := flag.NewFlagSet("cosign verify", flag.ExitOnError)
+	annotations := annotationsMap{}
+
+	flagset.StringVar(&cmd.Key, "kms", "", "verify via a public key stored in a KMS")
+	flagset.StringVar(&cmd.KmsVal, "kms", "", "verify via a public key stored in a KMS")
+	flagset.BoolVar(&cmd.CheckClaims, "check-claims", true, "whether to check the claims found")
+
+	// parse annotations
 	flagset.Var(&annotations, "a", "extra key=value pairs to sign")
+	cmd.Annotations = annotations.annotations
 
 	return &ffcli.Command{
 		Name:       "verify",
 		ShortUsage: "cosign verify -key <key> <image uri>",
 		ShortHelp:  "Verify a signature on the supplied container image",
 		FlagSet:    flagset,
-		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-
-			co := cosign.CheckOpts{
-				Annotations: annotations.annotations,
-				Claims:      *checkClaims,
-				Tlog:        cosign.Experimental(),
-				Roots:       fulcio.Roots,
-			}
-			// Keys are optional!
-			if *key != "" {
-				pubKeyDescriptor := *key
-				if *kmsVal != "" {
-					pubKeyDescriptor = *kmsVal
-				}
-				pubKey, err := cosign.LoadPublicKey(pubKeyDescriptor)
-				if err != nil {
-					return errors.Wrap(err, "loading public key")
-				}
-				co.PubKey = pubKey
-			}
-
-			verified, err := VerifyCmd(ctx, args[0], co)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(os.Stderr, "The following checks were performed on each of these signatures:")
-			if co.Claims {
-				if co.Annotations != nil {
-					fmt.Fprintln(os.Stderr, "  - The specified annotations were verified.")
-				}
-				fmt.Fprintln(os.Stderr, "  - The cosign claims were validated")
-			}
-			if co.Tlog {
-				fmt.Fprintln(os.Stderr, "  - The claims were present in the transparency log")
-				fmt.Fprintln(os.Stderr, "  - The signatures were integrated into the transparency log when the certificate was valid")
-			}
-			if co.PubKey != nil {
-				fmt.Fprintln(os.Stderr, "  - The signatures were verified against the specified public key")
-			}
-			if co.Roots != nil { // This is always true for now, we hardcode the fulcio root.
-				fmt.Fprintln(os.Stderr, "  - Any certificates were verified against the Fulcio roots.")
-				if !co.Tlog {
-					fmt.Fprintln(os.Stderr, "  - WARNING - THE CERTIFICATE EXPIRY WAS NOT CHECKED. set COSIGN_EXPERIMENTAL=1 to check!")
-				}
-			}
-			for _, vp := range verified {
-				if vp.Cert != nil {
-					fmt.Println("Certificate common name: ", vp.Cert.Subject.CommonName)
-				}
-				fmt.Println(string(vp.Payload))
-			}
-			return nil
-		},
+		Exec:       cmd.Exec,
 	}
 }
 
-func VerifyCmd(ctx context.Context, imageRef string, co cosign.CheckOpts) ([]cosign.SignedPayload, error) {
-	ref, err := name.ParseReference(imageRef)
-	if err != nil {
-		return nil, err
+// Exec runs the verification command
+func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+	if c.Key != "" && c.KmsVal != "" {
+		return &KeyParseError{}
 	}
 
-	sp, err := cosign.Verify(ctx, ref, co)
-	if err != nil {
-		return nil, err
+	co := cosign.CheckOpts{
+		Annotations: c.Annotations,
+		Claims:      c.CheckClaims,
+		Tlog:        cosign.Experimental(),
+		Roots:       fulcio.Roots,
 	}
-	return sp, nil
+	// Keys are optional!
+	if c.Key != "" {
+		pubKeyDescriptor := c.Key
+		if c.KmsVal != "" {
+			pubKeyDescriptor = c.KmsVal
+		}
+		pubKey, err := cosign.LoadPublicKey(pubKeyDescriptor)
+		if err != nil {
+			return errors.Wrap(err, "loading public key")
+		}
+		co.PubKey = pubKey
+	}
+
+	imageRef := args[0]
+
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return err
+	}
+
+	verified, err := cosign.Verify(ctx, ref, co)
+	if err != nil {
+		return err
+	}
+
+	printVerification(verified, co)
+	return nil
+}
+
+// printVerification logs details about the verification to stdout
+func printVerification(verified []cosign.SignedPayload, co cosign.CheckOpts) {
+	fmt.Fprintln(os.Stderr, "The following checks were performed on each of these signatures:")
+	if co.Claims {
+		if co.Annotations != nil {
+			fmt.Fprintln(os.Stderr, "  - The specified annotations were verified.")
+		}
+		fmt.Fprintln(os.Stderr, "  - The cosign claims were validated")
+	}
+	if co.Tlog {
+		fmt.Fprintln(os.Stderr, "  - The claims were present in the transparency log")
+		fmt.Fprintln(os.Stderr, "  - The signatures were integrated into the transparency log when the certificate was valid")
+	}
+	if co.PubKey != nil {
+		fmt.Fprintln(os.Stderr, "  - The signatures were verified against the specified public key")
+	}
+	if co.Roots != nil { // This is always true for now, we hardcode the fulcio root.
+		fmt.Fprintln(os.Stderr, "  - Any certificates were verified against the Fulcio roots.")
+		if !co.Tlog {
+			fmt.Fprintln(os.Stderr, "  - WARNING - THE CERTIFICATE EXPIRY WAS NOT CHECKED. set COSIGN_EXPERIMENTAL=1 to check!")
+		}
+	}
+	for _, vp := range verified {
+		if vp.Cert != nil {
+			fmt.Println("Certificate common name: ", vp.Cert.Subject.CommonName)
+		}
+		fmt.Println(string(vp.Payload))
+	}
 }

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -43,7 +43,7 @@ func Verify() *ffcli.Command {
 	flagset := flag.NewFlagSet("cosign verify", flag.ExitOnError)
 	annotations := annotationsMap{}
 
-	flagset.StringVar(&cmd.Key, "kms", "", "verify via a public key stored in a KMS")
+	flagset.StringVar(&cmd.Key, "key", "", "path to the public key")
 	flagset.StringVar(&cmd.KmsVal, "kms", "", "verify via a public key stored in a KMS")
 	flagset.BoolVar(&cmd.CheckClaims, "check-claims", true, "whether to check the claims found")
 

--- a/cmd/cosign/cli/verify_test.go
+++ b/cmd/cosign/cli/verify_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright The Sigstore Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestVerifyCmdLocalKeyAndKms verifies the Verify command returns an error
+// if both a local key path and a KMS key path are specified
+func TestVerifyCmdLocalKeyAndKms(t *testing.T) {
+	ctx := context.Background()
+
+	// specify both local and KMS keys
+	cmd := VerifyCommand{
+		KmsVal:      "testKmsVal",
+		Key:         "testLocalPath",
+		CheckClaims: false,
+		Annotations: map[string]string{},
+	}
+
+	err := cmd.Exec(ctx, []string{"testImage"})
+
+	if (errors.Is(err, &KeyParseError{}) == false) {
+		t.Fatal("expected KeyParseError")
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -33,19 +33,16 @@ var passFunc = func(_ bool) ([]byte, error) {
 	return keyPass, nil
 }
 
-var verify = func(k, i string, b bool, a map[string]string) error {
-	pk, err := cosign.LoadPublicKey(k)
-	if err != nil {
-		return err
+var verify = func(key, imageRef string, checkClaims bool, annotations map[string]string) error {
+	cmd := cli.VerifyCommand{
+		Key:         key,
+		CheckClaims: checkClaims,
+		Annotations: annotations,
 	}
-	co := cosign.CheckOpts{
-		PubKey:      pk,
-		Annotations: a,
-		Claims:      b,
-		Tlog:        cosign.Experimental(),
-	}
-	_, err = cli.VerifyCmd(context.Background(), i, co)
-	return err
+
+	args := []string{imageRef}
+
+	return cmd.Exec(context.Background(), args)
 }
 
 func TestSignVerify(t *testing.T) {


### PR DESCRIPTION
My second pass at fixing this, closes #78. Thankyou to @priyawadhwa for catching that the issue wasn't fully resolved.

In order to add a test around the change I have refactored [`cli/verify.go`](https://github.com/chrnorm/cosign/blob/3f83da7da087513ad9d98bf35e6b551126cc0dff/cmd/cosign/cli/verify.go) to be closer to an [idiomatic ffcli example](https://github.com/peterbourgon/ff/tree/master/ffcli/examples/objectctl): I've added a `VerifyCommand` struct with an `Exec` receiver method which executes the actual command. 

Using a struct to hold configuration and writing to the struct using `flagset.StringVar` allows tests to be written around command execution (in this case, I've added a test checking the behaviour of when `-key` and `-kms` are both passed). See [`cli/verify_test.go`](https://github.com/chrnorm/cosign/blob/3f83da7da087513ad9d98bf35e6b551126cc0dff/cmd/cosign/cli/verify_test.go) for an example.

We may want to consider the pattern presented above for other commands added in future over using an anonymous function for `ffcli.Command.Exec`, as shown the below snippet

```go
return &ffcli.Command{
		Name:       "mycommand",
		ShortUsage: "mycommand run -value <value>",
		ShortHelp:  "An example command",
		FlagSet:    flagset,
		Exec: func(ctx context.Context, args []string) error {
                       // difficult to test any behaviour here
                }
```

Instead replacing this with
```go
type MyCommand struct {
	MyConfigValue string
}

func NewMyCommand() *ffcli.Command {
	cmd := MyCommand{}
	flagset := flag.NewFlagSet("mycommand run", flag.ExitOnError)

	flagset.StringVar(&cmd.MyConfigValue, "value", "", "example command configuration value")

	return &ffcli.Command{
		Name:       "mycommand",
		ShortUsage: "mycommand run -value <value>",
		ShortHelp:  "An example command",
		FlagSet:    flagset,
		Exec:       cmd.Exec,
	}
}

func (c *MyCommand) Exec(ctx context.Context, args []string) error {
	fmt.Println("example command execution")
	return nil
}
```




Additionally:
- split logging of verification results into a separate function
- update end-to-end test to more closely represent the real CLI command under test, by calling cmd.Exec (which includes parsing and validation logic)