### PR TITLE
cmd: add option to specify public key output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ See the [Usage documentation](USAGE.md) for more commands!
 
 ## Registry Support
 
-`cosign` uses [go-containerregistry](github.com/google/go-containerregistry) for registry
+`cosign` uses [go-containerregistry](https://github.com/google/go-containerregistry) for registry
 interactions, which has excellent support, but some registries may have quirks.
 
 Today, `cosign` has been tested and works against the following registries:

--- a/USAGE.md
+++ b/USAGE.md
@@ -215,8 +215,6 @@ $ cosign download us-central1-docker.pkg.dev/dlorenc-vmtest2/test/taskrun
 KMS:
 ```
 $ cosign public-key -kms gcpkms://projects/someproject/locations/us-central1/keyRings/foo/cryptoKeys/bug
-Public key written to cosign.pub
-$ cat cosign.pub
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgrKKtyws86/APoULh/zXk4LONqII
 AcxvLtLEgRjRI4TKnMAXtIGp8K4X4CTWPEXMqSYZZUa2I1YvHyLLY2bEzA==
@@ -227,8 +225,6 @@ Private Key:
 ```
 $ ./cosign public-key -key cosign.key
 Enter password for private key:
-Public key written to cosign.pub
-$ cat cosign.pub
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjCxhhvb1KmIfe1J2ceT25kHepstb
 IDYuTA0U1ri4F0CXXazLiftzGlyfse1No4orr8w1ZIchQ8TJlyCSaSuR0Q==

--- a/cmd/cosign/cli/public_key_test.go
+++ b/cmd/cosign/cli/public_key_test.go
@@ -1,0 +1,70 @@
+// Copyright 2021 The Rekor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"testing"
+
+	"github.com/sigstore/cosign/pkg/cosign"
+)
+
+func pass(s string) cosign.PassFunc {
+	return func(_ bool) ([]byte, error) {
+		return []byte(s), nil
+	}
+}
+
+// Test success on getting public key with valid keypair.
+func TestPublicKeyLocation(t *testing.T) {
+	ctx := context.Background()
+	// Generate a valid keypair.
+	keys, err := cosign.GenerateKeyPair(pass("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	w := NamedWriter{"cosign.pub", &out}
+
+	err = GetPublicKey(ctx, bytes.NewReader(keys.PrivateBytes), "", w, pass("hello"))
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+
+	// Verify that key's public key matches the output buffer.
+	if !bytes.Equal(out.Bytes(), keys.PublicBytes) {
+		t.Fatalf("expect %s got %s", keys.PrivateBytes, out.Bytes())
+	}
+}
+
+// Tests failure with bad private key.
+func TestPublicKeyBadPrivateKey(t *testing.T) {
+	ctx := context.Background()
+	// Use random bytes for private key pair.
+	buf := []byte{}
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	w := NamedWriter{"cosign.pub", &out}
+
+	if err := GetPublicKey(ctx, bytes.NewReader(buf), "", w, pass("hello")); err == nil {
+		t.Error("expected error getting public key!")
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -345,6 +345,24 @@ func TestTlog(t *testing.T) {
 	must(verify(pubKeyPath, imgName, true, nil), t)
 }
 
+func TestGetPublicKeyCustomOut(t *testing.T) {
+	td := t.TempDir()
+	keys, privKeyPath, _ := keypair(t, td)
+	ctx := context.Background()
+
+	f, err := os.Open(privKeyPath)
+	must(err, t)
+	outFile := "output.pub"
+	outPath := filepath.Join(td, outFile)
+	outWriter, err := os.OpenFile(outPath, os.O_WRONLY|os.O_CREATE, 0600)
+	must(err, t)
+	must(cli.GetPublicKey(ctx, f, "", cli.NamedWriter{Name: outPath, Writer: outWriter}, passFunc), t)
+
+	output, err := ioutil.ReadFile(outFile)
+	must(err, t)
+	equals(keys.PublicBytes, output, t)
+}
+
 func mkfile(contents, td string, t *testing.T) string {
 	f, err := ioutil.TempFile(td, "")
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Adds a flag for specifying the output file for the public key when using `cosign public-key`:
`cosign public-key -key <key> -outfile somefile.pub`
By default, it writes to standard out now.

Example:
```
$ ./cosign public-key -key cosign.key -outfile a.txt
Enter password for private key: 
Public key written to  a.txt
$ cat a.txt
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETvioBh+xbZH4IMlltKuIGuVEYjqF
HdA7wGAHvdkB12TSULi6v/0PTdRU8Vap94/vspnNcD1SY9NkXavR5lt+Mw==
-----END PUBLIC KEY-----
$ ./cosign public-key -key cosign.key 
Enter password for private key: 
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETvioBh+xbZH4IMlltKuIGuVEYjqF
HdA7wGAHvdkB12TSULi6v/0PTdRU8Vap94/vspnNcD1SY9NkXavR5lt+Mw==
-----END PUBLIC KEY-----
```

Docs: Added usage explanation in the docstring.
Tests: Added e2e test and unit tests.

Fixes https://github.com/sigstore/cosign/issues/152

------------------------------------------------------------------
Maybe the option should also exist to specify placement for `generate-key-pair`? But maybe will wait until an ask.
