### PR TITLE
remove unnecessary COSIGN_PASSWORD

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,7 +96,6 @@ signs:
     cmd: ./dist/cosign-linux-amd64
     args: ["sign-blob", "-output", "${artifact}.sig", "-key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
-    stdin: "{{ .Env.COSIGN_PASSWORD }}"
 
 archives:
 - format: binary


### PR DESCRIPTION
Causing an issue with the newer release of `goreleaser` in the golang image:

`⨯ release failed after 227.51s error=template: tmpl:1:7: executing "tmpl" at <.Env.COSIGN_PASSWORD>: map has no entry for key "COSIGN_PASSWORD"`