### PR TITLE
enable unconvert and unparam linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,8 @@ linters:
   - gocritic
   - golint
   - misspell
+  - unconvert
+  - unparam
 output:
   uniq-by-line: false
 issues:


### PR DESCRIPTION
Also fixes an issue where bundle func no longer returns error.

Signed-off-by: Furkan Turkal <furkan.turkal@trendyol.com>