### PR TITLE
fix nil pointer deref in cli/upload.BlobCmd

### DIFF
--- a/cmd/cosign/cli/upload/blob.go
+++ b/cmd/cosign/cli/upload/blob.go
@@ -17,6 +17,7 @@ package upload
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -83,7 +84,7 @@ EXAMPLES
   `,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
+			if len(args) != 1 || len(fmap.Files) < 1 {
 				return flag.ErrHelp
 			}
 
@@ -101,6 +102,9 @@ func BlobCmd(ctx context.Context, files []cremote.File, contentType, imageRef st
 	dgster, err := cremote.UploadFiles(ref, files, cremote.DefaultMediaTypeGetter, cli.DefaultRegistryClientOpts(ctx)...)
 	if err != nil {
 		return err
+	}
+	if dgster == nil {
+		return errors.New("dgstr is nil, no files uploaded?")
 	}
 	dgst, err := dgster.Digest()
 	if err != nil {


### PR DESCRIPTION
I was playing around with the `cosign` cli and found that calling `cosign upload blob ...` with an image address but without any `-f` arguments leads to a nil pointer dereference. This patch adds a check that at least one file was provided.

The underlying cause is that calling `cremote.UploadFiles` with an empty `files` list never sets the `var img v1.Image` within and thus the returned `dgstr` is `nil`, I believe?

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
