### PR TITLE
Explicitly disable auth for the sigstore-tuf-root.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/net v0.0.0-20210726213435-c6fcb2dbf985 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
+	google.golang.org/api v0.50.0
 	k8s.io/api v0.22.0
 	k8s.io/apimachinery v0.22.0
 	k8s.io/client-go v0.22.0

--- a/pkg/cosign/tuf/store.go
+++ b/pkg/cosign/tuf/store.go
@@ -22,6 +22,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/theupdateframework/go-tuf/client"
+	"google.golang.org/api/option"
 )
 
 type GcsRemoteOptions struct {
@@ -47,7 +48,7 @@ func GcsRemoteStore(ctx context.Context, bucket string, opts *GcsRemoteOptions, 
 	store := gcsRemoteStore{ctx: ctx, bucket: bucket, opts: opts, client: client}
 	if client == nil {
 		var err error
-		store.client, err = storage.NewClient(ctx)
+		store.client, err = storage.NewClient(ctx, option.WithoutAuthentication())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I had expired credentials that were causing this to fail. The bucket
is public, so we should just not use auth (which apparently requires being
explicit).

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
