### PR TITLE
Add CGO_ENABLED=1 for ko.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ clean:
 .PHONY: ko
 ko:
 	# We can't pass more than one LDFLAG via GOFLAGS, you can't have spaces in there.
-	GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
+	CGO_ENABLED=1 GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
 		--tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		github.com/sigstore/cosign/cmd/cosign
 


### PR DESCRIPTION
This is needed for the hardware token drivers.
