### PR TITLE
release: update golang-cross image to use go 1.17

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
     git checkout ${_TOOL_REF}
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.16.6@sha256:a31f3981571aab561bfdc2c50bf25142f2460a47c35e76ae9d50826e3a1aabac
+- name: ghcr.io/gythialy/golang-cross:v1.17@sha256:c0b971a8e659fcdc7d1b14ddef3a59acd79a4c85deeebef7e1c302cfa009b9e0
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION
Update the go builder container for the release pipeline to use go1.17

PR in the source that upgrade Go: https://github.com/gythialy/golang-cross/pull/17

the release of the image: https://github.com/gythialy/golang-cross/releases/tag/v1.17
