### PR TITLE
upgrade in-toto-golang to adapt SLSA Provenance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/hashicorp/vault/api v1.1.1 // indirect
 	github.com/hashicorp/vault/sdk v0.2.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
-	github.com/in-toto/in-toto-golang v0.2.1-0.20210627200632-886210ae2ab9
+	github.com/in-toto/in-toto-golang v0.2.1-0.20210806133539-f50646681592
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20210703085342-c1f07ee84431 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -954,8 +954,9 @@ github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/in-toto/in-toto-golang v0.2.1-0.20210627200632-886210ae2ab9 h1:j7klXz5kh0ydPmHkBtJ/Al27G1/au4sH7OkGhkgRJWg=
 github.com/in-toto/in-toto-golang v0.2.1-0.20210627200632-886210ae2ab9/go.mod h1:Skbg04kmfB7IAnEIsspKPg/ny1eiFt/TgPr9SDCHusA=
+github.com/in-toto/in-toto-golang v0.2.1-0.20210806133539-f50646681592 h1:g9IxkZZUCtXHtU3fBXY+1WhEL6Hmcaelk4o4VGYSmsA=
+github.com/in-toto/in-toto-golang v0.2.1-0.20210806133539-f50646681592/go.mod h1:Skbg04kmfB7IAnEIsspKPg/ny1eiFt/TgPr9SDCHusA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -71,7 +71,7 @@ func GenerateStatement(opts GenerateOpts) (interface{}, error) {
 		stamp := now.UTC().Format(time.RFC3339)
 		return generateCustomStatement(rawPayload, opts.Digest, opts.Repo, stamp)
 	case "provenance":
-		return generateProvenanceStatement(rawPayload, opts.Digest, opts.Repo)
+		return generateSLSAProvenanceStatement(rawPayload, opts.Digest, opts.Repo)
 	case "spdx":
 		return generateSPDXStatement(rawPayload, opts.Digest, opts.Repo)
 	case "link":
@@ -107,7 +107,7 @@ func generateCustomStatement(rawPayload []byte, digest, repo, timestamp string) 
 	}, nil
 }
 
-func generateProvenanceStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
+func generateSLSAProvenanceStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
 	var predicate in_toto.ProvenancePredicate
 	err := checkRequiredJSONFields(rawPayload, reflect.TypeOf(predicate))
 	if err != nil {
@@ -118,7 +118,7 @@ func generateProvenanceStatement(rawPayload []byte, digest string, repo string) 
 		return "", errors.Wrap(err, "unmarshal Provenance predicate")
 	}
 	return in_toto.ProvenanceStatement{
-		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateProvenanceV01),
+		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateSLSAProvenanceV01),
 		Predicate:       predicate,
 	}, nil
 }


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

There are some updates on the `in-toto-golang` project such as changing the predicate type of `Provenance` from `https://in-toto.io/Provenance/v0.1` to `https://slsa.dev/provenance/v0.1` based on the updates in `in-toto attestations` project.

PR details:

* https://github.com/in-toto/in-toto-golang/pull/118
* https://github.com/in-toto/attestation/pull/57
