### PR TITLE
Switch from api.rekor.dev to api.sigstore.dev.

### DIFF
--- a/pkg/cosign/upload.go
+++ b/pkg/cosign/upload.go
@@ -38,7 +38,7 @@ const (
 	repoEnv             = "COSIGN_REPOSITORY"
 	DockerMediaTypesEnv = "COSIGN_DOCKER_MEDIA_TYPES"
 	ServerEnv           = "REKOR_SERVER"
-	rekorServer         = "https://api.rekor.dev"
+	rekorServer         = "https://api.sigstore.dev"
 )
 
 func Experimental() bool {


### PR DESCRIPTION
Signed-off-by: Dan Lorenc <dlorenc@google.com>

