### PR TITLE
Update sigtore dependency to include Azure KMS

### DIFF
--- a/cmd/cosign/cli/generate_key_pair.go
+++ b/cmd/cosign/cli/generate_key_pair.go
@@ -53,9 +53,15 @@ EXAMPLES:
   # generate key-pair and write to cosign.key and cosign.pub files
   cosign generate-key-pair
 
+  # generate a key-pair in Azure Key Vault
+  cosign generate-key-pair -kms azurekms://[VAULT_NAME][VAULT_URI]/[KEY]
+
+  # generate a key-pair in AWS KMS
+  cosign generate-key-pair -kms awskms://[ENDPOINT]/[ID/ALIAS/ARN]
+
   # generate a key-pair in Google Cloud KMS
   cosign generate-key-pair -kms gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]
-  
+
   # generate a key-pair in Hashicorp Vault
   cosign generate-key-pair -kms hashivault://[KEY]
 

--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -58,11 +58,17 @@ EXAMPLES
   # extract public key from URL.
   cosign public-key -key https://host.for/<FILE> -outfile <OUTPUT>
 
-  # extract public key from Google Cloud KMS key pair
-  cosign public-key -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY>
+  # extract public key from Azure Key Vault
+  cosign public-key -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY]
 
-  # extract public key from Hashicorp Vault KMS key pair
-  cosign public-key -key hashivault://<KEY>`,
+  # extract public key from AWS KMS
+  cosign public-key -key awskms://[ENDPOINT]/[ID/ALIAS/ARN]
+
+  # extract public key from Google Cloud KMS
+  cosign public-key -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]
+
+  # extract public key from Hashicorp Vault KMS
+  cosign public-key -key hashivault://[KEY]`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -105,11 +105,17 @@ EXAMPLES
   # sign a container image and add annotations
   cosign sign -key cosign.key -a key1=value1 -a key2=value2 <IMAGE>
 
+  # sign a container image with a key pair stored in Azure Key Vault
+  cosign sign -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <IMAGE>
+
+  # sign a container image with a key pair stored in AWS KMS
+  cosign sign -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <IMAGE>
+
   # sign a container image with a key pair stored in Google Cloud KMS
-  cosign sign -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY>/versions/[VERSION] <IMAGE>
+  cosign sign -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]/versions/[VERSION] <IMAGE>
 
   # sign a container image with a key pair stored in Hashicorp Vault
-  cosign sign -key hashivault://<KEY> <IMAGE>
+  cosign sign -key hashivault://[KEY] <IMAGE>
 
   # sign a container in a registry which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign -key cosign.key legacy-registry.example.com/my/image

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -60,8 +60,17 @@ EXAMPLES
   # sign a blob with a local key pair file
   cosign sign-blob -key cosign.key <FILE>
 
+  # sign a blob with a key pair stored in Azure Key Vault
+  cosign sign-blob -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <FILE>
+
+  # sign a blob with a key pair stored in AWS KMS
+  cosign sign-blob -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <FILE>
+
   # sign a blob with a key pair stored in Google Cloud KMS
-  cosign sign-blob -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <FILE>`,
+  cosign sign-blob -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <FILE>
+
+  # sign a blob with a key pair stored in Hashicorp Vault
+  cosign sign-blob -key hashivault://[KEY] <FILE>`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
 			// A key file is required unless we're in experimental mode!

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -61,17 +61,26 @@ The signature may be specified as a path to a file or a base64 encoded string.
 The blob may be specified as a path to a file or - for stdin.
 
 EXAMPLES
-	# Verify a simple blob and message
-	cosign verify-blob -key cosign.pub -signature sig msg
+  # Verify a simple blob and message
+  cosign verify-blob -key cosign.pub -signature sig msg
 
-	# Verify a signature from an environment variable
-	cosign verify-blob -key cosign.pub -signature $sig msg
+  # Verify a signature from an environment variable
+  cosign verify-blob -key cosign.pub -signature $sig msg
 
-	# Verify a signature against a payload from another process using process redirection
-	cosign verify-blob -key cosign.pub -signature $sig <(git rev-parse HEAD)
+  # Verify a signature against a payload from another process using process redirection
+  cosign verify-blob -key cosign.pub -signature $sig <(git rev-parse HEAD)
 
-	# Verify a signature against a KMS reference
-	cosign verify-blob -key gcpkms://projects/<PROJECT ID>/locations/<LOCATION>/keyRings/<KEYRING>/cryptoKeys/<KEY> -signature $sig <blob>`,
+  # Verify a signature against Azure Key Vault
+  cosign verify-blob -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] -signature $sig <blob>
+
+  # Verify a signature against AWS KMS
+  cosign verify-blob -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] -signature $sig <blob>
+
+  # Verify a signature against Google Cloud KMS
+  cosign verify-blob -key gcpkms://projects/[PROJECT ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY] -signature $sig <blob>
+
+  # Verify a signature against Hashicorp Vault
+  cosign verify-blob -key hashivault://[KEY] -signature $sig <blob>`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) != 1 {

