### PR TITLE
Create a helper to encapsulate a common pattern.

### DIFF
--- a/cmd/cosign/cli/attach/sbom.go
+++ b/cmd/cosign/cli/attach/sbom.go
@@ -71,21 +71,15 @@ func SBOMCmd(ctx context.Context, sbomRef, sbomType, imageRef string) error {
 		return err
 	}
 
-	h, err := cli.Digest(ctx, ref)
-	if err != nil {
-		return err
-	}
-
 	b, err := sbomBytes(sbomRef)
 	if err != nil {
 		return err
 	}
 
-	repo, err := cli.TargetRepositoryForImage(ref)
+	dstRef, err := cli.AttachedImageTag(ctx, ref, cosign.SBOMTagSuffix)
 	if err != nil {
 		return err
 	}
-	dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
 
 	fmt.Fprintf(os.Stderr, "Uploading SBOM file for [%s] to [%s] with mediaType [%s].\n", ref.Name(), dstRef.Name(), sbomType)
 	if _, err := cremote.UploadFile(b, dstRef, types.MediaType(sbomType), types.OCIConfigJSON, cli.DefaultRegistryClientOpts(ctx)...); err != nil {

--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -72,16 +72,14 @@ func SignatureCmd(ctx context.Context, sigRef, payloadRef, imageRef string) erro
 		return err
 	}
 
-	sigRepo, err := cli.TargetRepositoryForImage(ref)
+	dstRef, err := cli.AttachedImageTag(ctx, ref, cosign.SignatureTagSuffix)
 	if err != nil {
 		return err
 	}
-	dstRef := cosign.AttachedImageTag(sigRepo, h, cosign.SignatureTagSuffix)
 
 	var payload []byte
 	if payloadRef == "" {
-		repo := ref.Context()
-		img := repo.Digest(h.String())
+		img := ref.Context().Digest(h.String())
 		payload, err = (&sigPayload.Cosign{Image: img}).MarshalJSON()
 	} else {
 		payload, err = ioutil.ReadFile(filepath.Clean(payloadRef))

--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -53,16 +53,10 @@ func CleanCmd(ctx context.Context, imageRef string) error {
 		return err
 	}
 
-	h, err := Digest(ctx, ref)
+	sigRef, err := AttachedImageTag(ctx, ref, cosign.SignatureTagSuffix)
 	if err != nil {
 		return err
 	}
-
-	sigRepo, err := TargetRepositoryForImage(ref)
-	if err != nil {
-		return err
-	}
-	sigRef := cosign.AttachedImageTag(sigRepo, h, cosign.SignatureTagSuffix)
 	fmt.Println(sigRef)
 
 	fmt.Fprintln(os.Stderr, "Deleting signature metadata...")

--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -68,17 +68,10 @@ func CopyCmd(ctx context.Context, srcImg, dstImg string, sigOnly, force bool) er
 		return err
 	}
 
-	h, err := Digest(ctx, srcRef)
+	sigSrcRef, err := AttachedImageTag(ctx, srcRef, cosign.SignatureTagSuffix)
 	if err != nil {
 		return err
 	}
-
-	srcSigRepo, err := TargetRepositoryForImage(srcRef)
-	if err != nil {
-		return err
-	}
-
-	sigSrcRef := cosign.AttachedImageTag(srcSigRepo, h, cosign.SignatureTagSuffix)
 
 	dstRepoRef := dstRef.Context()
 	sigDstRef := dstRepoRef.Tag(sigSrcRef.Identifier())

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -55,16 +55,10 @@ func SBOMCmd(ctx context.Context, imageRef string, out io.Writer) ([]string, err
 		return nil, err
 	}
 
-	h, err := cli.Digest(ctx, ref)
+	dstRef, err := cli.AttachedImageTag(ctx, ref, cosign.SBOMTagSuffix)
 	if err != nil {
 		return nil, err
 	}
