### PR TITLE
Add support for COSIGN_REPOSITORY env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ Multiple signatures are stored in a list which is unfortunately "racy" today.
 To add a signtaure, clients orchestrate a "read-append-write" operation, so the last write
 will win in the case of contention.
 
+##### Specifying Registry
+`cosign` will default to storing signatures in the same repo as the image it is signing.
+To specify a different repo for signatures, you can set the `COSIGN_REPOSITORY` environment variable.
+
+This will replace the repo in the provided image like this:
+```
+export COSIGN_REPOSITORY=gcr.io/my-new-repo
+gcr.io/dlorenc-vmtest2/demo -> gcr.io/my-new-repo/demo:sha256-DIGEST.cosign
+```
+So the signature for `gcr.io/dlorenc-vmtest2/demo` will be stored in `gcr.io/my-new-repo/demo:sha256-DIGEST.cosign`.
+
+
 ## Signature Specification
 
 `cosign` is inspired by tools like [minisign](https://jedisct1.github.io/minisign/) and

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -172,7 +172,10 @@ func SignCmd(ctx context.Context, keyPath string,
 	}
 
 	// sha256:... -> sha256-...
-	dstTag := ref.Context().Tag(cosign.Munge(get.Descriptor))
+	dstTag, err := cosign.DestinationTag(ref, get)
+	if err != nil {
+		return err
+	}
 
 	fmt.Fprintln(os.Stderr, "Pushing signature to:", dstTag.String())
 

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -73,7 +73,10 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 		return err
 	}
 
-	dstTag := ref.Context().Tag(cosign.Munge(get.Descriptor))
+	dstTag, err := cosign.DestinationTag(ref, get)
+	if err != nil {
+		return err
+	}
 
 	var payload []byte
 	if payloadRef == "" {

--- a/pkg/cosign/upload_test.go
+++ b/pkg/cosign/upload_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright The Rekor Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cosign
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+func TestDestinationTag(t *testing.T) {
+	tests := []struct {
+		desc  string
+		image string
+		repo  string
+		want  string
+	}{
+		{
+			desc:  "don't specify repo",
+			image: "gcr.io/test/test",
+			want:  "gcr.io/test/test:sha256-digest.cosign",
+		}, {
+			desc:  "replace repo",
+			image: "gcr.io/test/image",
+			repo:  "gcr.io/new",
+			want:  "gcr.io/new/image:sha256-digest.cosign",
+		}, {
+			desc:  "image has subrepos",
+			image: "gcr.io/test/image/sub",
+			repo:  "gcr.io/new",
+			want:  "gcr.io/new/image/sub:sha256-digest.cosign",
+		}, {
+			desc:  "repo has subrepos",
+			image: "gcr.io/test/image/sub",
+			repo:  "gcr.io/new/subrepo",
+			want:  "gcr.io/new/subrepo/image/sub:sha256-digest.cosign",
+		}, {
+			desc:  "replace not gcr repo",
+			image: "test/image",
+			repo:  "newrepo",
+			want:  "index.docker.io/newrepo/image:sha256-digest.cosign",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			os.Setenv(repoEnv, test.repo)
+			defer os.Unsetenv(repoEnv)
+
+			ref, err := name.ParseReference(test.image)
+			if err != nil {
+				t.Fatalf("error parsing reference: %v", err)
+			}
+			img := &remote.Descriptor{
+				Descriptor: v1.Descriptor{
+					Digest: v1.Hash{
+						Algorithm: "sha256",
+						Hex:       "digest",
+					},
+				},
+			}
+			got, err := DestinationTag(ref, img)
+			if err != nil {
+				t.Fatalf("error destination tag: %v", err)
+			}
+			if got.Name() != test.want {
+				t.Fatalf("expected %s got %s", test.want, got.Name())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This env var will allow users to specify which repo they want cosign signatures stored in!

I had to do some kinda sketchy string replacement to replace just the subrepo -- if we just directly replace the registry, we'd end up with something like this (which would be cleaner in the code, but isn't as pretty):

```
export COSIGN_REPOSITORY=gcr.io/distroless-signatures
gcr.io/cosign-signatures/static -> gcr.io/distroless/cosign-signatures/static
```


fixes https://github.com/sigstore/cosign/issues/122

Signed-off-by: Priya Wadhwa <priyawadhwa@google.com>