### PR TITLE
Use same registry throughout e2e test

### DIFF
--- a/pkg/cosign/upload_test.go
+++ b/pkg/cosign/upload_test.go
@@ -54,6 +54,11 @@ func TestDestinationTag(t *testing.T) {
 			image: "test/image",
 			repo:  "newrepo",
 			want:  "index.docker.io/newrepo/image:sha256-digest.cosign",
+		}, {
+			desc:  "e2e test",
+			image: "us-central1-docker.pkg.dev/projectsigstore/cosign-ci/test",
+			repo:  "us-central1-docker.pkg.dev/projectsigstore/subrepo",
+			want:  "us-central1-docker.pkg.dev/projectsigstore/subrepo/cosign-ci/test:sha256-digest.cosign",
 		},
 	}
 

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -90,7 +90,7 @@ if (./cosign verify -a foo=bar -key cosign.pub $img); then false; fi
 ./cosign verify -key cosign.pub -a foo=bar $img
 
 # store signatures in a different repo
-export COSIGN_REPOSITORY=gcr.io/projectsigstore/subrepo
+export COSIGN_REPOSITORY=us-central1-docker.pkg.dev/projectsigstore/subrepo
 (crane delete $(./cosign triangulate $img)) || true
 ./cosign sign -kms $kms $img
 ./cosign verify -key cosign.pub $img


### PR DESCRIPTION
So  #222 [broke](https://github.com/sigstore/cosign/runs/2271983573?check_suite_focus=true) the e2e tests 😞 

Looks like it failed because `COSIGN_REPOITORY` tried to send signatures to a new registry (gcr) but actually resolved to (us-central1-docker.pkg.dev) -- this is something we should probably fix, but also I'm not sure how often people will be storing signatures in a different registry 

