### PR TITLE
ci/build: build/push when creating tags as well

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: sigstore/cosign-installer@main
+      - uses: sigstore/cosign-installer@v0.1.0
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,18 +1,19 @@
 name: CI-Build
 
-# Run this workflow every time a new commit pushed to your repository
 on:
   push:
+    branches:
+      - main
+      - release-*
+    tags:
+      - '*'
+
 jobs:
-  # Set the job key. The key is displayed as the job name
-  # when a job name is not provided
   build:
-    # Name the Job
     name: build
-    # Set the type of machine to run on
     runs-on: ubuntu-latest
+
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
       - uses: actions/checkout@v2
       - uses: sigstore/cosign-installer@main
       - uses: actions/setup-go@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         language: [ 'go' ]
-     
 
     steps:
     - name: Checkout repository
@@ -29,8 +28,6 @@ jobs:
       uses: github/codeql-action/init@v1
       with:
         languages: ${{ matrix.language }}
-
-
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
@@ -44,7 +41,6 @@ jobs:
     # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
-
     #- run: |
     #   make bootstrap
     #   make release

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -15,7 +15,6 @@ jobs:
     steps:
       # Checks out a copy of your repository on the ubuntu-latest machine
       - uses: actions/checkout@v2
-      
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16'
@@ -29,6 +28,5 @@ jobs:
         run: go install github.com/google/go-containerregistry/cmd/crane
       - name: creds
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-
       - name: Run e2e tests that need secrets
         run: ./test/e2e_test_secrets.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,21 +1,14 @@
 name: CI-Tests
 
-# Run this workflow every time a new commit pushed to your repository
 on: [push, pull_request]
 
 jobs:
-  # Set the job key. The key is displayed as the job name
-  # when a job name is not provided
   unit-tests:
-    # Name the Job
     name: Run tests
-    # Set the type of machine to run on
     runs-on: ubuntu-latest
 
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
       - uses: actions/checkout@v2
-
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
       - uses: actions/cache@v2
         with:
@@ -69,4 +62,4 @@ jobs:
         timeout-minutes: 5
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.39


### PR DESCRIPTION
- ci/build: build/push when creating tags as well
- ci: small cleanup 
- update golangci-lint to 1.39 release
- use sigstore/cosign-installer@v0.1.0 instead of sigstore/cosign-installer@main

When creating a Tag for the release the build workflow should be triggered to build cosign for the tag

/assign @dlorenc 