### PR TITLE
Consistently use STDERR for output.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -183,7 +183,7 @@ func AttestCmd(ctx context.Context, ko KeyOpts, imageRef string, certPath string
 	}
 
 	if !upload {
-		fmt.Println(base64.StdEncoding.EncodeToString(sig))
+		fmt.Fprintln(os.Stderr, base64.StdEncoding.EncodeToString(sig))
 		return nil
 	}
 

--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -63,7 +63,7 @@ func CleanCmd(ctx context.Context, imageRef string) error {
 		return err
 	}
 	sigRef := cosign.AttachedImageTag(sigRepo, h, cosign.SignatureTagSuffix)
-	fmt.Println(sigRef)
+	fmt.Fprintln(os.Stderr, sigRef)
 
 	fmt.Fprintln(os.Stderr, "Deleting signature metadata...")
 

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -43,7 +43,7 @@ func SBOM() *ffcli.Command {
 			if len(args) != 1 {
 				return flag.ErrHelp
 			}
-			_, err := SBOMCmd(ctx, args[0], os.Stdout)
+			_, err := SBOMCmd(ctx, args[0], os.Stderr)
 			return err
 		},
 	}

--- a/cmd/cosign/cli/download/signature.go
+++ b/cmd/cosign/cli/download/signature.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -64,7 +65,7 @@ func SignatureCmd(ctx context.Context, imageRef string) error {
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(b))
+		fmt.Fprintln(os.Stderr, string(b))
 	}
 	return nil
 }

--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -140,7 +140,7 @@ func getCertForOauthID(priv *ecdsa.PrivateKey, scp signingCertProvider, connecto
 	if err := VerifySCT(fr); err != nil {
 		return Resp{}, errors.Wrap(err, "verifying SCT")
 	}
-	fmt.Println("Successfully verified SCT...")
+	fmt.Fprintln(os.Stderr, "Successfully verified SCT...")
 	return fr, nil
 }
 

--- a/cmd/cosign/cli/generate.go
+++ b/cmd/cosign/cli/generate.go
@@ -59,7 +59,7 @@ EXAMPLES
 			if len(args) != 1 {
 				return flag.ErrHelp
 			}
-			return GenerateCmd(ctx, args[0], annotations.annotations, os.Stdout)
+			return GenerateCmd(ctx, args[0], annotations.annotations, os.Stderr)
 		},
 	}
 }

--- a/cmd/cosign/cli/pivcli/commands.go
+++ b/cmd/cosign/cli/pivcli/commands.go
@@ -136,27 +136,27 @@ func (a *Attestations) Output() {
 		Type:  "CERTIFICATE",
 		Bytes: a.DeviceCert.Raw,
 	})
-	fmt.Println(string(b))
+	fmt.Fprintln(os.Stderr, string(b))
 
 	fmt.Fprintln(os.Stderr, "Printing key attestation certificate")
 	b = pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: a.KeyCert.Raw,
 	})
-	fmt.Println(string(b))
+	fmt.Fprintln(os.Stderr, string(b))
 
 	fmt.Fprintln(os.Stderr, "Verifying certificates...")
 
 	fmt.Fprintln(os.Stderr, "Verified ok")
-	fmt.Println()
+	fmt.Fprintln(os.Stderr, )
 
 	fmt.Fprintln(os.Stderr, "Device info:")
-	fmt.Println("  Issuer:", a.DeviceCert.Issuer)
-	fmt.Println("  Form factor:", formFactorString(a.KeyAttestation.Formfactor))
-	fmt.Println("  PIN Policy:", pinPolicyStr(a.KeyAttestation.PINPolicy))
+	fmt.Fprintln(os.Stderr, "  Issuer:", a.DeviceCert.Issuer)
+	fmt.Fprintln(os.Stderr, "  Form factor:", formFactorString(a.KeyAttestation.Formfactor))
+	fmt.Fprintln(os.Stderr, "  PIN Policy:", pinPolicyStr(a.KeyAttestation.PINPolicy))
 
-	fmt.Printf("  Serial number: %d\n", a.KeyAttestation.Serial)
-	fmt.Printf("  Version: %d.%d.%d\n", a.KeyAttestation.Version.Major, a.KeyAttestation.Version.Minor, a.KeyAttestation.Version.Patch)
+	fmt.Fprintf(os.Stderr, "  Serial number: %d\n", a.KeyAttestation.Serial)
+	fmt.Fprintf(os.Stderr, "  Version: %d.%d.%d\n", a.KeyAttestation.Version.Major, a.KeyAttestation.Version.Minor, a.KeyAttestation.Version.Patch)
 }
 
 func AttestationCmd(_ context.Context, slotArg string) (*Attestations, error) {
@@ -261,7 +261,7 @@ func GenerateKeyCmd(ctx context.Context, managementKey string, randomKey bool, s
 		Bytes: b,
 	})
 
