### PR TITLE
Enable several new `golangci-lint` checks.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,14 +15,20 @@
 
 linters:
   enable:
+  - asciicheck
   - deadcode
+  - depguard
   - errcheck
   - gofmt
   - goimports
   - gosec
   - gocritic
+  - importas
+  - prealloc
   - revive
   - misspell
+  - stylecheck
+  - tparallel
   - unconvert
   - unparam
 output:

--- a/cmd/cosign/cli/keys_test.go
+++ b/cmd/cosign/cli/keys_test.go
@@ -62,23 +62,21 @@ func TestSignerFromPrivateKeyFileRef(t *testing.T) {
 		writePw   cosign.PassFunc
 		readPw    cosign.PassFunc
 		expectErr bool
-	}{
-		{
-			desc: "good password",
+	}{{
+		desc: "good password",
 
-			writePw: pass("hello"),
-			readPw:  pass("hello"),
-		},
-		{
-			desc: "bad password",
+		writePw: pass("hello"),
+		readPw:  pass("hello"),
+	}, {
+		desc: "bad password",
 
-			writePw:   pass("hello"),
-			readPw:    pass("something else"),
-			expectErr: true,
-		},
-	}
+		writePw:   pass("hello"),
+		readPw:    pass("something else"),
+		expectErr: true,
+	}}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			testFile, _ := generateKeyFile(t, tmpDir, tc.writePw)
 
 			signer, err := signerFromKeyRef(ctx, testFile, tc.readPw)


### PR DESCRIPTION
This also fixes the only instance of `tparallel` found in a local run, and tightens up a test to avoid whitespace (I wish `gofmt -s` supported this 😞 ).

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```
