### PR TITLE
fix in-toto.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Pushing signature to: us.gcr.io/dlorenc-vmtest2/wasm:sha256-9e7a511fb3130ee4641b
 
 #### In-Toto Attestations
 
-Cosign also has built-in support for [in-toto.io](https://in-toto.io) attestations.
+Cosign also has built-in support for [in-toto](https://in-toto.io) attestations.
 The specification for these is defined [here](https://github.com/in-toto/attestation).
 
 You can create and sign one from a local predicate file using the following commands:

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Pushing signature to: us.gcr.io/dlorenc-vmtest2/wasm:sha256-9e7a511fb3130ee4641b
 
 #### In-Toto Attestations
 
-Cosign also has built-in support for [in-toto.io](in-toto.io) attestations.
+Cosign also has built-in support for [in-toto.io](https://in-toto.io) attestations.
 The specification for these is defined [here](https://github.com/in-toto/attestation).
 
 You can create and sign one from a local predicate file using the following commands:


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

fix in-toto.io link in cosign/README.md

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
