### PR TITLE
add Sonatype Nexus Container Registry to tested registries list

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Today, `cosign` has been tested and works against the following registries:
 * GitHub Container Registry
 * The CNCF Harbor Registry
 * Digital Ocean Container Registry
+* Sonatype Nexus Container Registry
 
 We aim for wide registry support. To `sign` images in registries which do not yet fully support [OCI media types](https://github.com/sigstore/cosign/blob/main/SPEC.md#object-types), one may need to use `COSIGN_DOCKER_MEDIA_TYPES` to fall back to legacy equivalents. For example:
 ```shell


### PR DESCRIPTION
We've tested storing the cosign image signatures in Nexus Docker Registry. It works fine so, I though I submit this PR to append it to the list.

Signed-off-by: Balazs Zachar <zachar.balazs@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
