### PR TITLE
Avoid remote.Gets when the ref contains a digest

### DIFF
--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -53,6 +53,9 @@ func CleanCmd(ctx context.Context, imageRef string) error {
 	}
 
 	h, err := Digest(ctx, ref)
+	if err != nil {
+		return err
+	}
 
 	sigRepo, err := TargetRepositoryForImage(ref)
 	if err != nil {

--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -67,8 +67,8 @@ func CopyCmd(ctx context.Context, srcImg, dstImg string, sigOnly, force bool) er
 	if err != nil {
 		return err
 	}
-	regClientOpts := DefaultRegistryClientOpts(ctx)
-	gotSrc, err := remote.Get(srcRef, regClientOpts...)
+
+	h, err := Digest(ctx, srcRef)
 	if err != nil {
 		return err
 	}
@@ -78,11 +78,12 @@ func CopyCmd(ctx context.Context, srcImg, dstImg string, sigOnly, force bool) er
 		return err
 	}
 
-	sigSrcRef := cosign.AttachedImageTag(srcSigRepo, gotSrc, cosign.SignatureTagSuffix)
+	sigSrcRef := cosign.AttachedImageTag(srcSigRepo, h, cosign.SignatureTagSuffix)
 
 	dstRepoRef := dstRef.Context()
 	sigDstRef := dstRepoRef.Tag(sigSrcRef.Identifier())
 
+	regClientOpts := DefaultRegistryClientOpts(ctx)
 	if err := copyImage(sigSrcRef, sigDstRef, force, regClientOpts...); err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/digest.go
