### PR TITLE
Fix the verify_blob cli and e2e test.

### DIFF
--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -66,13 +66,11 @@ EXAMPLES
 	cosign verify-blob -kms gcpkms://projects/<PROJECT ID>/locations/<LOCATION>/keyRings/<KEYRING>/cryptoKeys/<KEY> -signature $sig <blob>`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) == 0 {
+			if len(args) != 1 {
 				return flag.ErrHelp
 			}
-			for _, blobRef := range args {
-				if err := VerifyBlobCmd(ctx, *key, *kmsVal, *cert, *signature, blobRef); err != nil {
-					return errors.Wrapf(err, "verifying blob %s", blobRef)
-				}
+			if err := VerifyBlobCmd(ctx, *key, *kmsVal, *cert, *signature, args[0]); err != nil {
+				return errors.Wrapf(err, "verifying blob %s", args)
 			}
 			return nil
 		},

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -72,8 +72,9 @@ if (./cosign verify-blob -key cosign.pub -signature myblob2.sig myblob); then fa
 ./cosign verify-blob -key cosign.pub -signature myblob2.sig myblob2
 
 ## sign and verify multiple blobs
-./cosign sign-blob -key cosign.key myblob myblob2
-./cosign verify-blob -key cosign.pub myblob myblob2
+./cosign sign-blob -key cosign.key myblob myblob2 > sigs
+./cosign verify-blob -key cosign.pub -signature <(head -n 1 sigs) myblob
+./cosign verify-blob -key cosign.pub -signature <(tail -n 1 sigs) myblob2
 
 ## KMS!
 kms="gcpkms://projects/projectsigstore/locations/global/keyRings/e2e-test/cryptoKeys/test"


### PR DESCRIPTION
It doesn't really make sense for multiple blobs to be verified against the same signature.
We'd either need to take multiple signatures or something else.

Signed-off-by: Dan Lorenc <dlorenc@google.com>
