### PR TITLE
Extract a `types` package for media and payload types.

### DIFF
--- a/cmd/cosign/cli/attach/sbom.go
+++ b/cmd/cosign/cli/attach/sbom.go
@@ -31,11 +31,12 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli"
 	"github.com/sigstore/cosign/pkg/cosign"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
+	ctypes "github.com/sigstore/cosign/pkg/types"
 )
 
 var mediaTypes = map[string]string{
-	"cyclonedx": "application/vnd.cyclonedx",
-	"spdx":      "text/spdx",
+	"cyclonedx": ctypes.CycloneDXMediaType,
+	"spdx":      ctypes.SPDXMediaType,
 }
 
 func SBOM() *ffcli.Command {

--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -31,6 +31,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign/attestation"
+	"github.com/sigstore/cosign/pkg/types"
 
 	"github.com/sigstore/cosign/pkg/cosign"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
@@ -103,11 +104,6 @@ EXAMPLES
 		},
 	}
 }
-
-const (
-	IntotoPayloadType = "application/vnd.in-toto+json"
-	DssePayloadType   = "application/vnd.dsse.envelope.v1+json"
-)
 
 const (
 	predicateCustom = "custom"
@@ -202,7 +198,7 @@ func AttestCmd(ctx context.Context, ko KeyOpts, imageRef string, certPath string
 		Chain:        sv.Chain,
 		DupeDetector: sv,
 		RemoteOpts:   remoteOpts,
-		MediaType:    DssePayloadType,
+		MediaType:    types.DssePayloadType,
 	}
 
 	uploadTLog, err := shouldUploadToTlog(ref, force, ko.RekorURL)

--- a/cmd/cosign/cli/upload/wasm.go
+++ b/cmd/cosign/cli/upload/wasm.go
@@ -26,6 +26,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/sigstore/cosign/cmd/cosign/cli"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
+	"github.com/sigstore/cosign/pkg/types"
 )
 
 func Wasm() *ffcli.Command {
@@ -48,11 +49,6 @@ func Wasm() *ffcli.Command {
 	}
 }
 
-const (
-	wasmLayerMediaType  = "application/vnd.wasm.content.layer.v1+wasm"
-	wasmConfigMediaType = "application/vnd.wasm.config.v1+json"
-)
-
 func WasmCmd(ctx context.Context, wasmPath, imageRef string) error {
 	b, err := ioutil.ReadFile(wasmPath)
 	if err != nil {
@@ -65,7 +61,7 @@ func WasmCmd(ctx context.Context, wasmPath, imageRef string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Uploading wasm file from [%s] to [%s].\n", wasmPath, ref.Name())
-	if _, err := cremote.UploadFile(b, ref, wasmLayerMediaType, wasmConfigMediaType, cli.DefaultRegistryClientOpts(ctx)...); err != nil {
+	if _, err := cremote.UploadFile(b, ref, types.WasmLayerMediaType, types.WasmConfigMediaType, cli.DefaultRegistryClientOpts(ctx)...); err != nil {
 		return err
 	}
 

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -34,12 +34,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
+	ctypes "github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
 const (
-	SimpleSigningMediaType = "application/vnd.dev.cosign.simplesigning.v1+json"
-
 	sigkey              = "dev.cosignproject.cosign/signature"
 	certkey             = "dev.sigstore.cosign/certificate"
 	chainkey            = "dev.sigstore.cosign/chain"
@@ -95,7 +94,7 @@ func SignatureImage(ref name.Reference, opts ...remote.Option) (v1.Image, error)
 func findDuplicate(sigImage v1.Image, payload []byte, dupeDetector signature.Verifier, annotations map[string]string) ([]byte, error) {
 	l := &staticLayer{
 		b:  payload,
-		mt: SimpleSigningMediaType,
+		mt: ctypes.SimpleSigningMediaType,
 	}
 
 	sigDigest, err := l.Digest()
@@ -115,7 +114,7 @@ LayerLoop:
 				continue LayerLoop
 			}
 		}
-		if layer.MediaType == SimpleSigningMediaType && layer.Digest == sigDigest && layer.Annotations[sigkey] != "" {
+		if layer.MediaType == ctypes.SimpleSigningMediaType && layer.Digest == sigDigest && layer.Annotations[sigkey] != "" {
 			uploadedSig, err := base64.StdEncoding.DecodeString(layer.Annotations[sigkey])
 			if err != nil {
 				return nil, err
@@ -154,7 +153,7 @@ type UploadOpts struct {
 func UploadSignature(signature, payload []byte, dst name.Reference, opts UploadOpts) (uploadedSig []byte, err error) {
 	// Preserve the default
 	if opts.MediaType == "" {
-		opts.MediaType = SimpleSigningMediaType
+		opts.MediaType = ctypes.SimpleSigningMediaType
 	}
 	l := &staticLayer{
 		b:  payload,

--- a/pkg/types/media.go
+++ b/pkg/types/media.go
@@ -1,0 +1,24 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	CycloneDXMediaType     = "application/vnd.cyclonedx"
+	SimpleSigningMediaType = "application/vnd.dev.cosign.simplesigning.v1+json"
+	SPDXMediaType          = "text/spdx"
+	WasmLayerMediaType     = "application/vnd.wasm.content.layer.v1+wasm"
+	WasmConfigMediaType    = "application/vnd.wasm.config.v1+json"
+)

--- a/pkg/types/payload.go
+++ b/pkg/types/payload.go
@@ -1,0 +1,21 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	DssePayloadType   = "application/vnd.dsse.envelope.v1+json"
+	IntotoPayloadType = "application/vnd.in-toto+json"
+)


### PR DESCRIPTION
I noticed Chains was consuming the `Dsse` type from `cli`, which was problematic because `cli` pulls in `glog` and triggers the `-log_dir` problem.

Cosign seems to have media and payload types sprinkled everywhere, so I factored out `pkg/types/{media,payload}.go` where we can define these in a common place that's dependency free.

Signed-off-by: Matt Moore <mattomata@gmail.com>

cc @priyawadhwa @dlorenc 