### PR TITLE
Move the prompting/confirmation down into the password implementations.

### DIFF
--- a/cmd/cosign/cli/generate_key_pair_test.go
+++ b/cmd/cosign/cli/generate_key_pair_test.go
@@ -25,7 +25,7 @@ import (
 func TestReadPasswordFn_env(t *testing.T) {
 	os.Setenv("COSIGN_PASSWORD", "foo")
 	defer os.Unsetenv("COSIGN_PASSWORD")
-	b, err := readPasswordFn()()
+	b, err := readPasswordFn(true)()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -37,7 +37,7 @@ func TestReadPasswordFn_env(t *testing.T) {
 func TestReadPasswordFn_envEmptyVal(t *testing.T) {
 	os.Setenv("COSIGN_PASSWORD", "")
 	defer os.Unsetenv("COSIGN_PASSWORD")
-	b, err := readPasswordFn()()
+	b, err := readPasswordFn(true)()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
We don't need to read from stdin or the env var twice :)

Signed-off-by: Dan Lorenc <dlorenc@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
