### PR TITLE
Add tag back in if lost during repository replacement

### DIFF
--- a/pkg/cosign/upload.go
+++ b/pkg/cosign/upload.go
@@ -72,7 +72,12 @@ func DestinationRef(ref name.Reference, img *remote.Descriptor) (name.Reference,
 	} else {
 		subRepo[1] = strings.TrimPrefix(s[1], "/")
 	}
-	subbed := dstTag.RegistryStr() + strings.Join(subRepo, "/")
+	newRepo := strings.Join(subRepo, "/")
+	// add the tag back in if we lost it
+	if !strings.Contains(newRepo, ":") {
+		newRepo = newRepo + ":" + dstTag.TagStr()
+	}
+	subbed := dstTag.RegistryStr() + newRepo
 	return name.ParseReference(subbed)
 }
 

--- a/pkg/cosign/upload_test.go
+++ b/pkg/cosign/upload_test.go
@@ -61,6 +61,12 @@ func TestDestinationTag(t *testing.T) {
 			repo:  "us-central1-docker.pkg.dev/projectsigstore/subrepo",
 			want:  "us-central1-docker.pkg.dev/projectsigstore/subrepo/cosign-ci/test:sha256-digest.sig",
 		},
+		{
+			desc:  "ecr test",
+			image: "myaccount.dkr.ecr.us-west-2.amazonaws.com/repo1:tag",
+			repo:  "myaccount.dkr.ecr.us-west-2.amazonaws.com/repo2",
+			want:  "myaccount.dkr.ecr.us-west-2.amazonaws.com/repo2:sha256-digest.sig",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I spent a while trying to figure out a cleaner way to solve this, but unfortunately this is the only way I could find that worked for all the test cases. 

fixes https://github.com/sigstore/cosign/issues/322