### PR TITLE
cloudbuild: remove not needed dependency library

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -66,8 +66,6 @@ steps:
   args:
   - '-c'
   - |
-    apt-get update
-    apt-get install libpcsclite-dev -y
     cp ./dist/cosign-linux-amd64 /usr/local/bin/cosign
     cosign verify-dockerfile -base-image-only -key https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub ./Dockerfile
     make sign-container-cloudbuild


### PR DESCRIPTION
We will build both static and nonstatic cosign for Linux and in the release job we will use the static compiled binary, so we don't need to install the extra dependency library

