### PR TITLE
Fix the flag parsing in verify.

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -34,7 +34,7 @@ type VerifyCommand struct {
 	KmsVal      string
 	Key         string
 	CheckClaims bool
-	Annotations map[string]string
+	Annotations *map[string]string
 }
 
 // Verify builds and returns an ffcli command
@@ -49,7 +49,7 @@ func Verify() *ffcli.Command {
 
 	// parse annotations
 	flagset.Var(&annotations, "a", "extra key=value pairs to sign")
-	cmd.Annotations = annotations.annotations
+	cmd.Annotations = &annotations.annotations
 
 	return &ffcli.Command{
 		Name:       "verify",
@@ -70,7 +70,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
 	}
 
 	co := cosign.CheckOpts{
-		Annotations: c.Annotations,
+		Annotations: *c.Annotations,
 		Claims:      c.CheckClaims,
 		Tlog:        cosign.Experimental(),
 		Roots:       fulcio.Roots,

--- a/cmd/cosign/cli/verify_test.go
+++ b/cmd/cosign/cli/verify_test.go
@@ -32,7 +32,7 @@ func TestVerifyCmdLocalKeyAndKms(t *testing.T) {
 		KmsVal:      "testKmsVal",
 		Key:         "testLocalPath",
 		CheckClaims: false,
-		Annotations: map[string]string{},
+		Annotations: &map[string]string{},
 	}
 
 	err := cmd.Exec(ctx, []string{"testImage"})

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -37,7 +37,7 @@ var verify = func(key, imageRef string, checkClaims bool, annotations map[string
 	cmd := cli.VerifyCommand{
 		Key:         key,
 		CheckClaims: checkClaims,
-		Annotations: annotations,
+		Annotations: &annotations,
 	}
 
 	args := []string{imageRef}


### PR DESCRIPTION
All of our testing (e2e and unit) unfortunately happens after flags are
parsed so we missed this.

Signed-off-by: Dan Lorenc <dlorenc@google.com>