### PR TITLE
Start signing the containers for our CI builds.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  pull_request: #REMOVE
 jobs:
   # Set the job key. The key is displayed as the job name
   # when a job name is not provided
@@ -38,7 +39,7 @@ jobs:
       - name: build
         run: make cross
       - name: container
-        run: KO_DOCKER_REPO=gcr.io/projectsigstore/cosign/ci-builds make ko
+        run: echo -n "${{secrets.COSIGN_PASSWORD}}" | KO_DOCKER_REPO=gcr.io/projectsigstore/cosign/ci/cosign make sign-container
       - name: Print Info
         run: ./cosign-linux-amd64 version && shasum -a 256 ./cosign-linux-amd64 > cosign.sha256 && cat cosign.sha256
       - name: sign

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,7 @@ ko:
 	GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
 		--tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		github.com/sigstore/cosign/cmd/cosign
+
+.PHONY: sign-container
+sign-container: cosign ko
+	./cosign sign -key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_DOCKER_REPO}:$(GIT_HASH)

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ and the resulting binary will be placed at `$HOME/go/bin/cosign`.
 
 ### Containers
 
-CI Built containers are published for every commit at `gcr.io/projectsigstore/cosign/ci-builds`.
+CI Built containers are published for every commit at `gcr.io/projectsigstore/cosign/ci/cosign`.
 They are tagged with the commit.
 They can be found with `crane ls`:
 
 ```
-$ crane ls gcr.io/projectsigstore/cosign/ci-builds
+$ crane ls gcr.io/projectsigstore/cosign/ci/cosign
 749f896
 749f896bb378aca5cb45c5154fc0cb43f6728d48
 ```


### PR DESCRIPTION
Also change the location to have 'cosign' in the last part of the repo.

Signed-off-by: Dan Lorenc <dlorenc@google.com>