### PR TITLE
Initial creation of Signer and Verifier interfaces.

### DIFF
--- a/cmd/cosign/cli/generate.go
+++ b/cmd/cosign/cli/generate.go
@@ -62,7 +62,7 @@ EXAMPLES
 	}
 }
 
-func GenerateCmd(_ context.Context, imageRef string, a map[string]string, w io.Writer) error {
+func GenerateCmd(_ context.Context, imageRef string, annotations map[string]string, w io.Writer) error {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func GenerateCmd(_ context.Context, imageRef string, a map[string]string, w io.W
 		return err
 	}
 
-	payload, err := cosign.Payload(get.Descriptor, a)
+	payload, err := (&cosign.ImagePayload{Img: get.Descriptor, Annotations: annotations}).MarshalJSON()
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -96,7 +96,6 @@ func SignBlobCmd(ctx context.Context, keyPath, kmsVal, payloadPath string, b64 b
 			return nil, errors.Wrap(err, "signing blob")
 		}
 		pemBytes = cosign.KeyToPem(pub)
-
 	case kmsVal != "":
 		k, err := kms.Get(ctx, kmsVal)
 		if err != nil {
@@ -145,4 +144,17 @@ func SignBlobCmd(ctx context.Context, keyPath, kmsVal, payloadPath string, b64 b
 		}
 	}
 	return signature, nil
+}
+
+func sign(ctx context.Context, keyPath string, payload []byte, pf cosign.PassFunc) (signature []byte, publicKey *ecdsa.PublicKey, err error) {
+	k, err := loadKey(keyPath, pf)
+	if err != nil {
+		return nil, nil, err
+	}
+	publicKey = &k.Key.PublicKey
+	signature, err = k.Sign(ctx, payload)
+	if err != nil {
+		return nil, nil, err
+	}
+	return signature, publicKey, nil
 }

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -78,7 +78,7 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 
 	var payload []byte
 	if payloadRef == "" {
-		payload, err = cosign.Payload(get.Descriptor, nil)
+		payload, err = (&cosign.ImagePayload{Img: get.Descriptor}).MarshalJSON()
 	} else {
 		payload, err = ioutil.ReadFile(filepath.Clean(payloadRef))
 	}

--- a/pkg/cosign/payload.go
+++ b/pkg/cosign/payload.go
@@ -20,20 +20,22 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-func Payload(img v1.Descriptor, a map[string]string) ([]byte, error) {
+type ImagePayload struct {
+	Img         v1.Descriptor
+	Annotations map[string]string
+}
+
+func (p *ImagePayload) MarshalJSON() ([]byte, error) {
 	simpleSigning := SimpleSigning{
 		Critical: Critical{
 			Image: Image{
-				DockerManifestDigest: img.Digest.String(),
+				DockerManifestDigest: p.Img.Digest.String(),
 			},
 			Type: "cosign container signature",
 		},
-		Optional: a,
+		Optional: p.Annotations,
 	}
-
-	b, err := json.Marshal(simpleSigning)
-	if err != nil {
-		return nil, err
-	}
-	return b, err
+	return json.Marshal(simpleSigning)
 }
+
+//TODO: Unmarshal JSON


### PR DESCRIPTION
We should be abstracting Signer and Verifier (and Public Key provider) sooner rather than later. This gets us a step in that direction, but there's a lot more retooling to do on the interfaces

Signed-off-by: Jake Sanders <jsand@google.com>