### PR TITLE
Fix a couple bugs in cosign

### DIFF
--- a/cmd/cosign/cli/generate_key_pair.go
+++ b/cmd/cosign/cli/generate_key_pair.go
@@ -16,12 +16,12 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"os"
 
+	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/kms"
 
@@ -69,7 +69,11 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string) error {
 		if err != nil {
 			return err
 		}
-		pemBytes, err := cosign.PublicKeyPem(ctx, k)
+		pubKey, err := k.CreateKey(ctx)
+		if err != nil {
+			return errors.Wrap(err, "creating key")
+		}
+		pemBytes, err := cosign.KeyToPem(pubKey)
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -194,14 +194,14 @@ func SignCmd(ctx context.Context, keyPath string,
 	}
 
 	// sha256:... -> sha256-...
-	dstTag, err := cosign.DestinationTag(ref, get)
+	dstRef, err := cosign.DestinationRef(ref, get)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(os.Stderr, "Pushing signature to:", dstTag.String())
+	fmt.Fprintln(os.Stderr, "Pushing signature to:", dstRef.String())
 
-	if err := cosign.Upload(signature, payload, dstTag, string(cert), string(chain)); err != nil {
+	if err := cosign.Upload(signature, payload, dstRef, string(cert), string(chain)); err != nil {
 		return err
 	}
 

--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -56,6 +56,11 @@ func MungeCmd(_ context.Context, imageRef string) error {
 		return err
 	}
 
-	fmt.Println(ref.Context().Tag(cosign.Munge(desc.Descriptor)))
+	dstRef, err := cosign.DestinationRef(ref, desc)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(dstRef.Context().Tag(cosign.Munge(desc.Descriptor)))
 	return nil
 }

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -71,7 +71,7 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 		return err
 	}
 
-	dstTag, err := cosign.DestinationTag(ref, get)
+	dstRef, err := cosign.DestinationRef(ref, get)
 	if err != nil {
 		return err
 	}
@@ -91,7 +91,7 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 	if err != nil {
 		return err
 	}
-	return cosign.Upload(sigBytes, payload, dstTag, "", "")
+	return cosign.Upload(sigBytes, payload, dstRef, "", "")
 }
 
 type SignatureArgType uint8

--- a/pkg/cosign/upload.go
+++ b/pkg/cosign/upload.go
@@ -47,7 +47,7 @@ func Experimental() bool {
 	return false
 }
 
-func DestinationTag(ref name.Reference, img *remote.Descriptor) (name.Tag, error) {
+func DestinationRef(ref name.Reference, img *remote.Descriptor) (name.Reference, error) {
 	dstTag := ref.Context().Tag(Munge(img.Descriptor))
 	wantRepo := os.Getenv(repoEnv)
 	if wantRepo == "" {
@@ -65,7 +65,7 @@ func DestinationTag(ref name.Reference, img *remote.Descriptor) (name.Tag, error
 		subRepo[1] = strings.TrimPrefix(s[1], "/")
 	}
 	subbed := dstTag.RegistryStr() + strings.Join(subRepo, "/")
-	return name.NewTag(subbed)
+	return name.ParseReference(subbed)
 }
 
 // Upload will upload the signature, public key and payload to the tlog

--- a/pkg/cosign/upload_test.go
+++ b/pkg/cosign/upload_test.go
@@ -74,7 +74,7 @@ func TestDestinationTag(t *testing.T) {
 					},
 				},
 			}
-			got, err := DestinationTag(ref, img)
+			got, err := DestinationRef(ref, img)
 			if err != nil {
 				t.Fatalf("error destination tag: %v", err)
 			}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -185,7 +185,7 @@ func Verify(ctx context.Context, ref name.Reference, co CheckOpts) ([]SignedPayl
 	// These are all the signatures attached to our image that we know how to parse.
 	allSignatures, desc, err := FetchSignatures(ctx, ref)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "fetching signatures")
 	}
 
 	validationErrs := []string{}

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -89,6 +89,13 @@ if (./cosign verify -a foo=bar -key cosign.pub $img); then false; fi
 ./cosign sign -kms $kms -a foo=bar $img
 ./cosign verify -key cosign.pub -a foo=bar $img
 
+# store signatures in a different repo
+export COSIGN_REPOSITORY=gcr.io/projectsigstore/subrepo
+(crane delete $(./cosign triangulate $img)) || true
+./cosign sign -kms $kms $img
+./cosign verify -key cosign.pub $img
+unset COSIGN_REPOSITORY
+
 # TODO: tlog
 
 


### PR DESCRIPTION
This fixes a few bugs in cosign:
1. Actually generate the key pair when we run generate-key-pair with the -kms flag
2. Account for COSIGN_REPOSITORY on verify
3. Account for COSIGN_REPOSITORY on triangulate
