### PR TITLE
helm/ci: update helm repo before installing the dependency

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -65,6 +65,7 @@ jobs:
 
       - name: Install Cert-Manager
         run: |
+          helm repo update
           helm install \
             cert-manager jetstack/cert-manager \
             --namespace cert-manager \


### PR DESCRIPTION
helm/ci: update helm repo before installing the dependency

the errors we see when merging the PR to the main branch like https://github.com/sigstore/cosign/runs/3445155267 can be related to the repo is not updated, but also to some network issues. I had similar behavior sometimes in my local.

but at least we update the repo and make sure that is up-to-date.
