### PR TITLE
WIP: Bundle rekor inclusion proof into signature

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -226,11 +226,12 @@ func SignCmd(ctx context.Context, keyPath string,
 			}
 		}
 	}
-	inclusionProof, err := cosign.UploadTLog(signature, payload, pemBytes)
+	inclusionProof, uuid, err := cosign.UploadTLog(signature, payload, pemBytes)
 	if err != nil {
 		return err
 	}
-	uploadOpts.RekorInclusionProof = base64.RawStdEncoding.EncodeToString([]byte(inclusionProof))
+	uploadOpts.RekorInclusionProof = inclusionProof
+	uploadOpts.RekorUUID = uuid
 	return cosign.Upload(dstRef, uploadOpts)
 }
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -230,8 +230,10 @@ func SignCmd(ctx context.Context, keyPath string,
 	if err != nil {
 		return err
 	}
-	uploadOpts.RekorInclusionProof = inclusionProof
-	uploadOpts.RekorUUID = uuid
+	uploadOpts.Bundle = &cosign.Bundle{
+		InclusionProof: inclusionProof,
+		UUID:           uuid,
+	}
 	return cosign.Upload(dstRef, uploadOpts)
 }
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -231,8 +231,10 @@ func SignCmd(ctx context.Context, keyPath string,
 		return err
 	}
 	uploadOpts.Bundle = &cosign.Bundle{
+		// TODO: this will be SignedInclusionProof
 		InclusionProof: inclusionProof,
 		UUID:           uuid,
+		// TODO: get the rekor intermediate cert and store it here
 	}
 	return cosign.Upload(dstRef, uploadOpts)
 }

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -226,11 +226,11 @@ func SignCmd(ctx context.Context, keyPath string,
 			}
 		}
 	}
-	index, err := cosign.UploadTLog(signature, payload, pemBytes)
+	inclusionProof, err := cosign.UploadTLog(signature, payload, pemBytes)
 	if err != nil {
 		return err
 	}
