### PR TITLE
Added transparency log address to warning

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -246,7 +246,7 @@ func SignCmd(ctx context.Context, so SignOpts,
 	uploadTLog := EnableExperimental()
 	if uploadTLog && !force {
 		if _, err := remote.Get(ref); err != nil {
-			fmt.Print("warning: uploading to the public transparency log for a private image, please confirm [Y/N]: ")
+			fmt.Printf("warning: uploading to the transparency log at %s for a private image, please confirm [Y/N]: ", TlogServer())
 
 			var tlogConfirmResponse string
 			if _, err := fmt.Scanln(&tlogConfirmResponse); err != nil {


### PR DESCRIPTION
### What issue does this PR address?

When pushing a signature to rekor originating from a private registry, the user gets the following warning message:

```
"warning: uploading to the public transparency log for a private image, please confirm [Y/N]: "
```

This message appears **even when you override the default public transparency log** with the `REKOR_SERVER` env. variable, which is confusing since the user is not sure which transparency log they are about to push to. 

### How does this PR address the issue?
In order to avoid this confusion, there were two potential avenues:

a) Override this check if `TlogServer() != rekorServer`
b) Display the transparency log address in the warning message

To avoid accidental pushes I decided to go with the b). Happy to switch to a) if you feel it's better. 

Signed-off-by: Paris Zoumpouloglou <pariszoump@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
