### PR TITLE
sign-blob: add option to save the signature to a file

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -108,7 +108,7 @@ EXAMPLES
 
   # sign a container image with a key pair stored in Hashicorp Vault
   cosign sign -key hashivault://<KEY> <IMAGE>
-  
+
   # sign a container in a registry which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign -key cosign.key legacy-registry.example.com/my/image
   `,

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -43,6 +43,7 @@ func SignBlob() *ffcli.Command {
 		sk      = flagset.Bool("sk", false, "whether to use a hardware security key")
 		slot    = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
 		idToken = flagset.String("identity-token", "", "[EXPERIMENTAL] identity token to use for certificate from fulcio")
+		output  = flagset.String("output", "", "write the signature to FILE")
 	)
 	return &ffcli.Command{
 		Name:       "sign-blob",
@@ -77,7 +78,7 @@ EXAMPLES
 				Slot:   *slot,
 			}
 			for _, blob := range args {
-				if _, err := SignBlobCmd(ctx, ko, blob, *b64, GetPass, *idToken); err != nil {
+				if _, err := SignBlobCmd(ctx, ko, blob, *b64, GetPass, *idToken, *output); err != nil {
 					return errors.Wrapf(err, "signing %s", blob)
 				}
 			}
@@ -92,7 +93,7 @@ type KeyOpts struct {
 	KeyRef string
 }
 
-func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, pf cosign.PassFunc, idToken string) ([]byte, error) {
+func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, pf cosign.PassFunc, idToken, output string) ([]byte, error) {
 	var payload []byte
 	var err error
 	if payloadPath == "-" {
@@ -161,12 +162,35 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, 
 		return sig, nil
 	}
 
-	if b64 {
-		sig = []byte(base64.StdEncoding.EncodeToString(sig))
-		fmt.Println(string(sig))
-	} else if _, err := os.Stdout.Write(sig); err != nil {
-		// No newline if using the raw signature
-		return nil, err
+	if output != "" {
+		f, err := os.Create(output)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		if b64 {
+			_, err = f.Write([]byte(base64.StdEncoding.EncodeToString(sig)))
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			_, err = f.Write(sig)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		fmt.Printf("Signature wrote in the file %s\n", f.Name())
+	} else {
+		if b64 {
+			sig = []byte(base64.StdEncoding.EncodeToString(sig))
+			fmt.Println(string(sig))
+		} else if _, err := os.Stdout.Write(sig); err != nil {
+			// No newline if using the raw signature
+			return nil, err
+		}
 	}
+
 	return sig, nil
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -337,7 +337,7 @@ func TestSignBlob(t *testing.T) {
 	mustErr(cli.VerifyBlobCmd(ctx, ko2, "", "badsig", blob), t)
 
 	// Now sign the blob with one key
-	sig, err := cli.SignBlobCmd(ctx, cli.KeyOpts{KeyRef: privKeyPath1}, bp, true, passFunc, "")
+	sig, err := cli.SignBlobCmd(ctx, cli.KeyOpts{KeyRef: privKeyPath1}, bp, true, passFunc, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds an option to save the signature to a file when using the `cosign sign-blob` this will be helpful in the release pipeline.

/assign @dlorenc 