-	fmt.Println("tlog entry created with index: ", index)
+	uploadOpts.RekorInclusionProof = base64.RawStdEncoding.EncodeToString([]byte(inclusionProof))
 	return cosign.Upload(dstRef, uploadOpts)
 }
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -201,12 +201,15 @@ func SignCmd(ctx context.Context, keyPath string,
 
 	fmt.Fprintln(os.Stderr, "Pushing signature to:", dstRef.String())
 
-	if err := cosign.Upload(signature, payload, dstRef, string(cert), string(chain)); err != nil {
-		return err
+	uploadOpts := cosign.Options{
+		Signature: signature,
+		Payload:   payload,
+		Cert:      string(cert),
+		Chain:     string(chain),
 	}
 
 	if !cosign.Experimental() {
-		return nil
+		return cosign.Upload(dstRef, uploadOpts)
 	}
 
 	// Check if the image is public (no auth in Get)
@@ -228,7 +231,7 @@ func SignCmd(ctx context.Context, keyPath string,
 		return err
 	}
 	fmt.Println("tlog entry created with index: ", index)
-	return nil
+	return cosign.Upload(dstRef, uploadOpts)
 }
 
 func loadKey(keyPath string, pf cosign.PassFunc) (*cosign.ECDSAKey, error) {

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -132,7 +132,7 @@ func SignBlobCmd(ctx context.Context, keyPath, kmsVal, payloadPath string, b64 b
 	}
 
 	if cosign.Experimental() {
-		index, err := cosign.UploadTLog(signature, payload, pemBytes)
+		_, index, err := cosign.UploadTLog(signature, payload, pemBytes)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -91,7 +91,11 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 	if err != nil {
 		return err
 	}
-	return cosign.Upload(sigBytes, payload, dstRef, "", "")
+	opts := cosign.Options{
+		Signature: sigBytes,
+		Payload:   payload,
+	}
+	return cosign.Upload(dstRef, opts)
 }
 
 type SignatureArgType uint8

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -36,6 +36,8 @@ type SignedPayload struct {
 	Payload         []byte
 	Cert            *x509.Certificate
 	Chain           []*x509.Certificate
+	InclusionProof  string
+	RekorUUID       string
 }
 
 // TODO: marshal the cert correctly.
@@ -124,6 +126,11 @@ func FetchSignatures(ctx context.Context, ref name.Reference) ([]SignedPayload, 
 					return err
 				}
 				sp.Chain = certs
+			}
+
+			if ip := desc.Annotations[rekorInclusionProof]; ip != "" {
+				sp.InclusionProof = ip
+				sp.RekorUUID = desc.Annotations[rekorUUID]
 			}
 
 			signatures[i] = sp

--- a/pkg/cosign/remote.go
+++ b/pkg/cosign/remote.go
@@ -50,6 +50,7 @@ type Options struct {
 	Cert                string
 	Chain               string
 	RekorInclusionProof string
+	RekorUUID           string
 }
 
 func Upload(dstTag name.Reference, opts Options) error {
@@ -78,6 +79,7 @@ func Upload(dstTag name.Reference, opts Options) error {
 	}
 	if opts.RekorInclusionProof != "" {
 		annotations[rekorInclusionProof] = opts.RekorInclusionProof
+		annotations[rekorUUID] = opts.RekorUUID
 	}
 	img, err := mutate.Append(base, mutate.Addendum{
 		Layer:       l,

--- a/pkg/cosign/remote.go
+++ b/pkg/cosign/remote.go
@@ -45,10 +45,11 @@ func Descriptors(ref name.Reference) ([]v1.Descriptor, error) {
 }
 
 type Options struct {
-	Signature []byte
-	Payload   []byte
-	Cert      string
-	Chain     string
+	Signature           []byte
+	Payload             []byte
+	Cert                string
+	Chain               string
+	RekorInclusionProof string
 }
 
 func Upload(dstTag name.Reference, opts Options) error {
@@ -74,6 +75,9 @@ func Upload(dstTag name.Reference, opts Options) error {
 	if opts.Cert != "" {
 		annotations[certkey] = opts.Cert
 		annotations[chainkey] = opts.Chain
+	}
+	if opts.RekorInclusionProof != "" {
+		annotations[rekorInclusionProof] = opts.RekorInclusionProof
 	}
 	img, err := mutate.Append(base, mutate.Addendum{
 		Layer:       l,

--- a/pkg/cosign/remote.go
+++ b/pkg/cosign/remote.go
@@ -44,9 +44,16 @@ func Descriptors(ref name.Reference) ([]v1.Descriptor, error) {
 	return m.Layers, nil
 }
 
-func Upload(signature, payload []byte, dstTag name.Reference, cert, chain string) error {
+type Options struct {
+	Signature []byte
+	Payload   []byte
+	Cert      string
+	Chain     string
+}
+
+func Upload(dstTag name.Reference, opts Options) error {
 	l := &staticLayer{
-		b:  payload,
+		b:  opts.Payload,
 		mt: "application/vnd.dev.cosign.simplesigning.v1+json",
 	}
 	base, err := remote.Image(dstTag, remote.WithAuthFromKeychain(authn.DefaultKeychain))
@@ -62,11 +69,11 @@ func Upload(signature, payload []byte, dstTag name.Reference, cert, chain string
 	}
 
 	annotations := map[string]string{
-		sigkey: base64.StdEncoding.EncodeToString(signature),
+		sigkey: base64.StdEncoding.EncodeToString(opts.Signature),
 	}
-	if cert != "" {
-		annotations[certkey] = cert
-		annotations[chainkey] = chain
+	if opts.Cert != "" {
+		annotations[certkey] = opts.Cert
+		annotations[chainkey] = opts.Chain
 	}
 	img, err := mutate.Append(base, mutate.Addendum{
 		Layer:       l,

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -31,7 +31,8 @@ const (
 	sigkey              = "dev.cosignproject.cosign/signature"
 	certkey             = "dev.sigstore.cosign/certificate"
 	chainkey            = "dev.sigstore.cosign/chain"
-	rekorInclusionProof = "dev.sigstore.cosign/rekor_inclusion_proof"
+	rekorInclusionProof = "dev.sigstore.cosign/rekor/inclusion_proof"
+	rekorUUID           = "dev.sigstore.cosign/rekor/uuid"
 )
 
 func LoadPrivateKey(key []byte, pass []byte) (*ECDSAKey, error) {

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -27,12 +27,11 @@ import (
 )
 
 const (
-	pemType             = "ENCRYPTED COSIGN PRIVATE KEY"
-	sigkey              = "dev.cosignproject.cosign/signature"
-	certkey             = "dev.sigstore.cosign/certificate"
-	chainkey            = "dev.sigstore.cosign/chain"
-	rekorInclusionProof = "dev.sigstore.cosign/rekor/inclusion_proof"
-	rekorUUID           = "dev.sigstore.cosign/rekor/uuid"
+	pemType  = "ENCRYPTED COSIGN PRIVATE KEY"
+	sigkey   = "dev.cosignproject.cosign/signature"
+	certkey  = "dev.sigstore.cosign/certificate"
+	chainkey = "dev.sigstore.cosign/chain"
+	bundle   = "dev.sigstore.cosign/bundle"
 )
 
 func LoadPrivateKey(key []byte, pass []byte) (*ECDSAKey, error) {

--- a/pkg/cosign/sign.go
+++ b/pkg/cosign/sign.go
@@ -27,10 +27,11 @@ import (
 )
 
 const (
-	pemType  = "ENCRYPTED COSIGN PRIVATE KEY"
-	sigkey   = "dev.cosignproject.cosign/signature"
-	certkey  = "dev.sigstore.cosign/certificate"
-	chainkey = "dev.sigstore.cosign/chain"
+	pemType             = "ENCRYPTED COSIGN PRIVATE KEY"
+	sigkey              = "dev.cosignproject.cosign/signature"
+	certkey             = "dev.sigstore.cosign/certificate"
+	chainkey            = "dev.sigstore.cosign/chain"
+	rekorInclusionProof = "dev.sigstore.cosign/rekor_inclusion_proof"
 )
 
 func LoadPrivateKey(key []byte, pass []byte) (*ECDSAKey, error) {


### PR DESCRIPTION
This WIP PR starts to address https://github.com/sigstore/cosign/issues/181 and allows us to verify an entry in rekor without having to check the tlog!

Basically it adds the following as annotations:
- signed inclusion proof
- UUID of the log entry

and then verifies. I've been checking with this and it seems to be working:

```
$ cosign sign -key cosign.key gcr.io/priya-wadhwa/test

$ REKOR_SERVER=notreallol cosign verify -key cosign.pub gcr.io/priya-wadhwa/test

Verification for gcr.io/priya-wadhwa/test --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The claims were present in the transparency log
  - The signatures were integrated into the transparency log when the certificate was valid
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.
{"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"sha256:af477e5d17fe3b451853679b31b2ac39872db395dd4bbaf4aa143cd10bd42d96"},"Type":"cosign container signature"},"Optional":null}
```

still have to figure out how to do this for keyless