### PR TITLE
Allow keyless option in experimental mode

### DIFF
--- a/cmd/cosign/cli/flags.go
+++ b/cmd/cosign/cli/flags.go
@@ -30,3 +30,15 @@ func oneOf(args ...interface{}) bool {
 	}
 	return foundOne
 }
+
+// allOf ensures that all of the supplied interfaces are set to a non-zero value.
+func allOf(args ...interface{}) bool {
+	foundAll := false
+	for _, arg := range args {
+		if reflect.ValueOf(arg).IsZero() {
+			return false
+		}
+		foundAll = true
+	}
+	return foundAll
+}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -95,12 +95,6 @@ EXAMPLES
   cosign sign -kms gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <IMAGE>`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			// A key file (or kms address) is required unless we're in experimental mode!
-			if !cosign.Experimental() {
-				if !oneOf(*kmsVal, *key) {
-					return &KeyParseError{}
-				}
-			}
 			if len(args) == 0 {
 				return flag.ErrHelp
 			}
@@ -119,7 +113,12 @@ func SignCmd(ctx context.Context, keyPath string,
 	imageRef string, upload bool, payloadPath string,
 	annotations map[string]interface{}, kmsVal string, pf cosign.PassFunc, force bool) error {
 
-	if !oneOf(keyPath, kmsVal) {
+	// A key file (or kms address) is required unless we're in experimental mode!
+	if !cosign.Experimental() {
+		if !oneOf(keyPath, kmsVal) {
+			return &KeyParseError{}
+		}
+	} else if allOf(keyPath, kmsVal) {
 		return &KeyParseError{}
 	}
 


### PR DESCRIPTION
Getting an error when using experimental mode with the keyless option. This fix allows it while still checking that if we're in experimental mode, we cannot provide both `-key` and `-kms`.

Signed-off-by: Ivan Font <ifont@redhat.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
