### PR TITLE
Define a shared `SignedEntity` interface.

### DIFF
--- a/internal/oci/index.go
+++ b/internal/oci/index.go
@@ -21,6 +21,7 @@ import v1 "github.com/google/go-containerregistry/pkg/v1"
 // for retrieving signed metadata associated with that ImageIndex.
 type SignedImageIndex interface {
 	v1.ImageIndex
+	SignedEntity
 
 	// SignedImage is the same as Image, but provides accessors for the nested
 	// image's signed metadata.
@@ -29,12 +30,4 @@ type SignedImageIndex interface {
 	// SignedImageIndex is the same as ImageIndex, but provides accessors for
 	// the nested image index's signed metadata.
 	SignedImageIndex(v1.Hash) (SignedImageIndex, error)
-
-	// Signatures returns the set of signatures currently associated with this
-	// image, or the empty equivalent if none are found.
-	Signatures() (Signatures, error)
-
-	// Attestations returns the set of attestations currently associated with this
-	// image, or the empty equivalent if none are found.
-	Attestations() (Attestations, error)
 }

--- a/internal/oci/interface.go
+++ b/internal/oci/interface.go
@@ -15,11 +15,12 @@
 
 package oci
 
-import v1 "github.com/google/go-containerregistry/pkg/v1"
+type SignedEntity interface {
+	// Signatures returns the set of signatures currently associated with this
+	// entity, or the empty equivalent if none are found.
+	Signatures() (Signatures, error)
 
-// SignedImage represents an OCI Image, complemented with accessors
-// for retrieving signed metadata associated with that image.
-type SignedImage interface {
-	v1.Image
-	SignedEntity
+	// Attestations returns the set of attestations currently associated with this
+	// entity, or the empty equivalent if none are found.
+	Attestations() (Attestations, error)
 }


### PR DESCRIPTION
Starting to look at things like `remote.Get`, I realized that it will be possible for us to return either a `SignedImage` or `SignedImageIndex` and the caller can still access `Signatures()` and `Attestations()`.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link

Related: https://github.com/sigstore/cosign/pull/701

#### Release Note
```release-note
NONE
```
