### PR TITLE
Lazy initialize the fulcio Root

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"sync"
 
 	"github.com/go-openapi/runtime"
 	httptransport "github.com/go-openapi/runtime/client"
@@ -179,9 +180,19 @@ func (f *Signer) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey,
 
 var _ signature.Signer = &Signer{}
 
-var Roots *x509.CertPool
+var (
+	rootsOnce sync.Once
+	roots     *x509.CertPool
+)
 
-func init() {
+func GetRoots() *x509.CertPool {
+	rootsOnce.Do(func() {
+		roots = initRoots()
+	})
+	return roots
+}
+
+func initRoots() *x509.CertPool {
 	cp := x509.NewCertPool()
 	rootEnv := os.Getenv(altRoot)
 	if rootEnv != "" {
@@ -195,5 +206,5 @@ func init() {
 	} else if !cp.AppendCertsFromPEM([]byte(rootPem)) {
 		panic("error creating root cert pool")
 	}
-	Roots = cp
+	return cp
 }

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -113,7 +113,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 
 	co := &cosign.CheckOpts{
 		Annotations:        *c.Annotations,
-		RootCerts:          fulcio.Roots,
+		RootCerts:          fulcio.GetRoots(),
 		RegistryClientOpts: DefaultRegistryClientOpts(ctx),
 	}
 	if c.CheckClaims {

--- a/cmd/cosign/cli/verify_attestation.go
+++ b/cmd/cosign/cli/verify_attestation.go
@@ -105,7 +105,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 	}
 
 	co := &cosign.CheckOpts{
-		RootCerts:            fulcio.Roots,
+		RootCerts:            fulcio.GetRoots(),
 		RegistryClientOpts:   DefaultRegistryClientOpts(ctx),
 		SigTagSuffixOverride: cosign.AttestationTagSuffix,
 	}

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -195,7 +195,7 @@ func VerifyBlobCmd(ctx context.Context, ko KeyOpts, certRef, sigRef, blobRef str
 	}
 
 	if cert != nil { // cert
-		if err := cosign.TrustedCert(cert, fulcio.Roots); err != nil {
+		if err := cosign.TrustedCert(cert, fulcio.GetRoots()); err != nil {
 			return err
 		}
 		fmt.Fprintln(os.Stderr, "Certificate is trusted by Fulcio Root CA")

--- a/cmd/sget/cli/sget.go
+++ b/cmd/sget/cli/sget.go
@@ -43,7 +43,7 @@ func SgetCmd(ctx context.Context, imageRef, keyRef string) (io.ReadCloser, error
 	co := &cosign.CheckOpts{
 		ClaimVerifier: cosign.SimpleClaimVerifier,
 		VerifyBundle:  true,
-		RootCerts:     fulcio.Roots,
+		RootCerts:     fulcio.GetRoots(),
 		RegistryClientOpts: []remote.Option{
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 			remote.WithContext(ctx),

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -197,7 +197,7 @@ func main() {
 				VerifyOpts:    []signature.VerifyOption{ctxOpt},
 				PKOpts:        []signature.PublicKeyOption{ctxOpt},
 				ClaimVerifier: cosign.SimpleClaimVerifier,
-				RootCerts:     fulcio.Roots,
+				RootCerts:     fulcio.GetRoots(),
 				RegistryClientOpts: []remote.Option{
 					remote.WithAuthFromKeychain(authn.DefaultKeychain),
 					remote.WithContext(bctx.Context),


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

Main motivation:
* I added a `cosign init` command that sets up the TUF repository locally so that trusted targets can be verified and retrieved from there.
* Unfortunately, it's kind of circular to init the fulcio root certificate before you do that, and that also means you can't run the init command to configure your TUF mirrors and trusted keys yourself if you wanted to.

So this lazily inits the fulcio roots
Sorry for breaking semantic versioning...

