### PR TITLE
Improve Kubernetes examples in docs and commands

### DIFF
--- a/KMS.md
+++ b/KMS.md
@@ -121,6 +121,42 @@ The URI format for Hashicorp Vault KMS is:
 This provider requires that the standard Vault environment variables (VAULT_ADDR, VAULT_TOKEN) are set correctly.
 This provider also requires that the `transit` secret engine is enabled
 
+### Kubernetes Secret
+
+Cosign can use keys stored in Kubernetes Secrets to so sign and verify signatures. In
+order to generate a secret you have to pass `cosign generate-key-pair` a
+`k8s://[NAMESPACE]/[NAME]` URI specifying the namespace and secret name:
+
+```
+cosign generate-key-pair k8s://default/testsecret
+Enter password for private key: ****
+Enter again: ****
+Successfully created secret testsecret in namespace default
+Public key written to cosign.pub
+```
+
+After generating the key pair, cosign will store it in a Kubernetes secret using
+your current context. The secret will contain the private and public keys, as 
+well as the password to decrypt the private key.
+
+The secret has the following structure:
+
+```
+apiVersion: v1
+kind: Secret
+metadata:
+  name: testsecret
+  namespace: default
+type: Opaque
+data:
+  cosign.key: LS0tLS1CRUdJTiBFTkNSWVBURUQgQ09TSUdOIFBSSVZBVEUgS0VZLS0tLS[...]==
+  cosign.password: YWJjMTIz
+  cosign.pub: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQo[...]==
+```
+
+When verifying an image signature using `cosign verify`, the key will be automatically
+decrypted using the password stored in the kubernetes secret under the `cosign.password`
+field.
 
 #### Local Setup
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This core set includes:
 * fixed, text-based keys generated using `cosign generate-key-pair`
 * cloud KMS-based keys generated using `cosign generate-key-pair -kms`
 * keys generated on hardware tokens using the PIV interface using `cosign piv-tool`
-* Kubernetes-secret based keys generated using `cosign generate-key-pair -k8s`
+* Kubernetes-secret based keys generated using `cosign generate-key-pair k8s://namespace/secretName`
 
 ### Artifact Types
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -155,6 +155,9 @@ EXAMPLES
   # sign a container image with a key pair stored in Hashicorp Vault
   cosign sign -key hashivault://[KEY] <IMAGE>
 
+  # sign a container image with a key pair stored in a Kubernetes secret
+  cosign sign -key k8s://[NAMESPACE]/[KEY] <IMAGE>
+
   # sign a container in a registry which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign -key cosign.key legacy-registry.example.com/my/image
   `,

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -88,13 +88,16 @@ EXAMPLES
   cosign verify -key cosign.pub <IMAGE>
 
   # verify image with public key provided by URL
-  cosign verify -key https://host.for/<FILE> <IMAGE>
+  cosign verify -key https://host.for/[FILE] <IMAGE>
 
   # verify image with public key stored in Google Cloud KMS
-  cosign verify -key gcpkms://projects/<PROJECT>/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY> <IMAGE>
+  cosign verify -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <IMAGE>
   
   # verify image with public key stored in Hashicorp Vault
-  cosign verify -key hashivault:///<KEY> <IMAGE>`,
+  cosign verify -key hashivault://[KEY] <IMAGE>
+
+  # verify image with public key stored in a Kubernetes secret
+  cosign verify -key k8s://[NAMESPACE]/[KEY] <IMAGE>`,
 
 		FlagSet: flagset,
 		Exec:    cmd.Exec,


### PR DESCRIPTION
This PR adds two commits to improve the examples of Kubernetes secrets in the cosign sign and verify commands, as well as the documentation:

#### Add Kubernetes KMS entry and fix README example
This commit adds a Kubernetes section to the KMS document explaining how
to generate a key pair and a general overview of how cosign interacts
with secrets in the cluster.

####  Add Kubernetes secrets examples to cosign sign|verify 
This commit adds kubernetes examples to the help output of `cosign verify` and `cosign sign`.

In addition, square and angled brackets used as placeholders in examples are modified to match the output of both subcommands.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
