### PR TITLE
release: update cross build image to use go 1.17.1

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -59,7 +59,7 @@ steps:
   waitFor: ['-']
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17@sha256:c0b971a8e659fcdc7d1b14ddef3a59acd79a4c85deeebef7e1c302cfa009b9e0
+- name: ghcr.io/gythialy/golang-cross:v1.17.1@sha256:d6982c0a6dae690b1f5ac977e377e75ba0db7022483c13b664a130a7934eb393
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION
#### Summary
release: update cross build image to use go 1.17.1

release: https://github.com/gythialy/golang-cross/releases/tag/v1.17.1

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
release: update cross build image to use go 1.17.1
```
