### PR TITLE
fix: lint warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
   - goimports
   - gosec
   - gocritic
-  - golint
+  - revive
   - misspell
   - unconvert
   - unparam

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 golangci-lint:
 	rm -f $(GOLANGCI_LINT) || :
 	set -e ;\
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.40.1 ;\
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.42.0 ;\
 
 lint: golangci-lint ## Runs golangci-lint linter
 	$(GOLANGCI_LINT) run  -n

--- a/cmd/cosign/cli/version.go
+++ b/cmd/cosign/cli/version.go
@@ -35,7 +35,7 @@ import (
 var (
 	// Output of "git describe". The prerequisite is that the branch should be
 	// tagged using the correct versioning strategy.
-	GitVersion string = "devel"
+	GitVersion = "devel"
 	// SHA1 from git, output of $(git rev-parse HEAD)
 	gitCommit = "unknown"
 	// State of git tree, either "clean" or "dirty"

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -77,7 +77,7 @@ func GenerateStatement(opts GenerateOpts) (interface{}, error) {
 	case "link":
 		return generateLinkStatement(rawPayload, opts.Digest, opts.Repo)
 	default:
-		return nil, errors.New(fmt.Sprintf("we don't know this predicate type: '%s'", opts.Type))
+		return nil, fmt.Errorf("we don't know this predicate type: '%s'", opts.Type)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

When running `lint`, we see the following warning message. 

```
WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.
```