### PR TITLE
fix attest command descriptions, changed attestation flag as predicate

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -61,25 +61,25 @@ func Attest() *ffcli.Command {
 
 EXAMPLES
   # attach an attestation to a container image Google sign-in (experimental)
-  COSIGN_EXPERIMENTAL=1 cosign attest -attestation <FILE> <IMAGE>
+  COSIGN_EXPERIMENTAL=1 cosign attest -predicate <FILE> <IMAGE>
 
   # attach an attestation to a container image with a local key pair file
-  cosign attest -attestation <FILE> -key cosign.key <IMAGE>
+  cosign attest -predicate <FILE> -key cosign.key <IMAGE>
 
   # attach an attestation to a container image with a key pair stored in Azure Key Vault
-  cosign attest -attestation <FILE> -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <IMAGE>
+  cosign attest -predicate <FILE> -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <IMAGE>
 
   # attach an attestation to a container image with a key pair stored in AWS KMS
-  cosign attest -attestation <FILE> -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <IMAGE>
+  cosign attest -predicate <FILE> -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <IMAGE>
 
   # attach an attestation to a container image with a key pair stored in Google Cloud KMS
-  cosign attest -attestation <FILE> -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]/versions/[VERSION] <IMAGE>
+  cosign attest -predicate <FILE> -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]/versions/[VERSION] <IMAGE>
 
   # attach an attestation to a container image with a key pair stored in Hashicorp Vault
-  cosign attest -attestation <FILE> -key hashivault://[KEY] <IMAGE>
+  cosign attest -predicate <FILE> -key hashivault://[KEY] <IMAGE>
 
   # attach an attestation to a container image which does not fully support OCI media types
-  COSIGN_DOCKER_MEDIA_TYPES=1 cosign attest -attestation <FILE> -key cosign.key legacy-registry.example.com/my/image
+  COSIGN_DOCKER_MEDIA_TYPES=1 cosign attest -predicate <FILE> -key cosign.key legacy-registry.example.com/my/image
   `,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
