### PR TITLE
disable pivkey on container build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ clean:
 .PHONY: ko
 ko:
 	# We can't pass more than one LDFLAG via GOFLAGS, you can't have spaces in there.
-	CGO_ENABLED=1 GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
+	CGO_ENABLED=0 GOFLAGS="-tags=pivkeydisabled -ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
 		--tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		github.com/sigstore/cosign/cmd/cosign
 

--- a/cmd/cosign/cli/pivcli/commands.go
+++ b/cmd/cosign/cli/pivcli/commands.go
@@ -1,3 +1,5 @@
+// +build !pivkeydisabled
+
 // Copyright 2021 The Sigstore Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmd/cosign/cli/pivcli/disabled.go
+++ b/cmd/cosign/cli/pivcli/disabled.go
@@ -1,0 +1,23 @@
+// +build pivkeydisabled
+
+// Copyright 2021 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pivcli
+
+import "github.com/peterbourgon/ff/v3/ffcli"
+
+func PivKey() *ffcli.Command {
+	return &ffcli.Command{}
+}

--- a/cmd/cosign/cli/pivcli/piv_tool.go
+++ b/cmd/cosign/cli/pivcli/piv_tool.go
@@ -1,3 +1,5 @@
+// +build !pivkeydisabled
+
 // Copyright 2021 The Sigstore Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -30,7 +30,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-piv/piv-go/piv"
 	"github.com/pkg/errors"
 	"github.com/theupdateframework/go-tuf/encrypted"
 
@@ -144,38 +143,6 @@ func LoadECDSAPrivateKey(key []byte, pass []byte) (signature.ECDSASignerVerifier
 		return signature.ECDSASignerVerifier{}, fmt.Errorf("invalid private key")
 	}
 	return signature.NewECDSASignerVerifier(epk, crypto.SHA256), nil
-}
-func GetYubikey() (*piv.YubiKey, error) {
-	cards, err := piv.Cards()
-	if err != nil {
-		return nil, err
-	}
-
-	// Find a YubiKey and open the reader.
-	var yk *piv.YubiKey
-	for _, card := range cards {
-		if strings.Contains(strings.ToLower(card), "yubikey") {
-			if yk, err = piv.Open(card); err != nil {
-				return nil, err
-			}
-			return yk, nil
-		}
-	}
-	return nil, errors.New("no yubikey found")
-}
-
-func GenYubikey(yk *piv.YubiKey) (crypto.PublicKey, error) {
-	// Generate a private key on the YubiKey.
-	key := piv.Key{
-		Algorithm:   piv.AlgorithmEC256,
-		PINPolicy:   piv.PINPolicyAlways,
-		TouchPolicy: piv.TouchPolicyAlways,
-	}
-	pub, err := yk.GenerateKey(piv.DefaultManagementKey, piv.SlotSignature, key)
-	if err != nil {
-		return nil, err
-	}
-	return pub, nil
 }
 
 const pubKeyPemType = "PUBLIC KEY"

--- a/pkg/cosign/pivkey/disabled.go
+++ b/pkg/cosign/pivkey/disabled.go
@@ -1,0 +1,50 @@
+// +build pivkeydisabled
+
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pivkey
+
+import (
+	"context"
+	"crypto"
+	"errors"
+
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+func NewPublicKeyProvider() (cosign.PublicKey, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func NewSigner() (signature.Signer, error) {
+	return nil, errors.New("unimplemented")
+}
+
+type PIVSigner struct {
+	Priv crypto.PrivateKey
+	Pub  crypto.PrivateKey
+	signature.ECDSAVerifier
+}
+
+func (ps *PIVSigner) Sign(ctx context.Context, rawPayload []byte) ([]byte, []byte, error) {
+	return nil, nil, errors.New("unimplemented")
+}
+
+func (ps *PIVSigner) PublicKey(context.Context) (crypto.PublicKey, error) {
+	return nil, errors.New("unimplemented")
+}
+
+var _ signature.Signer = &PIVSigner{}

--- a/test/piv_test.go
+++ b/test/piv_test.go
@@ -14,6 +14,7 @@
 
 // +build resetyubikey
 // +build e2e
+// +build !pivkeydisabled
 
 // DANGER
 // This test requires a yubikey to be present. It WILL reset the yubikey to exercise functionality.


### PR DESCRIPTION
Supporting privkey requires dynamic libs (`libpcsclite`) not present in `distroless/base`. The easiest way to fix the CI image is to drop yubikey support for the containerized `cosign` release

Signed-off-by: Jake Sanders <jsand@google.com>