### PR TITLE
Add a little workflow that checks for whitespace.

### DIFF
--- a/.github/workflows/whitespace.yaml
+++ b/.github/workflows/whitespace.yaml
@@ -1,0 +1,93 @@
+name: Whitespace
+
+on:
+  pull_request:
+    branches: [ 'main', 'release-*' ]
+
+jobs:
+
+  whitespace:
+    name: Check Whitespace
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.16.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.x
+        id: go
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Install Tools
+        run: |
+          TEMP_PATH="$(mktemp -d)"
+          cd $TEMP_PATH
+          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
+          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
+          echo '::endgroup::'
+          echo "${TEMP_PATH}" >> $GITHUB_PATH
+
+      - name: trailing whitespace
+        shell: bash
+        if: ${{ always() }}
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          cd "${GITHUB_WORKSPACE}" || exit 1
+          echo '::group:: Flagging trailing whitespace with reviewdog 🐶 ...'
+          # Don't fail because of grep
+          set +o pipefail
+          # Exclude generated and vendored files, plus some legacy
+          # paths until we update all .gitattributes
+          git ls-files |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          grep -Ev '^(vendor/|third_party/|.git)' |
+          xargs grep -nE " +$" |
+          reviewdog -efm="%f:%l:%m" \
+                -name="trailing whitespace" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="true" \
+                -level="error"
+          echo '::endgroup::'
+
+      - name: EOF newline
+        shell: bash
+        if: ${{ always() }}
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          cd "${GITHUB_WORKSPACE}" || exit 1
+          echo '::group:: Flagging missing EOF newlines with reviewdog 🐶 ...'
+          # Don't fail because of misspell
+          set +o pipefail
+          # Lint exclude rule:
+          #  - nothing in vendor/
+          #  - nothing in third_party
+          #  - nothing in .git/
+          #  - no *.ai (Adobe Illustrator) files.
+          LINT_FILES=$(git ls-files |
+          git check-attr --stdin linguist-generated | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          git check-attr --stdin linguist-vendored | grep -Ev ': (set|true)$' | cut -d: -f1 |
+          grep -Ev '^(vendor/|third_party/|.git)' |
+          grep -v '\.ai$')
+          for x in $LINT_FILES; do
+            # Based on https://stackoverflow.com/questions/34943632/linux-check-if-there-is-an-empty-line-at-the-end-of-a-file
+            if [[ -f $x && ! ( -s "$x" && -z "$(tail -c 1 $x)" ) ]]; then
+              # We add 1 to `wc -l` here because of this limitation (from the man page):
+              # Characters beyond the final <newline> character will not be included in the line count.
+              echo $x:$((1 + $(wc -l $x | tr -s ' ' | cut -d' ' -f 1))): Missing newline
+            fi
+          done |
+          reviewdog -efm="%f:%l: %m" \
+                -name="EOF Newline" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="true" \
+                -level="error"
+          echo '::endgroup::'


### PR DESCRIPTION
This flags trailing whitespace at the ends of lines, and ensures there is a newline at the ends of files.

This is based on the following workflows we run in Knative: https://github.com/knative-sandbox/.github/blob/7d63e57ca2793794eef0b7a44035818f37f5f448/workflow-templates/knative-style.yaml#L160-L227

The annotations look like this: https://github.com/sigstore/cosign/pull/680#issuecomment-920424768

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```
