### PR TITLE
version: add way to display a version when using go get or go install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ endif
 
 PKG=github.com/sigstore/cosign/cmd/cosign/cli
 
-LDFLAGS="-X $(PKG).gitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)"
+LDFLAGS="-X $(PKG).GitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)"
 
 .PHONY: all lint test clean cosign cross
 

--- a/cmd/cosign/cli/version.go
+++ b/cmd/cosign/cli/version.go
@@ -35,7 +35,7 @@ import (
 var (
 	// Output of "git describe". The prerequisite is that the branch should be
 	// tagged using the correct versioning strategy.
-	gitVersion = "unknown"
+	GitVersion string = "devel"
 	// SHA1 from git, output of $(git rev-parse HEAD)
 	gitCommit = "unknown"
 	// State of git tree, either "clean" or "dirty"
@@ -82,10 +82,8 @@ type Info struct {
 }
 
 func VersionInfo() Info {
-	// These variables typically come from -ldflags settings and in
-	// their absence fallback to the global defaults set above.
 	return Info{
-		GitVersion:   gitVersion,
+		GitVersion:   GitVersion,
 		GitCommit:    gitCommit,
 		GitTreeState: gitTreeState,
 		BuildDate:    buildDate,


### PR DESCRIPTION
Add way to display the version when using `go install`/ `go get`

related to https://github.com/sigstore/rekor/issues/212 and similar we did for rekor: https://github.com/sigstore/rekor/pull/405

