### PR TITLE
Refactor to avoid not necessary conversion

### DIFF
--- a/cmd/cosign/cli/verify_manifest.go
+++ b/cmd/cosign/cli/verify_manifest.go
@@ -104,7 +104,7 @@ func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
 		return fmt.Errorf("could not read manifest: %v", err)
 	}
 
-	images, err := getImagesFromYamlManifest(string(manifest))
+	images, err := getImagesFromYamlManifest(manifest)
 	if err != nil {
 		return fmt.Errorf("unable to extract the container image references in the manifest %v", err)
 	}
@@ -116,8 +116,8 @@ func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
 	return c.VerifyCommand.Exec(ctx, images)
 }
 
-func getImagesFromYamlManifest(manifest string) ([]string, error) {
-	dec := yaml.NewYAMLOrJSONDecoder(bytes.NewReader([]byte(manifest)), 4096)
+func getImagesFromYamlManifest(manifest []byte) ([]string, error) {
+	dec := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(manifest), 4096)
 	cScheme := runtime.NewScheme()
 	var images []string
 	if err := corev1.AddToScheme(cScheme); err != nil {

--- a/cmd/cosign/cli/verify_manifest_test.go
+++ b/cmd/cosign/cli/verify_manifest_test.go
@@ -105,27 +105,27 @@ spec:
 func TestGetImagesFromYamlManifest(t *testing.T) {
 	testCases := []struct {
 		name         string
-		fileContents string
+		fileContents []byte
 		expected     []string
 	}{
 		{
 			name:         "single image",
-			fileContents: SingleContainerManifest,
+			fileContents: []byte(SingleContainerManifest),
 			expected:     []string{"nginx:1.21.1"},
 		},
 		{
 			name:         "multi image",
-			fileContents: MultiContainerManifest,
+			fileContents: []byte(MultiContainerManifest),
 			expected:     []string{"nginx:1.21.1", "ubuntu:21.10"},
 		},
 		{
 			name:         "multiple resources and images within a document",
-			fileContents: MultiResourceContainerManifest,
+			fileContents: []byte(MultiResourceContainerManifest),
 			expected:     []string{"nginx:1.14.2", "nginx:1.21.1", "ubuntu:21.10"},
 		},
 		{
 			name:         "no images found",
-			fileContents: ``,
+			fileContents: []byte(``),
 			expected:     nil,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Jose Donizetti <jdbjunior@gmail.com>

Minor refactor to avoid the conversion string <-> []byte. 
Let me know if you okay with small changes like this. Thanks