### PR TITLE
Add `cosign verify-manifest` command

### DIFF
--- a/cmd/cosign/cli/verify_manifest.go
+++ b/cmd/cosign/cli/verify_manifest.go
@@ -1,0 +1,120 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/pkg/errors"
+)
+
+// VerifyCommand verifies all image signatures on a supplied k8s resource
+type VerifyManifestCommand struct {
+	VerifyCommand
+}
+
+// Verify builds and returns an ffcli command
+func VerifyManifest() *ffcli.Command {
+	cmd := VerifyManifestCommand{VerifyCommand: VerifyCommand{}}
+	flagset := flag.NewFlagSet("cosign verify-manifest", flag.ExitOnError)
+	applyVerifyFlags(&cmd.VerifyCommand, flagset)
+
+	return &ffcli.Command{
+		Name:       "verify-manifest",
+		ShortUsage: "cosign verify-manifest -key <key path>|<key url>|<kms uri> <path/to/manifest>",
+		ShortHelp:  "Verify all signatures of images specified in the manifest",
+		LongHelp: `Verify all signature of images in a Kubernetes resource manifest by checking claims
+against the transparency log.
+
+Shell-like variables in the Dockerfile's FROM lines will be substituted with values from the OS ENV.
+
+EXAMPLES
+  # verify cosign claims and signing certificates on images in the manifest
+  cosign verify-manifest <path/to/my-deployment.yaml>
+
+  # additionally verify specified annotations
+  cosign verify-manifest -a key1=val1 -a key2=val2 <path/to/my-deployment.yaml>
+
+  # (experimental) additionally, verify with the transparency log
+  COSIGN_EXPERIMENTAL=1 cosign verify-dockerfile <path/to/my-deployment.yaml>
+
+  # verify images with public key
+  cosign verify-manifest -key cosign.pub <path/to/my-deployment.yaml>
+
+  # verify images with public key provided by URL
+  cosign verify-manifest -key https://host.for/<FILE> <path/to/my-deployment.yaml>
+
+  # verify images with public key stored in Azure Key Vault
+  cosign verify-manifest -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <path/to/my-deployment.yaml>
+
+  # verify images with public key stored in AWS KMS
+  cosign verify-manifest -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <path/to/my-deployment.yaml>
+
+  # verify images with public key stored in Google Cloud KMS
+  cosign verify-manifest -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <path/to/my-deployment.yaml>
+
+  # verify images with public key stored in Hashicorp Vault
+  cosign verify-manifest -key hashivault://[KEY] <path/to/my-deployment.yaml>`,
+
+		FlagSet: flagset,
+		Exec:    cmd.Exec,
+	}
+}
+
+// Exec runs the verification command
+func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		return flag.ErrHelp
+	}
+
+	manifestPath := args[0]
+
+	if filepath.Ext(strings.TrimSpace(manifestPath)) != ".yaml" {
+		return fmt.Errorf("only yaml manifests are supported at this time")
+	}
+
+	manifest, err := ioutil.ReadFile(manifestPath)
+	if err != nil {
+		return fmt.Errorf("could not read manifest: %v", err)
+	}
+
+	images, err := getImagesFromYamlManifest(string(manifest))
+	if err != nil {
+		return fmt.Errorf("failed extracting images from manifest: %v", err)
+	}
+	if len(images) == 0 {
+		return errors.New("no images found in manifest")
+	}
+	fmt.Fprintf(os.Stderr, "Extracted image(s): %s\n", strings.Join(images, ", "))
+
+	return c.VerifyCommand.Exec(ctx, images)
+}
+
+func getImagesFromYamlManifest(manifest string) ([]string, error) {
+	var images []string
+	re := regexp.MustCompile(`image:\s?(?P<Image>.*)\s?`)
+	for _, s := range re.FindAllStringSubmatch(manifest, -1) {
+		images = append(images, s[1])
+	}
+	return images, nil
+}

