### PR TITLE
update cloudbuild and goreleaser to build cosign also with piv-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+.DS_STORE
 *.exe
 *.exe~
 *.dll
@@ -24,4 +25,4 @@
 *fuzz.a
 
 bin*
-release/cosign.pub
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,90 @@
+project_name: cosign
+
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=1
+
 builds:
-  - skip: true
+- id: cosign-linux
+  binary: cosign_{{ .Target }}
+  main: ./cmd/cosign
+  goos:
+    - linux
+  goarch:
+    - amd64
+  tags:
+    - pivkey
+  ldflags:
+    - "{{ .Env.LDFLAGS }}"
+  hooks:
+    pre:
+      - apt-get update
+      - apt-get -y install libpcsclite-dev
+  env:
+    - PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/"
+
+- id: cosign-darwin-amd64
+  binary: cosign_{{ .Target }}
+  env:
+    - CC=o64-clang
+    - CXX=o64-clang++
+  main: ./cmd/cosign
+  goos:
+    - darwin
+  goarch:
+    - amd64
+  ldflags:
+    - "{{ .Env.LDFLAGS }}"
+  tags:
+    - pivkey
+
+- id: cosign-darwin-arm64
+  binary: cosign_{{ .Target }}
+  env:
+    - CC=aarch64-apple-darwin20.2-clang
+    - CXX=aarch64-apple-darwin20.2-clang++
+  main: ./cmd/cosign
+  goos:
+    - darwin
+  goarch:
+    - arm64
+  tags:
+    - pivkey
+  ldflags:
+    - "{{.Env.LDFLAGS}}"
+
+- id: cosign-windows-x64
+  binary: cosign_{{.Target}}
+  env:
+    - CC=x86_64-w64-mingw32-gcc
+    - CXX=x86_64-w64-mingw32-g++
+  main: ./cmd/cosign
+  goos:
+    - windows
+  goarch:
+    - amd64
+  ldflags:
+    - -buildmode=exe
+    - "{{ .Env.LDFLAGS }}"
+  tags:
+    - pivkey
+
+signs:
+  - id: cosign
+    signature: "${artifact}.sig"
+    cmd: ./dist/cosign-linux_linux_amd64/cosign_linux_amd64
+    args: ["sign-blob", "-output", "${artifact}.sig", "-key", "./.github/workflows/cosign.key", "${artifact}"]
+    artifacts: binary
+    stdin: "{{ .Env.COSIGN_PASSWORD }}"
+
+archives:
+- format: binary
+
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+
+snapshot:
+  name_template: SNAPSHOT-{{.ShortCommit}}
 
 release:
   prerelease: true # remove this when we start publishin non-prerelease or set to auto
@@ -10,7 +95,4 @@ release:
     ### Thanks for all contributors!
 
   extra_files:
-      - glob: "cosign-*"
-      - glob: "cosign-*.sig"
-      - glob: "*.sha256"
-      - glob: "./.github/workflows/cosign.pub"
+    - glob: "./.github/workflows/cosign.pub"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright 2021 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.16.5 as build
+
+WORKDIR /go/src/cosign
+ADD . /go/src/cosign
+
+RUN make cosign
+
+FROM gcr.io/distroless/base:debug
+
+COPY --from=build /go/src/cosign/cosign /bin/
+
+ENTRYPOINT [ "/bin/cosign" ]

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,47 +32,8 @@ steps:
     echo "Checking out ${_TOOL_REF}"
     git checkout ${_TOOL_REF}
 
