### PR TITLE
Fix bug with -kms flag and verify

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -92,12 +92,12 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
 		Tlog:        cosign.Experimental(),
 		Roots:       fulcio.Roots,
 	}
+	pubKeyDescriptor := c.Key
+	if c.KmsVal != "" {
+		pubKeyDescriptor = c.KmsVal
+	}
 	// Keys are optional!
-	if c.Key != "" {
-		pubKeyDescriptor := c.Key
-		if c.KmsVal != "" {
-			pubKeyDescriptor = c.KmsVal
-		}
+	if pubKeyDescriptor != "" {
 		pubKey, err := cosign.LoadPublicKey(pubKeyDescriptor)
 		if err != nil {
 			return errors.Wrap(err, "loading public key")


### PR DESCRIPTION
Fixes a bug where nothing happens if we pass in `-kms` because we're checking to make sure `-key` has a value

Signed-off-by: Priya Wadhwa <priyawadhwa@google.com>


