### PR TITLE
Allow for arbitrary `remote.Option`s in `cosign.Upload`

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -139,11 +139,13 @@ func SignCmd(ctx context.Context, so SignOpts,
 		}
 	}
 
+	remoteAuth := remote.WithAuthFromKeychain(authn.DefaultKeychain)
+
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return errors.Wrap(err, "parsing reference")
 	}
-	get, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	get, err := remote.Get(ref, remoteAuth)
 	if err != nil {
 		return errors.Wrap(err, "getting remote image")
 	}
@@ -212,10 +214,11 @@ func SignCmd(ctx context.Context, so SignOpts,
 		Cert:         string(cert),
 		Chain:        string(chain),
 		DupeDetector: dupeDetector,
+		RemoteOpts:   []remote.Option{remoteAuth},
 	}
 
 	if !cosign.Experimental() {
-		_, err := cosign.Upload(ctx, sig, payload, dstRef, authn.DefaultKeychain, uo)
+		_, err := cosign.Upload(ctx, sig, payload, dstRef, uo)
 		return err
 	}
 
@@ -257,7 +260,7 @@ func SignCmd(ctx context.Context, so SignOpts,
 	}
 	uo.Bundle = bund
 	uo.AdditionalAnnotations = annotations(entry)
-	if _, err = cosign.Upload(ctx, sig, payload, dstRef, authn.DefaultKeychain, uo); err != nil {
+	if _, err = cosign.Upload(ctx, sig, payload, dstRef, uo); err != nil {
 		return errors.Wrap(err, "uploading")
 	}
 	return nil

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -69,7 +69,9 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 		return err
 	}
 
-	get, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	auth := remote.WithAuthFromKeychain(authn.DefaultKeychain)
+
+	get, err := remote.Get(ref, auth)
 	if err != nil {
 		return err
 	}
@@ -96,7 +98,7 @@ func UploadCmd(ctx context.Context, sigRef, payloadRef, imageRef string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := cosign.Upload(ctx, sigBytes, payload, dstRef, authn.DefaultKeychain, cosign.UploadOpts{}); err != nil {
+	if _, err := cosign.Upload(ctx, sigBytes, payload, dstRef, cosign.UploadOpts{RemoteOpts: []remote.Option{auth}}); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cosign/remote.go
+++ b/pkg/cosign/remote.go
@@ -118,15 +118,16 @@ type UploadOpts struct {
 	DupeDetector          signature.Verifier
 	Bundle                *Bundle
 	AdditionalAnnotations map[string]string
+	RemoteOpts            []remote.Option
 }
 
-func Upload(ctx context.Context, signature, payload []byte, dst name.Reference, auth authn.Keychain, opts UploadOpts) (uploadedSig []byte, err error) {
+func Upload(ctx context.Context, signature, payload []byte, dst name.Reference, opts UploadOpts) (uploadedSig []byte, err error) {
 	l := &staticLayer{
 		b:  payload,
 		mt: SimpleSigningMediaType,
 	}
 
-	base, err := SignatureImage(dst, remote.WithAuthFromKeychain(auth))
+	base, err := SignatureImage(dst, opts.RemoteOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +160,7 @@ func Upload(ctx context.Context, signature, payload []byte, dst name.Reference, 
 		return nil, err
 	}
 
-	if err := remote.Write(dst, img, remote.WithAuthFromKeychain(auth)); err != nil {
+	if err := remote.Write(dst, img, opts.RemoteOpts...); err != nil {
 		return nil, err
 	}
 	return signature, nil


### PR DESCRIPTION
Signed-off-by: Jake Sanders <jsand@google.com>