### PR TITLE
make builds static (and yubikey support disabled) by default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,8 +36,9 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.16.4'
-      - name: deps
-        run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
+      # Required for `make cosign-pivkey`
+      # - name: deps
+      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: install ko
         run: |
           curl -L https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | tar xzf - ko && \

--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -30,15 +30,12 @@ jobs:
           go-version: 1.16.4
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: install deps
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
+      # Required for `make cosign-pivkey`
+      # - name: install deps
+      #   if: matrix.os == 'ubuntu-latest'
+      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: build
-        if: matrix.os != 'ubuntu-latest'
         run: make cosign && mv ./cosign ./${{matrix.TARGET}}
-      - name: build-static
-        if: matrix.os == 'ubuntu-latest'
-        run: make cosign-static && mv ./cosign ./${{matrix.TARGET}}
       - name: Print Info
         shell: pwsh
         run: |

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -43,7 +43,8 @@ jobs:
         run: go install github.com/google/go-containerregistry/cmd/crane
       - name: creds
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-      - name: deps
-        run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
+      # Required for `make cosign-pivkey`
+      # - name: deps
+      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: Run e2e tests that need secrets
         run: ./test/e2e_test_secrets.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,8 +47,9 @@ jobs:
         run: |
           curl -L https://github.com/google/ko/releases/download/v0.8.1/ko_0.8.1_Linux_x86_64.tar.gz | tar xzf - ko && \
           chmod +x ./ko && sudo mv ko /usr/local/bin/
-      - name: deps
-        run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
+      # Required for `make cosign-pivkey`
+      # - name: deps
+      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: Run Go tests
         run: go test ./...
 

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ all: cosign
 SRCS = $(shell find cmd -iname "*.go") $(shell find pkg -iname "*.go")
 
 cosign: $(SRCS)
-	CGO_ENABLED=1 go build -ldflags $(LDFLAGS) -o $@ ./cmd/cosign
+	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o $@ ./cmd/cosign
 
-cosign-static: $(SRCS)
-	CGO_ENABLED=0 go build -ldflags $(LDFLAGS) -o cosign ./cmd/cosign
+cosign-pivkey: $(SRCS)
+	CGO_ENABLED=1 go build -tags=pivkey -ldflags $(LDFLAGS) -o cosign ./cmd/cosign
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
@@ -80,14 +80,14 @@ clean:
 .PHONY: ko
 ko:
 	# We can't pass more than one LDFLAG via GOFLAGS, you can't have spaces in there.
-	CGO_ENABLED=0 GOFLAGS="-tags=pivkeydisabled -ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
+	CGO_ENABLED=0 GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
 		--tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		github.com/sigstore/cosign/cmd/cosign
 
 .PHONY: ko-local
 ko-local:
 	# We can't pass more than one LDFLAG via GOFLAGS, you can't have spaces in there.
-	CGO_ENABLED=0 GOFLAGS="-tags=pivkeydisabled -ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
+	CGO_ENABLED=0 GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
 		--tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
 		github.com/sigstore/cosign/cmd/cosign
 

--- a/cmd/cosign/cli/pivcli/commands.go
+++ b/cmd/cosign/cli/pivcli/commands.go
@@ -1,4 +1,4 @@
-// +build !pivkeydisabled
+// +build pivkey
 // +build cgo
 
 // Copyright 2021 The Sigstore Authors

--- a/cmd/cosign/cli/pivcli/disabled.go
+++ b/cmd/cosign/cli/pivcli/disabled.go
@@ -1,4 +1,4 @@
-// +build pivkeydisabled !cgo
+// +build !pivkey !cgo
 
 // Copyright 2021 The Sigstore Authors
 //

--- a/cmd/cosign/cli/pivcli/piv_tool.go
+++ b/cmd/cosign/cli/pivcli/piv_tool.go
@@ -1,4 +1,4 @@
-// +build !pivkeydisabled
+// +build pivkey
 // +build cgo
 
 // Copyright 2021 The Sigstore Authors

--- a/pkg/cosign/pivkey/disabled.go
+++ b/pkg/cosign/pivkey/disabled.go
@@ -1,4 +1,4 @@
-// +build pivkeydisabled !cgo
+// +build !pivkey !cgo
 
 // Copyright 2021 The Sigstore Authors.
 //

--- a/pkg/cosign/pivkey/pivkey.go
+++ b/pkg/cosign/pivkey/pivkey.go
@@ -1,4 +1,4 @@
-// +build !pivkeydisabled
+// +build pivkey
 // +build cgo
 
 // Copyright 2021 The Sigstore Authors.


### PR DESCRIPTION
Added `make cosign-pivkey` to offer support

Fixes: https://github.com/sigstore/cosign/issues/305

Signed-off-by: Jake Sanders <jsand@google.com>
