### PR TITLE
Add e2e tests with a new secret.

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -1,0 +1,34 @@
+name: e2e-tests
+
+# Run this workflow every time a new commit pushed to your repository
+on: [push]
+
+jobs:
+  # Set the job key. The key is displayed as the job name
+  # when a job name is not provided
+  e2e-tests:
+    # Name the Job
+    name: Run tests
+    # Set the type of machine to run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks out a copy of your repository on the ubuntu-latest machine
+      - uses: actions/checkout@v2
+      
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16.2'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: projectsigstore
+          service_account_key: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
+          export_default_credentials: true
+      - name: Install Crane
+        run: go install github.com/google/go-containerregistry/cmd/crane
+      - name: creds
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Run e2e tests that need secrets
+        run: ./test/e2e_test_secrets.sh

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -ex
+
+go build -o cosign ./cmd/cosign
+tmp=$(mktemp -d)
+cp cosign $tmp/
+
+pushd $tmp
+
+pass="$RANDOM"
+
+export COSIGN_PASSWORD=$pass
+# setup
+./cosign generate-key-pair
+img="us-central1-docker.pkg.dev/projectsigstore/cosign-ci/test"
+(crane delete $(./cosign triangulate $img)) || true
+crane cp busybox $img
+
+## sign/verify
+./cosign sign -key cosign.key $img
+./cosign verify -key cosign.pub $img
+
+# annotations
+if (./cosign verify -key cosign.pub -a foo=bar $img); then false; fi
+./cosign sign -key cosign.key -a foo=bar $img
+./cosign verify -key cosign.pub -a foo=bar $img
+
+if (./cosign verify -key cosign.pub -a foo=bar bar=baz $img); then false; fi
+./cosign sign -key cosign.key -a foo=bar -a bar=baz $img
+./cosign verify -key cosign.pub -a foo=bar -a bar=baz $img
+./cosign verify -key cosign.pub -a bar=baz $img
+
+# wrong keys
+mkdir wrong && pushd wrong
+../cosign generate-key-pair
+if (../cosign verify -key cosign.pub $img); then false; fi
+popd
+
+echo "SUCCESS"
+
+# TODO: kms
+# TODO: tlog
+# TODO: sign-blob
+# What else needs auth?


### PR DESCRIPTION
These run through the full bash flow rather than using go to hook
up after flag parsing.