### PR TITLE
Make .sha256 file compatible with sha256sum

### DIFF
--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -38,7 +38,8 @@ jobs:
       - name: Print Info
         shell: pwsh
         run: |
-          $(Get-FileHash -Path ./${{matrix.TARGET}}).Hash | Tee-Object -Path ${{matrix.TARGET}}.sha256
+          $hash=Get-FileHash -Path ./${{matrix.TARGET}}
+          Write-Output $($hash.Hash + " " + $(([io.fileinfo]$hash.path).basename)) | Tee-Object -Path ${{matrix.TARGET}}.sha256
       - name: sign
         shell: bash
         env:


### PR DESCRIPTION
Updates the output of the CI step generating the sha256 checksum in
order to make it compatible with the `sha256sum` tool.

With this update, the checksum can be verified using:

```
$ sha256sum -c cosign-darwin-amd64.sha256
cosign-darwin-amd64: OK
```

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
