### PR TITLE
split mime-type to support AWS ECR

### DIFF
--- a/pkg/cosign/remote/index.go
+++ b/pkg/cosign/remote/index.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -96,7 +97,7 @@ func UploadFile(fileRef string, ref name.Reference, kc authn.Keychain) (v1.Image
 	if err != nil {
 		return nil, err
 	}
-	mt := http.DetectContentType(b)
+	mt := strings.Split(http.DetectContentType(b), ";")[0]
 	l := &StaticLayer{
 		b:  b,
 		mt: types.MediaType(mt),


### PR DESCRIPTION
Signed-off-by: Rotem Bar <rotem@cidersecurity.io>

Resolves issue in using upload-blob with AWS ECR. 
See discussion on slack - https://sigstore.slack.com/archives/C01PZKDL4DP/p1622552109047700
