### PR TITLE
Make the warning around TUF roots a little less scary.

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -214,7 +214,7 @@ func initRoots() *x509.CertPool {
 		err := tuf.GetTarget(ctx, fulcioTargetStr, &buf)
 		if err != nil {
 			// The user may not have initialized the local root metadata. Log the error and use the embedded root.
-			fmt.Fprintln(os.Stderr, "using embedded fulcio certificate. did you run `cosign init`? error retrieving target: ", err)
+			fmt.Fprintln(os.Stderr, "No TUF root installed, using embedded CA certificate.")
 			if !cp.AppendCertsFromPEM([]byte(rootPem)) {
 				panic("error creating root cert pool")
 			}

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -116,7 +116,6 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 
 	co := &cosign.CheckOpts{
 		Annotations:        *c.Annotations,
-		RootCerts:          fulcio.GetRoots(),
 		RegistryClientOpts: DefaultRegistryClientOpts(ctx),
 	}
 	if c.CheckClaims {
@@ -124,7 +123,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 	}
 	if EnableExperimental() {
 		co.RekorURL = c.RekorURL
-
+		co.RootCerts = fulcio.GetRoots()
 	}
 	keyRef := c.KeyRef
 

--- a/cmd/cosign/cli/verify_attestation.go
+++ b/cmd/cosign/cli/verify_attestation.go
@@ -116,7 +116,6 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 	}
 
 	co := &cosign.CheckOpts{
-		RootCerts:            fulcio.GetRoots(),
 		RegistryClientOpts:   DefaultRegistryClientOpts(ctx),
 		SigTagSuffixOverride: cosign.AttestationTagSuffix,
 	}
@@ -125,6 +124,8 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 	}
 	if EnableExperimental() {
 		co.RekorURL = c.RekorURL
+		co.RootCerts = fulcio.GetRoots()
+
 	}
 	keyRef := c.KeyRef
 

--- a/cmd/sget/cli/sget.go
+++ b/cmd/sget/cli/sget.go
@@ -43,7 +43,6 @@ func SgetCmd(ctx context.Context, imageRef, keyRef string) (io.ReadCloser, error
 	co := &cosign.CheckOpts{
 		ClaimVerifier: cosign.SimpleClaimVerifier,
 		VerifyBundle:  true,
-		RootCerts:     fulcio.GetRoots(),
 		RegistryClientOpts: []remote.Option{
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 			remote.WithContext(ctx),
@@ -58,6 +57,7 @@ func SgetCmd(ctx context.Context, imageRef, keyRef string) (io.ReadCloser, error
 	}
 
 	if co.SigVerifier != nil || cli.EnableExperimental() {
+		co.RootCerts = fulcio.GetRoots()
 		sigRepo, err := cli.TargetRepositoryForImage(ref)
 		if err != nil {
 			return nil, err

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -53,7 +53,7 @@ func GetRekorPub() string {
 	err := tuf.GetTarget(ctx, rekorTargetStr, &buf)
 	if err != nil {
 		// The user may not have initialized the local root metadata. Log the error and use the embedded root.
-		fmt.Fprintln(os.Stderr, "using embedded rekor public key. did you run `cosign init`? error retrieving target: ", err)
+		fmt.Fprintln(os.Stderr, "No TUF root installed, using embedded rekor key")
 		return rekorPub
 	}
 	return buf.String()


### PR DESCRIPTION
Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
