### PR TITLE
verify the SET when getting a log entry

### DIFF
--- a/KEYLESS.md
+++ b/KEYLESS.md
@@ -73,15 +73,12 @@ $ cosign sign --identity-token=$(gcloud auth print-identity-token --audiences=fu
 
 ### Timestamps
 
-Signature timestamps are checked in the [rekor](https://github.com/sigstore/rekor) transparency log.
-Signatures without timestamps are still validated, but show up with a warning because we cannot verify that the signature
-was created while the certificate was valid.
+Signature timestamps are checked in the [rekor](https://github.com/sigstore/rekor) transparency log. Rekor's `IntegratedTime` is signed as part of its `signedEntryTimestamp`. Cosign verifies the signature over the timestamp and checks that the signature was created while the certificate was valid.
 
 ## Upcoming work
 
 * Root CA hardening: We should use intermediate certs rather than the root, and support chained verification.
 * Root CA configuration: We should allow users to change the roots and add their own.
 * Other timestamps: We should allow for other timestamp attestations, including attached [RFC3161](https://www.ietf.org/rfc/rfc3161.txt) signatures.
-* Better timestamp validation in Rekor: We rely on the Rekor `IntegratedTime`, which is not as verifiable as a `STH` timestamp.
 * Probably a lot more: This is very experimental.
 * More OIDC providers: Obvious.

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -340,6 +340,9 @@ func (sp *SignedPayload) VerifyBundle() (bool, error) {
 }
 
 func VerifySET(entry *models.LogEntryAnon, signature []byte, pub *ecdsa.PublicKey) error {
+	// need to take the hash over the rest
+	entry.Verification = nil
+
 	contents, err := entry.MarshalBinary()
 	if err != nil {
 		return errors.Wrap(err, "marshaling")


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

I noticed that in non-bundle, we are still using the integratedTime to check expiration without verifying rekor's signature of the signedEntryTimestamp
