### PR TITLE
Add a ko-built docker image to the makefile.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
           echo -n "${{secrets.COSIGN_PASSWORD}}" | ./cosign-linux-amd64 sign-blob -key ./.github/workflows/cosign.key ././cosign-linux-amd64 > cosign-linux-amd64.sig
           echo -n "${{secrets.COSIGN_PASSWORD}}" | ./cosign-linux-amd64 sign-blob -key ./.github/workflows/cosign.key ././cosign-darwin-amd64 > cosign-darwin-amd64.sig
       - name: verify
-        run: ./cosign verify-blob -key ./.github/workflows/cosign.pub -signature cosign.sig ./cosign
+        run: ./cosign verify-blob -key ./.github/workflows/cosign.pub -signature cosign.sig ./cosign-linux-amd64
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,0 +1,2 @@
+# We need a shell for a lot of redirection/piping to work
+defaultBaseImage: gcr.io/distroless/base:debug

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,9 @@ ifeq ($(DIFF), 1)
     GIT_TREESTATE = "dirty"
 endif
 
-LDFLAGS = "-X github.com/sigstore/cosign/cmd/cosign/cli.gitVersion=$(GIT_VERSION) \
-             -X github.com/sigstore/cosign/cmd/cosign/cli.gitCommit=$(GIT_HASH) \
-             -X github.com/sigstore/cosign/cmd/cosign/cli.gitTreeState=$(GIT_TREESTATE) \
-             -X github.com/sigstore/cosign/cmd/cosign/cli.buildDate=$(BUILDDATE)"
+PKG=github.com/sigstore/cosign/cmd/cosign/cli
+
+LDFLAGS="-X $(PKG).gitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE)"
 
 .PHONY: all lint test clean cosign cross
 
@@ -54,3 +53,7 @@ test:
 clean:
 	rm -rf cosign
 
+.PHONY: ko
+ko:
+	# We can't pass more than one LDFLAG via GOFLAGS, you can't have spaces in there.
+	GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish github.com/sigstore/cosign/cmd/cosign


### PR DESCRIPTION
This still doesn't build as part of our release process, we need to hook up GCP creds
somewhere.

This also fixes #126 

Signed-off-by: Dan Lorenc <dlorenc@google.com>