### PR TITLE
fix usage example for sign + verify subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ cosign generate-key-pair
 Enter password for private key:
 Enter again:
 Private key written to cosign.key
-Public key written to cosign.key
+Public key written to cosign.pub
 ```
 
 ### Sign a container and store the signature in the registry

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -89,10 +89,10 @@ EXAMPLES
   COSIGN_EXPERIMENTAL=1 cosign sign <IMAGE>
 
   # sign a container image with a local key pair file
-  cosign sign -key cosign.pub <IMAGE>
+  cosign sign -key cosign.key <IMAGE>
 
   # sign a container image and add annotations
-  cosign sign -key cosign.pub -a key1=value1 -a key2=value2 <IMAGE>
+  cosign sign -key cosign.key -a key1=value1 -a key2=value2 <IMAGE>
 
   # sign a container image with a key pair stored in Google Cloud KMS
   cosign sign -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY>/versions/[VERSION] <IMAGE>

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -52,7 +52,7 @@ EXAMPLES
   COSIGN_EXPERIMENTAL=1 cosign sign-blob <FILE>
 
   # sign a blob with a local key pair file
-  cosign sign-blob -key cosign.pub <FILE>
+  cosign sign-blob -key cosign.key <FILE>
 
   # sign a blob with a key pair stored in Google Cloud KMS
   cosign sign-blob -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <FILE>`,

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -75,7 +75,7 @@ EXAMPLES
   COSIGN_EXPERIMENTAL=1 cosign verify <IMAGE>
 
   # verify image with public key
-  cosign verify -key <FILE> <IMAGE>
+  cosign verify -key cosign.pub <IMAGE>
 
   # verify image with public key provided by URL
   cosign verify -key https://host.for/<FILE> <IMAGE>


### PR DESCRIPTION
`$ cosign verify -k cosign.pub ...` is the wrong usage since we need to verify with a private key and enter the password in prompt. In case if we give a public key, it throws: `unsupported pem type: PUBLIC KEY`

Signed-off-by: Furkan Turkal <furkan.turkal@trendyol.com>