### PR TITLE
Add JSON formatting for the device attestation commands.

### DIFF
--- a/cmd/cosign/cli/pivcli/piv_tool.go
+++ b/cmd/cosign/cli/pivcli/piv_tool.go
@@ -19,7 +19,9 @@ package pivcli
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
+	"fmt"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
@@ -126,6 +128,7 @@ func Unblock() *ffcli.Command {
 func Attestation() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign piv-tool attestation", flag.ExitOnError)
+		output  = flagset.String("output", "text", "format to output attestation information in. text|json, default text.")
 	)
 
 	return &ffcli.Command{
@@ -134,7 +137,17 @@ func Attestation() *ffcli.Command {
 		ShortHelp:  "attestation contains commands to manage a hardware token",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			_, err := AttestationCmd(ctx)
+			a, err := AttestationCmd(ctx)
+			switch *output {
+			case "text":
+				a.Output()
+			case "json":
+				b, err := json.Marshal(a)
+				if err != nil {
+					return err
+				}
+				fmt.Println(string(b))
+			}
 			return err
 		},
 	}


### PR DESCRIPTION
This will make scripting the setup much easier.

Here's what it looks like now:

```shell
$ cosign piv-tool attestation -output=json | jq .
{
  "DeviceCertPem": "-----BEGIN CERTIFICATE-----\nMIIC+jCCAeKgAwIBAgIJAJDjrwcvIYiiMA0GCSqGSIb3DQEBCwUAMCsxKTAnBgNV\nBAMMIFl1YmljbyBQSVYgUm9vdCBDQSBTZXJpYWwgMjYzNzUxMCAXDTE2MDMxNDAw\nMDAwMFoYDzIwNTIwNDE3MDAwMDAwWjAhMR8wHQYDVQQDDBZZdWJpY28gUElWIEF0\ndGVzdGF0aW9uMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyS4ANsMp\nRQA9cigP1oUG8yQ8tQkel2IergXvY9WSYy/muj30exFWXvO323i9RaQtoT7hOS5d\nSsH1hNvSTD56fIaKpg+8jHsQLM6mF2Jo0Kb4rBduYNi+waFbGcwgrmRX1d9NcYb6\nUDJt0o0RW6aGPY6wqUvMlIj0EwNIN7Ct1wSjIdL1qFmyVwUkQkPDd/0jDv7giE0P\nM36qISQ6U8t2jNg5aWDEjf7wwWTIiMjbv0FaaiL5Vqmc7WboofKZN5nQyWGAtAtz\njTXzSkBfNPDO1eAUgbCbmu5efD8WeAtiPQyz8zQDU5UyihmDUEF1Dgr9/QMtQ5bd\nZ+FkBTtBYFp4aQIDAQABoykwJzARBgorBgEEAYLECgMDBAMFAgYwEgYDVR0TAQH/\nBAgwBgEB/wIBADANBgkqhkiG9w0BAQsFAAOCAQEAQutaY0Wf/o2MPyRmsMM1QQuX\nJI1ncaiDczWpFGj8YFUqlwLsEgYMzzGMrgPHIyE+CCgbYfyJu2mGU7goEHFq2/Ky\ni8mjJtk/nVMF/m+dD7zbLvXPU0f9BKdpm1LUjC/YscvkFuI+sFrZvk8e1DAM49D5\nDm3MsEw9KjGhhTSv8iMoz9QMN7O1ozfsLTkj5eJQFEzkeUtgPxoJVnJqd4JkqnhF\nZoN7tG+9N6wouG5pCzOJDgraGwow11UdcheQze2SVktYcRdWVgr86YBiYdfAzkLz\nFN4tXEiGuQyX6gWKBdd91niHF27RIWNGuz6X9KzMwgJ374n2ld8BiLg9PU30xA==\n-----END CERTIFICATE-----\n",
  "KeyCertPem": "-----BEGIN CERTIFICATE-----\nMIICVTCCAT2gAwIBAgIQAQVhRwJkTzR1rumaJuMuxDANBgkqhkiG9w0BAQsFADAh\nMR8wHQYDVQQDDBZZdWJpY28gUElWIEF0dGVzdGF0aW9uMCAXDTE2MDMxNDAwMDAw\nMFoYDzIwNTIwNDE3MDAwMDAwWjAlMSMwIQYDVQQDDBpZdWJpS2V5IFBJViBBdHRl\nc3RhdGlvbiA5YzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABMdXql+6vOYu0HrI\nBTzXsJp6DY8ogglnyqiACkHvJoLVeGBNxOtB12D2r7vjuYAQ5ASXePSVg13DSOWQ\nE2/uX9CjTjBMMBEGCisGAQQBgsQKAwMEAwUCBjAUBgorBgEEAYLECgMHBAYCBADH\nkP4wEAYKKwYBBAGCxAoDCAQCAwIwDwYKKwYBBAGCxAoDCQQBAzANBgkqhkiG9w0B\nAQsFAAOCAQEAiXHu8RnH1ZGI6sd14Adyey8F10jxnEiVb4tXUO+MdUaoqoA2EFmh\ni3c6N/nc65guAYvRdQ+bM0GnSM22iRgoqsMhDRx1/wwfw1cwwVVyvH+YnqchOTUw\n4Q9AOCsrExGYifUEzY5zJvpbmaZWAA71IYheSVSiyALnX+ZCGrnaSL4W8FYGji3v\nXilPEFTm0q0ubEQMHPel4tJvCBJ1NjNpTu5MPjM7lK53x5TotNXwRa74JJEmDCUh\nGEczA3gOBbds08lflieCUDazAsoWET0v0mHgqn+sImo4F9Rue+f8SvdlOzOwRZhA\nieZG6krNatVk4qyujcCthc80PDHXEjl5Ig==\n-----END CERTIFICATE-----\n",
  "KeyAttestation": {
    "Version": {
      "Major": 5,
      "Minor": 2,
      "Patch": 6
    },
    "Serial": 13078782,
    "Formfactor": 3,
    "PINPolicy": 3,
    "TouchPolicy": 2
  }
}
```