### PR TITLE
Move "verify-manifest" into "verify".

### DIFF
--- a/cmd/cosign/cli/flags.go
+++ b/cmd/cosign/cli/flags.go
@@ -15,7 +15,10 @@
 
 package cli
 
-import "reflect"
+import (
+	"reflect"
+	"strings"
+)
 
 // oneOf ensures that only one of the supplied interfaces is set to a non-zero value.
 func oneOf(args ...interface{}) bool {
@@ -31,4 +34,17 @@ func nOf(args ...interface{}) int {
 		}
 	}
 	return n
+}
+
+type StringSlice struct {
+	slice []string
+}
+
+func (ss *StringSlice) Set(s string) error {
+	ss.slice = append(ss.slice, s)
+	return nil
+}
+
+func (ss *StringSlice) String() string {
+	return strings.Join(ss.slice, ",")
 }

--- a/cmd/cosign/cli/verify_manifest.go
+++ b/cmd/cosign/cli/verify_manifest.go
@@ -89,6 +89,7 @@ EXAMPLES
 
 // Exec runs the verification command
 func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
+	fmt.Fprintln(os.Stderr, "This command is deprecated and will be removed in the next release. Please use `cosign verify -f <manifest>` instead.")
 	if len(args) != 1 {
 		return flag.ErrHelp
 	}

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -60,6 +60,7 @@ if (test_image="ubuntu" ./cosign verify-dockerfile -key ${DISTROLESS_PUB_KEY} ./
 # Test `cosign verify-manifest`
 ./cosign verify-manifest -key ${DISTROLESS_PUB_KEY} ./test/testdata/signed_manifest.yaml
 if (./cosign verify-manifest -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_manifest.yaml); then false; fi
+./cosign verify -key ${DISTROLESS_PUB_KEY} -f ./test/testdata/signed_manifest.yaml
 
 # Run the built container to make sure it doesn't crash
 make ko-local


### PR DESCRIPTION
We'll keep both commands for now, but deprecate verify-manifest.

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
