### PR TITLE
Add Gitlab Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Today, `cosign` has been tested and works against the following registries:
 * Azure Container Registry
 * JFrog Artifactory Container Registry
 * The CNCF distribution/distribution Registry
+* Gitlab Container Registry
 
 We aim for wide registry support.
 Please help test!


### PR DESCRIPTION
 I have tested cosign for gitlab container registry and work! 

My verify result:
```
$ cosign verify -key cosign.pub registry.gitlab.com/eminks/denemler:latest
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.
  - WARNING - THE CERTIFICATE EXPIRY WAS NOT CHECKED. set COSIGN_EXPERIMENTAL=1 to check!
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:c93fa5b332de47c9f031284c7aa7a95988536e515571b73fa6294a0f54b289aa"},"Type":"cosign container signature"},"Optional":null}
```
Based on: #40 