### PR TITLE
Store attestations in the layer (payload) rather than the annotation.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -218,7 +218,9 @@ func AttestCmd(ctx context.Context, ko KeyOpts, imageRef string, certPath string
 	}
 
 	fmt.Fprintln(os.Stderr, "Pushing attestation to:", attRef.String())
-	if _, err = cremote.UploadSignature(sig, payload, attRef, uo); err != nil {
+	// An attestation represents both the signature and payload. So store the entire thing
+	// in the payload field since they can get large
+	if _, err = cremote.UploadSignature([]byte{}, sig, attRef, uo); err != nil {
 		return errors.Wrap(err, "uploading")
 	}
 


### PR DESCRIPTION
These can be quite large, especially when they are SBOMs.

I don't love having to swap signature/payload here, but it seems inevitable given our interfaces.

Signed-off-by: Dan Lorenc <dlorenc@google.com>