### PR TITLE
Document the usage of COSIGN_PASSWORD env var when signing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Enter password for private key:
 Pushing signature to: index.docker.io/dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 ```
 
+The cosign command above prompts the user to enter the password for the private key.
+The user can either manually enter the password, or if the environment variable `COSIGN_PASSWORD` is set then it is used automatically.
+
+
 ### Verify a container against a public key
 
 This command returns `0` if *at least one* `cosign` formatted signature for the image is found
@@ -161,7 +165,7 @@ The following feature set is not considered stable yet, but we are committed to 
 * Integration with the `Rekor` transparency log
 * Keyless signatures using the `Fulcio` CA
 
-#### Formats/Specifications 
+#### Formats/Specifications
 
 While the `cosign` code for uploading, signing, retrieving, and verifying several artifact types is stable,
 the format specifications for some of those types may not be considered stable yet.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
