### PR TITLE
feat: add support for downloading signature from remote

### DIFF
--- a/cmd/cosign/cli/init.go
+++ b/cmd/cosign/cli/init.go
@@ -19,10 +19,6 @@ import (
 	"context"
 	_ "embed" // To enable the `go:embed` directive.
 	"flag"
-	"io/ioutil"
-	"net/http"
-	"path/filepath"
-	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	ctuf "github.com/sigstore/cosign/pkg/cosign/tuf"
@@ -30,29 +26,6 @@ import (
 
 //go:embed 1.root.json
 var initialRoot string
-
-func loadFileOrURL(fileRef string) ([]byte, error) {
-	var raw []byte
-	var err error
-	if strings.HasPrefix(fileRef, "http://") || strings.HasPrefix(fileRef, "https://") {
-		// #nosec G107
-		resp, err := http.Get(fileRef)
-		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		raw, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		raw, err = ioutil.ReadFile(filepath.Clean(fileRef))
-		if err != nil {
-			return nil, err
-		}
-	}
-	return raw, nil
-}
 
 func Init() *ffcli.Command {
 	var (

--- a/cmd/cosign/cli/verify_blob.go
+++ b/cmd/cosign/cli/verify_blob.go
@@ -166,17 +166,17 @@ func VerifyBlobCmd(ctx context.Context, ko KeyOpts, certRef, sigRef, blobRef str
 			return err
 		}
 	} else {
-		b, err := ioutil.ReadFile(filepath.Clean(sigRef))
+		targetSig, err := loadFileOrURL(sigRef)
 		if err != nil {
 			return err
 		}
-		// If in a file, it could be raw or base64-encoded.
-		// We want them to be encoded eventually, but not double encoded!
-		if isb64(b) {
-			b64sig = string(b)
+
+		if isb64(targetSig) {
+			b64sig = string(targetSig)
 		} else {
-			b64sig = base64.StdEncoding.EncodeToString(b)
+			b64sig = base64.StdEncoding.EncodeToString(targetSig)
 		}
+
 	}
 
 	var blobBytes []byte


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->


Fix #608

we developed this code with @Dentrax @erkanzileli 

![Screen Shot 2021-09-06 at 21 28 56](https://user-images.githubusercontent.com/16693043/132252765-02eaab22-1bf5-4c50-9305-db55fdfd8830.png)

