### PR TITLE
Add a policy-init using TUF metadata and Fulcio signers

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -124,6 +124,7 @@ func New() *cobra.Command {
 
 	// Add sub-commands.
 	addPublicKey(cmd)
+	addPolicyInit(cmd)
 	addGenerate(cmd)
 	addSign(cmd)
 	addSignBlob(cmd)

--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -124,7 +124,7 @@ func New() *cobra.Command {
 
 	// Add sub-commands.
 	addPublicKey(cmd)
-	addPolicyInit(cmd)
+	addPolicy(cmd)
 	addGenerate(cmd)
 	addSign(cmd)
 	addSignBlob(cmd)

--- a/cmd/cosign/cli/options/policy.go
+++ b/cmd/cosign/cli/options/policy.go
@@ -1,0 +1,45 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// PolicyInitOptions is the top level wrapper for the policy-init command.
+type PolicyInitOptions struct {
+	ImageRef    string
+	Maintainers []string
+	Threshold   int
+	OutFile     string
+}
+
+var _ Interface = (*PolicyInitOptions)(nil)
+
+// AddFlags implements Interface
+func (o *PolicyInitOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.ImageRef, "namespace", "ns",
+		"registry namespace that the root policy belongs to")
+
+	cmd.Flags().StringVar(&o.OutFile, "out", "o",
+		"output policy locally")
+
+	cmd.Flags().IntVar(&o.Threshold, "threshold", 1,
+		"threshold for root policy signers")
+
+	cmd.Flags().StringSliceVarP(&o.Maintainers, "maintainers", "m", nil,
+		"list of maintainers to add to the root policy")
+}

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -35,16 +35,25 @@ func validEmail(email string) bool {
 	return err == nil
 }
 
-func addPolicyInit(topLevel *cobra.Command) {
+func addPolicy(topLevel *cobra.Command) {
 	o := &options.PolicyInitOptions{}
 
-	cmd := &cobra.Command{
-		Use:   "policy-init",
+	policyCmd := &cobra.Command{
+		Use:   "policy",
+		Short: "subcommand to manage a keyless policy.",
+		Long:  "policy is used to manage a root.json policy\nfor keyless signing delegation. This is used to establish a policy for a registry namespace,\na signing threshold and a list of maintainers who can sign over the body section.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	initCmd := &cobra.Command{
+		Use:   "init",
 		Short: "generate a new keyless policy.",
-		Long:  "policy-init is used to generate a root.json policy\nfor keyless signing delegation. This is used to establish a policy for a registry namespace,\na signing threshold and a list of maintainers who can sign over the body section.",
+		Long:  "init is used to generate a root.json policy\nfor keyless signing delegation. This is used to establish a policy for a registry namespace,\na signing threshold and a list of maintainers who can sign over the body section.",
 		Example: `
   # extract public key from private key to a specified out file.
-  cosign policy-init -ns <project_namespace> --maintainers {email_addresses} --threshold <int> --expires <int>(days)`,
+  cosign policy init -ns <project_namespace> --maintainers {email_addresses} --threshold <int> --expires <int>(days)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var publicKeys []*tuf.Key
 
@@ -55,6 +64,7 @@ func addPolicyInit(topLevel *cobra.Command) {
 				if !validEmail(email) {
 					panic(fmt.Sprintf("Invalid email format: %s", email))
 				} else {
+					// Currently no issuer is set: this would need to be set by the initializer.
 					key := tuf.FulcioVerificationKey(strings.TrimSpace(email), "")
 					publicKeys = append(publicKeys, key)
 				}
@@ -110,6 +120,7 @@ func addPolicyInit(topLevel *cobra.Command) {
 		},
 	}
 
-	o.AddFlags(cmd)
-	topLevel.AddCommand(cmd)
+	o.AddFlags(initCmd)
+	policyCmd.AddCommand(initCmd)
+	topLevel.AddCommand(policyCmd)
 }

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -74,50 +74,6 @@ func addPolicyInit(topLevel *cobra.Command) {
 			root.Roles["root"] = role
 			root.Namespace = o.ImageRef
 
-			// Current user may sign the body of the root.json and add the signatures.
-			/*
-					rootMeta, err := root.
-					if err != nil {
-						return err
-					}
-
-
-				fulcioSigner, err := ctuf.GenerateFulcioSigner(ctx, "")
-				if err != nil {
-					return err
-				}
-				rootSig, err := fulcioSigner.Sign(rand.Reader, rootMeta.Signed, crypto.Hash(0))
-				if err != nil {
-					return errors.Wrap(err, "Error occurred while during artifact signing")
-				}
-				certStr, _ := json.Marshal(fulcioSigner.Cert())
-				for _, id := range fulcioSigner.IDs() {
-					if err := r.AddOrUpdateSignature("root.json", data.Signature{
-						KeyID:     id,
-						Signature: rootSig,
-						Cert:      string(certStr)}); err != nil {
-						return err
-					}
-				}
-
-				// Send to rekor
-				fmt.Println("Sending policy to transparency log")
-				rekorClient, err := rekorClient.GetRekorClient(TlogServer())
-				if err != nil {
-					return err
-				}
-				entry, err := cosign.UploadTLog(rekorClient, rootSig, rootMeta.Signed, []byte(fulcioSigner.Cert()))
-				if err != nil {
-					return err
-				}
-				fmt.Println("tlog entry created with index:", *entry.LogIndex)
-
-				meta, err := local.GetMeta()
-				if err != nil {
-					return err
-				}
-			*/
-
 			policy, err := root.Marshal()
 			if err != nil {
 				return err

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -1,0 +1,153 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/mail"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/pkg/cosign/tuf"
+	"github.com/spf13/cobra"
+)
+
+func validEmail(email string) bool {
+	_, err := mail.ParseAddress(email)
+	return err == nil
+}
+
+func addPolicyInit(topLevel *cobra.Command) {
+	o := &options.PolicyInitOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "policy-init",
+		Short: "generate a new keyless policy.",
+		Long:  "policy-init is used to generate a root.json policy\nfor keyless signing delegation. This is used to establish a policy for a registry namespace,\na signing threshold and a list of maintainers who can sign over the body section.",
+		Example: `
+  # extract public key from private key to a specified out file.
+  cosign policy-init -ns <project_namespace> --maintainers {email_addresses} --threshold <int> --expires <int>(days)`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var publicKeys []*tuf.Key
+
+			// Process the list of maintainers by
+			// 1. Ensure each entry is a correctly formatted email address
+			// 2. If 1 is true, then remove surplus whitespace (caused by gaps between commas)
+			for _, email := range o.Maintainers {
+				if !validEmail(email) {
+					panic(fmt.Sprintf("Invalid email format: %s", email))
+				} else {
+					key := tuf.FulcioVerificationKey(strings.TrimSpace(email), "")
+					publicKeys = append(publicKeys, key)
+				}
+			}
+
+			// Create a new root.
+			root := tuf.NewRoot()
+
+			// Add the maintainer identities to the root's trusted keys.
+			for _, key := range publicKeys {
+				root.AddKey(key)
+			}
+
+			// Set root keys, threshold, and namespace.
+			role, ok := root.Roles["root"]
+			if !ok {
+				role = &tuf.Role{KeyIDs: []string{}, Threshold: 1}
+			}
+			role.AddKeysWithThreshold(publicKeys, o.Threshold)
+			root.Roles["root"] = role
+			root.Namespace = o.ImageRef
+
+			// Current user may sign the body of the root.json and add the signatures.
+			/*
+					rootMeta, err := root.
+					if err != nil {
+						return err
+					}
+
+
+				fulcioSigner, err := ctuf.GenerateFulcioSigner(ctx, "")
+				if err != nil {
+					return err
+				}
+				rootSig, err := fulcioSigner.Sign(rand.Reader, rootMeta.Signed, crypto.Hash(0))
+				if err != nil {
+					return errors.Wrap(err, "Error occurred while during artifact signing")
+				}
+				certStr, _ := json.Marshal(fulcioSigner.Cert())
+				for _, id := range fulcioSigner.IDs() {
+					if err := r.AddOrUpdateSignature("root.json", data.Signature{
+						KeyID:     id,
+						Signature: rootSig,
+						Cert:      string(certStr)}); err != nil {
+						return err
+					}
+				}
+
+				// Send to rekor
+				fmt.Println("Sending policy to transparency log")
+				rekorClient, err := rekorClient.GetRekorClient(TlogServer())
+				if err != nil {
+					return err
+				}
+				entry, err := cosign.UploadTLog(rekorClient, rootSig, rootMeta.Signed, []byte(fulcioSigner.Cert()))
+				if err != nil {
+					return err
+				}
+				fmt.Println("tlog entry created with index:", *entry.LogIndex)
+
+				meta, err := local.GetMeta()
+				if err != nil {
+					return err
+				}
+			*/
+
+			policy, err := root.Marshal()
+			if err != nil {
+				return err
+			}
+			policyFile, err := policy.JsonMarshal("", "\t")
+			if err != nil {
+				return err
+			}
+
+			if o.OutFile != "" {
+				err = ioutil.WriteFile(o.OutFile, policyFile, 0600)
+				if err != nil {
+					return errors.Wrapf(err, "error writing to root.json")
+				}
+			}
+
+			/*
+				files := []cremote.File{
+					{Path: *outFile},
+				}
+
+				if err := upload.BlobCmd(ctx, files, "", *imageRef+"/root.json"); err != nil {
+					return err
+				}
+			*/
+
+			return nil
+		},
+	}
+
+	o.AddFlags(cmd)
+	topLevel.AddCommand(cmd)
+}

--- a/cmd/cosign/cli/policy_init_test.go
+++ b/cmd/cosign/cli/policy_init_test.go
@@ -13,32 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tuf
+package cli
 
 import (
-	"encoding/json"
+	"testing"
 )
 
-const (
-	KeyTypeFulcio   = "sigstore-oidc"
-	KeySchemeFulcio = "https://fulcio.sigstore.dev"
-)
+// Tests correctly formatted emails do not fail validEmail call
+// Tests incorrectly formatted emails do not pass validEmail call
+func TestEmailValid(t *testing.T) {
+	goodEmail := "foo@foo.com"
+	strongBadEmail := "foofoocom"
 
-var (
-	KeyAlgorithms = []string{"sha256", "sha512"}
-)
-
-type FulcioKeyVal struct {
-	Identity string `json:"identity"`
-	Issuer   string `json:"issuer"`
-}
-
-func FulcioVerificationKey(email string, issuer string) *Key {
-	keyValBytes, _ := json.Marshal(FulcioKeyVal{Identity: email, Issuer: issuer})
-	return &Key{
-		Type:       KeyTypeFulcio,
-		Scheme:     KeySchemeFulcio,
-		Algorithms: KeyAlgorithms,
-		Value:      keyValBytes,
+	if !validEmail(goodEmail) {
+		t.Errorf("correct email %s, failed valid check", goodEmail)
+	} else if validEmail(strongBadEmail) {
+		t.Errorf("bad email %s, passed valid check", strongBadEmail)
 	}
 }

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -49,7 +49,7 @@ func main() {
 	// escape the remaining args to let them be passed to cobra.
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
-		case "public-key", "generate-key-pair",
+		case "public-key", "policy-init", "generate-key-pair",
 			"generate", "sign", "sign-blob",
 			"attest", "copy", "clean",
 			"version":

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -49,7 +49,7 @@ func main() {
 	// escape the remaining args to let them be passed to cobra.
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
-		case "public-key", "policy-init", "generate-key-pair",
+		case "public-key", "policy", "generate-key-pair",
 			"generate", "sign", "sign-blob",
 			"attest", "copy", "clean",
 			"version":

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.1.0
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/cobra v1.2.1
+	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613
 	github.com/urfave/cli v1.22.5 // indirect
 	go.opentelemetry.io/contrib v0.22.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.9.0 // indirect

--- a/pkg/cosign/tuf/policy.go
+++ b/pkg/cosign/tuf/policy.go
@@ -131,7 +131,7 @@ func (r *Root) Marshal() (*Signed, error) {
 	return &Signed{Signed: b}, nil
 }
 
-func (s *Signed) JsonMarshal(prefix, indent string) ([]byte, error) {
+func (s *Signed) JSONMarshal(prefix, indent string) ([]byte, error) {
 	b, err := cjson.Marshal(s)
 	if err != nil {
 		return []byte{}, err

--- a/pkg/cosign/tuf/policy.go
+++ b/pkg/cosign/tuf/policy.go
@@ -124,6 +124,7 @@ func (r *Role) AddKeysWithThreshold(keys []*Key, threshold int) bool {
 }
 
 func (r *Root) Marshal() (*Signed, error) {
+	// Marshals the Root into a Signed type
 	b, err := cjson.Marshal(r)
 	if err != nil {
 		return nil, err
@@ -132,6 +133,7 @@ func (r *Root) Marshal() (*Signed, error) {
 }
 
 func (s *Signed) JSONMarshal(prefix, indent string) ([]byte, error) {
+	// Marshals Signed with prefix and indent.
 	b, err := cjson.Marshal(s)
 	if err != nil {
 		return []byte{}, err

--- a/pkg/cosign/tuf/policy.go
+++ b/pkg/cosign/tuf/policy.go
@@ -1,0 +1,146 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains root policy definitions.
+// Eventually, this will move this to go-tuf definitions.
+
+package tuf
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"time"
+
+	cjson "github.com/tent/canonical-json-go"
+)
+
+type Signed struct {
+	Signed     json.RawMessage `json:"signed"`
+	Signatures []Signature     `json:"signatures"`
+}
+
+type Signature struct {
+	KeyID     string `json:"keyid"`
+	Signature string `json:"sig"`
+	Cert      string `json:"cert,omitempty"`
+}
+
+type Key struct {
+	Type       string          `json:"keytype"`
+	Scheme     string          `json:"scheme"`
+	Algorithms []string        `json:"keyid_hash_algorithms,omitempty"`
+	Value      json.RawMessage `json:"keyval"`
+
+	id     string
+	idOnce sync.Once
+}
+
+func (k *Key) ID() string {
+	k.idOnce.Do(func() {
+		data, _ := cjson.Marshal(k)
+		digest := sha256.Sum256(data)
+		k.id = hex.EncodeToString(digest[:])
+	})
+	return k.id
+}
+
+func (k *Key) ContainsID(id string) bool {
+	return id == k.ID()
+}
+
+type Root struct {
+	Type        string           `json:"_type"`
+	SpecVersion string           `json:"spec_version"`
+	Version     int              `json:"version"`
+	Expires     time.Time        `json:"expires"`
+	Keys        map[string]*Key  `json:"keys"`
+	Roles       map[string]*Role `json:"roles"`
+	Namespace   string           `json:"namespace"`
+
+	ConsistentSnapshot bool `json:"consistent_snapshot"`
+}
+
+func DefaultExpires(role string) time.Time {
+	// Default expires in 3 months
+	return time.Now().AddDate(0, 3, 0).UTC().Round(time.Second)
+}
+
+func NewRoot() *Root {
+	return &Root{
+		Type:               "root",
+		SpecVersion:        "1.0",
+		Version:            1,
+		Expires:            DefaultExpires("root"),
+		Keys:               make(map[string]*Key),
+		Roles:              make(map[string]*Role),
+		ConsistentSnapshot: true,
+	}
+}
+
+func (r *Root) AddKey(key *Key) bool {
+	changed := false
+	if _, ok := r.Keys[key.ID()]; !ok {
+		changed = true
+		r.Keys[key.ID()] = key
+	}
+
+	return changed
+}
+
+type Role struct {
+	KeyIDs    []string `json:"keyids"`
+	Threshold int      `json:"threshold"`
+}
+
+func (r *Role) AddKeysWithThreshold(keys []*Key, threshold int) bool {
+	roleIDs := make(map[string]struct{})
+	for _, id := range r.KeyIDs {
+		roleIDs[id] = struct{}{}
+	}
+	changed := false
+	for _, key := range keys {
+		if _, ok := roleIDs[key.ID()]; !ok {
+			changed = true
+			r.KeyIDs = append(r.KeyIDs, key.ID())
+		}
+	}
+	r.Threshold = threshold
+	return changed
+}
+
+func (r *Root) Marshal() (*Signed, error) {
+	b, err := cjson.Marshal(r)
+	if err != nil {
+		return nil, err
+	}
+	return &Signed{Signed: b}, nil
+}
+
+func (s *Signed) JsonMarshal(prefix, indent string) ([]byte, error) {
+	b, err := cjson.Marshal(s)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	var out bytes.Buffer
+	if err := json.Indent(&out, b, prefix, indent); err != nil {
+		return []byte{}, err
+	}
+
+	return out.Bytes(), nil
+}

--- a/pkg/cosign/tuf/policy_test.go
+++ b/pkg/cosign/tuf/policy_test.go
@@ -1,0 +1,71 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Contains root policy definitions.
+// Eventually, this will move this to go-tuf definitions.
+
+package tuf
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAddKey(t *testing.T) {
+	root := NewRoot()
+	publicKey := FulcioVerificationKey("test@rekor.dev", "")
+	if !root.AddKey(publicKey) {
+		t.Errorf("Adding new key failed")
+	}
+	if _, ok := root.Keys[publicKey.ID()]; !ok {
+		t.Errorf("Error adding public key")
+	}
+	// Add duplicate key.
+	if root.AddKey(publicKey) {
+		t.Errorf("Duplicate key should not add to dictionary")
+	}
+	if len(root.Keys) != 1 {
+		t.Errorf("Root keys should contain exactly one key.")
+	}
+}
+
+func TestRootRole(t *testing.T) {
+	root := NewRoot()
+	publicKey := FulcioVerificationKey("test@rekor.dev", "")
+	role := &Role{KeyIDs: []string{}, Threshold: 1}
+	role.AddKeysWithThreshold([]*Key{publicKey}, 2)
+	root.Roles["root"] = role
+	policy, err := root.Marshal()
+	if err != nil {
+		t.Errorf("Error marshalling root policy")
+	}
+	newRoot := Root{}
+	if err := json.Unmarshal(policy.Signed, &newRoot); err != nil {
+		t.Errorf("Error marshalling root policy")
+	}
+	rootRole, ok := newRoot.Roles["root"]
+	if !ok {
+		t.Errorf("Missing root role")
+	}
+	if len(rootRole.KeyIDs) != 1 {
+		t.Errorf("Missing root key ID")
+	}
+	if rootRole.KeyIDs[0] != publicKey.ID() {
+		t.Errorf("Bad root role key ID")
+	}
+	if rootRole.Threshold != 2 {
+		t.Errorf("Threshold incorrect")
+	}
+}

--- a/pkg/cosign/tuf/signer.go
+++ b/pkg/cosign/tuf/signer.go
@@ -57,28 +57,6 @@ type FulcioSigner struct {
 	issuer   string
 }
 
-/*
-func GenerateFulcioSigner(ctx context.Context, idToken string) (*FulcioSigner, error) {
-	k, err := fulcio.NewSigner(ctx, idToken)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting key from Fulcio")
-	}
-	certs, err := cosign.LoadCerts(k.Cert)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting Fulcio certificate")
-	}
-
-	return &FulcioSigner{
-		Signer:        k,
-		ids:           []string{certs[0].EmailAddresses[0]},
-		cert:          k.Cert,
-		keyType:       KeyTypeFulcio,
-		keyScheme:     KeySchemeFulcio,
-		keyAlgorithms: data.KeyAlgorithms,
-	}, nil
-}
-*/
-
 func (s *FulcioSigner) PublicData() *Key {
 	return FulcioVerificationKey(s.identity, s.issuer)
 }

--- a/pkg/cosign/tuf/signer.go
+++ b/pkg/cosign/tuf/signer.go
@@ -1,0 +1,131 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuf
+
+import (
+	"bytes"
+	"crypto"
+	"encoding/json"
+	"io"
+
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+const (
+	KeyTypeFulcio   = "sigstore-oidc"
+	KeySchemeFulcio = "https://fulcio.sigstore.dev"
+)
+
+var (
+	KeyAlgorithms = []string{"sha256", "sha512"}
+)
+
+type FulcioKeyVal struct {
+	Identity string `json:"identity"`
+	Issuer   string `json:"issuer"`
+}
+
+func FulcioVerificationKey(email string, issuer string) *Key {
+	keyValBytes, _ := json.Marshal(FulcioKeyVal{Identity: email, Issuer: issuer})
+	return &Key{
+		Type:       KeyTypeFulcio,
+		Scheme:     KeySchemeFulcio,
+		Algorithms: KeyAlgorithms,
+		Value:      keyValBytes,
+	}
+}
+
+// Implements Fulcio signer
+type FulcioSigner struct {
+	signature.Signer
+
+	cert     string
+	identity string
+	issuer   string
+}
+
+/*
+func GenerateFulcioSigner(ctx context.Context, idToken string) (*FulcioSigner, error) {
+	k, err := fulcio.NewSigner(ctx, idToken)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting key from Fulcio")
+	}
+	certs, err := cosign.LoadCerts(k.Cert)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting Fulcio certificate")
+	}
+
+	return &FulcioSigner{
+		Signer:        k,
+		ids:           []string{certs[0].EmailAddresses[0]},
+		cert:          k.Cert,
+		keyType:       KeyTypeFulcio,
+		keyScheme:     KeySchemeFulcio,
+		keyAlgorithms: data.KeyAlgorithms,
+	}, nil
+}
+*/
+
+func (s *FulcioSigner) PublicData() *Key {
+	return FulcioVerificationKey(s.identity, s.issuer)
+}
+
+func (s *FulcioSigner) Type() string {
+	return KeyTypeFulcio
+}
+
+func (s *FulcioSigner) Scheme() string {
+	return KeySchemeFulcio
+}
+
+func (s *FulcioSigner) Cert() string {
+	// PEM encoded, new lines escaped
+	return s.cert
+}
+
+func (s *FulcioSigner) Public() crypto.PublicKey {
+	pk, _ := s.Signer.PublicKey()
+	return pk
+}
+
+func (s *FulcioSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) (signature []byte, err error) {
+	return s.Signer.SignMessage(bytes.NewReader(digest))
+}
+
+func Sign(s *Signed, key *FulcioSigner) (*Signed, error) {
+	// Check if valid key
+	publicKey := FulcioVerificationKey(key.identity, key.issuer)
+
+	// Sign
+	sig, err := key.SignMessage(bytes.NewReader(s.Signed))
+	if err != nil {
+		return nil, err
+	}
+
+	// Add or update signature.
+	signatures := make([]Signature, 0, len(s.Signatures)+1)
+	for _, signature := range s.Signatures {
+		if publicKey.ID() != signature.KeyID {
+			signatures = append(signatures, signature)
+		}
+	}
+	signatures = append(signatures, Signature{KeyID: publicKey.ID(),
+		Cert:      key.cert,
+		Signature: string(sig)})
+	s.Signatures = signatures
+
+	return s, nil
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Hoping to iterate on this. This only initializes the root policy. We need to:
* Add the sign command
* Add ISSUER information to trust?

Replaces/uses code from
- https://github.com/sigstore/cosign/pull/366
- https://github.com/sigstore/cosign/pull/407


Current usage:
`./cosign policy-init --namespace gcr.io/asra-ali/busybox --maintainers asraa@google.com,lukehinds@redhat.com --threshold 2 --out root.json`

```
./cosign policy-init --namespace gcr.io/asra-ali/busybox --maintainers asraa@google.com,lukehinds@redhat.com --threshold 2 --out root.json
Uploading file from [root.json] to [gcr.io/asra-ali/busybox/root.json:latest] with media type [text/plain]
File [root.json] is available directly at [gcr.io/v2/asra-ali/busybox/root.json/blobs/sha256:973a21f41a3884b9f40e70df6bfdd19b04c3ddcbd8935b82a09fd9bdac2ed8c8]
Uploaded image to:
gcr.io/asra-ali/busybox/root.json@sha256:6e6251e7f656c207e265d0629e9cf9d1fb9539b12f3505ceebb90bf16be9befc
```

The output file is (currently unsigned)
```
{
  "signatures": null,
  "signed": {
    "_type": "root",
    "consistent_snapshot": true,
    "expires": "2021-12-29T19:48:52Z",
    "keys": {
      "94e61dba379a148be37639c8bf7ece0087df6dd59733d0a3fd21da7ad1a0ac29": {
        "keyid_hash_algorithms": [
          "sha256",
          "sha512"
        ],
        "keytype": "sigstore-oidc",
        "keyval": {
          "identity": "lukehinds@redhat.com",
          "issuer": ""
        },
        "scheme": "https://fulcio.sigstore.dev"
      },
      "d9e0fe253edc4349d26dcdac691dad02c142be05e959b11577d151551c34ab8c": {
        "keyid_hash_algorithms": [
          "sha256",
          "sha512"
        ],
        "keytype": "sigstore-oidc",
        "keyval": {
          "identity": "asraa@google.com",
          "issuer": ""
        },
        "scheme": "https://fulcio.sigstore.dev"
      }
    },
    "namespace": "gcr.io/asra-ali/busybox",
    "roles": {
      "root": {
        "keyids": [
          "d9e0fe253edc4349d26dcdac691dad02c142be05e959b11577d151551c34ab8c",
          "94e61dba379a148be37639c8bf7ece0087df6dd59733d0a3fd21da7ad1a0ac29"
        ],
        "threshold": 2
      }
    },
    "spec_version": "1.0",
    "version": 1
  }
}

```