### PR TITLE
Add AWS KMS Support

### DIFF
--- a/KMS.md
+++ b/KMS.md
@@ -1,16 +1,16 @@
 # KMS Integrations
 
 This page contains detailed instructions on how to configure `cosign` to work with KMS providers.
-Right now `cosign` supports Vault and GCP KMS, but are hoping to support more in the future!
+Right now `cosign` supports Hashicorp Vault, AWS KMS, and GCP KMS, and we are hoping to support more in the future!
 
 ## Basic Usage
 
 When referring to a key managed by a KMS provider, `cosign` takes a [go-cloud](https://gocloud.dev) style URI to refer to the specific provider.
 For example:
 
-`gcpkms://` or `hashivault://`
+`gcpkms://`, `awskms://`, or `hashivault://`
 
-The URI path sytnax is provider specific and explained in the section for each provider.
+The URI path syntax is provider specific and explained in the section for each provider.
 
 ### Key Generation and Management
 
@@ -60,6 +60,40 @@ $ cosign verify -key kms.pub gcr.io/dlorenc-vmtest2/demo
 ### Providers
 
 This section contains the provider-specific documentation.
+
+
+### AWS
+
+AWS KMS keys can be used in `cosign` for signing and verification.
+The URI format for AWS KMS is:
+
+`awskms://$ENDPOINT/$KEYID`
+
+where ENDPOINT and KEYID are replaced with the correct values.
+
+The ENDPOINT value is left blank in most scenerios, but can be set for testing with KMS-compatible servers such as [localstack](https://localstack.cloud/).
+If omiting a custom endpoint, it is mandatory to prefix the URI with `awskms:///` (with three slashes).
+
+If a custom endpoint is used, you may disable TLS verification by setting an environment variable: `AWS_TLS_INSECURE_SKIP_VERIFY=1`.
+
+AWS credentials are provided using standard configuration as [described in AWS docs](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
+
+The KEYID value must conform to any [AWS KMS key identifier](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#key-id)
+format as described in the linked document (Key ARN, Key ID, Alias ARN, or Alias ID).
+
+Note that key creation is not supported by cosign if using the Key ARN or Key ID formats, so it is recommended to use [Key Aliases](https://docs.aws.amazon.com/kms/latest/developerguide/kms-alias.html)
+for most situations.
+
+The following URIs are valid:
+
+- Key ID: `awskms:///1234abcd-12ab-34cd-56ef-1234567890ab`
+- Key ID with endpoint: `awskms://localhost:4566/1234abcd-12ab-34cd-56ef-1234567890ab`
+- Key ARN: `awskms:///arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`
+- Key ARN with endpoint: `awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab`
+- Alias name: `awskms:///alias/ExampleAlias`
+- Alias name with endpoint: `awskms://localhost:4566/alias/ExampleAlias`
+- Alias ARN: `awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias`
+- Alias ARN with endpoint: `awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias`
 
 ### GCP
 

--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ The proposed mechanism is flexible enough to support signing arbitrary things.
 ### KMS Support
 
 `cosign` supports using a KMS provider to generate and sign keys.
-Right now cosign supports Vault and GCP KMS, but are hoping to support more in the future!
+Right now cosign supports Hashicorp Vault, AWS KMS, and GCP KMS, and we are hoping to support more in the future!
 
 See the [KMS docs](KMS.md) for more details.
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/prometheus/common v0.29.0 // indirect
 	github.com/sigstore/fulcio v0.0.0-20210705024150-f64f6358e3a8
 	github.com/sigstore/rekor v0.2.1-0.20210705133645-dbbbff597bc2
-	github.com/sigstore/sigstore v0.0.0-20210708111253-ff2f2ab801d2
+	github.com/sigstore/sigstore v0.0.0-20210709190449-2ab5ec881a5f
 	github.com/stretchr/testify v1.7.0
 	github.com/theupdateframework/go-tuf v0.0.0-20210630170422-22a94818d17b
 	go.mongodb.org/mongo-driver v1.5.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -191,6 +191,7 @@ github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/aws/aws-sdk-go v1.38.35 h1:7AlAO0FC+8nFjxiGKEmq0QLpiA8/XFr6eIxgRTwkdTg=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
@@ -819,7 +820,9 @@ github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSn
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -1183,8 +1186,8 @@ github.com/sigstore/rekor v0.1.1/go.mod h1:b+T8TvGKWgaFbtPRQgF/gXjbj/R9HdJ5lA93c
 github.com/sigstore/rekor v0.2.1-0.20210705133645-dbbbff597bc2 h1:wV5rxZPXoEpjmTrJE8DPTdHd9yrRfe4KV8Ggu3GGtMk=
 github.com/sigstore/rekor v0.2.1-0.20210705133645-dbbbff597bc2/go.mod h1:R2IbR1/nrCB9TKZGxPlTtoq2LDLvZYJsoO+V4cQyAPg=
 github.com/sigstore/sigstore v0.0.0-20210415112811-cb2061113e4a/go.mod h1:EoLIp5JbrCE2VZqdCCIemNEdNYiOcdwF0igIvorqo1o=
-github.com/sigstore/sigstore v0.0.0-20210708111253-ff2f2ab801d2 h1:mansPA67Z+qqRv1iadEJulQJKPGw+EyPrtLpqSYB+cc=
-github.com/sigstore/sigstore v0.0.0-20210708111253-ff2f2ab801d2/go.mod h1:1grnVUDnR8Y8e24D7pW0D6fn2y3/93PnuAj5qVViph4=
+github.com/sigstore/sigstore v0.0.0-20210709190449-2ab5ec881a5f h1:z9KsF6DqYLaznxzIwAb7Oplp07L8Z/2zeVsOLI5XfZo=
+github.com/sigstore/sigstore v0.0.0-20210709190449-2ab5ec881a5f/go.mod h1:6zV4pS+mANwsLqrQBQn5IEf7+Vo1aNPiM3CkoydYn9U=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=


### PR DESCRIPTION
This bumps the sigstore dep to include https://github.com/sigstore/sigstore/pull/74 and adds documentation.

Signed-off-by: Cody Soyland <cody.soyland@solarwinds.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