-
-	repo, err := cli.TargetRepositoryForImage(ref)
-	if err != nil {
-		return nil, err
-	}
-	dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
 	img, err := remote.Image(dstRef, cli.DefaultRegistryClientOpts(ctx)...)
 	if err != nil {
 		return nil, err

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
-	ggcrV1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/pkg/errors"
@@ -207,16 +206,10 @@ func getAttachedImageRef(ctx context.Context, imageRef string, attachment string
 			return "", err
 		}
 
-		h, err := Digest(ctx, ref)
+		dstRef, err := AttachedImageTag(ctx, ref, cosign.SBOMTagSuffix)
 		if err != nil {
 			return "", err
 		}
-
-		repo, err := TargetRepositoryForImage(ref)
-		if err != nil {
-			return "", err
-		}
-		dstRef := cosign.AttachedImageTag(repo, h, cosign.SBOMTagSuffix)
 		return dstRef.Name(), nil
 	}
 	return "", fmt.Errorf("unknown attachment type %s", attachment)
@@ -344,15 +337,10 @@ func SignCmd(ctx context.Context, ko KeyOpts, annotations map[string]interface{}
 			continue
 		}
 
-		sigRepo, err := TargetRepositoryForImage(img)
+		sigRef, err := AttachedImageTag(ctx, img, cosign.SignatureTagSuffix)
 		if err != nil {
 			return err
 		}
-		imgHash, err := ggcrV1.NewHash(img.Identifier())
-		if err != nil {
-			return err
-		}
-		sigRef := cosign.AttachedImageTag(sigRepo, imgHash, cosign.SignatureTagSuffix)
 
 		uo := cremote.UploadOpts{
 			Cert:         sv.Cert,

--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -51,25 +51,19 @@ func MungeCmd(ctx context.Context, imageRef string, attachmentType string) error
 		return err
 	}
 
-	h, err := Digest(ctx, ref)
-	if err != nil {
-		return err
-	}
-
-	sigRepo, err := TargetRepositoryForImage(ref)
-	if err != nil {
-		return err
-	}
 	var dstRef name.Tag
 	switch attachmentType {
 	case cosign.Signature:
-		dstRef = cosign.AttachedImageTag(sigRepo, h, cosign.SignatureTagSuffix)
+		dstRef, err = AttachedImageTag(ctx, ref, cosign.SignatureTagSuffix)
 	case cosign.SBOM:
-		dstRef = cosign.AttachedImageTag(sigRepo, h, cosign.SBOMTagSuffix)
+		dstRef, err = AttachedImageTag(ctx, ref, cosign.SBOMTagSuffix)
 	case cosign.Attestation:
-		dstRef = cosign.AttachedImageTag(sigRepo, h, cosign.AttestationTagSuffix)
+		dstRef, err = AttachedImageTag(ctx, ref, cosign.AttestationTagSuffix)
 	default:
-		return fmt.Errorf("unknown attachment type %s", attachmentType)
+		err = fmt.Errorf("unknown attachment type %s", attachmentType)
+	}
+	if err != nil {
+		return err
 	}
 
 	fmt.Println(dstRef.Name())

--- a/cmd/cosign/cli/util.go
+++ b/cmd/cosign/cli/util.go
@@ -53,6 +53,19 @@ func TargetRepositoryForImage(img name.Reference) (name.Repository, error) {
 	return name.NewRepository(wantRepo)
 }
 
+func AttachedImageTag(ctx context.Context, ref name.Reference, suffix string) (name.Tag, error) {
+	h, err := Digest(ctx, ref)
+	if err != nil {
+		return name.Tag{}, err
+	}
+
+	repo, err := TargetRepositoryForImage(ref)
+	if err != nil {
+		return name.Tag{}, err
+	}
+	return cosign.AttachedImageTag(repo, h, suffix), nil
+}
+
 func loadFileOrURL(fileRef string) ([]byte, error) {
 	var raw []byte
 	var err error


### PR DESCRIPTION
Following up on https://github.com/sigstore/cosign/pull/671 which identified a bunch of places we were incorrectly constructing the target tag name, this creates a helper that cuts this boilerplate down, since the majority of these call sites were following the exact same pattern and only computing the repo and hash for the tag construction.

Signed-off-by: Matt Moore <mattomata@gmail.com>
