### PR TITLE
typo fix in usage.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -91,7 +91,7 @@ crane manifest $(cosign triangulate gcr.io/dlorenc-vmtest2/demo) | jq .
 Some registries support deletion too (DockerHub does not):
 
 ```shell
-$ crane clean gcr.io/dlorenc-vmtest2/demo
+$ cosign clean gcr.io/dlorenc-vmtest2/demo
 ```
 
 ## Sign but skip upload (to store somewhere else)


### PR DESCRIPTION
I think cosign was intended here. `crane clean` does not exist

Signed-off-by: Russell Brown <rjbrown57@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
