### PR TITLE
Enable `errorlint` checks.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ linters:
   - deadcode
   - depguard
   - errcheck
+  - errorlint
   - gofmt
   - goimports
   - gosec

--- a/cmd/cosign/cli/dockerfile/verify.go
+++ b/cmd/cosign/cli/dockerfile/verify.go
@@ -94,13 +94,13 @@ func (c *VerifyDockerfileCommand) Exec(ctx context.Context, args []string) error
 
 	dockerfile, err := os.Open(args[0])
 	if err != nil {
-		return fmt.Errorf("could not open Dockerfile: %v", err)
+		return fmt.Errorf("could not open Dockerfile: %w", err)
 	}
 	defer dockerfile.Close()
 
 	images, err := getImagesFromDockerfile(dockerfile)
 	if err != nil {
-		return fmt.Errorf("failed extracting images from Dockerfile: %v", err)
+		return fmt.Errorf("failed extracting images from Dockerfile: %w", err)
 	}
 	if len(images) == 0 {
 		return errors.New("no images found in Dockerfile")

--- a/cmd/cosign/cli/verify_manifest.go
+++ b/cmd/cosign/cli/verify_manifest.go
@@ -102,12 +102,12 @@ func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
 	}
 	manifest, err := ioutil.ReadFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("could not read manifest: %v", err)