--- a/cmd/cosign/cli/verify_dockerfile.go
+++ b/cmd/cosign/cli/verify_dockerfile.go
@@ -68,11 +68,17 @@ EXAMPLES
   # verify images with public key provided by URL
   cosign verify-dockerfile -key https://host.for/<FILE> <path/to/Dockerfile>
 
+  # verify images with public key stored in Azure Key Vault
+  cosign verify-dockerfile -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <path/to/Dockerfile>
+
+  # verify images with public key stored in AWS KMS
+  cosign verify-dockerfile -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <path/to/Dockerfile>
+
   # verify images with public key stored in Google Cloud KMS
-  cosign verify-dockerfile -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <path/to/Dockerfile>
-  
+  cosign verify-dockerfile -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <path/to/Dockerfile>
+
   # verify images with public key stored in Hashicorp Vault
-  cosign verify-dockerfile -key hashivault://<KEY> <path/to/Dockerfile>`,
+  cosign verify-dockerfile -key hashivault://[KEY] <path/to/Dockerfile>`,
 
 		FlagSet: flagset,
 		Exec:    cmd.Exec,

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sigstore/fulcio v0.0.0-20210714122808-6d21ab53f962
 	github.com/sigstore/rekor v0.2.1-0.20210714185543-38d532d5c0b1
-	github.com/sigstore/sigstore v0.0.0-20210714122742-a9aeb218f4d1
+	github.com/sigstore/sigstore v0.0.0-20210718202323-1c1454ffa6b3
 	github.com/stretchr/testify v1.7.0
 	github.com/theupdateframework/go-tuf v0.0.0-20210630170422-22a94818d17b
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/Azure/azure-sdk-for-go v29.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v30.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v51.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v54.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v55.0.0+incompatible h1:L4/vUGbg1Xkw5L20LZD+hJI5I+ibWSytqQ68lTCfLwY=
+github.com/Azure/azure-sdk-for-go v55.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-service-bus-go v0.9.1/go.mod h1:yzBx6/BUGfjfeqbRZny9AQIbIe3AcV9WZbAdpkoXOa0=
 github.com/Azure/azure-service-bus-go v0.10.11/go.mod h1:AWw9eTTWZVZyvgpPahD1ybz3a8/vT3GsJDS8KYex55U=
 github.com/Azure/azure-storage-blob-go v0.8.0/go.mod h1:lPI3aLPpuLTeUwh1sViKXFxwl2B6teiRqI0deQUvsw0=
@@ -86,8 +88,9 @@ github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSW
 github.com/Azure/go-autorest/autorest v0.11.3/go.mod h1:JFgpikqFJ/MleTTxwepExTKnFUKKszPS8UavbQYUMuw=
 github.com/Azure/go-autorest/autorest v0.11.12/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
 github.com/Azure/go-autorest/autorest v0.11.17/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
-github.com/Azure/go-autorest/autorest v0.11.18 h1:90Y4srNYrwOtAgVo3ndrQkTYn6kf1Eg/AjTFJ8Is2aM=
 github.com/Azure/go-autorest/autorest v0.11.18/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
+github.com/Azure/go-autorest/autorest v0.11.19 h1:7/IqD2fEYVha1EPeaiytVKhzmPV223pfkRIQUGOK2IE=
+github.com/Azure/go-autorest/autorest v0.11.19/go.mod h1:dSiJPy22c3u0OtOKDNttNgqpNFY/GeWa7GH/Pz56QRA=
 github.com/Azure/go-autorest/autorest/adal v0.9.0/go.mod h1:/c022QCutn2P7uY+/oQWWNcK9YU+MH96NgK+jErpbcg=
 github.com/Azure/go-autorest/autorest/adal v0.9.2/go.mod h1:/3SMAM86bP6wC9Ev35peQDUeqFZBMH07vvUOmg4z/fE=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
