### PR TITLE
adding documentation of the usage Hashicorp Vault for both verify and sign sub-commands, used clean sub-command in USAGE.md instead of using both delete and triangulate commands

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -91,7 +91,7 @@ crane manifest $(cosign triangulate gcr.io/dlorenc-vmtest2/demo) | jq .
 Some registries support deletion too (DockerHub does not):
 
 ```shell
-$ crane delete $(cosign triangulate gcr.io/dlorenc-vmtest2/demo)
+$ crane clean gcr.io/dlorenc-vmtest2/demo
 ```
 
 ## Sign but skip upload (to store somewhere else)

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -105,6 +105,9 @@ EXAMPLES
 
   # sign a container image with a key pair stored in Google Cloud KMS
   cosign sign -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY>/versions/[VERSION] <IMAGE>
+
+  # sign a container image with a key pair stored in Hashicorp Vault
+  cosign sign -key hashivault://<KEY> <IMAGE>
   
   # sign a container in a registry which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign -key cosign.key legacy-registry.example.com/my/image

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -84,7 +84,11 @@ EXAMPLES
   cosign verify -key https://host.for/<FILE> <IMAGE>
 
   # verify image with public key stored in Google Cloud KMS
-  cosign verify -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <IMAGE>`,
+  cosign verify -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <IMAGE>
+  
+  # verify image with public key stored in Hashicorp Vault
+  cosign verify -key hashivault:///<KEY> <IMAGE>`,
+
 		FlagSet: flagset,
 		Exec:    cmd.Exec,
 	}


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

TLDR;
- used clean sub-command instead of using both delete and triangulate commands in USAGE.md
- added usage of Hashicorp Vault KMS support to the description parts of both verify and sign sub-commands

NOTE: I did the test to make sure everything is working properly, and it worked. 
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->


