### PR TITLE
Allow passing in multiple image names to sign and verify

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -103,7 +103,7 @@ EXAMPLES
 				return flag.ErrHelp
 			}
 
-			for _, img := range args[0:] {
+			for _, img := range args {
 				if err := SignCmd(ctx, *key, img, *upload, *payloadPath, annotations.annotations, *kmsVal, GetPass, *force); err != nil {
 					return errors.Wrapf(err, "signing %s", img)
 				}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -99,11 +99,16 @@ EXAMPLES
 					return &KeyParseError{}
 				}
 			}
-			if len(args) != 1 {
+			if len(args) == 0 {
 				return flag.ErrHelp
 			}
 
-			return SignCmd(ctx, *key, args[0], *upload, *payloadPath, annotations.annotations, *kmsVal, GetPass, *force)
+			for _, img := range args[0:] {
+				if err := SignCmd(ctx, *key, img, *upload, *payloadPath, annotations.annotations, *kmsVal, GetPass, *force); err != nil {
+					return errors.Wrapf(err, "signing %s", img)
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -62,12 +62,15 @@ EXAMPLES
 				}
 			}
 
-			if len(args) != 1 {
+			if len(args) == 0 {
 				return flag.ErrHelp
 			}
-
-			_, err := SignBlobCmd(ctx, *key, *kmsVal, args[0], *b64, GetPass)
-			return err
+			for _, blob := range args[0:] {
+				if _, err := SignBlobCmd(ctx, *key, *kmsVal, blob, *b64, GetPass); err != nil {
+					return errors.Wrapf(err, "signing %s", blob)
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -65,7 +65,7 @@ EXAMPLES
 			if len(args) == 0 {
 				return flag.ErrHelp
 			}
-			for _, blob := range args[0:] {
+			for _, blob := range args {
 				if _, err := SignBlobCmd(ctx, *key, *kmsVal, blob, *b64, GetPass); err != nil {
 					return errors.Wrapf(err, "signing %s", blob)
 				}

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -105,7 +105,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
 		co.PubKey = pubKey
 	}
 
-	for _, imageRef := range args[0:] {
+	for _, imageRef := range args {
 		ref, err := name.ParseReference(imageRef)
 		if err != nil {
 			return err

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -79,7 +79,7 @@ EXAMPLES
 
 // Exec runs the verification command
 func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
-	if len(args) != 1 {
+	if len(args) == 0 {
 		return flag.ErrHelp
 	}
 	if c.Key != "" && c.KmsVal != "" {
@@ -105,24 +105,26 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
 		co.PubKey = pubKey
 	}
 
-	imageRef := args[0]
+	for _, imageRef := range args[0:] {
+		ref, err := name.ParseReference(imageRef)
+		if err != nil {
+			return err
+		}
 
-	ref, err := name.ParseReference(imageRef)
-	if err != nil {
-		return err
+		verified, err := cosign.Verify(ctx, ref, co)
+		if err != nil {
+			return err
+		}
+
+		printVerification(imageRef, verified, co)
 	}
 
-	verified, err := cosign.Verify(ctx, ref, co)
-	if err != nil {
-		return err
-	}
-
-	printVerification(verified, co)
 	return nil
 }
 
 // printVerification logs details about the verification to stdout
-func printVerification(verified []cosign.SignedPayload, co cosign.CheckOpts) {
+func printVerification(imgRef string, verified []cosign.SignedPayload, co cosign.CheckOpts) {
+	fmt.Fprintf(os.Stderr, "\nVerification for %s --\n", imgRef)
 	fmt.Fprintln(os.Stderr, "The following checks were performed on each of these signatures:")
 	if co.Claims {
 		if co.Annotations != nil {

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -66,10 +66,15 @@ EXAMPLES
 	cosign verify-blob -kms gcpkms://projects/<PROJECT ID>/locations/<LOCATION>/keyRings/<KEYRING>/cryptoKeys/<KEY> -signature $sig <blob>`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
+			if len(args) == 0 {
 				return flag.ErrHelp
 			}
-			return VerifyBlobCmd(ctx, *key, *kmsVal, *cert, *signature, args[0])
+			for _, blobRef := range args[0:] {
+				if err := VerifyBlobCmd(ctx, *key, *kmsVal, *cert, *signature, blobRef); err != nil {
+					return errors.Wrapf(err, "verifying blob %s", blobRef)
+				}
+			}
+			return nil
 		},
 	}
 }

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -69,7 +69,7 @@ EXAMPLES
 			if len(args) == 0 {
 				return flag.ErrHelp
 			}
-			for _, blobRef := range args[0:] {
+			for _, blobRef := range args {
 				if err := VerifyBlobCmd(ctx, *key, *kmsVal, *cert, *signature, blobRef); err != nil {
 					return errors.Wrapf(err, "verifying blob %s", blobRef)
 				}


### PR DESCRIPTION
This will be nice to have for signing kaniko and distroless in Cloud Build -- it's easier to have one cosign image step that can take in multiple image names to sign, than to have one step per image.

Output now looks like:

```
$ ./cosign sign -kms gcpkms://projects/priya-wadhwa/locations/global/keyRings/cosign/cryptoKeys/cosign gcr.io/priya-wadhwa/test gcr.io/priya-wadhwa/executor:test
Pushing signature to: gcr.io/priya-wadhwa/test:sha256-74e4a68dfba6f40b01787a3876cc1be0fb1d9025c3567cf8367c659f2187234f.cosign
Pushing signature to: gcr.io/priya-wadhwa/executor:sha256-aea14d1c82ad9b52bc10a05d12c99c513d55606627bcc31825c54abbaac9ed78.cosign

$ ./cosign verify -key cosign.pub gcr.io/priya-wadhwa/test gcr.io/priya-wadhwa/executor:test

Verification for gcr.io/priya-wadhwa/test --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:74e4a68dfba6f40b01787a3876cc1be0fb1d9025c3567cf8367c659f2187234f"},"Type":"cosign container signature"},"Optional":{"kms":"true"}}
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:74e4a68dfba6f40b01787a3876cc1be0fb1d9025c3567cf8367c659f2187234f"},"Type":"cosign container signature"},"Optional":{"kms":"true"}}
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:74e4a68dfba6f40b01787a3876cc1be0fb1d9025c3567cf8367c659f2187234f"},"Type":"cosign container signature"},"Optional":{"kms":"true"}}
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:74e4a68dfba6f40b01787a3876cc1be0fb1d9025c3567cf8367c659f2187234f"},"Type":"cosign container signature"},"Optional":{"kms":"true"}}
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:74e4a68dfba6f40b01787a3876cc1be0fb1d9025c3567cf8367c659f2187234f"},"Type":"cosign container signature"},"Optional":{"kms":"done"}}
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:74e4a68dfba6f40b01787a3876cc1be0fb1d9025c3567cf8367c659f2187234f"},"Type":"cosign container signature"},"Optional":null}

Verification for gcr.io/priya-wadhwa/executor:test --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:aea14d1c82ad9b52bc10a05d12c99c513d55606627bcc31825c54abbaac9ed78"},"Type":"cosign container signature"},"Optional":null}
```

We really only need it for sign, but I added it for verify too. Can remove if people don't think it would be useful for verify.