### PR TITLE
Fix verify-dockerfile to allow lowercase FROM

### DIFF
--- a/cmd/cosign/cli/verify_dockerfile.go
+++ b/cmd/cosign/cli/verify_dockerfile.go
@@ -117,7 +117,7 @@ func getImagesFromDockerfile(dockerfile io.Reader) ([]string, error) {
 	fileScanner := bufio.NewScanner(dockerfile)
 	for fileScanner.Scan() {
 		line := strings.TrimSpace(fileScanner.Text())
-		if strings.HasPrefix(line, "FROM") {
+		if strings.HasPrefix(strings.ToUpper(line), "FROM") {
 			switch image := getImageFromLine(line); image {
 			case "scratch":
 				fmt.Fprintln(os.Stderr, "- scratch image ignored")

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -56,6 +56,7 @@ if (./cosign verify-dockerfile -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsign
 test_image="gcr.io/distroless/base" ./cosign verify-dockerfile -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile
 # Image exists, but is unsigned
 if (test_image="ubuntu" ./cosign verify-dockerfile -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile); then false; fi
+./cosign verify-dockerfile -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_lowercase.Dockerfile
 
 # Test `cosign verify-manifest`
 ./cosign verify-manifest -key ${DISTROLESS_PUB_KEY} ./test/testdata/signed_manifest.yaml

--- a/test/testdata/with_lowercase.Dockerfile
+++ b/test/testdata/with_lowercase.Dockerfile
@@ -1,0 +1,15 @@
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gcr.io/distroless/base


### PR DESCRIPTION
This is a simple fix to allow "from" in dockerfiles to have their
image arguments detected by verify-dockerfile command.

Signed-off-by: Michael <mlieberman85@gmail.com>
