### PR TITLE
release: update builder container to use go 1.16.6

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
     git checkout ${_TOOL_REF}
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.16.5@sha256:5874d76072f0d434b4328c77977f1a9fb9bf28b21f083cf1b9a53ec497656128
+- name: ghcr.io/gythialy/golang-cross:v1.16.6@sha256:a31f3981571aab561bfdc2c50bf25142f2460a47c35e76ae9d50826e3a1aabac
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION
Update the go builder container for the release pipeline to use go1.16.6

PR in the source that upgrade Go: https://github.com/gythialy/golang-cross/pull/13

the release of the image: https://github.com/gythialy/golang-cross/releases/tag/v1.16.6
