### PR TITLE
add clean sub-command for deleting signature metadata from a given image

### DIFF
--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -1,0 +1,77 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/sigstore/cosign/pkg/cosign"
+)
+
+func Clean() *ffcli.Command {
+	var (
+		flagset = flag.NewFlagSet("cosign clean", flag.ExitOnError)
+	)
+
+	return &ffcli.Command{
+		Name:       "clean",
+		ShortUsage: "cosign clean <image uri>",
+		ShortHelp:  "Remove all signatures from an image",
+		FlagSet:    flagset,
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) != 1 {
+				return flag.ErrHelp
+			}
+
+			return CleanCmd(ctx, args[0])
+		},
+	}
+}
+
+func CleanCmd(_ context.Context, imageRef string) error {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return err
+	}
+	// TODO: just return the descriptor directly if we have a digest reference.
+	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return err
+	}
+
+	dstRef, err := cosign.DestinationRef(ref, desc)
+	if err != nil {
+		return err
+	}
+
+	signRef := dstRef.Context().Tag(cosign.Munge(desc.Descriptor))
+	fmt.Println(signRef)
+
+	fmt.Println("Deleting signature metadata...")
+
+	err = remote.Delete(signRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -41,7 +41,7 @@ func main() {
 		FlagSet:    rootFlagSet,
 		Subcommands: []*ffcli.Command{
 			cli.Verify(), cli.Sign(), cli.Upload(), cli.Generate(), cli.Download(), cli.GenerateKeyPair(), cli.SignBlob(),
-			cli.VerifyBlob(), cli.Triangulate(), cli.Version(), cli.PublicKey(), pivcli.PivKey(), cli.Copy()},
+			cli.VerifyBlob(), cli.Triangulate(), cli.Version(), cli.PublicKey(), pivcli.PivKey(), cli.Copy(), cli.Clean()},
 		Exec: func(context.Context, []string) error {
 			return flag.ErrHelp
 		},


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
