### PR TITLE
Create our very own `empty` package.

### DIFF
--- a/internal/oci/doc.go
+++ b/internal/oci/doc.go
@@ -1,0 +1,20 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package oci holds functions and types intended to align and compose with
+// github.com/google/go-containerregistry.
+// This is under internal/ to avoid folks taking a dependency on these while
+// they are still in flux.
+package oci

--- a/internal/oci/empty/empty.go
+++ b/internal/oci/empty/empty.go
@@ -1,0 +1,39 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package empty
+
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/internal/oci"
+)
+
+// Image constructs an empty image on which to base signature images.
+func Image() v1.Image {
+	base := empty.Image
+	if !oci.DockerMediaTypes() {
+		base = mutate.MediaType(base, types.OCIManifestSchema1)
+		m, err := base.Manifest()
+		if err != nil {
+			// It is impossible for this to happen.
+			panic(err.Error())
+		}
+		m.Config.MediaType = types.OCIConfigJSON
+	}
+	return base
+}

--- a/internal/oci/empty/empty_test.go
+++ b/internal/oci/empty/empty_test.go
@@ -1,0 +1,72 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package empty
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/internal/oci"
+)
+
+func TestEmptyImage(t *testing.T) {
+	tests := []struct {
+		name         string
+		value        string
+		wantMT       types.MediaType
+		wantConfigMT types.MediaType
+	}{{
+		name:         "unset",
+		wantMT:       types.OCIManifestSchema1,
+		wantConfigMT: types.OCIConfigJSON,
+	}, {
+		name:         "set false",
+		value:        "false",
+		wantMT:       types.OCIManifestSchema1,
+		wantConfigMT: types.OCIConfigJSON,
+	}, {
+		name:         "set true",
+		value:        "true",
+		wantMT:       types.DockerManifestSchema2,
+		wantConfigMT: types.DockerConfigJSON,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := os.Setenv(oci.DockerMediaTypesEnv, test.value); err != nil {
+				t.Fatalf("Setenv() = %v", err)
+			}
+
+			img := Image()
+
+			if mt, err := img.MediaType(); err != nil {
+				t.Errorf("MediaType() = %v", err)
+			} else if mt != test.wantMT {
+				t.Errorf("MediaType() = %v, wanted %v", mt, test.wantMT)
+			}
+
+			m, err := img.Manifest()
+			if err != nil {
+				t.Fatalf("ConfigFile() = %v", err)
+			}
+
+			if mt := m.Config.MediaType; mt != test.wantConfigMT {
+				t.Errorf("Config.MediaType = %v, wanted %v", mt, test.wantConfigMT)
+			}
+		})
+	}
+}

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -1,0 +1,32 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"os"
+	"strconv"
+)
+
+const (
+	DockerMediaTypesEnv = "COSIGN_DOCKER_MEDIA_TYPES"
+)
+
+func DockerMediaTypes() bool {
+	if b, err := strconv.ParseBool(os.Getenv(DockerMediaTypesEnv)); err == nil {
+		return b
+	}
+	return false
+}


### PR DESCRIPTION
#### Summary

Cosign has it's own flavor of GGCR's `empty` package, which lets users toggle the media type we use with an environment variable.  This creates our own package to mirror this.

This also start to set up an `internal/` package structure that we can use to develop the new package structure without (yet) worrying about breaking folks downstream when we change things.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
