### PR TITLE
Pinned the dockerfile to sha256

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
 
-FROM golang:1.17.0 as build
+FROM golang@sha256:c994ea4c0e524ea97ea7b4b21c19b968170a0c804b2fa7eee3c70c779fe84211 as build
 
 WORKDIR /go/src/cosign
 ADD . /go/src/cosign

--- a/Dockerfile.cosigned
+++ b/Dockerfile.cosigned
@@ -14,7 +14,7 @@
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
 
-FROM golang:1.17.0 as build
+FROM golang@sha256:c994ea4c0e524ea97ea7b4b21c19b968170a0c804b2fa7eee3c70c779fe84211  as build
 
 WORKDIR /go/src/cosign
 ADD . /go/src/cosign


### PR DESCRIPTION
The dockerfile was referring to the tag. It is recommended to use pinned
dependencies based on SHA https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies

Changed the go:1.17 to SHA256 digest. This still works with dependabot.
