### PR TITLE
Consistently use `TargetRepositoryForImage` with `AttachedImageTag`.

### DIFF
--- a/cmd/cosign/cli/attach/sbom.go
+++ b/cmd/cosign/cli/attach/sbom.go
@@ -81,7 +81,10 @@ func SBOMCmd(ctx context.Context, sbomRef, sbomType, imageRef string) error {
 		return err
 	}
 
-	repo := ref.Context()
+	repo, err := cli.TargetRepositoryForImage(ref)
+	if err != nil {
+		return err
+	}
 	dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
 
 	fmt.Fprintf(os.Stderr, "Uploading SBOM file for [%s] to [%s] with mediaType [%s].\n", ref.Name(), dstRef.Name(), sbomType)

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -60,7 +60,10 @@ func SBOMCmd(ctx context.Context, imageRef string, out io.Writer) ([]string, err
 		return nil, err
 	}
 
-	repo := ref.Context()
+	repo, err := cli.TargetRepositoryForImage(ref)
+	if err != nil {
+		return nil, err
+	}
 	dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
 	img, err := remote.Image(dstRef, cli.DefaultRegistryClientOpts(ctx)...)
 	if err != nil {

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -212,7 +212,10 @@ func getAttachedImageRef(ctx context.Context, imageRef string, attachment string
 			return "", err
 		}
 
-		repo := ref.Context()
+		repo, err := TargetRepositoryForImage(ref)
+		if err != nil {
+			return "", err
+		}
 		dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
 		return dstRef.Name(), nil
 	}


### PR DESCRIPTION
As I've been reading the code, I noticed a pretty consistent pattern of:

```go
// ref -> digest (nop if a digest!)
h, err := Digest(ctx, ref)
if err != nil {
	return "", err
}

// ref -> repo (env var overrides!) 
repo, err := TargetRepositoryForImage(ref)
if err != nil {
	return "", err
}

// construct tag with above and well-defined suffix.
dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
```

There were a handful of places missing the env variable override helper: `TargetRepositoryForImage`.

Signed-off-by: Matt Moore <mattomata@gmail.com>
