### PR TITLE
fix for documentation of the command verify-dockerfile

### DIFF
--- a/cmd/cosign/cli/verify_dockerfile.go
+++ b/cmd/cosign/cli/verify_dockerfile.go
@@ -69,7 +69,11 @@ EXAMPLES
   cosign verify-dockerfile -key https://host.for/<FILE> <path/to/Dockerfile>
 
   # verify images with public key stored in Google Cloud KMS
-  cosign verify-dockerfile -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <path/to/Dockerfile>`,
+  cosign verify-dockerfile -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <path/to/Dockerfile>
+  
+  # verify images with public key stored in Hashicorp Vault
+  cosign verify-dockerfile -key hashivault://<KEY> <path/to/Dockerfile>`,
+
 		FlagSet: flagset,
 		Exec:    cmd.Exec,
 	}


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
