### PR TITLE
Whoops, sign with the linux binary always in our CI builds.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: sign
         run: |
           echo -n "${{secrets.COSIGN_PASSWORD}}" | ./cosign-linux-amd64 sign-blob -key ./.github/workflows/cosign.key ././cosign-linux-amd64 > cosign-linux-amd64.sig
-          echo -n "${{secrets.COSIGN_PASSWORD}}" | ./cosign-darwin-amd64 sign-blob -key ./.github/workflows/cosign.key ././cosign-darwin-amd64 > cosign-darwin-amd64.sig
+          echo -n "${{secrets.COSIGN_PASSWORD}}" | ./cosign-linux-amd64 sign-blob -key ./.github/workflows/cosign.key ././cosign-darwin-amd64 > cosign-darwin-amd64.sig
       - name: verify
         run: ./cosign verify-blob -key ./.github/workflows/cosign.pub -signature cosign.sig ./cosign
       - name: Upload artifacts


### PR DESCRIPTION
Signed-off-by: Dan Lorenc <dlorenc@google.com>