### PR TITLE
Make the auth pluggable for Upload.

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -206,7 +206,7 @@ func SignCmd(ctx context.Context, so SignOpts,
 		return err
 	}
 	fmt.Fprintln(os.Stderr, "Pushing signature to:", dstRef.String())
-	sig, err = cosign.Upload(ctx, sig, payload, dstRef, string(cert), string(chain), dupeDetector)
+	sig, err = cosign.Upload(ctx, sig, payload, dstRef, string(cert), string(chain), dupeDetector, authn.DefaultKeychain)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -96,7 +96,7 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := cosign.Upload(ctx, sigBytes, payload, dstRef, "", "", nil); err != nil {
+	if _, err := cosign.Upload(ctx, sigBytes, payload, dstRef, "", "", nil, authn.DefaultKeychain); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cosign/remote.go
+++ b/pkg/cosign/remote.go
@@ -95,13 +95,13 @@ func findDuplicate(ctx context.Context, sigImage v1.Image, payload []byte, dupeD
 	return nil, nil
 }
 
-func Upload(ctx context.Context, signature, payload []byte, dst name.Reference, cert, chain string, dupeDetector signature.Verifier) (uploadedSig []byte, err error) {
+func Upload(ctx context.Context, signature, payload []byte, dst name.Reference, cert, chain string, dupeDetector signature.Verifier, auth authn.Keychain) (uploadedSig []byte, err error) {
 	l := &staticLayer{
 		b:  payload,
 		mt: SimpleSigningMediaType,
 	}
 
-	base, err := SignatureImage(dst, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	base, err := SignatureImage(dst, remote.WithAuthFromKeychain(auth))
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func Upload(ctx context.Context, signature, payload []byte, dst name.Reference, 
 		return nil, err
 	}
 
-	if err := remote.Write(dst, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+	if err := remote.Write(dst, img, remote.WithAuthFromKeychain(auth)); err != nil {
 		return nil, err
 	}
 	return signature, nil


### PR DESCRIPTION
This is needed for cosign integration in chains!

Signed-off-by: Dan Lorenc <dlorenc@google.com>

