### PR TITLE
add documentation for new environment variable for Vault KMS support

### DIFF
--- a/KMS.md
+++ b/KMS.md
@@ -99,3 +99,9 @@ $ export VAULT_ADDR=http://localhost:8200
 $ export VAULT_TOKEN=testtoken
 $ vault secrets enable transit
 ```
+
+If you enabled `transit` secret engine at different path with the use of `-path` flag (i.e., `$ vault secrets enable -path="someotherpath" transit`), you can use `TRANSIT_SECRET_ENGINE_PATH` environment variable to specify this path while generating a key pair like the following:
+
+```shell
+$ TRANSIT_SECRET_ENGINE_PATH="someotherpath" cosign generate-key-pair -kms hashivault://testkey
+```


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

We recently added support for storing key pairs at the different paths for `Transit Secret Engine` at this [PR](https://github.com/sigstore/sigstore/pull/67) while using KMS support.
cc: @Dentrax 