### PR TITLE
add flags to specify slot, PIN, and touch policies for security keys

### DIFF
--- a/cmd/cosign/cli/pivcli/piv_tool.go
+++ b/cmd/cosign/cli/pivcli/piv_tool.go
@@ -129,6 +129,7 @@ func Attestation() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign piv-tool attestation", flag.ExitOnError)
 		output  = flagset.String("output", "text", "format to output attestation information in. text|json, default text.")
+		slot    = flagset.String("slot", "", "Slot to use for generated key (authentication|signature|card-authentication|key-management)")
 	)
 
 	return &ffcli.Command{
@@ -137,7 +138,7 @@ func Attestation() *ffcli.Command {
 		ShortHelp:  "attestation contains commands to manage a hardware token",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			a, err := AttestationCmd(ctx)
+			a, err := AttestationCmd(ctx, *slot)
 			switch *output {
 			case "text":
 				a.Output()
@@ -158,6 +159,9 @@ func GenerateKey() *ffcli.Command {
 		flagset       = flag.NewFlagSet("cosign piv-tool generate-key", flag.ExitOnError)
 		managementKey = flagset.String("management-key", "", "management key, uses default if empty")
 		randomKey     = flagset.Bool("random-management-key", false, "if set to true, generates a new random management key and deletes it after")
+		slot          = flagset.String("slot", "", "Slot to use for generated key (authentication|signature|card-authentication|key-management)")
+		pinPolicy     = flagset.String("pin-policy", "", "PIN policy for slot (never|once|always)")
+		touchPolicy   = flagset.String("touch-policy", "", "Touch policy for slot (never|always|cached)")
 	)
 
 	return &ffcli.Command{
@@ -166,7 +170,8 @@ func GenerateKey() *ffcli.Command {
 		ShortHelp:  "generate-key generates a new signing key on the hardware token",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			return GenerateKeyCmd(ctx, *managementKey, *randomKey)
+			return GenerateKeyCmd(ctx, *managementKey, *randomKey,
+				*slot, *pinPolicy, *touchPolicy)
 		},
 	}
 }

--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -39,6 +39,7 @@ func PublicKey() *ffcli.Command {
 		flagset = flag.NewFlagSet("cosign public-key", flag.ExitOnError)
 		key     = flagset.String("key", "", "path to the private key file, public key URL, or KMS URI")
 		sk      = flagset.Bool("sk", false, "whether to use a hardware security key")
+		slot    = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
 		outFile = flagset.String("outfile", "", "file to write public key")
 	)
 
@@ -83,6 +84,7 @@ EXAMPLES
 			pk := Pkopts{
 				KeyRef: *key,
 				Sk:     *sk,
+				Slot:   *slot,
 			}
 			return GetPublicKey(ctx, pk, writer, GetPass)
 		},
@@ -92,6 +94,7 @@ EXAMPLES
 type Pkopts struct {
 	KeyRef string
 	Sk     bool
+	Slot   string
 }
 
 func GetPublicKey(ctx context.Context, opts Pkopts, writer NamedWriter, pf cosign.PassFunc) error {
@@ -104,7 +107,7 @@ func GetPublicKey(ctx context.Context, opts Pkopts, writer NamedWriter, pf cosig
 		}
 		k = s
 	case opts.Sk:
-		sk, err := pivkey.NewPublicKeyProvider()
+		sk, err := pivkey.NewPublicKeyProvider(opts.Slot)
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -75,6 +75,7 @@ func Sign() *ffcli.Command {
 		key         = flagset.String("key", "", "path to the private key file or KMS URI")
 		upload      = flagset.Bool("upload", true, "whether to upload the signature")
 		sk          = flagset.Bool("sk", false, "whether to use a hardware security key")
+		slot        = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
 		payloadPath = flagset.String("payload", "", "path to a payload file to use rather than generating one.")
 		force       = flagset.Bool("f", false, "skip warnings and confirmations")
 		recursive   = flagset.Bool("r", false, "if a multi-arch image is specified, additionally sign each discrete image")
@@ -118,6 +119,7 @@ EXAMPLES
 				Annotations: annotations.annotations,
 				Pf:          GetPass,
 				Sk:          *sk,
+				Slot:        *slot,
 				IDToken:     *idToken,
 			}
 			for _, img := range args {
@@ -134,6 +136,7 @@ type SignOpts struct {
 	Annotations map[string]interface{}
 	KeyRef      string
 	Sk          bool
+	Slot        string
 	Pf          cosign.PassFunc
 	IDToken     string
 }
@@ -216,7 +219,7 @@ func SignCmd(ctx context.Context, so SignOpts,
 	var cert, chain string
 	switch {
 	case so.Sk:
-		sk, err := pivkey.NewSignerVerifier()
+		sk, err := pivkey.NewSignerVerifier(so.Slot)
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -41,6 +41,7 @@ func SignBlob() *ffcli.Command {
 		key     = flagset.String("key", "", "path to the private key file or a KMS URI")
 		b64     = flagset.Bool("b64", true, "whether to base64 encode the output")
 		sk      = flagset.Bool("sk", false, "whether to use a hardware security key")
+		slot    = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
 		idToken = flagset.String("identity-token", "", "[EXPERIMENTAL] identity token to use for certificate from fulcio")
 	)
 	return &ffcli.Command{
@@ -73,6 +74,7 @@ EXAMPLES
 			ko := KeyOpts{
 				KeyRef: *key,
 				Sk:     *sk,
+				Slot:   *slot,
 			}
 			for _, blob := range args {
 				if _, err := SignBlobCmd(ctx, ko, blob, *b64, GetPass, *idToken); err != nil {
@@ -86,6 +88,7 @@ EXAMPLES
 
 type KeyOpts struct {
 	Sk     bool
+	Slot   string
 	KeyRef string
 }
 
@@ -112,7 +115,7 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, 
 		}
 		signer = k
 	case ko.Sk:
-		k, err := pivkey.NewSignerVerifier()
+		k, err := pivkey.NewSignerVerifier(ko.Slot)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -37,6 +37,7 @@ type VerifyCommand struct {
 	CheckClaims bool
 	KeyRef      string
 	Sk          bool
+	Slot        string
 	Output      string
 	Annotations *map[string]interface{}
 }
@@ -49,7 +50,7 @@ func Verify() *ffcli.Command {
 
 	flagset.StringVar(&cmd.KeyRef, "key", "", "path to the public key file, URL, or KMS URI")
 	flagset.BoolVar(&cmd.Sk, "sk", false, "whether to use a hardware security key")
-
+	flagset.StringVar(&cmd.Slot, "slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
 	flagset.BoolVar(&cmd.CheckClaims, "check-claims", true, "whether to check the claims found")
 	flagset.StringVar(&cmd.Output, "output", "json", "output the signing image information. Default JSON.")
 
@@ -113,7 +114,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) error {
 		}
 		co.PubKey = pubKey
 	} else if c.Sk {
-		pubKey, err := pivkey.NewPublicKeyProvider()
+		pubKey, err := pivkey.NewPublicKeyProvider(c.Slot)
 		if err != nil {
 			return errors.Wrap(err, "loading public key")
 		}

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -43,6 +43,7 @@ func VerifyBlob() *ffcli.Command {
 		flagset   = flag.NewFlagSet("cosign verify-blob", flag.ExitOnError)
 		key       = flagset.String("key", "", "path to the public key file, URL, or KMS URI")
 		sk        = flagset.Bool("sk", false, "whether to use a hardware security key")
+		slot      = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
 		cert      = flagset.String("cert", "", "path to the public certificate")
 		signature = flagset.String("signature", "", "path to the signature")
 	)
@@ -77,6 +78,7 @@ EXAMPLES
 			ko := KeyOpts{
 				KeyRef: *key,
 				Sk:     *sk,
+				Slot:   *slot,
 			}
 			if err := VerifyBlobCmd(ctx, ko, *cert, *signature, args[0]); err != nil {
 				return errors.Wrapf(err, "verifying blob %s", args)
@@ -108,7 +110,7 @@ func VerifyBlobCmd(ctx context.Context, ko KeyOpts, certRef, sigRef, blobRef str
 			return errors.Wrap(err, "loading public key")
 		}
 	case ko.Sk:
-		pubKey, err = pivkey.NewPublicKeyProvider()
+		pubKey, err = pivkey.NewPublicKeyProvider(ko.Slot)
 		if err != nil {
 			return errors.Wrap(err, "loading public key from token")
 		}

--- a/pkg/cosign/pivkey/disabled.go
+++ b/pkg/cosign/pivkey/disabled.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-func NewPublicKeyProvider() (cosign.PublicKey, error) {
+func NewPublicKeyProvider(slotName string) (cosign.PublicKey, error) {
 	return nil, errors.New("unimplemented")
 }
 
@@ -49,6 +49,6 @@ func (ps *PIVSigner) PublicKey(context.Context) (crypto.PublicKey, error) {
 
 var _ signature.Signer = &PIVSigner{}
 
-func NewSignerVerifier() (signature.SignerVerifier, error) {
+func NewSignerVerifier(slotName string) (signature.SignerVerifier, error) {
 	return nil, errors.New("unimplemented")
 }

--- a/pkg/cosign/pivkey/pivkey.go
+++ b/pkg/cosign/pivkey/pivkey.go
@@ -62,12 +62,18 @@ func getPin() (string, error) {
 	return string(b), err
 }
 
-func NewPublicKeyProvider() (cosign.PublicKey, error) {
+func NewPublicKeyProvider(slotName string) (cosign.PublicKey, error) {
 	pk, err := GetKey()
 	if err != nil {
 		return nil, err
 	}
-	cert, err := pk.Attest(piv.SlotSignature)
+
+	slot := SlotForName(slotName)
+	if slot == nil {
+		return nil, errors.New("invalid slot name")
+	}
+	
+	cert, err := pk.Attest(*slot)
 	if err != nil {
 		return nil, err
 	}
@@ -80,12 +86,18 @@ func NewPublicKeyProvider() (cosign.PublicKey, error) {
 	}, nil
 }
 
-func NewSignerVerifier() (signature.SignerVerifier, error) {
+func NewSignerVerifier(slotName string) (signature.SignerVerifier, error) {
 	pk, err := GetKey()
 	if err != nil {
 		return nil, err
 	}
-	cert, err := pk.Attest(piv.SlotSignature)
+
+	slot := SlotForName(slotName)
+	if slot == nil {
+		return nil, errors.New("invalid slot name")
+	}
+	
+	cert, err := pk.Attest(*slot)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +105,7 @@ func NewSignerVerifier() (signature.SignerVerifier, error) {
 	auth := piv.KeyAuth{
 		PINPrompt: getPin,
 	}
-	privKey, err := pk.PrivateKey(piv.SlotSignature, cert.PublicKey, auth)
+	privKey, err := pk.PrivateKey(*slot, cert.PublicKey, auth)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/pivkey/util.go
+++ b/pkg/cosign/pivkey/util.go
@@ -1,0 +1,109 @@
+// +build pivkey
+// +build cgo
+
+// Copyright 2021 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pivkey
+
+import (
+	"github.com/go-piv/piv-go/piv"
+)
+
+func SlotForName(slotName string) *piv.Slot {
+	switch slotName {
+	case "":
+		return &piv.SlotAuthentication
+	case "authentication":
+		return &piv.SlotAuthentication
+	case "signature":
+		return &piv.SlotSignature
+	case "card-authentication":
+		return &piv.SlotCardAuthentication
+	case "key-management":
+		return &piv.SlotKeyManagement
+	default:
+		return nil
+	}
+}
+
+func PINPolicyForName(policyName string, slot piv.Slot) piv.PINPolicy {
+	switch policyName {
+	case "":
+		return defaultPINPolicyForSlot(slot)
+	case "never":
+		return piv.PINPolicyNever
+	case "once":
+		return piv.PINPolicyOnce
+	case "always":
+		return piv.PINPolicyAlways
+	default:
+		return -1
+	}
+}
+
+func TouchPolicyForName(policyName string, slot piv.Slot) piv.TouchPolicy {
+	switch policyName {
+	case "":
+		return defaultTouchPolicyForSlot(slot)
+	case "never":
+		return piv.TouchPolicyNever
+	case "cached":
+		return piv.TouchPolicyCached
+	case "always":
+		return piv.TouchPolicyAlways
+	default:
+		return -1
+	}
+}
+
+func defaultPINPolicyForSlot(slot piv.Slot) piv.PINPolicy {
+	//
+	// Defaults from https://developers.yubico.com/PIV/Introduction/Certificate_slots.html
+	//
+
+	switch slot {
+	case piv.SlotAuthentication:
+		return piv.PINPolicyOnce
+	case piv.SlotSignature:
+		return piv.PINPolicyAlways
+	case piv.SlotKeyManagement:
+		return piv.PINPolicyOnce
+	case piv.SlotCardAuthentication:
+		return piv.PINPolicyNever
+	default:
+		// This should never happen
+		panic("invalid value for slot")
+	}
+}
+
+func defaultTouchPolicyForSlot(slot piv.Slot) piv.TouchPolicy {
+	//
+	// Defaults from https://developers.yubico.com/PIV/Introduction/Certificate_slots.html
+	//
+
+	switch slot {
+	case piv.SlotAuthentication:
+		return piv.TouchPolicyCached
+	case piv.SlotSignature:
+		return piv.TouchPolicyAlways
+	case piv.SlotKeyManagement:
+		return piv.TouchPolicyCached
+	case piv.SlotCardAuthentication:
+		return piv.TouchPolicyNever
+	default:
+		// This should never happen
+		panic("invalid value for slot")
+	}
+}


### PR DESCRIPTION
This permits flexibility to use different PIN and touch policies
for container signing. Key generation will use the default PIN
and touch policies for the specified slot unless additional flags
are set to attempt to override the default. The security key is
not guaranteed to honor a particular PIN and touch policy for the
specified slot.

Signed-off-by: Dino A. Dai Zovi <ddz@theta44.org>