### PR TITLE
docs: add AWS ECR to list of supported registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ interactions, which has excellent support, but some registries may have quirks.
 
 Today, `cosign` has been tested and works against the following registries:
 
+* AWS Elastic Container Registry
 * GCP's Artifact Registry and Container Registry
 * Docker Hub
 * Azure Container Registry


### PR DESCRIPTION
Tested ECR successfully on an EC2 box with an IAM role that had permissions to ECR.

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
