### PR TITLE
Fix CI issues for forked repos

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -19,16 +19,13 @@ name: e2e-tests
 on: [push]
 
 jobs:
-  # Set the job key. The key is displayed as the job name
-  # when a job name is not provided
   e2e-tests:
-    # Name the Job
+    # Skip if running in a fork that might not have secrets configured.
+    if: ${{ github.repository == 'sigstore/cosign' }}
     name: Run tests
-    # Set the type of machine to run on
     runs-on: ubuntu-latest
 
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
@@ -39,12 +36,7 @@ jobs:
           project_id: projectsigstore
           service_account_key: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
           export_default_credentials: true
-      - name: Install Crane
-        run: go install github.com/google/go-containerregistry/cmd/crane
-      - name: creds
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-      # Required for `make cosign-pivkey`
-      # - name: deps
-      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
-      - name: Run e2e tests that need secrets
-        run: ./test/e2e_test_secrets.sh
+      - run: |
+          go install github.com/google/go-containerregistry/cmd/crane
+          gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+          ./test/e2e_test_secrets.sh

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -15,8 +15,8 @@
 
 name: e2e-tests
 
-# Run this workflow every time a new commit pushed to your repository
-on: [push]
+# Run on every push and PR, and allow it to be run manually.
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   e2e-tests:

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/open-policy-agent/opa v0.31.0
 	github.com/peterbourgon/ff/v3 v3.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/common v0.29.0 // indirect
 	github.com/sigstore/fulcio v0.1.1
 	github.com/sigstore/rekor v0.3.0
 	github.com/sigstore/sigstore v0.0.0-20210729211320-56a91f560f44

--- a/go.sum
+++ b/go.sum
@@ -1079,6 +1079,7 @@ github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/mattn/go-shellwords v1.0.10/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
 github.com/mattn/go-zglob v0.0.1/go.mod h1:9fxibJccNxU2cnpIKLRRFA7zX7qhkJIQWBb449FYHOo=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mediocregopher/radix/v4 v4.0.0-beta.1/go.mod h1:Z74pilm773ghbGV4EEoPvi6XWgkAfr0VCNkfa8gI1PU=


### PR DESCRIPTION
This fixes two CI-related issues hit while proposing #536 

1. e2e tests are run for all pushes, even to forked repos. This causes them to fail when they don't have the required secret configured. See https://github.com/imjasonh/cosign/actions/runs/1125396335 -- this change disables e2e tests when the repo != `sigstore/cosign`, and tells GitHub Actions to run the workflow when it's as a PR to the cosign repo, not only when it's a push. Also allow manual execution, because why not.
2. CI tests failed due to an out-of-date module dependency. See https://github.com/imjasonh/cosign/actions/runs/1125396339 -- this change runs the `go get` command in that error message.

This change also removes some unnecessary comments from e2e_tests.yml for (I think) better readability.