-	fmt.Println(string(pemBytes))
+	fmt.Fprintln(os.Stderr, string(pemBytes))
 	yk.Close()
 
 	att, err := AttestationCmd(ctx, slotArg)
@@ -305,7 +305,7 @@ var Confirm = func(p string) bool {
 
 	result, err := prompt.Run()
 	if err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		return false
 	}
 	return strings.ToLower(result) == "y"

--- a/cmd/cosign/cli/pivcli/piv_tool.go
+++ b/cmd/cosign/cli/pivcli/piv_tool.go
@@ -147,7 +147,7 @@ func Attestation() *ffcli.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Println(string(b))
+				fmt.Fprintln(os.Stderr, string(b))
 			}
 			return err
 		},

--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -90,7 +90,7 @@ EXAMPLES
 				writer.Writer = f
 				defer f.Close()
 			} else {
-				writer.Writer = os.Stdout
+				writer.Writer = os.Stderr
 			}
 			pk := Pkopts{
 				KeyRef: *key,

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -339,7 +339,7 @@ func SignCmd(ctx context.Context, ko KeyOpts, annotations map[string]interface{}
 		}
 
 		if !upload {
-			fmt.Println(base64.StdEncoding.EncodeToString(sig))
+			fmt.Fprintln(os.Stderr, base64.StdEncoding.EncodeToString(sig))
 			continue
 		}
 

--- a/cmd/cosign/cli/sign_blob.go
+++ b/cmd/cosign/cli/sign_blob.go
@@ -187,12 +187,12 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, payloadPath string, b64 bool, 
 			}
 		}
 
-		fmt.Printf("Signature wrote in the file %s\n", f.Name())
+		fmt.Fprintf(os.Stderr, "Signature wrote in the file %s\n", f.Name())
 	} else {
 		if b64 {
 			sig = []byte(base64.StdEncoding.EncodeToString(sig))
-			fmt.Println(string(sig))
-		} else if _, err := os.Stdout.Write(sig); err != nil {
+			fmt.Fprintln(os.Stderr, string(sig))
+		} else if _, err := os.Stderr.Write(sig); err != nil {
 			// No newline if using the raw signature
 			return nil, err
 		}

--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -72,6 +73,6 @@ func MungeCmd(ctx context.Context, imageRef string, attachmentType string) error
 		return fmt.Errorf("unknown attachment type %s", attachmentType)
 	}
 
-	fmt.Println(dstRef.Name())
+	fmt.Fprintln(os.Stderr, dstRef.Name())
 	return nil
 }

--- a/cmd/cosign/cli/upload/blob.go
+++ b/cmd/cosign/cli/upload/blob.go
@@ -116,7 +116,7 @@ func BlobCmd(ctx context.Context, files []cremote.File, contentType, imageRef st
 		fmt.Fprintf(os.Stderr, "Uploading multi-platform index to %s\n", dgstAddr)
 	} else {
 		fmt.Fprintln(os.Stderr, "Uploaded image to:")
-		fmt.Println(dgstAddr)
+		fmt.Fprintln(os.Stderr, dgstAddr)
 	}
 	return nil
 }

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -211,10 +211,10 @@ func PrintVerification(imgRef string, verified []cosign.SignedPayload, co *cosig
 	case "text":
 		for _, vp := range verified {
 			if vp.Cert != nil {
-				fmt.Println("Certificate subject: ", vp.Cert.EmailAddresses)
+				fmt.Fprintln(os.Stderr, "Certificate subject: ", vp.Cert.EmailAddresses)
 			}
 
-			fmt.Println(string(vp.Payload))
+			fmt.Fprintln(os.Stderr, string(vp.Payload))
 		}
 	default:
 		var outputKeys []payload.SimpleContainerImage
@@ -222,7 +222,7 @@ func PrintVerification(imgRef string, verified []cosign.SignedPayload, co *cosig
 			ss := payload.SimpleContainerImage{}
 			err := json.Unmarshal(vp.Payload, &ss)
 			if err != nil {
-				fmt.Println("error decoding the payload:", err.Error())
+				fmt.Fprintln(os.Stderr, "error decoding the payload:", err.Error())
 				return
 			}
 
@@ -244,10 +244,10 @@ func PrintVerification(imgRef string, verified []cosign.SignedPayload, co *cosig
 
 		b, err := json.Marshal(outputKeys)
 		if err != nil {
-			fmt.Println("error when generating the output:", err.Error())
+			fmt.Fprintln(os.Stderr, "error when generating the output:", err.Error())
 			return
 		}
 
-		fmt.Printf("\n%s\n", string(b))
+		fmt.Fprintf(os.Stderr, "\n%s\n", string(b))
 	}
 }

--- a/cmd/cosign/cli/version.go
+++ b/cmd/cosign/cli/version.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 	"runtime"
 	"strings"
 	"text/tabwriter"
@@ -65,7 +66,7 @@ func Version() *ffcli.Command {
 				res = j
 			}
 
-			fmt.Println(res)
+			fmt.Fprintln(os.Stderr, res)
 			return nil
 		},
 	}

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -88,12 +88,12 @@ func main() {
 			fmt.Fprintf(os.Stderr, "error: %v\n", errors.Wrapf(err, "Error creating output file %s", *outputFilename))
 			os.Exit(1)
 		}
