### PR TITLE
Add a commented out list of OWNERS for transparency.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,11 @@
 @sigstore/cosign-codeowners
+
+# The CODEOWNERS are managed via a GitHub team, but the current list is:
+# dlorenc
+# dekakgaijin
+# asraa
+# loosebazooka
+# bobcallaway
+# font
+# lukehinds
+# developer-guy


### PR DESCRIPTION
We manage the CODEOWNERS via a GitHub team which unfortunately means the list
isn't present here. Let's keep them in sync manually until we come up with
something better.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
