### PR TITLE
pass fulcio.Roots properly

### DIFF
--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/cosign/fulcio"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/cmd"
@@ -176,6 +177,7 @@ func main() {
 			co := cosign.CheckOpts{
 				PubKey: pubKey,
 				Claims: true,
+				Roots:  fulcio.Roots,
 			}
 			sps, err := cosign.Verify(context.Background(), ref, co)
 			if err != nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -38,12 +38,12 @@ import (
 	"github.com/google/trillian/merkle/rfc6962/hasher"
 	"github.com/pkg/errors"
 
-	"github.com/sigstore/cosign/pkg/cosign/fulcio"
-	"github.com/sigstore/cosign/pkg/cosign/kms"
 	"github.com/sigstore/rekor/cmd/cli/app"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/models"
+
+	"github.com/sigstore/cosign/pkg/cosign/kms"
 )
 
 const pubKeyPemType = "PUBLIC KEY"
@@ -358,7 +358,7 @@ func TrustedCert(cert *x509.Certificate, roots *x509.CertPool) error {
 		// THE CERTIFICATE IS TREATED AS TRUSTED FOREVER
 		// WE CHECK THAT THE SIGNATURES WERE CREATED DURING THIS WINDOW
 		CurrentTime: cert.NotBefore,
-		Roots:       fulcio.Roots,
+		Roots:       roots,
 		KeyUsages: []x509.ExtKeyUsage{
 			x509.ExtKeyUsage(x509.KeyUsageDigitalSignature),
 			x509.ExtKeyUsageCodeSigning,


### PR DESCRIPTION
previously the roots were hardcoded in TrustedCert() function as
fulcio.Roots (and the passed value was usuned), but I assume this is not
what was intended.