### PR TITLE
Fix/verify dockerfile parser

### DIFF
--- a/cmd/cosign/cli/verify_dockerfile.go
+++ b/cmd/cosign/cli/verify_dockerfile.go
@@ -122,10 +122,15 @@ func getImagesFromDockerfile(dockerfile io.Reader) ([]string, error) {
 }
 
 func getImageFromLine(line string) string {
-	line = strings.TrimPrefix(line, "FROM")     // Remove "FROM" prefix
-	line = os.ExpandEnv(line)                   // Substitute templated vars
-	line = strings.ReplaceAll(line, "as", "AS") // replace lower "as" with "AS"
-	line = strings.Split(line, " AS ")[0]       // Remove the "AS" portion of line
+	line = strings.TrimPrefix(line, "FROM") // Remove "FROM" prefix
+	line = os.ExpandEnv(line)               // Substitute templated vars
 	fields := strings.Fields(line)
+	for i := len(fields) - 1; i > 0; i-- {
+		// Remove the "AS" portion of line
+		if strings.EqualFold(fields[i], "AS") {
+			fields = fields[:i]
+			break
+		}
+	}
 	return fields[len(fields)-1] // The image should be the last portion of the line that remains
 }

--- a/cmd/cosign/cli/verify_dockerfile.go
+++ b/cmd/cosign/cli/verify_dockerfile.go
@@ -122,9 +122,10 @@ func getImagesFromDockerfile(dockerfile io.Reader) ([]string, error) {
 }
 
 func getImageFromLine(line string) string {
-	line = strings.TrimPrefix(line, "FROM") // Remove "FROM" prefix
-	line = os.ExpandEnv(line)               // Substitute templated vars
-	line = strings.Split(line, " AS ")[0]   // Remove the "AS" portion of line
+	line = strings.TrimPrefix(line, "FROM")     // Remove "FROM" prefix
+	line = os.ExpandEnv(line)                   // Substitute templated vars
+	line = strings.ReplaceAll(line, "as", "AS") // replace lower "as" with "AS"
+	line = strings.Split(line, " AS ")[0]       // Remove the "AS" portion of line
 	fields := strings.Fields(line)
 	return fields[len(fields)-1] // The image should be the last portion of the line that remains
 }

--- a/cmd/cosign/cli/verify_dockerfile_test.go
+++ b/cmd/cosign/cli/verify_dockerfile_test.go
@@ -39,8 +39,8 @@ func TestGetImagesFromDockerfile(t *testing.T) {
 		},
 		{
 			name:         "tag with as",
-			fileContents: `FROM golang:1.16.5 as build`,
-			expected:     []string{"gcr.io/test/image:latest"},
+			fileContents: `FROM gcr.io/test/image:1.16.5 as build`,
+			expected:     []string{"gcr.io/test/image:1.16.5"},
 		},
 		{
 			name:         "digest",

--- a/cmd/cosign/cli/verify_dockerfile_test.go
+++ b/cmd/cosign/cli/verify_dockerfile_test.go
@@ -38,6 +38,11 @@ func TestGetImagesFromDockerfile(t *testing.T) {
 			expected:     []string{"gcr.io/test/image:latest"},
 		},
 		{
+			name:         "tag with as",
+			fileContents: `FROM golang:1.16.5 as build`,
+			expected:     []string{"gcr.io/test/image:latest"},
+		},
+		{
 			name:         "digest",
 			fileContents: `FROM gcr.io/test/image@sha256:d131624e6f5d8695e9aea7a0439f7bac0fcc50051282e0c3d4d627cab8845ba5`,
 			expected:     []string{"gcr.io/test/image@sha256:d131624e6f5d8695e9aea7a0439f7bac0fcc50051282e0c3d4d627cab8845ba5"},


### PR DESCRIPTION
Fixes #430 

Parser now replace the `as` keyword to `AS` before moving into the splitting function. 

> _`AS` is the one of the special keywords that we allowed the write-in lowercase._