### PR TITLE
cmd: more meaningful error when -key|-kms missing

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -85,7 +85,7 @@ func Sign() *ffcli.Command {
 			// A key file (or kms address) is required unless we're in experimental mode!
 			if !cosign.Experimental() {
 				if *key == "" && *kmsVal == "" {
-					return flag.ErrHelp
+					return &KeyParseError{}
 				}
 			}
 			if len(args) != 1 {

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -49,7 +49,7 @@ func SignBlob() *ffcli.Command {
 			// A key file is required unless we're in experimental mode!
 			if !cosign.Experimental() {
 				if *key == "" && *kmsVal == "" {
-					return flag.ErrHelp
+					return &KeyParseError{}
 				}
 			}
 


### PR DESCRIPTION
Use KeyParseError (instead of "help requested" error) when both -key and -kms
are omitted.