### PR TITLE
Yubikey/PIV signing support!

### DIFF
--- a/cmd/cosign/cli/flags.go
+++ b/cmd/cosign/cli/flags.go
@@ -19,14 +19,16 @@ import "reflect"
 
 // oneOf ensures that only one of the supplied interfaces is set to a non-zero value.
 func oneOf(args ...interface{}) bool {
-	foundOne := false
+	return nOf(args...) == 1
+}
+
+// nOf returns how many of the fields are non-zero
+func nOf(args ...interface{}) int {
+	n := 0
 	for _, arg := range args {
 		if !reflect.ValueOf(arg).IsZero() {
-			if foundOne {
-				return false
-			}
-			foundOne = true
+			n++
 		}
 	}
-	return foundOne
+	return n
 }

--- a/cmd/cosign/cli/keys_test.go
+++ b/cmd/cosign/cli/keys_test.go
@@ -22,12 +22,6 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign"
 )
 
-func pass(s string) cosign.PassFunc {
-	return func(_ bool) ([]byte, error) {
-		return []byte(s), nil
-	}
-}
-
 func generateKeyFile(t *testing.T, tmpDir string, pf cosign.PassFunc) (privFile, pubFile string) {
 	t.Helper()
 

--- a/cmd/cosign/cli/pivcli/commands.go
+++ b/cmd/cosign/cli/pivcli/commands.go
@@ -27,10 +27,11 @@ import (
 
 	"github.com/go-piv/piv-go/piv"
 	"github.com/manifoldco/promptui"
+	"github.com/sigstore/cosign/pkg/cosign/pivkey"
 )
 
 func SetManagementKeyCmd(_ context.Context, oldKey, newKey string, randomKey bool) error {
-	yk, err := getKey()
+	yk, err := pivkey.GetKey()
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func SetManagementKeyCmd(_ context.Context, oldKey, newKey string, randomKey boo
 }
 
 func SetPukCmd(_ context.Context, oldPuk, newPuk string) error {
-	yk, err := getKey()
+	yk, err := pivkey.GetKey()
 	if err != nil {
 		return err
 	}
@@ -80,7 +81,7 @@ func SetPukCmd(_ context.Context, oldPuk, newPuk string) error {
 }
 
 func UnblockCmd(_ context.Context, oldPuk, newPin string) error {
-	yk, err := getKey()
+	yk, err := pivkey.GetKey()
 	if err != nil {
 		return err
 	}
@@ -98,7 +99,7 @@ func UnblockCmd(_ context.Context, oldPuk, newPin string) error {
 }
 
 func SetPinCmd(_ context.Context, oldPin, newPin string) error {
-	yk, err := getKey()
+	yk, err := pivkey.GetKey()
 	if err != nil {
 		return err
 	}
@@ -123,7 +124,7 @@ type Attestations struct {
 }
 
 func AttestationCmd(_ context.Context) (*Attestations, error) {
-	yk, err := getKey()
+	yk, err := pivkey.GetKey()
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +178,7 @@ func AttestationCmd(_ context.Context) (*Attestations, error) {
 }
 
 func GenerateKeyCmd(ctx context.Context, managementKey string, randomKey bool) error {
-	yk, err := getKey()
+	yk, err := pivkey.GetKey()
 	if err != nil {
 		return err
 	}
@@ -230,7 +231,7 @@ func GenerateKeyCmd(ctx context.Context, managementKey string, randomKey bool) e
 }
 
 func ResetKeyCmd(ctx context.Context) error {
-	yk, err := getKey()
+	yk, err := pivkey.GetKey()
 	if err != nil {
 		return err
 	}
@@ -240,24 +241,6 @@ func ResetKeyCmd(ctx context.Context) error {
 	}
 
 	return yk.Reset()
-}
-
-func getKey() (*piv.YubiKey, error) {
-	cards, err := piv.Cards()
-	if err != nil {
-		return nil, err
-	}
-	if len(cards) == 0 {
-		return nil, errors.New("no cards found")
-	}
-	if len(cards) > 1 {
-		return nil, fmt.Errorf("found %d cards, please attach only one", len(cards))
-	}
-	yk, err := piv.Open(cards[0])
-	if err != nil {
-		return nil, err
-	}
-	return yk, nil
 }
 
 func keyBytes(s string) (*[24]byte, error) {

--- a/cmd/cosign/cli/public_key_test.go
+++ b/cmd/cosign/cli/public_key_test.go
@@ -1,0 +1,88 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/sigstore/cosign/pkg/cosign"
+)
+
+func pass(s string) cosign.PassFunc {
+	return func(_ bool) ([]byte, error) {
+		return []byte(s), nil
+	}
+}
+
+// Test success on getting public key with valid keypair.
+func TestPublicKeyLocation(t *testing.T) {
+	ctx := context.Background()
+	// Generate a valid keypair.
+	keys, err := cosign.GenerateKeyPair(pass("hello"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	w := NamedWriter{"cosign.pub", &out}
+
+	td := t.TempDir()
+	f := filepath.Join(td, "private.key")
+	if err := ioutil.WriteFile(f, keys.PrivateBytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := Pkopts{
+		KeyRef: f,
+	}
+	err = GetPublicKey(ctx, opts, w, pass("hello"))
+	if err != nil {
+		t.Fatalf("got error %s", err)
+	}
+
+	// Verify that key's public key matches the output buffer.
+	if !bytes.Equal(out.Bytes(), keys.PublicBytes) {
+		t.Fatalf("expect %s got %s", keys.PrivateBytes, out.Bytes())
+	}
+}
+
+// Tests failure with bad private key.
+func TestPublicKeyBadPrivateKey(t *testing.T) {
+	ctx := context.Background()
+	// Use random bytes for private key pair.
+	buf := []byte{}
+	if _, err := rand.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	td := t.TempDir()
+	f := filepath.Join(td, "private.key")
+	if err := ioutil.WriteFile(f, buf, 0644); err != nil {
+		t.Fatal(err)
+	}
+	var out bytes.Buffer
+	w := NamedWriter{"cosign.pub", &out}
+	opts := Pkopts{
+		KeyRef: f,
+	}
+	if err := GetPublicKey(ctx, opts, w, pass("hello")); err == nil {
+		t.Error("expected error getting public key!")
+	}
+}

--- a/cmd/cosign/cli/sign_test.go
+++ b/cmd/cosign/cli/sign_test.go
@@ -15,10 +15,28 @@
 
 package cli
 
-// KeyParseError is an error returned when an incorrect set of key flags
-// are parsed by the CLI
-type KeyParseError struct{}
+import (
+	"context"
+	"errors"
+	"testing"
+)
 
-func (e *KeyParseError) Error() string {
-	return "exactly one of: key reference (-key), or hardware token (-sk) must be provided"
+// TestSignCmdLocalKeyAndSk verifies the SignCmd returns an error
+// if both a local key path and a sk are specified
+func TestSignCmdLocalKeyAndSk(t *testing.T) {
+	ctx := context.Background()
+
+	for _, so := range []SignOpts{
+		// local and sk keys
+		{
+			KeyRef: "testLocalPath",
+			Pf:     GetPass,
+			Sk:     true,
+		},
+	} {
+		err := SignCmd(ctx, so, "", false, "", false)
+		if (errors.Is(err, &KeyParseError{}) == false) {
+			t.Fatal("expected KeyParseError")
+		}
+	}
 }

--- a/pkg/cosign/pivkey/pivkey.go
+++ b/pkg/cosign/pivkey/pivkey.go
@@ -1,0 +1,127 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pivkey
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/go-piv/piv-go/piv"
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"golang.org/x/term"
+)
+
+func GetKey() (*piv.YubiKey, error) {
+	cards, err := piv.Cards()
+	if err != nil {
+		return nil, err
+	}
+	if len(cards) == 0 {
+		return nil, errors.New("no cards found")
+	}
+	if len(cards) > 1 {
+		return nil, fmt.Errorf("found %d cards, please attach only one", len(cards))
+	}
+	yk, err := piv.Open(cards[0])
+	if err != nil {
+		return nil, err
+	}
+	return yk, nil
+}
+
+func getPin() (string, error) {
+	fmt.Fprint(os.Stderr, "Enter PIN for security key: ")
+	b, err := term.ReadPassword(0)
+	if err != nil {
+		return "", err
+	}
+	fmt.Fprintln(os.Stderr, "\nPlease tap security key...")
+	return string(b), err
+}
+
+func NewPublicKeyProvider() (cosign.PublicKey, error) {
+	pk, err := GetKey()
+	if err != nil {
+		return nil, err
+	}
+	cert, err := pk.Attest(piv.SlotSignature)
+	if err != nil {
+		return nil, err
+	}
+	return &PIVSigner{
+		Pub: cert.PublicKey,
+		ECDSAVerifier: signature.ECDSAVerifier{
+			Key:     cert.PublicKey.(*ecdsa.PublicKey),
+			HashAlg: crypto.SHA256,
+		},
+	}, nil
+}
+
+func NewSigner() (signature.Signer, error) {
+	pk, err := GetKey()
+	if err != nil {
+		return nil, err
+	}
+	cert, err := pk.Attest(piv.SlotSignature)
+	if err != nil {
+		return nil, err
+	}
+
+	auth := piv.KeyAuth{
+		PINPrompt: getPin,
+	}
+	privKey, err := pk.PrivateKey(piv.SlotSignature, cert.PublicKey, auth)
+	if err != nil {
+		return nil, err
+	}
+	return &PIVSigner{
+		Priv: privKey,
+		Pub:  cert.PublicKey,
+		ECDSAVerifier: signature.ECDSAVerifier{
+			Key:     cert.PublicKey.(*ecdsa.PublicKey),
+			HashAlg: crypto.SHA256,
+		},
+	}, nil
+}
+
+type PIVSigner struct {
+	Priv crypto.PrivateKey
+	Pub  crypto.PrivateKey
+	signature.ECDSAVerifier
+}
+
+func (ps *PIVSigner) Sign(ctx context.Context, rawPayload []byte) ([]byte, []byte, error) {
+	signer := ps.Priv.(crypto.Signer)
+	h := sha256.Sum256(rawPayload)
+	sig, err := signer.Sign(rand.Reader, h[:], crypto.SHA256)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sig, h[:], err
+}
+
+func (ps *PIVSigner) PublicKey(context.Context) (crypto.PublicKey, error) {
+	return ps.Pub, nil
+}
+
+var _ signature.Signer = &PIVSigner{}


### PR DESCRIPTION
This replaces #169, and fixes #108 

The only thing I don't love here is the poor test coverage. I can't think of anything meaningful here though, unit testing the API with a mock key seems like a waste of effort and maintenance headache.

Maybe a manual test that we can run that requires actual key presses?

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
