### PR TITLE
Make the build action run on all branch pushes.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,8 +3,6 @@ name: CI-Build
 # Run this workflow every time a new commit pushed to your repository
 on:
   push:
-    branches:
-      - main
 jobs:
   # Set the job key. The key is displayed as the job name
   # when a job name is not provided


### PR DESCRIPTION
This is the only way to test changes to the workflow without merging to main.
