### PR TITLE
chore: cleanup Makefile targers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,10 +136,3 @@ cosigned-sign-container-cloudbuild: cosigned-docker-cloudbuild
 	docker push gcr.io/${PROJECT_ID}/cosigned:$(GIT_TAG)
 	cosign sign -key gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION} -a GIT_HASH=$(GIT_HASH) gcr.io/${PROJECT_ID}/cosigned:$(GIT_HASH)
 	cosign sign -key gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION} -a GIT_TAG=$(GIT_TAG) gcr.io/${PROJECT_ID}/cosigned:$(GIT_TAG)
-
-uninstall-cosigned: manifests
-	helm delete cosigned -n cosigned
-
-# Install cosigned webhook in the configured Kubernetes cluster in ~/.kube/config
-install-cosigned: cosigned
-	helm install cosigned -n cosigned chart/cosigned --replace --set webhook.secretKeyRef.name=k8s://cosigned/mysecret --create-namespace


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

I found some unused targets in our Makefile.