### PR TITLE
cmd: check for missing args in public-key

### DIFF
--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -45,6 +45,9 @@ func PublicKey() *ffcli.Command {
 		LongHelp:   "public-key gets a public key from the key-pair",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
+			if (*key == "" && *kmsVal == "") || (*key != "" && *kmsVal != "") {
+				return &KeyParseError{}
+			}
 			return GetPublicKey(ctx, *key, *kmsVal, GetPass)
 		},
 	}


### PR DESCRIPTION
If you don't specify any args to "cosign public-key" right now it fails with

    error: read: . is a directory

which is fairly confusing. So I'm using KeyParseError to indicate there's an
issue with these flags.