### PR TITLE
Fix verify and verify-attestation output flag

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -51,7 +51,7 @@ func applyVerifyFlags(cmd *VerifyCommand, flagset *flag.FlagSet) {
 	flagset.StringVar(&cmd.Slot, "slot", "", "security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
 	flagset.StringVar(&cmd.RekorURL, "rekor-url", "https://rekor.sigstore.dev", "address of rekor STL server")
 	flagset.BoolVar(&cmd.CheckClaims, "check-claims", true, "whether to check the claims found")
-	flagset.StringVar(&cmd.Output, "output", "json", "output the signing image information. Default JSON.")
+	flagset.StringVar(&cmd.Output, "output", "json", "output format for the signing image information (default JSON) (json|text)")
 
 	// parse annotations
 	flagset.Var(&annotations, "a", "extra key=value pairs to sign")
@@ -163,7 +163,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 			return err
 		}
 
-		PrintVerification(imageRef, verified, co, "text")
+		PrintVerification(imageRef, verified, co, c.Output)
 	}
 
 	return nil

--- a/cmd/cosign/cli/verify_attestation.go
+++ b/cmd/cosign/cli/verify_attestation.go
@@ -46,7 +46,7 @@ func applyVerifyAttestationFlags(cmd *VerifyAttestationCommand, flagset *flag.Fl
 	flagset.BoolVar(&cmd.Sk, "sk", false, "whether to use a hardware security key")
 	flagset.StringVar(&cmd.Slot, "slot", "", "security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
 	flagset.BoolVar(&cmd.CheckClaims, "check-claims", true, "whether to check the claims found")
-	flagset.StringVar(&cmd.Output, "output", "json", "output the signing image information. Default JSON.")
+	flagset.StringVar(&cmd.Output, "output", "json", "output format for the signing image information (default JSON) (json|text)")
 	flagset.StringVar(&cmd.FulcioURL, "fulcio-url", "https://fulcio.sigstore.dev", "[EXPERIMENTAL] address of sigstore PKI server")
 	flagset.StringVar(&cmd.RekorURL, "rekor-url", "https://rekor.sigstore.dev", "[EXPERIMENTAL] address of rekor STL server")
 }
@@ -155,7 +155,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 			return err
 		}
 
-		PrintVerification(imageRef, verified, co, "text")
+		PrintVerification(imageRef, verified, co, c.Output)
 	}
 
 	return nil


### PR DESCRIPTION
There are a few things on this PR.

1 - improve documentation, listing the possible options for `-output` -> '(json|text)'
2 - fix existing behavior, where `-output` is actually ignored, [using always `text`](https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/verify.go#L166), even though the documentation says the [default is `json`](https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/verify.go#L54).

A couple questions:

1 - I think it makes more sense to rename this flag to `-format`, instead of `-output` considering the options (json/text).
2 - The current default is `text`, but fixing this to follow the documentation, it becomes `json`, but I think text looks better on the command line.

wdyt?