-# maybe use gcr.io/cloud-builders/go when it have go1.16
-- name: gcr.io/k8s-staging-releng/releng-ci:latest-go1.16
-  dir: "go/src/sigstore/cosign"
-  entrypoint: "bash"
-  env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
-  - PROJECT_ID=${PROJECT_ID}
-  - GIT_VERSION=${_GIT_TAG}
-  secretEnv:
-  - COSIGN_PASSWORD
-  args:
-  - '-c'
-  - |
-    make cross
-
-    mv cosign-windows-amd64 cosign-windows-amd64.exe
-    mv cosign-windows-amd64.sha256 cosign-windows-amd64.exe.sha256
-
-    ./cosign-linux-amd64 sign-blob -key ./.github/workflows/cosign.key cosign-linux-amd64 > cosign-linux-amd64.sig
-    ./cosign-linux-amd64 sign-blob -key ./.github/workflows/cosign.key cosign-darwin-amd64 > cosign-darwin-amd64.sig
-    ./cosign-linux-amd64 sign-blob -key ./.github/workflows/cosign.key cosign-windows-amd64.exe > cosign-windows-amd64.exe.sig
-
-    ./cosign-linux-amd64 verify-blob -key ./.github/workflows/cosign.pub -signature cosign-linux-amd64.sig cosign-linux-amd64
-    ./cosign-linux-amd64 verify-blob -key ./.github/workflows/cosign.pub -signature cosign-darwin-amd64.sig cosign-darwin-amd64
-    ./cosign-linux-amd64 verify-blob -key ./.github/workflows/cosign.pub -signature cosign-windows-amd64.exe.sig cosign-windows-amd64.exe
-
-    curl -L https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_Linux_x86_64.tar.gz | tar xzf - ko
-    chmod +x ./ko
-    mv ko /usr/local/bin/
-
-    # copy the just build cosign to use here
-    chmod +x ./cosign-linux-amd64
-    cp cosign-linux-amd64 /usr/local/bin/cosign
-
-    export KO_DOCKER_REPO=gcr.io/${PROJECT_ID}/cosign
-    export GIT_TAG=${_GIT_TAG}
-    make sign-container-cloudbuild
-
-# Create github release.
-- name: goreleaser/goreleaser
+# maybe we can build our own image and use that to be more in a safe side
+- name: ghcr.io/gythialy/golang-cross:v1.16.5@sha256:5874d76072f0d434b4328c77977f1a9fb9bf28b21f083cf1b9a53ec497656128
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -80,11 +41,28 @@ steps:
   - "GOBIN=/workspace/bin"
   secretEnv:
   - GITHUB_TOKEN
+  - COSIGN_PASSWORD
   args:
     - '-c'
     - |
       git tag ${_GIT_TAG}
-      goreleaser release
+      make release
+
+- name: gcr.io/cloud-builders/docker
+  entrypoint: "bash"
+  dir: "go/src/sigstore/cosign"
+  env:
+  - GIT_TAG=${_GIT_TAG}
+  - PROJECT_ID=${PROJECT_ID}
+  args:
+  - '-c'
+  - |
+    apt-get update
+    apt-get install libpcsclite-dev -y
+    cp ./dist/cosign-linux_linux_amd64/cosign_linux_amd64 /usr/local/bin/cosign
+    make sign-container-cloudbuild
+  secretEnv:
+  - COSIGN_PASSWORD
 
 availableSecrets:
   secretManager:
@@ -97,9 +75,8 @@ artifacts:
   objects:
     location: 'gs://${_STORAGE_LOCATION}/${_GIT_TAG}'
     paths:
-    - "go/src/sigstore/cosign/cosign-*"
-    - "go/src/sigstore/cosign/*.sha256"
-    - "go/src/sigstore/cosign/cosign-*.sig"
+    - "go/src/sigstore/cosign/dist/*/cosign*"
+    - "go/src/sigstore/cosign/.github/workflows/cosign.pub"
 
 options:
   machineType: E2_HIGHCPU_8


### PR DESCRIPTION
This PR updates the cloudbuild that will be used for the release process

- use goreleaser to build and do the cross compile and enable the piv-tool commands
- Add dockerfile to build the cosign image, due the limitation of `ko` to not support multiple ldflags at this moment


Tested in my fork repo: https://github.com/cpanato/cosign/releases/tag/v99.99.99
and image available for testing here: `gcr.io/cpanato-general/cosign:v99.99.99-1`
