### PR TITLE
Several small changes.

### DIFF
--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -76,11 +76,6 @@ func SignatureCmd(ctx context.Context, regOpts cli.RegistryOpts, sigRef, payload
 		return err
 	}
 
-	dstRef, err := cli.AttachedImageTag(ref, cosign.SignatureTagSuffix, remoteOpts...)
-	if err != nil {
-		return err
-	}
-
 	var payload []byte
 	if payloadRef == "" {
 		img := ref.Context().Digest(h.String())
@@ -97,6 +92,12 @@ func SignatureCmd(ctx context.Context, regOpts cli.RegistryOpts, sigRef, payload
 	if err != nil {
 		return err
 	}
+
+	dstRef, err := cli.AttachedImageTag(ref, cosign.SignatureTagSuffix, remoteOpts...)
+	if err != nil {
+		return err
+	}
+
 	if _, err := cremote.UploadSignature(sigBytes, payload, dstRef, cremote.UploadOpts{RemoteOpts: remoteOpts}); err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -180,11 +180,6 @@ func AttestCmd(ctx context.Context, ko KeyOpts, regOpts RegistryOpts, imageRef s
 		return nil
 	}
 
-	attRef, err := AttachedImageTag(ref, cosign.AttestationTagSuffix, remoteOpts...)
-	if err != nil {
-		return err
-	}
-
 	uo := cremote.UploadOpts{
 		Cert:         sv.Cert,
 		Chain:        sv.Chain,
@@ -223,6 +218,11 @@ func AttestCmd(ctx context.Context, ko KeyOpts, regOpts RegistryOpts, imageRef s
 
 		uo.Bundle = bundle(entry)
 		uo.AdditionalAnnotations = parseAnnotations(entry)
+	}
+
+	attRef, err := AttachedImageTag(ref, cosign.AttestationTagSuffix, remoteOpts...)
+	if err != nil {
+		return err
 	}
 
 	fmt.Fprintln(os.Stderr, "Pushing attestation to:", attRef.String())

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -326,11 +326,6 @@ func SignCmd(ctx context.Context, ko KeyOpts, regOpts RegistryOpts, annotations 
 			continue
 		}
 
-		sigRef, err := AttachedImageTag(img, cosign.SignatureTagSuffix, remoteOpts...)
-		if err != nil {
-			return err
-		}
-
 		uo := cremote.UploadOpts{
 			Cert:         sv.Cert,
 			Chain:        sv.Chain,
@@ -368,6 +363,11 @@ func SignCmd(ctx context.Context, ko KeyOpts, regOpts RegistryOpts, annotations 
 
 			uo.Bundle = bundle(entry)
 			uo.AdditionalAnnotations = parseAnnotations(entry)
+		}
+
+		sigRef, err := AttachedImageTag(img, cosign.SignatureTagSuffix, remoteOpts...)
+		if err != nil {
+			return err
 		}
 
 		fmt.Fprintln(os.Stderr, "Pushing signature to:", sigRef.String())

--- a/internal/oci/remote/remote.go
+++ b/internal/oci/remote/remote.go
@@ -65,15 +65,21 @@ func (s *sigs) Get() ([]oci.Signature, error) {
 	}
 	signatures := make([]oci.Signature, 0, len(m.Layers))
 	for _, desc := range m.Layers {
+		layer, err := s.Image.LayerByDigest(desc.Digest)
+		if err != nil {
+			return nil, err
+		}
 		signatures = append(signatures, &sigLayer{
-			img:  s,
-			desc: desc,
+			Layer: layer,
+			img:   s,
+			desc:  desc,
 		})
 	}
 	return signatures, nil
 }
 
 type sigLayer struct {
+	v1.Layer
 	img  *sigs
 	desc v1.Descriptor
 }

--- a/internal/oci/signatures.go
+++ b/internal/oci/signatures.go
@@ -37,6 +37,8 @@ type Signatures interface {
 
 // Signature holds a single image signature.
 type Signature interface {
+	v1.Layer
+
 	// Payload fetches the opaque data that is being signed.
 	// This will always return data when there is no error.
 	Payload() ([]byte, error)


### PR DESCRIPTION
1. Move `AttachedImageTag` calls closer to `UploadSignature` (and friends),
1. Make `sbom.go` use `remote.Signatures`,
1. Make `Signature` embed `v1.Layer`.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
