### PR TITLE
pivkey: Change default slot to Signature (9c)

### DIFF
--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -40,7 +40,7 @@ func PublicKey() *ffcli.Command {
 		flagset = flag.NewFlagSet("cosign public-key", flag.ExitOnError)
 		key     = flagset.String("key", "", "path to the private key file, public key URL, or KMS URI")
 		sk      = flagset.Bool("sk", false, "whether to use a hardware security key")
-		slot    = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
+		slot    = flagset.String("slot", "", "security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
 		outFile = flagset.String("outfile", "", "file to write public key")
 	)
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -78,7 +78,7 @@ func Sign() *ffcli.Command {
 		key         = flagset.String("key", "", "path to the private key file, KMS URI or Kubernetes Secret")
 		upload      = flagset.Bool("upload", true, "whether to upload the signature")
 		sk          = flagset.Bool("sk", false, "whether to use a hardware security key")
-		slot        = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
+		slot        = flagset.String("slot", "", "security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
 		payloadPath = flagset.String("payload", "", "path to a payload file to use rather than generating one.")
 		force       = flagset.Bool("f", false, "skip warnings and confirmations")
 		recursive   = flagset.Bool("r", false, "if a multi-arch image is specified, additionally sign each discrete image")

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -43,7 +43,7 @@ func SignBlob() *ffcli.Command {
 		key     = flagset.String("key", "", "path to the private key file or a KMS URI")
 		b64     = flagset.Bool("b64", true, "whether to base64 encode the output")
 		sk      = flagset.Bool("sk", false, "whether to use a hardware security key")
-		slot    = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
+		slot    = flagset.String("slot", "", "security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
 		idToken = flagset.String("identity-token", "", "[EXPERIMENTAL] identity token to use for certificate from fulcio")
 		output  = flagset.String("output", "", "write the signature to FILE")
 	)

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -49,7 +49,7 @@ func applyVerifyFlags(cmd *VerifyCommand, flagset *flag.FlagSet) {
 	annotations := annotationsMap{}
 	flagset.StringVar(&cmd.KeyRef, "key", "", "path to the public key file, URL, KMS URI or Kubernetes Secret")
 	flagset.BoolVar(&cmd.Sk, "sk", false, "whether to use a hardware security key")
-	flagset.StringVar(&cmd.Slot, "slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
+	flagset.StringVar(&cmd.Slot, "slot", "", "security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
 	flagset.BoolVar(&cmd.CheckClaims, "check-claims", true, "whether to check the claims found")
 	flagset.StringVar(&cmd.Output, "output", "json", "output the signing image information. Default JSON.")
 

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -45,7 +45,7 @@ func VerifyBlob() *ffcli.Command {
 		flagset   = flag.NewFlagSet("cosign verify-blob", flag.ExitOnError)
 		key       = flagset.String("key", "", "path to the public key file, URL, or KMS URI")
 		sk        = flagset.Bool("sk", false, "whether to use a hardware security key")
-		slot      = flagset.String("slot", "", "security key slot to use for generated key (authentication|signature|card-authentication|key-management)")
+		slot      = flagset.String("slot", "", "security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
 		cert      = flagset.String("cert", "", "path to the public certificate")
 		signature = flagset.String("signature", "", "path to the signature")
 	)

--- a/pkg/cosign/pivkey/util.go
+++ b/pkg/cosign/pivkey/util.go
@@ -24,7 +24,7 @@ import (
 func SlotForName(slotName string) *piv.Slot {
 	switch slotName {
 	case "":
-		return &piv.SlotAuthentication
+		return &piv.SlotSignature
 	case "authentication":
 		return &piv.SlotAuthentication
 	case "signature":


### PR DESCRIPTION
Previously, the default slot was Authentication (9a) which is intended to be used
for authentication with SSH or similar systems. In the context of cosign, it makes
more sense to default to the Signature slot which is intended for use with message
and code signing.

Signed-off-by: James Alseth <james@jalseth.me>
