### PR TITLE
Reduce some of the noise in e2e tests by hiding the SBOM output unles…

### DIFF
--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 
@@ -42,13 +43,13 @@ func SBOM() *ffcli.Command {
 			if len(args) != 1 {
 				return flag.ErrHelp
 			}
-			_, err := SBOMCmd(ctx, args[0])
+			_, err := SBOMCmd(ctx, args[0], os.Stdout)
 			return err
 		},
 	}
 }
 
-func SBOMCmd(ctx context.Context, imageRef string) ([]string, error) {
+func SBOMCmd(ctx context.Context, imageRef string, out io.Writer) ([]string, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return nil, err
@@ -87,7 +88,7 @@ func SBOMCmd(ctx context.Context, imageRef string) ([]string, error) {
 			return nil, err
 		}
 		sboms = append(sboms, string(sbom))
-		fmt.Println(string(sbom))
+		fmt.Fprintln(out, string(sbom))
 	}
 	return sboms, nil
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -539,18 +539,22 @@ func TestAttachSBOM(t *testing.T) {
 	img, _, cleanup := mkimage(t, imgName)
 	defer cleanup()
 
-	_, err := download.SBOMCmd(ctx, img.Name())
+	out := bytes.Buffer{}
+	_, err := download.SBOMCmd(ctx, img.Name(), &out)
 	if err == nil {
 		t.Fatal("Expected error")
 	}
+	t.Log(out)
+	out.Reset()
 
 	// Upload it!
 	must(attach.SBOMCmd(ctx, "./testdata/bom-go-mod.spdx", "spdx", imgName), t)
 
-	sboms, err := download.SBOMCmd(ctx, imgName)
+	sboms, err := download.SBOMCmd(ctx, imgName, &out)
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log(out)
 	if len(sboms) != 1 {
 		t.Fatalf("Expected one sbom, got %d", len(sboms))
 	}


### PR DESCRIPTION
…s the test fails.

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
