### PR TITLE
fixing verify-dockerfile command in such cases that arg instruction comes before the from instruction

### DIFF
--- a/cmd/cosign/cli/verify_dockerfile_test.go
+++ b/cmd/cosign/cli/verify_dockerfile_test.go
@@ -53,6 +53,12 @@ func TestGetImagesFromDockerfile(t *testing.T) {
 			expected:     []string{"gcr.io/fancy/test/image"},
 		},
 		{
+			name: "arg-before-from",
+			fileContents: `ARG IMAGE=gcr.io/fancy/test/image
+			FROM $IMAGE AS fancy`,
+			expected: []string{"gcr.io/fancy/test/image"},
+		},
+		{
 			name: "multistage",
 			fileContents: `FROM build_image_1
 			RUN script1


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

Fixes #435 

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
