### PR TITLE
Provide a mechanism for downstream folks to avoid `_` imports.

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -44,13 +44,9 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/pivkey"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
-	"github.com/sigstore/cosign/pkg/providers"
+	providers "github.com/sigstore/cosign/pkg/providers/all"
 	fulcioClient "github.com/sigstore/fulcio/pkg/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
-
-	// These are the ambient OIDC providers to link in.
-	_ "github.com/sigstore/cosign/pkg/providers/github"
-	_ "github.com/sigstore/cosign/pkg/providers/google"
 
 	rekorClient "github.com/sigstore/rekor/pkg/client"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"

--- a/pkg/providers/all/all.go
+++ b/pkg/providers/all/all.go
@@ -1,0 +1,30 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package all
+
+import (
+	"github.com/sigstore/cosign/pkg/providers"
+
+	// Link in all of the providers.
+	_ "github.com/sigstore/cosign/pkg/providers/github"
+	_ "github.com/sigstore/cosign/pkg/providers/google"
+)
+
+// Alias these methods, so that folks can import this to get all providers.
+var (
+	Enabled = providers.Enabled
+	Provide = providers.Provide
+)


### PR DESCRIPTION
With this change folks can avoid `_` imports to enable all plugins with:

```go
import (
   providers "github.com/sigstore/cosign/pkg/providers/all"
)
```

Signed-off-by: Matt Moore <mattomata@gmail.com>
