### PR TITLE
Add cosign upload wasm command!

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,20 @@ tlog entry created with index:  5086
 Pushing signature to: us.gcr.io/dlorenc-vmtest2/demo:sha256-124e1fdee94fe5c5f902bc94da2d6e2fea243934c74e76c2368acdc8d3ac7155.sig
 ```
 
+#### WASM
+
+Web Assembly Modules can also be stored in an OCI registry, using this [specification](https://github.com/solo-io/wasm/tree/master/spec).
+
+Cosign can upload these using the `cosign wasm upload` command:
+
+```shell
+$ cosign upload wasm -f hello.wasm us.gcr.io/dlorenc-vmtest2/wasm
+$ cosign sign -key cosign.key us.gcr.io/dlorenc-vmtest2/wasm
+Enter password for private key:
+tlog entry created with index:  5198
+Pushing signature to: us.gcr.io/dlorenc-vmtest2/wasm:sha256-9e7a511fb3130ee4641baf1adc0400bed674d4afc3f1b81bb581c3c8f613f812.sig
+```
+
 ## Detailed Usage
 
 See the [Usage documentation](USAGE.md) for more commands!

--- a/cmd/cosign/cli/upload/upload.go
+++ b/cmd/cosign/cli/upload/upload.go
@@ -32,7 +32,7 @@ func Upload() *ffcli.Command {
 		ShortUsage:  "cosign upload",
 		ShortHelp:   "upload contains tools to upload artifacts to a registry",
 		FlagSet:     flagset,
-		Subcommands: []*ffcli.Command{Blob()},
+		Subcommands: []*ffcli.Command{Blob(), Wasm()},
 		Exec: func(ctx context.Context, args []string) error {
 			return flag.ErrHelp
 		},

--- a/cmd/cosign/cli/upload/wasm.go
+++ b/cmd/cosign/cli/upload/wasm.go
@@ -1,0 +1,87 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package upload
+
+import (
+	"context"
+	"flag"
+	"io/ioutil"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/peterbourgon/ff/v3/ffcli"
+	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
+)
+
+func Wasm() *ffcli.Command {
+	var (
+		flagset = flag.NewFlagSet("cosign upload wasm", flag.ExitOnError)
+		f       = flagset.String("f", "", "path to the wasm file to upload")
+	)
+	return &ffcli.Command{
+		Name:       "wasm",
+		ShortUsage: "cosign upload wasm -f foo.wasm <image uri>",
+		ShortHelp:  "upload a wasm module to the supplied container image reference",
+		FlagSet:    flagset,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) != 1 {
+				return flag.ErrHelp
+			}
+
+			return WasmCmd(ctx, *f, args[0])
+		},
+	}
+}
+
+func WasmCmd(ctx context.Context, wasmPath, imageRef string) error {
+
+	img := mutate.MediaType(empty.Image, types.OCIManifestSchema1)
+
+	b, err := ioutil.ReadFile(wasmPath)
+	if err != nil {
+		return err
+	}
+	s := &cremote.StaticLayer{
+		B:  b,
+		Mt: types.MediaType("application/vnd.wasm.content.layer.v1+wasm"),
+	}
+
+	img, err = mutate.Append(img, mutate.Addendum{
+		Layer: s,
+	})
+	if err != nil {
+		return err
+	}
+
+	m, err := img.Manifest()
+	if err != nil {
+		return err
+	}
+	m.Config.MediaType = "application/vnd.wasm.config.v1+json"
+
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return err
+	}
+	if err := remote.Write(ref, img, remote.WithAuthFromKeychain(authn.DefaultKeychain)); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cosign/remote/index.go
+++ b/pkg/cosign/remote/index.go
@@ -99,8 +99,8 @@ func UploadFile(fileRef string, ref name.Reference, kc authn.Keychain) (v1.Image
 	}
 	mt := strings.Split(http.DetectContentType(b), ";")[0]
 	l := &StaticLayer{
-		b:  b,
-		mt: types.MediaType(mt),
+		B:  b,
+		Mt: types.MediaType(mt),
 	}
 	fmt.Fprintf(os.Stderr, "Uploading file from [%s] to [%s] with media type [%s]\n", fileRef, ref.Name(), mt)
 

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -95,8 +95,8 @@ func SignatureImage(dstTag name.Reference, opts ...remote.Option) (v1.Image, err
 
 func findDuplicate(ctx context.Context, sigImage v1.Image, payload []byte, dupeDetector signature.Verifier, annotations map[string]string) ([]byte, error) {
 	l := &StaticLayer{
-		b:  payload,
-		mt: SimpleSigningMediaType,
+		B:  payload,
+		Mt: SimpleSigningMediaType,
 	}
 
 	sigDigest, err := l.Digest()
@@ -153,8 +153,8 @@ type UploadOpts struct {
 
 func UploadSignature(ctx context.Context, signature, payload []byte, dst name.Reference, opts UploadOpts) (uploadedSig []byte, err error) {
 	l := &StaticLayer{
-		b:  payload,
-		mt: SimpleSigningMediaType,
+		B:  payload,
+		Mt: SimpleSigningMediaType,
 	}
 
 	base, err := SignatureImage(dst, opts.RemoteOpts...)
@@ -197,37 +197,37 @@ func UploadSignature(ctx context.Context, signature, payload []byte, dst name.Re
 }
 
 type StaticLayer struct {
-	b  []byte
-	mt types.MediaType
+	B  []byte
+	Mt types.MediaType
 }
 
 func (l *StaticLayer) Digest() (v1.Hash, error) {
-	h, _, err := v1.SHA256(bytes.NewReader(l.b))
+	h, _, err := v1.SHA256(bytes.NewReader(l.B))
 	return h, err
 }
 
 // DiffID returns the Hash of the uncompressed layer.
 func (l *StaticLayer) DiffID() (v1.Hash, error) {
-	h, _, err := v1.SHA256(bytes.NewReader(l.b))
+	h, _, err := v1.SHA256(bytes.NewReader(l.B))
 	return h, err
 }
 
 // Compressed returns an io.ReadCloser for the compressed layer contents.
 func (l *StaticLayer) Compressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
+	return ioutil.NopCloser(bytes.NewReader(l.B)), nil
 }
 
 // Uncompressed returns an io.ReadCloser for the uncompressed layer contents.
 func (l *StaticLayer) Uncompressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
+	return ioutil.NopCloser(bytes.NewReader(l.B)), nil
 }
 
 // Size returns the compressed size of the Layer.
 func (l *StaticLayer) Size() (int64, error) {
-	return int64(len(l.b)), nil
+	return int64(len(l.B)), nil
 }
 
 // MediaType returns the media type of the Layer.
 func (l *StaticLayer) MediaType() (types.MediaType, error) {
-	return l.mt, nil
+	return l.Mt, nil
 }


### PR DESCRIPTION
This probably isn't the ideal location/UX for the command, but I was able to get it working here when playing with https://www.kubewarden.io/.

We want to be helping sign/push WASM for other uses cases too, but they might use different storage mechanisms. This version (for kubewarden) used the one defined at https://github.com/engineerd/wasm-to-oci. There's another spec here: https://www.solo.io/blog/announcing-the-webassembly-wasm-oci-image-spec/

I'll need to understand the differences between these specs to see which (if any) might make sense to support here. For kubewarden, the policies need to be compiled to wasm and uploaded to a registry for retrieval. The documentation points to using the actual `wasm-to-oci` tool, but I was unable to get that working with GCR.

I read the spec and tried to reimplement it here, where it did work!

