### PR TITLE
Drop the distinction between Create/Update.

### DIFF
--- a/cmd/cosign/webhook/main.go
+++ b/cmd/cosign/webhook/main.go
@@ -71,31 +71,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	cosignedValidationFuncs := map[schema.GroupVersionKind]webhook.ValidationFuncs{
-		corev1.SchemeGroupVersion.WithKind("Pod"): {
-			ValidateCreate: webhook.ValidateSignedResources,
-			ValidateUpdate: webhook.ValidateSignedResourcesUpdate,
-		},
-		batchv1.SchemeGroupVersion.WithKind("Job"): {
-			ValidateCreate: webhook.ValidateSignedResources,
-			ValidateUpdate: webhook.ValidateSignedResourcesUpdate,
-		},
-		appsv1.SchemeGroupVersion.WithKind("Deployment"): {
-			ValidateCreate: webhook.ValidateSignedResources,
-			ValidateUpdate: webhook.ValidateSignedResourcesUpdate,
-		},
-		appsv1.SchemeGroupVersion.WithKind("StatefulSet"): {
-			ValidateCreate: webhook.ValidateSignedResources,
-			ValidateUpdate: webhook.ValidateSignedResourcesUpdate,
-		},
-		appsv1.SchemeGroupVersion.WithKind("ReplicateSet"): {
-			ValidateCreate: webhook.ValidateSignedResources,
-			ValidateUpdate: webhook.ValidateSignedResourcesUpdate,
-		},
-		appsv1.SchemeGroupVersion.WithKind("DaemonSet"): {
-			ValidateCreate: webhook.ValidateSignedResources,
-			ValidateUpdate: webhook.ValidateSignedResourcesUpdate,
-		},
+	cosignedValidationFuncs := map[schema.GroupVersionKind]webhook.ValidationFunc{
+		corev1.SchemeGroupVersion.WithKind("Pod"):          webhook.ValidateSignedResources,
+		batchv1.SchemeGroupVersion.WithKind("Job"):         webhook.ValidateSignedResources,
+		appsv1.SchemeGroupVersion.WithKind("Deployment"):   webhook.ValidateSignedResources,
+		appsv1.SchemeGroupVersion.WithKind("StatefulSet"):  webhook.ValidateSignedResources,
+		appsv1.SchemeGroupVersion.WithKind("ReplicateSet"): webhook.ValidateSignedResources,
+		appsv1.SchemeGroupVersion.WithKind("DaemonSet"):    webhook.ValidateSignedResources,
 	}
 
 	dynamicClient, err := kubernetesClientOptions.NewDynamicClient()

--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -49,24 +49,6 @@ func ValidateSignedResources(obj runtime.Object, apiReader client.Reader, keys [
 	return validateSignedContainerImages(containers, keys)
 }
 
-func ValidateSignedResourcesUpdate(newObj runtime.Object, oldObj runtime.Object, apiReader client.Reader, keys []*ecdsa.PublicKey) field.ErrorList {
-	var allErrs field.ErrorList
-
-	containers, err := getContainers(newObj)
-	if err != nil {
-		return field.ErrorList{field.InternalError(field.NewPath(""), err)}
-	}
-
-	_, err = getContainers(oldObj)
-	if err != nil {
-		return field.ErrorList{field.InternalError(field.NewPath(""), err)}
-	}
-
-	allErrs = append(allErrs, validateSignedContainerImages(containers, keys)...)
-
-	return allErrs
-}
-
 func validateSignedContainerImages(containers []corev1.Container, keys []*ecdsa.PublicKey) field.ErrorList {
 	var allErrs field.ErrorList
 


### PR DESCRIPTION
There was a bunch of boilerplate to differentiate between Create/Update, which wasn't particularly useful.  This drops it and streamlines a bunch of the logic.

I expect this will be the first cleanup of a number to follow...

/assign @dlorenc 