### PR TITLE
Cleanup output formatting so messages go to stderr.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -211,7 +211,7 @@ func AttestCmd(ctx context.Context, ko KeyOpts, imageRef string, certPath string
 		if err != nil {
 			return err
 		}
-		fmt.Println("tlog entry created with index: ", *entry.LogIndex)
+		fmt.Fprintln(os.Stderr, "tlog entry created with index: ", *entry.LogIndex)
 
 		uo.Bundle = bundle(entry)
 		uo.AdditionalAnnotations = parseAnnotations(entry)

--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -64,7 +65,7 @@ func CleanCmd(ctx context.Context, imageRef string) error {
 	sigRef := cosign.AttachedImageTag(sigRepo, h, cosign.SignatureTagSuffix)
 	fmt.Println(sigRef)
 
-	fmt.Println("Deleting signature metadata...")
+	fmt.Fprintln(os.Stderr, "Deleting signature metadata...")
 
 	err = remote.Delete(sigRef, DefaultRegistryClientOpts(ctx)...)
 	if err != nil {

--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -214,7 +214,7 @@ func initRoots() *x509.CertPool {
 		err := tuf.GetTarget(ctx, fulcioTargetStr, &buf)
 		if err != nil {
 			// The user may not have initialized the local root metadata. Log the error and use the embedded root.
-			fmt.Println("using embedded fulcio certificate. did you run `cosign init`? error retrieving target: ", err)
+			fmt.Fprintln(os.Stderr, "using embedded fulcio certificate. did you run `cosign init`? error retrieving target: ", err)
 			if !cp.AppendCertsFromPEM([]byte(rootPem)) {
 				panic("error creating root cert pool")
 			}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -97,7 +97,7 @@ func shouldUploadToTlog(ref name.Reference, force bool, url string) (bool, error
 			return false, err
 		}
 		if tlogConfirmResponse != "Y" {
-			fmt.Println("not uploading to transparency log")
+			fmt.Fprintln(os.Stderr, "not uploading to transparency log")
 			return false, nil
 		}
 	}
@@ -345,7 +345,7 @@ func SignCmd(ctx context.Context, ko KeyOpts, annotations map[string]interface{}
 			if err != nil {
 				return err
 			}
-			fmt.Println("tlog entry created with index: ", *entry.LogIndex)
+			fmt.Fprintln(os.Stderr, "tlog entry created with index: ", *entry.LogIndex)
 
 			uo.Bundle = bundle(entry)
 			uo.AdditionalAnnotations = parseAnnotations(entry)

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -146,8 +146,11 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, 
 
 	if EnableExperimental() {
 		// TODO: Refactor with sign.go
-		rekorBytes := sv.Cert
-		if rekorBytes == nil {
+		var rekorBytes []byte
+		if sv.Cert != nil {
+			fmt.Fprintf(os.Stderr, "signing with ephemeral certificate:\n%s\n", string(sv.Cert))
+			rekorBytes = sv.Cert
+		} else {
 			pemBytes, err := publicKeyPem(sv, options.WithContext(ctx))
 			if err != nil {
 				return nil, err
@@ -162,8 +165,7 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, 
 		if err != nil {
 			return nil, err
 		}
-		fmt.Println("tlog entry created with index:", *entry.LogIndex)
-		return sig, nil
+		fmt.Fprintln(os.Stderr, "tlog entry created with index:", *entry.LogIndex)
 	}
 
 	if output != "" {

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -20,6 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 
 	_ "embed" // To enable the `go:embed` directive.
@@ -52,7 +53,7 @@ func GetRekorPub() string {
 	err := tuf.GetTarget(ctx, rekorTargetStr, &buf)
 	if err != nil {
 		// The user may not have initialized the local root metadata. Log the error and use the embedded root.
-		fmt.Println("using embedded rekor public key. did you run `cosign init`? error retrieving target: ", err)
+		fmt.Fprintln(os.Stderr, "using embedded rekor public key. did you run `cosign init`? error retrieving target: ", err)
 		return rekorPub
 	}
 	return buf.String()


### PR DESCRIPTION
This also correctly outputs the certificate and signature in sign-blob.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
