### PR TITLE
Add a simple "DO NOT SUBMIT" workflow.

### DIFF
--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -1,0 +1,44 @@
+name: Do Not Submit
+
+on:
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+jobs:
+
+  donotsubmit:
+    name: Do Not Submit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Do Not Submit
+        shell: bash
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          cd "${GITHUB_WORKSPACE}" || exit 1
+
+          TEMP_PATH="$(mktemp -d)"
+          PATH="${TEMP_PATH}:$PATH"
+
+          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
+          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
+          echo '::endgroup::'
+
+          echo '::group:: Running DO NOT SUBMIT with reviewdog 🐶 ...'
+          # Don't fail because of grep
+          set +o pipefail
+          find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*' -not -path './.github/workflows/*' |
+          xargs grep -n "DO NOT SUBMIT" |
+          reviewdog -efm="%f:%l:%m" \
+                -name="DO NOT SUBMIT" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="true" \
+                -level="error"
+
+          echo '::endgroup::'


### PR DESCRIPTION
#### Summary

This is a workflow I wrote for Knative, which is based on a presubmit check we had at Google.

Essentially, it fails the check (and flags the line) if it sees the words `DO NOT SUBMIT`.

So a comment practice with "work in progress" changes is to tag things that shouldn't get merged with:
```go
// TODO(mattmoor): DO NOT SUBMIT
```

Personally, I find this kind of workflow keeps me honest about things, so I thought I'd share!

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```