--- a/cmd/cosign/cli/verify_manifest.go
+++ b/cmd/cosign/cli/verify_manifest.go
@@ -46,8 +46,6 @@ func VerifyManifest() *ffcli.Command {
 		LongHelp: `Verify all signature of images in a Kubernetes resource manifest by checking claims
 against the transparency log.
 
-Shell-like variables in the Dockerfile's FROM lines will be substituted with values from the OS ENV.
-
 EXAMPLES
   # verify cosign claims and signing certificates on images in the manifest
   cosign verify-manifest <path/to/my-deployment.yaml>
@@ -56,7 +54,7 @@ EXAMPLES
   cosign verify-manifest -a key1=val1 -a key2=val2 <path/to/my-deployment.yaml>
 
   # (experimental) additionally, verify with the transparency log
-  COSIGN_EXPERIMENTAL=1 cosign verify-dockerfile <path/to/my-deployment.yaml>
+  COSIGN_EXPERIMENTAL=1 cosign verify-manifest <path/to/my-deployment.yaml>
 
   # verify images with public key
   cosign verify-manifest -key cosign.pub <path/to/my-deployment.yaml>

--- a/cmd/cosign/cli/verify_manifest.go
+++ b/cmd/cosign/cli/verify_manifest.go
@@ -89,8 +89,9 @@ func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
 
 	manifestPath := args[0]
 
-	if filepath.Ext(strings.TrimSpace(manifestPath)) != ".yaml" {
-		return fmt.Errorf("only yaml manifests are supported at this time")
+	err := isExtensionAllowed(manifestPath)
+	if err != nil {
+		return errors.Wrap(err, "check if extension is valid")
 	}
 
 	manifest, err := ioutil.ReadFile(manifestPath)
@@ -117,4 +118,18 @@ func getImagesFromYamlManifest(manifest string) ([]string, error) {
 		images = append(images, s[1])
 	}
 	return images, nil
+}
+
+func isExtensionAllowed(ext string) error {
+	allowedExtensions := allowedExtensionsForManifest()
+	for _, v := range allowedExtensions {
+		if strings.EqualFold(filepath.Ext(strings.TrimSpace(ext)), v) {
+			return nil
+		}
+	}
+	return fmt.Errorf("only %v manifests are supported at this time", allowedExtensions)
+}
+
+func allowedExtensionsForManifest() []string {
+	return []string{".yaml", ".yml"}
 }

--- a/cmd/cosign/cli/verify_manifest.go
+++ b/cmd/cosign/cli/verify_manifest.go
@@ -97,10 +97,7 @@ func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
 		return fmt.Errorf("could not read manifest: %v", err)
 	}
 
-	images, err := getImagesFromYamlManifest(string(manifest))
-	if err != nil {
-		return fmt.Errorf("failed extracting images from manifest: %v", err)
-	}
+	images := getImagesFromYamlManifest(string(manifest))
 	if len(images) == 0 {
 		return errors.New("no images found in manifest")
 	}
@@ -109,13 +106,13 @@ func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
 	return c.VerifyCommand.Exec(ctx, images)
 }
 
-func getImagesFromYamlManifest(manifest string) ([]string, error) {
+func getImagesFromYamlManifest(manifest string) []string {
 	var images []string
 	re := regexp.MustCompile(`image:\s?(?P<Image>.*)\s?`)
 	for _, s := range re.FindAllStringSubmatch(manifest, -1) {
 		images = append(images, s[1])
 	}
-	return images, nil
+	return images
 }
 
 func isExtensionAllowed(ext string) error {

--- a/cmd/cosign/cli/verify_manifest_test.go
+++ b/cmd/cosign/cli/verify_manifest_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"reflect"
+	"testing"
+)
+
+const SingleContainerManifest = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: single-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nginx-container
+      image: nginx:1.21.1
+`
+
+const MultiContainerManifest = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-pod
+spec:
+  restartPolicy: Never
+  volumes:
+    - name: shared-data
+      emptyDir: {}
+  containers:
+    - name: nginx-container
+      image: nginx:1.21.1
+      volumeMounts:
+        - name: shared-data
+          mountPath: /usr/share/nginx/html
+    - name: ubuntu-container
+      image: ubuntu:21.10
+      volumeMounts:
+        - name: shared-data
+          mountPath: /pod-data
+      command: ["/bin/sh"]
+      args: ["-c", "echo Hello, World > /pod-data/index.html"]
+`
+
+func TestGetImagesFromYamlManifest(t *testing.T) {
+	testCases := []struct {
+		name         string
+		fileContents string
+		expected     []string
+	}{
+		{
+			name:         "single image",
+			fileContents: SingleContainerManifest,
+			expected:     []string{"nginx:1.21.1"},
+		},
+		{
+			name:         "multi image",
+			fileContents: MultiContainerManifest,
+			expected:     []string{"nginx:1.21.1", "ubuntu:21.10"},
+		},
+		{
+			name:         "no images found",
+			fileContents: ``,
+			expected:     nil,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := getImagesFromYamlManifest(tc.fileContents)
+			if err != nil {
+				t.Fatalf("getImagesFromYamlManifest returned error: %v", err)
+			}
+			if !reflect.DeepEqual(tc.expected, got) {
+				t.Errorf("getImagesFromYamlManifest returned %v, wanted %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/cmd/cosign/cli/verify_manifest_test.go
+++ b/cmd/cosign/cli/verify_manifest_test.go
@@ -80,10 +80,7 @@ func TestGetImagesFromYamlManifest(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := getImagesFromYamlManifest(tc.fileContents)
-			if err != nil {
-				t.Fatalf("getImagesFromYamlManifest returned error: %v", err)
-			}
+			got := getImagesFromYamlManifest(tc.fileContents)
 			if !reflect.DeepEqual(tc.expected, got) {
 				t.Errorf("getImagesFromYamlManifest returned %v, wanted %v", got, tc.expected)
 			}

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -55,6 +55,7 @@ func main() {
 			cli.VerifyAttestation(),
 			cli.VerifyBlob(),
 			cli.VerifyDockerfile(),
+			cli.VerifyManifest(),
 			// Upload sub-tree
 			upload.Upload(),
 			// Download sub-tree

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -57,6 +57,10 @@ test_image="gcr.io/distroless/base" ./cosign verify-dockerfile -key ${DISTROLESS
 # Image exists, but is unsigned
 if (test_image="ubuntu" ./cosign verify-dockerfile -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile); then false; fi
 
+# Test `cosign verify-manifest`
+./cosign verify-manifest -key ${DISTROLESS_PUB_KEY} ./test/testdata/signed_manifest.yaml
+if (./cosign verify-manifest -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_manifest.yaml); then false; fi
+
 # Run the built container to make sure it doesn't crash
 make ko-local
 img="ko.local:$(git rev-parse HEAD)"

--- a/test/testdata/signed_manifest.yaml
+++ b/test/testdata/signed_manifest.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: single-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: distroless
+      image: gcr.io/distroless/base

--- a/test/testdata/signed_manifest.yaml
+++ b/test/testdata/signed_manifest.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/test/testdata/unsigned_manifest.yaml
+++ b/test/testdata/unsigned_manifest.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: single-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: nginx-container
+      image: nginx

--- a/test/testdata/unsigned_manifest.yaml
+++ b/test/testdata/unsigned_manifest.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: Pod
 metadata:


### PR DESCRIPTION
Adds support for verifying kubernetes resources (manifests) and addresses #437 

It's a naive approach, but wanted to get feedback early on, especially around YAML parsing via regex and JSON support as discussed in the ticket.
