### PR TITLE
verify_blob: add missing help option to use the pub key from a remote

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -92,7 +92,7 @@ EXAMPLES
 
   # verify image with public key stored in Google Cloud KMS
   cosign verify -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <IMAGE>
-  
+
   # verify image with public key stored in Hashicorp Vault
   cosign verify -key hashivault://[KEY] <IMAGE>
 

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -70,6 +70,9 @@ EXAMPLES
   # Verify a signature from an environment variable
   cosign verify-blob -key cosign.pub -signature $sig msg
 
+  # verify a signature with public key provided by URL
+  cosign verify-dockerfile -key https://host.for/<FILE> -signature $sig msg
+
   # Verify a signature against a payload from another process using process redirection
   cosign verify-blob -key cosign.pub -signature $sig <(git rev-parse HEAD)
 


### PR DESCRIPTION
verify_blob: add missing help option to use the pub key from a remote