+		return fmt.Errorf("could not read manifest: %w", err)
 	}
 
 	images, err := getImagesFromYamlManifest(manifest)
 	if err != nil {
-		return fmt.Errorf("unable to extract the container image references in the manifest %v", err)
+		return fmt.Errorf("unable to extract the container image references in the manifest %w", err)
 	}
 	if len(images) == 0 {
 		return errors.New("no images found in manifest")
@@ -135,10 +135,10 @@ func getImagesFromYamlManifest(manifest []byte) ([]string, error) {
 	for {
 		ext := runtime.RawExtension{}
 		if err := dec.Decode(&ext); err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				break
 			}
-			return images, fmt.Errorf("unable to decode the manifest")
+			return images, errors.New("unable to decode the manifest")
 		}
 
 		ext.Raw = bytes.TrimSpace(ext.Raw)
@@ -148,7 +148,7 @@ func getImagesFromYamlManifest(manifest []byte) ([]string, error) {
 
 		decoded, _, err := deserializer.Decode(ext.Raw, nil, nil)
 		if err != nil {
-			return images, fmt.Errorf("unable to decode the manifest")
+			return images, errors.New("unable to decode the manifest")
 		}
 
 		var (

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -19,6 +19,7 @@ import (
 	"archive/tar"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -236,7 +237,7 @@ func findFile(img v1.Image, path string) ([]byte, error) {
 	tr := tar.NewReader(rc)
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break // End of archive
 		}
 		if err != nil {

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -77,7 +77,7 @@ func GenerateStatement(opts GenerateOpts) (interface{}, error) {
 	case "link":
 		return generateLinkStatement(rawPayload, opts.Digest, opts.Repo)
 	default:
-		return nil, fmt.Errorf("we don't know this predicate type: '%s'", opts.Type)
+		return nil, fmt.Errorf("we don't know this predicate type: %q", opts.Type)
 	}
 }
 
@@ -111,7 +111,7 @@ func generateSLSAProvenanceStatement(rawPayload []byte, digest string, repo stri
 	var predicate in_toto.ProvenancePredicate
 	err := checkRequiredJSONFields(rawPayload, reflect.TypeOf(predicate))
 	if err != nil {
-		return nil, fmt.Errorf("provenance predicate: %v", err)
+		return nil, fmt.Errorf("provenance predicate: %w", err)
 	}
 	err = json.Unmarshal(rawPayload, &predicate)
 	if err != nil {
@@ -127,7 +127,7 @@ func generateLinkStatement(rawPayload []byte, digest string, repo string) (inter
 	var link in_toto.Link
 	err := checkRequiredJSONFields(rawPayload, reflect.TypeOf(link))
 	if err != nil {
-		return nil, fmt.Errorf("link statement: %v", err)
+		return nil, fmt.Errorf("link statement: %w", err)
 	}
 	err = json.Unmarshal(rawPayload, &link)
 	if err != nil {

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -128,7 +128,7 @@ func LoadECDSAPrivateKey(key []byte, pass []byte) (*signature.ECDSASignerVerifie
 	}
 	epk, ok := pk.(*ecdsa.PrivateKey)
 	if !ok {
-		return nil, fmt.Errorf("invalid private key")
+		return nil, errors.New("invalid private key")
 	}
 	return signature.LoadECDSASignerVerifier(epk, crypto.SHA256)
 }

--- a/pkg/cosign/kubernetes/client.go
+++ b/pkg/cosign/kubernetes/client.go
@@ -39,13 +39,13 @@ func restClientConfig() (*rest.Config, error) {
 	if clientcmd.IsEmptyConfig(err) {
 		restConfig, err := rest.InClusterConfig()
 		if err != nil {
-			return restConfig, fmt.Errorf("error creating REST client config in-cluster: %v", err)
+			return restConfig, fmt.Errorf("error creating REST client config in-cluster: %w", err)
 		}
 
 		return restConfig, nil
 	}
 	if err != nil {
-		return restConfig, fmt.Errorf("error creating REST client config: %v", err)
+		return restConfig, fmt.Errorf("error creating REST client config: %w", err)
 	}
 
 	return restConfig, nil

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -70,7 +70,8 @@ func DockerMediaTypes() bool {
 func SignatureImage(ref name.Reference, opts ...remote.Option) (v1.Image, error) {
 	base, err := remote.Image(ref, opts...)
 	if err != nil {
-		if te, ok := err.(*transport.Error); ok {
+		var te *transport.Error
+		if errors.As(err, &te) {
 			if te.StatusCode != http.StatusNotFound {
 				return nil, te
 			}

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -86,8 +86,8 @@ func doUpload(rekorClient *client.Rekor, pe models.ProposedEntry) (*models.LogEn
 	if err != nil {
 		// If the entry already exists, we get a specific error.
 		// Here, we display the proof and succeed.
-		if existsErr, ok := err.(*entries.CreateLogEntryConflict); ok {
-
+		var existsErr *entries.CreateLogEntryConflict
+		if errors.As(err, &existsErr) {
 			fmt.Println("Signature already exists. Displaying proof")
 			uriSplit := strings.Split(existsErr.Location.String(), "/")
 			uuid := uriSplit[len(uriSplit)-1]
@@ -209,7 +209,7 @@ func verifyTLogEntry(rekorClient *client.Rekor, uuid string) (*models.LogEntryAn
 
 	v := logverifier.New(hasher.DefaultHasher)
 	if e.Verification == nil || e.Verification.InclusionProof == nil {
-		return nil, fmt.Errorf("inclusion proof not provided")
+		return nil, errors.New("inclusion proof not provided")
 	}
 	if err := v.VerifyInclusionProof(*e.Verification.InclusionProof.LogIndex, *e.Verification.InclusionProof.TreeSize, hashes, rootHash, leafHash); err != nil {
 		return nil, errors.Wrap(err, "verifying inclusion proof")

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -302,7 +302,7 @@ func VerifySET(bundlePayload cremote.BundlePayload, signature []byte, pub *ecdsa
 	// verify the SET against the public key
 	hash := sha256.Sum256(canonicalized)
 	if !ecdsa.VerifyASN1(pub, hash[:], signature) {
-		return fmt.Errorf("unable to verify")
+		return errors.New("unable to verify")
 	}
 	return nil
 }


### PR DESCRIPTION
This mainly enables (and fixes) the `errorlint` checks.

This also fixes a handful of other things I noticed as I was passing through:
 * `fmt.Errorf` without formatting -> `errors.New`
 * `'%s'` -> `%q`

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```
