### PR TITLE
Try dropping dependency in `golangci-lint` leg.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,8 +81,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: deps
-        run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         timeout-minutes: 5


### PR DESCRIPTION
I noticed this adding other actions, and it seemed odd.  Looks like copy/pasta from some of the other actions that need it for h/w support.

I figure if it fails, we can just close this 🤣 

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```
