### PR TITLE
signing&verifying container images based on Kubernetes Secrets

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -73,7 +73,7 @@ func (a *annotationsMap) String() string {
 func Sign() *ffcli.Command {
 	var (
 		flagset     = flag.NewFlagSet("cosign sign", flag.ExitOnError)
-		key         = flagset.String("key", "", "path to the private key file or KMS URI")
+		key         = flagset.String("key", "", "path to the private key file, KMS URI or Kubernetes Secret")
 		upload      = flagset.Bool("upload", true, "whether to upload the signature")
 		sk          = flagset.Bool("sk", false, "whether to use a hardware security key")
 		slot        = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -46,7 +46,7 @@ type VerifyCommand struct {
 
 func applyVerifyFlags(cmd *VerifyCommand, flagset *flag.FlagSet) {
 	annotations := annotationsMap{}
-	flagset.StringVar(&cmd.KeyRef, "key", "", "path to the public key file, URL, or KMS URI")
+	flagset.StringVar(&cmd.KeyRef, "key", "", "path to the public key file, URL, KMS URI or Kubernetes Secret")
 	flagset.BoolVar(&cmd.Sk, "sk", false, "whether to use a hardware security key")
 	flagset.StringVar(&cmd.Slot, "slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
 	flagset.BoolVar(&cmd.CheckClaims, "check-claims", true, "whether to check the claims found")

--- a/pkg/cosign/kubernetes/secret_test.go
+++ b/pkg/cosign/kubernetes/secret_test.go
@@ -88,16 +88,16 @@ func TestParseRef(t *testing.T) {
 	}{
 		{
 			desc:      "valid",
-			ref:       "default/cosign-secret",
+			ref:       "k8s://default/cosign-secret",
 			name:      "cosign-secret",
 			namespace: "default",
 		}, {
 			desc:      "invalid, 1 field",
-			ref:       "something",
+			ref:       "k8s://something",
 			shouldErr: true,
 		}, {
 			desc:      "invalid, more than 2 fields",
-			ref:       "yet/another/arg",
+			ref:       "k8s://yet/another/arg",
 			shouldErr: true,
 		},
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -252,7 +252,7 @@ func TestGenerateKeyPairK8s(t *testing.T) {
 	ctx := context.Background()
 	name := "cosign-secret"
 	namespace := "default"
-	if err := kubernetes.KeyPairSecret(ctx, fmt.Sprintf("%s/%s", namespace, name), cli.GetPass); err != nil {
+	if err := kubernetes.KeyPairSecret(ctx, fmt.Sprintf("k8s://%s/%s", namespace, name), cli.GetPass); err != nil {
 		t.Fatal(err)
 	}
 	// make sure the secret actually exists


### PR DESCRIPTION
Closes #347

<img width="1523" alt="Screen Shot 2021-07-01 at 00 20 54" src="https://user-images.githubusercontent.com/16693043/124034640-2925ce80-da04-11eb-87a5-da1cf545f4d4.png">

Known issues about the implementation:
* We duplicated the Kubernetes Client logics (reducing both responsibilities to a single function?)
* It's a bit hard to distinguish `namespace/name` compared to other providers (adding a new -k8s flag for signing and verifying)
* Ref priority refactoring? (File -> KMS -> K8s) - we're checking K8s `namespace/name` in first-order ever since a file exists in that path
* We bring a brand-new `loadPublicKey` function to `cli/keys.go` due to `import cycle now allowed` problem

* We haven't been checked the values of the data map of the secret whether is nil or not nil.


* Use public key as a file
```bash 
$ kubectl get secrets my-secret -ojson | jq -r '.data["cosign.pub"]' | base64 -D > /tmp/cosign.pub
$ ./cosign verify -key /tmp/cosign.pub gcr.io/$(gcloud config get-value project)/hello-world:cosign --> #OK
```

* Use public key as a K8s Secret
 ```bash
$ ./cosign verify -key tmp/cosign.pub2 gcr.io/$(gcloud config get-value project)/hello-world:cosign
error: loading public key: checking if secret exists: secrets "cosign.pub2" not found
```
<img width="1372" alt="Screen Shot 2021-07-06 at 09 20 14" src="https://user-images.githubusercontent.com/16693043/124551850-6a224680-de3b-11eb-90f8-d8ff2a29e16c.png">

![Screen Shot 2021-07-06 at 00 03 56](https://user-images.githubusercontent.com/16693043/124518068-34a33c00-ddee-11eb-8d15-2adad2c3ccce.png)
