### PR TITLE
More work on the Signer, Verifier, PublicKeyProvider APIs

### DIFF
--- a/cmd/cosign/cli/generate_key_pair.go
+++ b/cmd/cosign/cli/generate_key_pair.go
@@ -69,11 +69,10 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string) error {
 		if err != nil {
 			return err
 		}
-		pub, err := k.CreateKey(ctx)
+		pemBytes, err := cosign.PublicKeyPem(ctx, k)
 		if err != nil {
 			return err
 		}
-		pemBytes := cosign.KeyToPem(pub)
 		if err := ioutil.WriteFile("cosign.pub", pemBytes, 0600); err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -16,7 +16,6 @@ package cli
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"flag"
 	"fmt"
 	"io"
@@ -94,13 +93,13 @@ EXAMPLES
 }
 
 func GetPublicKey(ctx context.Context, reader io.Reader, kmsVal string, writer NamedWriter, pf cosign.PassFunc) error {
-	var pub *ecdsa.PublicKey
+	var pemBytes []byte
 	if kmsVal != "" {
 		k, err := kms.Get(ctx, kmsVal)
 		if err != nil {
 			return err
 		}
-		pub, err = k.PublicKey(ctx)
+		pemBytes, err = cosign.PublicKeyPem(ctx, k)
 		if err != nil {
 			return err
 		}
@@ -117,9 +116,11 @@ func GetPublicKey(ctx context.Context, reader io.Reader, kmsVal string, writer N
 		if err != nil {
 			return err
 		}
-		pub = &pk.PublicKey
+		pemBytes, err = cosign.PublicKeyPem(ctx, pk)
+		if err != nil {
+			return err
+		}
 	}
-	pemBytes := cosign.KeyToPem(pub)
 	if _, err := writer.Write(pemBytes); err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -98,7 +98,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
 	}
 	// Keys are optional!
 	if pubKeyDescriptor != "" {
-		pubKey, err := cosign.LoadPublicKey(pubKeyDescriptor)
+		pubKey, err := cosign.LoadPublicKey(ctx, pubKeyDescriptor)
 		if err != nil {
 			return errors.Wrap(err, "loading public key")
 		}

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -85,24 +85,19 @@ func isb64(data []byte) bool {
 }
 
 func VerifyBlobCmd(ctx context.Context, keyRef, kmsVal, certRef, sigRef, blobRef string) error {
-
-	var pubKey *ecdsa.PublicKey
+	var pubKey cosign.PublicKey
 	var err error
 	var cert *x509.Certificate
 	switch {
 	case keyRef != "":
-		pubKey, err = cosign.LoadPublicKey(keyRef)
+		pubKey, err = cosign.LoadPublicKey(ctx, keyRef)
 		if err != nil {
 			return err
 		}
 	case kmsVal != "":
-		k, err := kms.Get(ctx, kmsVal)
+		pubKey, err = kms.Get(ctx, kmsVal)
 		if err != nil {
 			return errors.Wrap(err, "getting kms")
-		}
-		pubKey, err = k.PublicKey(ctx)
-		if err != nil {
-			return errors.Wrap(err, "kms public key")
 		}
 	case certRef != "": // KEYLESS MODE!
 		pems, err := ioutil.ReadFile(certRef)
@@ -118,7 +113,9 @@ func VerifyBlobCmd(ctx context.Context, keyRef, kmsVal, certRef, sigRef, blobRef
 			return errors.New("no certs found in pem file")
 		}
 		cert = certs[0]
-		pubKey = cert.PublicKey.(*ecdsa.PublicKey)
+		pubKey = &cosign.ECDSAPublicKey{
+			Key: cert.PublicKey.(*ecdsa.PublicKey),
+		}
 	default:
 		return errors.New("one of -key and -cert required")
 	}
@@ -155,14 +152,15 @@ func VerifyBlobCmd(ctx context.Context, keyRef, kmsVal, certRef, sigRef, blobRef
 		return err
 	}
 
-	if pubKey != nil {
-		if err := cosign.VerifySignature(pubKey, b64sig, blobBytes); err != nil {
-			return err
-		}
-	} else { // cert
-		if err := cosign.VerifySignature(cert.PublicKey.(*ecdsa.PublicKey), b64sig, blobBytes); err != nil {
-			return err
-		}
+	sig, err := base64.StdEncoding.DecodeString(b64sig)
+	if err != nil {
+		return err
+	}
+	if err := pubKey.Verify(ctx, blobBytes, sig); err != nil {
+		return err
+	}
+
+	if cert != nil { // cert
 		if err := cosign.TrustedCert(cert, fulcio.Roots); err != nil {
 			return err
 		}
@@ -178,8 +176,12 @@ func VerifyBlobCmd(ctx context.Context, keyRef, kmsVal, certRef, sigRef, blobRef
 		}
 		var pubBytes []byte
 		if pubKey != nil {
-			pubBytes = cosign.KeyToPem(pubKey)
-		} else {
+			pubBytes, err = cosign.PublicKeyPem(ctx, pubKey)
+			if err != nil {
+				return err
+			}
+		}
+		if cert != nil {
 			pubBytes = cosign.CertToPem(cert)
 		}
 		index, err := cosign.FindTlogEntry(rekorClient, b64sig, blobBytes, pubBytes)

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -170,7 +170,7 @@ func main() {
 				return nil, err
 			}
 
-			pubKey, err := cosign.LoadPublicKey(key)
+			pubKey, err := cosign.LoadPublicKey(bctx.Context, key)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cosign/kms/kms.go
+++ b/pkg/cosign/kms/kms.go
@@ -16,6 +16,7 @@ package kms
 
 import (
 	"context"
+	"crypto"
 	"crypto/ecdsa"
 	"fmt"
 
@@ -32,7 +33,10 @@ type KMS interface {
 	Sign(ctx context.Context, payload []byte) (signature []byte, err error)
 
 	// PublicKey returns the public key stored in the KMS
-	PublicKey(ctx context.Context) (*ecdsa.PublicKey, error)
+	PublicKey(ctx context.Context) (crypto.PublicKey, error)
+
+	// Verify the signature of the payload.
+	Verify(ctx context.Context, payload, signature []byte) error
 }
 
 func Get(ctx context.Context, keyResourceID string) (KMS, error) {


### PR DESCRIPTION
There's still more work to be done to productionize and de-spaghettify things:

* Verifier wrapper for x509 certs
* Refactoring to consolidate duplicated code
* Probably move interface types to their own file for the sake of clarity w.r.t. the relationships

Signed-off-by: Jake Sanders <jsand@google.com>