### PR TITLE
Add another unimplemented mock for pivkey.

### DIFF
--- a/pkg/cosign/pivkey/disabled.go
+++ b/pkg/cosign/pivkey/disabled.go
@@ -48,3 +48,7 @@ func (ps *PIVSigner) PublicKey(context.Context) (crypto.PublicKey, error) {
 }
 
 var _ signature.Signer = &PIVSigner{}
+
+func NewSignerVerifier() (signature.SignerVerifier, error) {
+	return nil, errors.New("unimplemented")
+}


### PR DESCRIPTION
We should add a test for this during the container tests.

This was introduced in https://github.com/sigstore/cosign/pull/280

We should test for it in #273 

Signed-off-by: Dan Lorenc <dlorenc@google.com>

