### PR TITLE
Something changed in go 1.17 to make this a failure now.

### DIFF
--- a/cmd/cosign/cli/pivcli/disabled.go
+++ b/cmd/cosign/cli/pivcli/disabled.go
@@ -1,3 +1,4 @@
+//go:build !pivkey || !cgo
 // +build !pivkey !cgo
 
 // Copyright 2021 The Sigstore Authors

--- a/pkg/cosign/pivkey/disabled.go
+++ b/pkg/cosign/pivkey/disabled.go
@@ -1,3 +1,4 @@
+//go:build !pivkey || !cgo
 // +build !pivkey !cgo
 
 // Copyright 2021 The Sigstore Authors.

--- a/pkg/cosign/pivkey/pivkey.go
+++ b/pkg/cosign/pivkey/pivkey.go
@@ -1,5 +1,5 @@
-// +build pivkey
-// +build cgo
+//go:build pivkey && cgo
+// +build pivkey,cgo
 
 // Copyright 2021 The Sigstore Authors.
 //

--- a/pkg/cosign/pivkey/util.go
+++ b/pkg/cosign/pivkey/util.go
@@ -1,5 +1,5 @@
-// +build pivkey
-// +build cgo
+//go:build pivkey && cgo
+// +build pivkey,cgo
 
 // Copyright 2021 The Sigstore Authors
 //


### PR DESCRIPTION
A bunch of PRs are failing with this.

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
