### PR TITLE
Fix USAGE.md link

### DIFF
--- a/specs/SIGNATURE_SPEC.md
+++ b/specs/SIGNATURE_SPEC.md
@@ -122,7 +122,7 @@ Gyp4apdU7AXEwysEQIb034aPrTlpmxh90SnTZFs2DHOvCjCPPAmoWfuQUwPhSPRb
       - The `logIndex` is the index of the log entry in the transparency log
       - The `logID` is the SHA256 hash of the DER-encoded public key for the log at the time the entry was included in the log
 
-For instructions on using the `bundle` for verification, see [USAGE.md](USAGE.md).
+For instructions on using the `bundle` for verification, see [USAGE.md](../USAGE.md#verify-a-signature-was-added-to-the-transparency-log).
 
 ## Storage
 


### PR DESCRIPTION
USAGE.md isn't under the spec/ directory, it's up one level
in the repo root.

Also linking directly to 'Verify a signature was added to the
transparency log'.

Signed-off-by: Tom Hennen <tomhennen@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
