### PR TITLE
cmd/sign: Add `-cert` flag

### DIFF
--- a/cmd/cosign/cli/pivcli/commands.go
+++ b/cmd/cosign/cli/pivcli/commands.go
@@ -160,22 +160,17 @@ func (a *Attestations) Output() {
 }
 
 func AttestationCmd(_ context.Context, slotArg string) (*Attestations, error) {
-	slot := pivkey.SlotForName(slotArg)
-	if slot == nil {
-		return nil, flag.ErrHelp
-	}
-
-	yk, err := pivkey.GetKey()
+	yk, err := pivkey.GetKeyWithSlot(slotArg)
 	if err != nil {
 		return nil, err
 	}
 	defer yk.Close()
-	deviceCert, err := yk.AttestationCertificate()
+	deviceCert, err := yk.GetAttestationCertificate()
 	if err != nil {
 		return nil, err
 	}
 
-	keyCert, err := yk.Attest(*slot)
+	keyCert, err := yk.Attest()
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -228,12 +228,17 @@ func SignCmd(ctx context.Context, so SignOpts,
 	var cert, chain string
 	switch {
 	case so.Sk:
-		sk, err := pivkey.NewSignerVerifier(so.Slot)
+		sk, err := pivkey.GetKeyWithSlot(so.Slot)
 		if err != nil {
 			return err
 		}
-		signer = sk
-		dupeDetector = sk
+		defer sk.Close()
+		skSigner, err := sk.SignerVerifier()
+		if err != nil {
+			return err
+		}
+		signer = skSigner
+		dupeDetector = skSigner
 	case so.KeyRef != "":
 		k, err := signerVerifierFromKeyRef(ctx, so.KeyRef, so.Pf)
 		if err != nil {

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -118,9 +118,14 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, 
 		}
 		signer = k
 	case ko.Sk:
-		k, err := pivkey.NewSignerVerifier(ko.Slot)
+		sk, err := pivkey.GetKeyWithSlot(ko.Slot)
 		if err != nil {
-			return nil, err
+			return nil, errors.Wrap(err, "opening piv token")
+		}
+		defer sk.Close()
+		k, err := sk.SignerVerifier()
+		if err != nil {
+			return nil, errors.Wrap(err, "initializing signer on piv token")
 		}
 		signer = k
 	default:

--- a/cmd/cosign/cli/sign_test.go
+++ b/cmd/cosign/cli/sign_test.go
@@ -34,7 +34,7 @@ func TestSignCmdLocalKeyAndSk(t *testing.T) {
 			Sk:     true,
 		},
 	} {
-		err := SignCmd(ctx, so, "", false, "", false, false)
+		err := SignCmd(ctx, so, "", "", false, "", false, false)
 		if (errors.Is(err, &KeyParseError{}) == false) {
 			t.Fatal("expected KeyParseError")
 		}

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -133,9 +133,14 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 			return errors.Wrap(err, "loading public key")
 		}
 	} else if c.Sk {
-		pubKey, err = pivkey.NewPublicKeyProvider(c.Slot)
+		sk, err := pivkey.GetKeyWithSlot(c.Slot)
 		if err != nil {
-			return errors.Wrap(err, "initializing security key")
+			return errors.Wrap(err, "opening piv token")
+		}
+		defer sk.Close()
+		pubKey, err = sk.Verifier()
+		if err != nil {
+			return errors.Wrap(err, "initializing piv token verifier")
 		}
 	}
 	co.SigVerifier = pubKey

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -112,7 +112,12 @@ func VerifyBlobCmd(ctx context.Context, ko KeyOpts, certRef, sigRef, blobRef str
 			return errors.Wrap(err, "loading public key")
 		}
 	case ko.Sk:
-		pubKey, err = pivkey.NewPublicKeyProvider(ko.Slot)
+		sk, err := pivkey.GetKeyWithSlot(ko.Slot)
+		if err != nil {
+			return errors.Wrap(err, "opening piv token")
+		}
+		defer sk.Close()
+		pubKey, err = sk.Verifier()
 		if err != nil {
 			return errors.Wrap(err, "loading public key from token")
 		}

--- a/pkg/cosign/pivkey/disabled.go
+++ b/pkg/cosign/pivkey/disabled.go
@@ -23,7 +23,9 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-type empty struct{}
+// The empty struct is used so this file never imports piv-go which is
+// dependent on cgo and will fail to build if imported.
+type empty struct{} //nolint
 
 type Key struct{}
 
@@ -69,7 +71,7 @@ func (k *Key) Unblock(puk, newPIN string) error {
 	return errors.New("unimplemented")
 }
 
-func (k *Key) GenerateKey(mgmtKey [24]byte, slot *empty, opts *empty) (*empty, error) {
+func (k *Key) GenerateKey(mgmtKey [24]byte, slot *empty, opts *empty) (*empty, error) { //nolint
 	return nil, errors.New("unimplemented")
 }
 

--- a/pkg/cosign/pivkey/disabled.go
+++ b/pkg/cosign/pivkey/disabled.go
@@ -17,42 +17,70 @@
 package pivkey
 
 import (
-	"context"
-	"crypto"
+	"crypto/x509"
 	"errors"
-	"io"
 
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-func NewPublicKeyProvider(slotName string) (signature.Verifier, error) {
+type empty struct{}
+
+type Key struct{}
+
+func GetKey() (*Key, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func NewSigner() (signature.Signer, error) {
+func GetKeyWithSlot(slot string) (*Key, error) {
 	return nil, errors.New("unimplemented")
 }
 
-type PIVSigner struct {
-	Priv crypto.PrivateKey
-	Pub  crypto.PrivateKey
-	signature.ECDSAVerifier
-}
+func (k *Key) Close() {}
 
-func (ps *PIVSigner) Sign(ctx context.Context, rawPayload []byte) ([]byte, []byte, error) {
-	return nil, nil, errors.New("unimplemented")
-}
+func (k *Key) Authenticate(pin string) {}
 
-func (ps *PIVSigner) SignMessage(rawPayload io.Reader, opts ...signature.SignOption) ([]byte, error) {
+func (k *Key) SetSlot(slot string) {}
+
+func (k *Key) Attest() (*x509.Certificate, error) {
 	return nil, errors.New("unimplemented")
 }
 
-func (ps *PIVSigner) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+func (k *Key) GetAttestationCertificate() (*x509.Certificate, error) {
 	return nil, errors.New("unimplemented")
 }
 
-var _ signature.Signer = &PIVSigner{}
+func (k *Key) SetManagementKey(old, new [24]byte) error {
+	return errors.New("unimplemented")
+}
 
-func NewSignerVerifier(slotName string) (signature.SignerVerifier, error) {
+func (k *Key) SetPIN(old, new string) error {
+	return errors.New("unimplemented")
+}
+
+func (k *Key) SetPUK(old, new string) error {
+	return errors.New("unimplemented")
+}
+
+func (k *Key) Reset() error {
+	return errors.New("unimplemented")
+}
+
+func (k *Key) Unblock(puk, newPIN string) error {
+	return errors.New("unimplemented")
+}
+
+func (k *Key) GenerateKey(mgmtKey [24]byte, slot *empty, opts *empty) (*empty, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (k *Key) Verifier() (signature.Verifier, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (k *Key) Certificate() (*x509.Certificate, error) {
+	return nil, errors.New("unimplemented")
+}
+
+func (k *Key) SignerVerifier() (signature.SignerVerifier, error) {
 	return nil, errors.New("unimplemented")
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -89,7 +89,7 @@ func TestSignVerify(t *testing.T) {
 
 	// Now sign the image
 	so := cli.SignOpts{KeyRef: privKeyPath, Pf: passFunc}
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 
 	// Now verify and download should work!
 	must(verify(pubKeyPath, imgName, true, nil), t)
@@ -100,7 +100,7 @@ func TestSignVerify(t *testing.T) {
 
 	// Sign the image with an annotation
 	so.Annotations = map[string]interface{}{"foo": "bar"}
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 
 	// It should match this time.
 	must(verify(pubKeyPath, imgName, true, map[string]interface{}{"foo": "bar"}), t)
@@ -124,7 +124,7 @@ func TestSignVerifyClean(t *testing.T) {
 
 	// Now sign the image
 	so := cli.SignOpts{KeyRef: privKeyPath, Pf: passFunc}
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 
 	// Now verify and download should work!
 	must(verify(pubKeyPath, imgName, true, nil), t)
@@ -162,7 +162,7 @@ func TestBundle(t *testing.T) {
 	}
 
 	// Sign the image
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 	// Make sure verify works
 	must(verify(pubKeyPath, imgName, true, nil), t)
 
@@ -191,14 +191,14 @@ func TestDuplicateSign(t *testing.T) {
 
 	// Now sign the image
 	so := cli.SignOpts{KeyRef: privKeyPath, Pf: passFunc}
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 
 	// Now verify and download should work!
 	must(verify(pubKeyPath, imgName, true, nil), t)
 	must(download.SignatureCmd(ctx, imgName), t)
 
 	// Signing again should work just fine...
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 	// but a duplicate signature should not be a uploaded
 	sigRepo, err := cli.TargetRepositoryForImage(ref)
 	if err != nil {
@@ -292,14 +292,14 @@ func TestMultipleSignatures(t *testing.T) {
 
 	// Now sign the image with one key
 	so := cli.SignOpts{KeyRef: priv1, Pf: passFunc}
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 	// Now verify should work with that one, but not the other
 	must(verify(pub1, imgName, true, nil), t)
 	mustErr(verify(pub2, imgName, true, nil), t)
 
 	// Now sign with the other key too
 	so.KeyRef = priv2
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 
 	// Now verify should work with both
 	must(verify(pub1, imgName, true, nil), t)
@@ -595,7 +595,7 @@ func TestTlog(t *testing.T) {
 		KeyRef: privKeyPath,
 		Pf:     passFunc,
 	}
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 
 	// Now verify should work!
 	must(verify(pubKeyPath, imgName, true, nil), t)
@@ -607,7 +607,7 @@ func TestTlog(t *testing.T) {
 	mustErr(verify(pubKeyPath, imgName, true, nil), t)
 
 	// Sign again with the tlog env var on
-	must(cli.SignCmd(ctx, so, imgName, true, "", false, false), t)
+	must(cli.SignCmd(ctx, so, imgName, "", true, "", false, false), t)
 	// And now verify works!
 	must(verify(pubKeyPath, imgName, true, nil), t)
 }


### PR DESCRIPTION
The `-cert` flag allows for the certificate to be included in the
Signature object when signing with `-key` or `-sk`. Adding this
certificate ensures that a verifying party does not need to fetch the
certificate from some unknown location before being able to validate the
identity of the actor that created the signature.

---

This also includes a refactor of the `pivkey` library to make it more idiomatic and to resolve an issue where calling `NewPublicKeyProvider` or `NewSignerVerifier` would lock the PIV token until the program had exited, making future calls to the PIV token outside of the signer/verifier flow impossible.