### PR TITLE
add well-known attestation specs support to the attest command

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -23,12 +23,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	ggcrV1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign/attestation"
-	"os"
 
 	"github.com/sigstore/cosign/pkg/cosign"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -1,3 +1,18 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package attestation
 
 import (

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -1,0 +1,150 @@
+package attestation
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+)
+
+const (
+	// CosignCustomPredicateType specifies the type of the Predicate.
+	CosignCustomPredicateType = "cosign.sigstore.dev/attestation/v1"
+)
+
+// CosignAttestation specifies the format of the Custom Predicate.
+type CosignAttestation struct {
+	Data string
+}
+
+// GenerateOpts specifies the options of the Statement generator.
+type GenerateOpts struct {
+	// Path is the given path to the predicate file.
+	Path string
+	// Type is the pre-defined enums (provenance|link|spdx).
+	// default: custom
+	Type string
+	// Digest of the Image reference.
+	Digest string
+	// Repo context of the reference.
+	Repo string
+}
+
+// GenerateStatement returns corresponding Predicate (custom|provenance|spdx|link)
+// based on the type you specified.
+func GenerateStatement(opts GenerateOpts) (interface{}, error) {
+	rawPayload, err := readPayload(opts.Path)
+	if err != nil {
+		return nil, err
+	}
+	switch opts.Type {
+	case "custom":
+		return generateCustomStatement(rawPayload, opts.Digest, opts.Repo)
+	case "provenance":
+		return generateProvenanceStatement(rawPayload, opts.Digest, opts.Repo)
+	case "spdx":
+		return generateSPDXStatement(rawPayload, opts.Digest, opts.Repo)
+	case "link":
+		return generateLinkStatement(rawPayload, opts.Digest, opts.Repo)
+	default:
+		return nil, errors.New(fmt.Sprintf("we don't know this predicate type: '%s'", opts.Type))
+	}
+}
+
+func generateStatementHeader(digest, repo, predicateType string) in_toto.StatementHeader {
+	return in_toto.StatementHeader{
+		Type:          in_toto.StatementInTotoV01,
+		PredicateType: predicateType,
+		Subject: []in_toto.Subject{
+			{
+				Name: repo,
+				Digest: map[string]string{
+					"sha256": digest,
+				},
+			},
+		},
+	}
+}
+
+//
+func generateCustomStatement(rawPayload []byte, digest, repo string) (interface{}, error) {
+	return in_toto.Statement{
+		StatementHeader: generateStatementHeader(digest, repo, in_toto.StatementInTotoV01),
+		Predicate: CosignAttestation{
+			Data: string(rawPayload),
+		},
+	}, nil
+}
+
+func generateProvenanceStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
+	var predicate in_toto.ProvenancePredicate
+	err := checkRequiredJSONFields(rawPayload, reflect.TypeOf(predicate))
+	if err != nil {
+		return nil, fmt.Errorf("provenance predicate: %v", err)
+	}
+	err = json.Unmarshal(rawPayload, &predicate)
+	if err != nil {
+		return "", errors.Wrap(err, "unmarshal Provenance predicate")
+	}
+	return in_toto.ProvenanceStatement{
+		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateProvenanceV01),
+		Predicate:       predicate,
+	}, nil
+}
+
+func generateLinkStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
+	var link in_toto.Link
+	err := checkRequiredJSONFields(rawPayload, reflect.TypeOf(link))
+	if err != nil {
+		return nil, fmt.Errorf("link statement: %v", err)
+	}
+	err = json.Unmarshal(rawPayload, &link)
+	if err != nil {
+		return "", errors.Wrap(err, "unmarshal Link statement")
+	}
+	return in_toto.LinkStatement{
+		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateLinkV1),
+		Predicate:       link,
+	}, nil
+}
+
+func generateSPDXStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
+	return in_toto.SPDXStatement{
+		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateSPDX),
+		Predicate: CosignAttestation{
+			Data: string(rawPayload),
+		},
+	}, nil
+}
+
+func readPayload(predicatePath string) ([]byte, error) {
+	rawPayload, err := ioutil.ReadFile(filepath.Clean(predicatePath))
+	if err != nil {
+		return nil, errors.Wrap(err, "payload from file")
+	}
+	return rawPayload, nil
+}
+
+func checkRequiredJSONFields(rawPayload []byte, typ reflect.Type) error {
+	var tmp map[string]interface{}
+	if err := json.Unmarshal(rawPayload, &tmp); err != nil {
+		return err
+	}
+	// Create list of json tags, e.g. `json:"_type"`
+	attributeCount := typ.NumField()
+	allFields := make([]string, 0)
+	for i := 0; i < attributeCount; i++ {
+		allFields = append(allFields, typ.Field(i).Tag.Get("json"))
+	}
+
+	// Assert that there's a key in the passed map for each tag
+	for _, field := range allFields {
+		if _, ok := tmp[field]; !ok {
+			return fmt.Errorf("required field %s missing", field)
+		}
+	}
+	return nil
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -172,7 +172,7 @@ func TestAttestVerify(t *testing.T) {
 
 	// Now attest the image
 	ko := cli.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-	must(cli.AttestCmd(ctx, ko, imgName, "", true, ap, false), t)
+	must(cli.AttestCmd(ctx, ko, imgName, "", true, ap, false, "custom"), t)
 
 	// Now verify and download should work!
 	must(verifyAttestation.Exec(ctx, []string{imgName}), t)


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
Fixes #472

![Screen Shot 2021-07-29 at 00 29 03](https://user-images.githubusercontent.com/16693043/127398678-5855db2c-12eb-426e-880e-0ed272bf1706.png)
![Screen Shot 2021-07-29 at 00 20 11](https://user-images.githubusercontent.com/16693043/127398684-0bcdc59a-b918-4835-86e3-351b24fbca79.png)

Known Limitations:
* We don't add support for SPDX predicate yet, because of [that](https://github.com/in-toto/in-toto-golang/blob/886210ae2ab9bfe02fc975213d9bc0cb7ae5f6b8/in_toto/model.go#L960-L966):
> Currently not implemented. Some tooling exists here:
https://github.com/spdx/tools-golang, but this software is still in
early state.

cc: @Dentrax 