@@ -95,13 +98,18 @@ github.com/Azure/go-autorest/autorest/adal v0.9.11/go.mod h1:nBKAnTomx8gDtl+3ZCJ
 github.com/Azure/go-autorest/autorest/adal v0.9.13 h1:Mp5hbtOePIzM8pJVRa3YLrWWmZtoxRXqUEzCfJt3+/Q=
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/azure/auth v0.5.7/go.mod h1:AkzUsqkrdmNhfP2i54HqINVQopw0CLDnvHpJ88Zz1eI=
+github.com/Azure/go-autorest/autorest/azure/auth v0.5.8 h1:TzPg6B6fTZ0G1zBf3T54aI7p3cAT6u//TOXGPmFMOXg=
+github.com/Azure/go-autorest/autorest/azure/auth v0.5.8/go.mod h1:kxyKZTSfKh8OVFWPAgOgQ/frrJgeYQJPyR5fLFmXko4=
+github.com/Azure/go-autorest/autorest/azure/cli v0.4.2 h1:dMOmEJfkLKW/7JsokJqkyoYSgmR08hi9KrhjZb+JALY=
 github.com/Azure/go-autorest/autorest/azure/cli v0.4.2/go.mod h1:7qkJkT+j6b+hIpzMOwPChJhTqS8VbsqqgULzMNRugoM=
 github.com/Azure/go-autorest/autorest/date v0.3.0 h1:7gUk1U5M/CQbp9WoqinNzJar+8KY+LPI6wiWrP/myHw=
 github.com/Azure/go-autorest/autorest/date v0.3.0/go.mod h1:BI0uouVdmngYNUzGWeSYnokU+TrmwEsOqdt8Y6sso74=
 github.com/Azure/go-autorest/autorest/mocks v0.4.0/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1 h1:K0laFcLE6VLTOwNgSxaGbUcLPuGXlNkbVvq4cW4nIHk=
 github.com/Azure/go-autorest/autorest/mocks v0.4.1/go.mod h1:LTp+uSrOhSkaKrUy935gNZuuIPPVsHlr9DSOxSayd+k=
+github.com/Azure/go-autorest/autorest/to v0.4.0 h1:oXVqrxakqqV1UZdSazDOPOLvOIz+XA683u8EctwboHk=
 github.com/Azure/go-autorest/autorest/to v0.4.0/go.mod h1:fE8iZBn7LQR7zH/9XU2NcPR4o9jEImooCeWJcYV/zLE=
+github.com/Azure/go-autorest/autorest/validation v0.3.1 h1:AgyqjAd94fwNAoTjl/WQXg4VvFeRFpO+UhNyRXqF1ac=
 github.com/Azure/go-autorest/autorest/validation v0.3.1/go.mod h1:yhLgjC0Wda5DYXl6JAsWyUe4KVNffhoDhG0zVzUMo3E=
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+ZtXWSmf4Tg=
@@ -296,6 +304,7 @@ github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mz
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
 github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017 h1:2HQmlpI3yI9deH18Q6xiSOIjXD4sLI55Y/gfpa8/558=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -1113,8 +1122,8 @@ github.com/sigstore/fulcio v0.0.0-20210714122808-6d21ab53f962/go.mod h1:FZL7iVdW
 github.com/sigstore/rekor v0.2.1-0.20210714185543-38d532d5c0b1 h1:oSxPcSsScZwrurlM+FjMs+lbjdE/I42WdGy+jV0lO88=
 github.com/sigstore/rekor v0.2.1-0.20210714185543-38d532d5c0b1/go.mod h1:cL9B3+/gp3BG+/bhkSHBA3MQZMten5xM6BhJYd5b5zU=
 github.com/sigstore/sigstore v0.0.0-20210713222344-1fee53516622/go.mod h1:aOSeNrlcHsfUD8Q1hwWd8KloNqBnxEZlu4k47cFg5rg=
-github.com/sigstore/sigstore v0.0.0-20210714122742-a9aeb218f4d1 h1:idJ0BRQWE0v2gA2DztL5XP2Yp6uyIj8JgN/qSQjK5uU=
-github.com/sigstore/sigstore v0.0.0-20210714122742-a9aeb218f4d1/go.mod h1:aOSeNrlcHsfUD8Q1hwWd8KloNqBnxEZlu4k47cFg5rg=
+github.com/sigstore/sigstore v0.0.0-20210718202323-1c1454ffa6b3 h1:ElH4+bzuVhIRosDDPMb/4Sb7G7igabnwbB4KSSe3CKc=
+github.com/sigstore/sigstore v0.0.0-20210718202323-1c1454ffa6b3/go.mod h1:2Hh18S8hM7eZUbmKhMtfD0udPhDozwmdNPN+xunFnt4=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -1360,6 +1369,7 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210616213533-5ff15b29337e/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97 h1:/UOmuWzQfxxo9UtlXMwuQU8CMgg1eZXqTRwkSQJWKOI=
 golang.org/x/crypto v0.0.0-20210711020723-a769d52b0f97/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=


### PR DESCRIPTION
- update sigstore dependency to include Azure KMS
- Add AWS/Azure/Vault in the help for each command and format the text to make similar to each other



