### PR TITLE
Add extra replacement variables and GCP's role identifier

### DIFF
--- a/KMS.md
+++ b/KMS.md
@@ -102,14 +102,14 @@ The URI format for GCP KMS is:
 
 `gcpkms://projects/$PROJECT/locations/$LOCATION/keyRings/$KEYRING/cryptoKeys/$KEY/versions/$KEY_VERSION`
 
-where PROJECT, LOCATION, KEYRUNG and KEY are replaced with the correct values.
+where PROJECT, LOCATION, KEYRING, KEY and KEY_VERSION are replaced with the correct values.
 
 Cosign automatically uses GCP Application Default Credentials for authentication.
 See the GCP [API documentation](https://cloud.google.com/docs/authentication/production) for information on how to authenticate in different environments.
 
 The user must have the following IAM roles:
 * Safer KMS Viewer Role
-* Cloud KMS CryptoKey Signer/Verifier
+* Cloud KMS CryptoKey Signer/Verifier (`roles/cloudkms.signerVerifier`)
 
 ### Hashicorp Vault
 


### PR DESCRIPTION
Just a minor tidy-up.

### Resource Name

Curiously - the GCP resource name for a key is a slightly different format to the key format in cosign:

GCP format: `projects/$PROJECT/locations/$LOCATION/keyRings/$KEYRING/cryptoKeys/$KEY/cryptoKeyVersions/$KEY_VERSION`
Cosign format: `gcpkms://projects/$PROJECT/locations/$LOCATION/keyRings/$KEYRING/cryptoKeys/$KEY/versions/$KEY_VERSION`

Note that the 2nd last path segment is "cryptoKeyVersions" not "versions" - this is based on copying the resource name out of the GCP console.

### Roles

"Safer KMS Viewer Role" - I suspect this is wrong too (as I can't find anything called this) - but I don't know what the correct value is - as I wasn't able to get signing working without using KMS Admin role.

Once I get over that hurdle I'll be back...