### PR TITLE
cosign/version: fix buildDate and add flag to output in json

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,13 @@ endif
 # Set version variables for LDFLAGS
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
-BUILDDATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
+DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
 GIT_TREESTATE = "clean"
 DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
 ifeq ($(DIFF), 1)
@@ -17,7 +23,7 @@ endif
 
 PKG=github.com/sigstore/cosign/cmd/cosign/cli
 
-LDFLAGS="-X $(PKG).gitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE)"
+LDFLAGS="-X $(PKG).gitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)"
 
 .PHONY: all lint test clean cosign cross
 

--- a/cmd/cosign/cli/version.go
+++ b/cmd/cosign/cli/version.go
@@ -16,11 +16,15 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"runtime"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/pkg/errors"
 )
 
 // Base version information.
@@ -42,6 +46,7 @@ var (
 func Version() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign version", flag.ExitOnError)
+		outJSON = flagset.Bool("json", false, "print JSON instead of text")
 	)
 	return &ffcli.Command{
 		Name:       "version",
@@ -49,13 +54,23 @@ func Version() *ffcli.Command {
 		ShortHelp:  "Prints the cosign version",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			fmt.Printf("%#v\n", versionInfo())
+			v := VersionInfo()
+			res := v.String()
+			if *outJSON {
+				j, err := v.JSONString()
+				if err != nil {
+					return errors.Wrap(err, "unable to generate JSON from version info")
+				}
+				res = j
+			}
+
+			fmt.Println(res)
 			return nil
 		},
 	}
 }
 
-type VersionInfo struct {
+type Info struct {
 	GitVersion   string
 	GitCommit    string
 	GitTreeState string
@@ -65,10 +80,10 @@ type VersionInfo struct {
 	Platform     string
 }
 
-func versionInfo() VersionInfo {
+func VersionInfo() Info {
 	// These variables typically come from -ldflags settings and in
 	// their absence fallback to the global defaults set above.
-	return VersionInfo{
+	return Info{
 		GitVersion:   gitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
@@ -77,4 +92,31 @@ func versionInfo() VersionInfo {
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
+}
+
+// String returns the string representation of the version info
+func (i *Info) String() string {
+	b := strings.Builder{}
+	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
+	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
+	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
+	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
+	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
+	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+
+	w.Flush()
+	return b.String()
+}
+
+// JSONString returns the JSON representation of the version info
+func (i *Info) JSONString() (string, error) {
+	b, err := json.MarshalIndent(i, "", "  ")
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
 }

--- a/cmd/cosign/cli/version_test.go
+++ b/cmd/cosign/cli/version_test.go
@@ -1,0 +1,34 @@
+// Copyright 2021 The Rekor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionText(t *testing.T) {
+	sut := VersionInfo()
+	require.NotEmpty(t, sut.String())
+}
+
+func TestVersionJSON(t *testing.T) {
+	sut := VersionInfo()
+	json, err := sut.JSONString()
+
+	require.Nil(t, err)
+	require.NotEmpty(t, json)
+}

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sigstore/fulcio v0.0.0-20210326124948-da14a294bcc2
 	github.com/sigstore/rekor v0.1.1-0.20210228052401-f0b66bf3835c
+	github.com/stretchr/testify v1.7.0
 	github.com/theupdateframework/go-tuf v0.0.0-20201230183259-aee6270feb55
 	golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
- Fix buildDate
- add flag to output the version in json. Default plain text

examples:

```console
$ ./cosign version
GitVersion:    v0.2.0-3-g1a75ff2
GitCommit:     1a75ff292076142483955e4681b1e0b0a7e3f1a9
GitTreeState:  clean
BuildDate:     2021-03-30T15:31:42Z
GoVersion:     go1.16.1
Compiler:      gc
Platform:      darwin/amd64

$ ./cosign version --json
{
  "GitVersion": "v0.2.0-3-g1a75ff2",
  "GitCommit": "1a75ff292076142483955e4681b1e0b0a7e3f1a9",
  "GitTreeState": "clean",
  "BuildDate": "2021-03-30T15:31:42Z",
  "GoVersion": "go1.16.1",
  "Compiler": "gc",
  "Platform": "darwin/amd64"
}

$ ./cosign version --json | jq -r '.GitVersion'
v0.2.0-3-g1a75ff2
```


/assign @dlorenc 