### PR TITLE
Send log statement to STDERR

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -140,7 +140,7 @@ func getCertForOauthID(priv *ecdsa.PrivateKey, scp signingCertProvider, connecto
 	if err := VerifySCT(fr); err != nil {
 		return Resp{}, errors.Wrap(err, "verifying SCT")
 	}
-	fmt.Println("Successfully verified SCT...")
+	fmt.Fprintln(os.Stderr, "Successfully verified SCT...")
 	return fr, nil
 }
 


### PR DESCRIPTION
I noticed this experimenting with integration with `ko` downstream.

Signed-off-by: Matt Moore <mattomata@gmail.com>

cc @dlorenc 