### PR TITLE
Drop the unused `apiReader`

### DIFF
--- a/cmd/cosign/webhook/main.go
+++ b/cmd/cosign/webhook/main.go
@@ -63,8 +63,6 @@ func main() {
 	flags.Uint16Var(&bindPort, "secure-port", bindPort, "The port on which to serve HTTPS.")
 	flags.StringVar(&tlsCertDirectory, "tls-cert-dir", tlsCertDirectory, "The directory where the TLS certs are located.")
 
-	kubernetesClientOptions := webhook.NewClientOptions(webhook.Scheme)
-
 	err := flags.Parse(os.Args[1:])
 	if err != nil {
 		klog.Error(err)
@@ -80,13 +78,7 @@ func main() {
 		appsv1.SchemeGroupVersion.WithKind("DaemonSet"):    webhook.ValidateSignedResources,
 	}
 
-	dynamicClient, err := kubernetesClientOptions.NewDynamicClient()
-	if err != nil {
-		klog.Error(err, "Failed to create client")
-		os.Exit(1)
-	}
-
-	cosignedValidationHook := webhook.NewFuncAdmissionValidator(webhook.Scheme, dynamicClient, cosignedValidationFuncs, secretKeyRef)
+	cosignedValidationHook := webhook.NewFuncAdmissionValidator(webhook.Scheme, cosignedValidationFuncs, secretKeyRef)
 
 	opts := ctrl.Options{
 		Scheme:             webhook.Scheme,

--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -33,14 +33,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
 	log = ctrl.Log.WithName("cosigned")
 )
 
-func ValidateSignedResources(obj runtime.Object, apiReader client.Reader, keys []*ecdsa.PublicKey) field.ErrorList {
+func ValidateSignedResources(obj runtime.Object, keys []*ecdsa.PublicKey) field.ErrorList {
 	containers, err := getContainers(obj)
 	if err != nil {
 		return field.ErrorList{field.InternalError(field.NewPath(""), err)}


### PR DESCRIPTION
I noticed the unused parameter in my previous change and tugged.  Seems completely unused.

Signed-off-by: Matt Moore <mattomata@gmail.com>

/assign @dlorenc 