### PR TITLE
Run `gofmt -s` and `goimports` against PRs.

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -1,0 +1,68 @@
+name: Code Style
+
+on:
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+jobs:
+
+  autoformat:
+    name: Auto-format and Check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Keep running if one leg fails.
+      matrix:
+        tool:
+          - goimports
+          - gofmt
+
+        include:
+        - tool: gofmt
+          options: -s
+        - tool: goimports
+          importpath: golang.org/x/tools/cmd/goimports
+
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Dependencies
+        if: ${{ matrix.importpath != '' }}
+        run: |
+          cd $(mktemp -d)
+          GO111MODULE=on go get ${{ matrix.importpath }}
+
+      - name: ${{ matrix.tool }} ${{ matrix.options }}
+        shell: bash
+        run: >
+          ${{ matrix.tool }} ${{ matrix.options }} -w
+          $(find .
+          -path './vendor' -prune
+          -o -path './third_party' -prune
+          -o -name '*.pb.go' -prune
+          -o -name 'wire_gen.go' -prune
+          -o -type f -name '*.go' -print)
+
+      - name: Verify ${{ matrix.tool }}
+        shell: bash
+        run: |
+          # From: https://backreference.org/2009/12/23/how-to-match-newlines-in-sed/
+          # This is to leverage this workaround:
+          # https://github.com/actions/toolkit/issues/193#issuecomment-605394935
+          function urlencode() {
+            sed ':begin;$!N;s/\n/%0A/;tbegin'
+          }
+          if [[ $(git diff-index --name-only HEAD --) ]]; then
+              for x in $(git diff-index --name-only HEAD --); do
+                echo "::error file=$x::Please run ${{ matrix.tool }} ${{ matrix.options }}.%0A$(git diff $x | urlencode)"
+              done
+              echo "${{ github.repository }} is out of style. Please run ${{ matrix.tool }} ${{ matrix.options }}."
+              exit 1
+          fi
+          echo "${{ github.repository }} is formatted correctly."


### PR DESCRIPTION
This change runs a few of the standard Go linting tools against PRs, and instead of just failing it annotates files that contain problems so users can run `gofmt -s -w <filename>` (or `goimports`).

The annotations look like this: https://github.com/sigstore/cosign/pull/680#issuecomment-920424768

This is a nice little hygiene check that we can use to keep things consistent.

This is based on the following, which we used in Knative: https://github.com/knative-sandbox/.github/blob/7d63e57ca2793794eef0b7a44035818f37f5f448/workflow-templates/knative-style.yaml#L26-L85

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```