-		stdout := os.Stdout
+		stderr := os.Stderr
 		defer func() {
-			os.Stdout = stdout
+			os.Stderr = stderr
 			out.Close()
 		}()
-		os.Stdout = out
+		os.Stderr = out
 	}
 
 	if *logDebug {

--- a/cmd/sget/main.go
+++ b/cmd/sget/main.go
@@ -75,7 +75,7 @@ func printErrAndExit(err error) {
 func createSink(path string) (io.WriteCloser, error) {
 	if path == "" {
 		// When writing to stdout, buffer so we can check the digest first.
-		return &buffered{os.Stdout, &bytes.Buffer{}}, nil
+		return &buffered{os.Stderr, &bytes.Buffer{}}, nil
 	}
 
 	return os.Create(path)

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -224,7 +224,7 @@ func main() {
 	)
 
 	if err := cmd.RootCommand.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -88,7 +88,7 @@ func doUpload(rekorClient *client.Rekor, pe models.ProposedEntry) (*models.LogEn
 		// Here, we display the proof and succeed.
 		if existsErr, ok := err.(*entries.CreateLogEntryConflict); ok {
 
-			fmt.Println("Signature already exists. Displaying proof")
+			fmt.Fprintln(os.Stderr, "Signature already exists. Displaying proof")
 			uriSplit := strings.Split(existsErr.Location.String(), "/")
 			uuid := uriSplit[len(uriSplit)-1]
 			return verifyTLogEntry(rekorClient, uuid)


### PR DESCRIPTION
This is basically these commands (I also renamed a variable in the output-capture code):
```shell
sed -i 's@fmt.Printf(@fmt.Fprintf(os.Stderr, @g' $(git grep fmt.Printf | cut -d':' -f 1 | uniq)
sed -i 's@fmt.Println(@fmt.Fprintln(os.Stderr, @g' $(git grep fmt.Println | cut -d':' -f 1 | uniq)
sed -i 's/os.Stdout/os.Stderr/g' $(git grep os.Stdout | cut -d':' -f 1)
```

---
_(some context around motivation)_

I have been experimenting with adding inline keyless verification in downstream tooling with:
```go
	if cli.EnableExperimental() {
		if err := cli.Verify().Exec(cmd.Context(), []string{opts.ref.String()}); err != nil {
			return err
		}
	}
```

(and similar for keyless signing, but that's more verbose currently, so omitted)

However, some of these tools reserve STDOUT to enable command composition, e.g.
```shell
kn service create foo --image=$(ko publish ./cmd/bar)
```

So if (in this illustrative example) we wanted `ko` to automatically verify base images when `COSIGN_EXPERIMENTAL=true` then we would need all of the output from `cli.Verify().Exec(...)` to either go to STDERR, or surface some capacity for redirecting output (similar to cobra's `cmd.Set{Out,Err}` methods).

---

There is some existing logic to redirect STDOUT to a file, but I couldn't really discern a pattern for what goes to STDOUT vs. STDERR.  The two general motivations for this (I'd assume) would be:
1. Quiet and/or capture the full command output for publishing (in which case, it was missing all the STDERR today!)
2. To capture schematized data to a file for processing by downstream tools (e.g. the way `ko publish` emits a digest to STDOUT, and nothing else; but there is no obvious schema to any of the paths I looked at...?)

So I'm **assuming** that the motivation is `1.`, and "fixing" it to capture STDERR here, but it would be good to get some eyeballs on this that are more familiar with the motivation for capturing output to make sure this isn't somehow breaking (let's see what the tests say)!


Signed-off-by: Matt Moore <mattomata@gmail.com>