+++ b/cmd/cosign/cli/digest.go
@@ -27,16 +27,12 @@ import (
 // If the reference is by digest already, it simply extracts the digest.
 // Otherwise, it looks up the digest from the registry.
 func Digest(ctx context.Context, ref name.Reference) (v1.Hash, error) {
-
-	// If the image ref contains the digest, use it.
-	// Otherwise, look up the digest the tag currently points to.
 	if d, ok := ref.(name.Digest); ok {
 		return v1.NewHash(d.DigestStr())
-	} else {
-		desc, err := remote.Get(ref, DefaultRegistryClientOpts(ctx)...)
-		if err != nil {
-			return v1.Hash{}, err
-		}
-		return desc.Digest, nil
 	}
+	desc, err := remote.Get(ref, DefaultRegistryClientOpts(ctx)...)
+	if err != nil {
+		return v1.Hash{}, err
+	}
+	return desc.Digest, nil
 }

--- a/cmd/cosign/cli/digest.go
+++ b/cmd/cosign/cli/digest.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"context"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+// Digest returns the digest of the image at the reference.
+//
+// If the reference is by digest already, it simply extracts the digest.
+// Otherwise, it looks up the digest from the registry.
+func Digest(ctx context.Context, ref name.Reference) (v1.Hash, error) {
+
+	// If the image ref contains the digest, use it.
+	// Otherwise, look up the digest the tag currently points to.
+	if d, ok := ref.(name.Digest); ok {
+		return v1.NewHash(d.DigestStr())
+	} else {
+		desc, err := remote.Get(ref, DefaultRegistryClientOpts(ctx)...)
+		if err != nil {
+			return v1.Hash{}, err
+		}
+		return desc.Digest, nil
+	}
+}

--- a/cmd/cosign/cli/digest.go
+++ b/cmd/cosign/cli/digest.go
@@ -1,3 +1,17 @@
+// Copyright 2021 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cli
 
 import (

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -56,15 +55,13 @@ func SBOMCmd(ctx context.Context, imageRef string, out io.Writer) ([]string, err
 		return nil, err
 	}
 
-	auth := remote.WithAuthFromKeychain(authn.DefaultKeychain)
-
-	get, err := remote.Get(ref, auth)
+	h, err := cli.Digest(ctx, ref)
 	if err != nil {
 		return nil, err
 	}
 
 	repo := ref.Context()
-	dstRef := cosign.AttachedImageTag(repo, get, cosign.SBOMTagSuffix)
+	dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
 	img, err := remote.Image(dstRef, cli.DefaultRegistryClientOpts(ctx)...)
 	if err != nil {
 		return nil, err

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -307,11 +307,7 @@ func SignCmd(ctx context.Context, ko KeyOpts, annotations map[string]interface{}
 		if err != nil {
 			return err
 		}
-		sigRef := cosign.AttachedImageTag(sigRepo, &remote.Descriptor{
-			Descriptor: ggcrV1.Descriptor{
-				Digest: imgHash,
-			},
-		}, cosign.SignatureTagSuffix)
+		sigRef := cosign.AttachedImageTag(sigRepo, imgHash, cosign.SignatureTagSuffix)
 
 		uo := cremote.UploadOpts{
 			Cert:         sv.Cert,

--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -20,9 +20,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sigstore/cosign/pkg/cosign"
@@ -52,8 +50,7 @@ func MungeCmd(ctx context.Context, imageRef string) error {
 		return err
 	}
 
-	// TODO: just return the descriptor directly if we have a digest reference.
-	desc, err := remote.Get(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain), remote.WithContext(ctx))
+	h, err := Digest(ctx, ref)
 	if err != nil {
 		return err
 	}
@@ -62,7 +59,7 @@ func MungeCmd(ctx context.Context, imageRef string) error {
 	if err != nil {
 		return err
 	}
-	dstRef := cosign.AttachedImageTag(sigRepo, desc, cosign.SignatureTagSuffix)
+	dstRef := cosign.AttachedImageTag(sigRepo, h, cosign.SignatureTagSuffix)
 
 	fmt.Println(dstRef.Name())
 	return nil

--- a/pkg/cosign/verifiers.go
+++ b/pkg/cosign/verifiers.go
@@ -24,13 +24,13 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-func SimpleClaimVerifier(sp SignedPayload, desc *v1.Descriptor, annotations map[string]interface{}) error {
+func SimpleClaimVerifier(sp SignedPayload, digest v1.Hash, annotations map[string]interface{}) error {
 	ss := &payload.SimpleContainerImage{}
 	if err := json.Unmarshal(sp.Payload, ss); err != nil {
 		return err
 	}
 
-	if err := sp.VerifyClaims(desc, ss); err != nil {
+	if err := sp.VerifyClaims(digest, ss); err != nil {
 		return err
 	}
 
@@ -42,7 +42,7 @@ func SimpleClaimVerifier(sp SignedPayload, desc *v1.Descriptor, annotations map[
 	return nil
 }
 
-func IntotoSubjectClaimVerifier(sp SignedPayload, desc *v1.Descriptor, _ map[string]interface{}) error {
+func IntotoSubjectClaimVerifier(sp SignedPayload, digest v1.Hash, _ map[string]interface{}) error {
 	st := &in_toto.Statement{}
 	if err := json.Unmarshal(sp.Payload, st); err != nil {
 		return err
@@ -54,7 +54,7 @@ func IntotoSubjectClaimVerifier(sp SignedPayload, desc *v1.Descriptor, _ map[str
 			continue
 		}
 		subjDigest := "sha256:" + dgst
-		if subjDigest == desc.Digest.String() {
+		if subjDigest == digest.String() {
 			return nil
 		}
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -170,7 +170,7 @@ type CheckOpts struct {
 	RegistryClientOpts   []remote.Option
 
 	Annotations   map[string]interface{}
-	ClaimVerifier func(SignedPayload, *v1.Descriptor, map[string]interface{}) error
+	ClaimVerifier func(SignedPayload, v1.Hash, map[string]interface{}) error
 	VerifyBundle  bool
 
 	RekorURL string
@@ -190,11 +190,24 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 		return nil, errors.New("one of verifier or root certs is required")
 	}
 
-	// These are all the signatures attached to our image that we know how to parse.
-	signedImgDesc, err := remote.Get(signedImgRef, co.RegistryClientOpts...)
-	if err != nil {
-		return nil, err
+	// If the image ref contains the digest, use it.
+	// Otherwise, look up the digest the tag currently points to.
+	var h v1.Hash
+	if d, ok := signedImgRef.(name.Digest); ok {
+		var err error
+		h, err = v1.NewHash(d.DigestStr())
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		signedImgDesc, err := remote.Get(signedImgRef, co.RegistryClientOpts...)
+		if err != nil {
+			return nil, err
+		}
+		h = signedImgDesc.Descriptor.Digest
 	}
+
+	// These are all the signatures attached to our image that we know how to parse.
 	sigRepo := co.SignatureRepo
 	if (sigRepo == name.Repository{}) {
 		sigRepo = signedImgRef.Context()
@@ -203,7 +216,8 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 	if co.SigTagSuffixOverride != "" {
 		tagSuffix = co.SigTagSuffixOverride
 	}
-	allSignatures, err := FetchSignaturesForDescriptor(ctx, signedImgDesc, sigRepo, tagSuffix, co.RegistryClientOpts...)
+
+	allSignatures, err := FetchSignaturesForImageDigest(ctx, h, sigRepo, tagSuffix, co.RegistryClientOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching signatures")
 	}
@@ -244,7 +258,7 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 
 		// We can't check annotations without claims, both require unmarshalling the payload.
 		if co.ClaimVerifier != nil {
-			if err := co.ClaimVerifier(sp, &signedImgDesc.Descriptor, co.Annotations); err != nil {
+			if err := co.ClaimVerifier(sp, h, co.Annotations); err != nil {
 				validationErrs = append(validationErrs, err.Error())
 				continue
 			}
@@ -333,9 +347,9 @@ func (sp *SignedPayload) VerifySignature(verifier signature.Verifier, verifyOpts
 	return verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(sp.Payload), verifyOpts...)
 }
 
-func (sp *SignedPayload) VerifyClaims(d *v1.Descriptor, ss *payload.SimpleContainerImage) error {
+func (sp *SignedPayload) VerifyClaims(digest v1.Hash, ss *payload.SimpleContainerImage) error {
 	foundDgst := ss.Critical.Image.DockerManifestDigest
-	if foundDgst != d.Digest.String() {
+	if foundDgst != digest.String() {
 		return fmt.Errorf("invalid or missing digest in claim: %s", foundDgst)
 	}
 	return nil

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -718,7 +718,7 @@ func mkimage(t *testing.T, n string) (name.Reference, *remote.Descriptor, func()
 
 	cleanup := func() {
 		_ = remote.Delete(ref, regClientOpts...)
-		ref := cosign.AttachedImageTag(ref.Context(), remoteImage, cosign.SignatureTagSuffix)
+		ref := cosign.AttachedImageTag(ref.Context(), remoteImage.Descriptor.Digest, cosign.SignatureTagSuffix)
 		_ = remote.Delete(ref, regClientOpts...)
 	}
 	return ref, remoteImage, cleanup


### PR DESCRIPTION
@jonjohnsonjr noticed these and says this should make cosign a lot faster.

Some of these were TODOs, some just fell out of having `AttachedImageTag` take a digest instead of a descriptor, and looking around while fixing the resulting code breakage.