### PR TITLE
ci/operations: add milestone applier

### DIFF
--- a/.github/workflows/milestone.yaml
+++ b/.github/workflows/milestone.yaml
@@ -1,0 +1,41 @@
+name: Milestone
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  milestone:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v4
+        with:
+          script: |
+            if (!context.payload.pull_request.merged) {
+              console.log('PR was not merged, skipping.');
+              return;
+            }
+
+            if (!!context.payload.pull_request.milestone) {
+              console.log('PR has existing milestone, skipping.');
+              return;
+            }
+
+            milestones = await github.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'due_on',
+              direction: 'asc'
+            })
+            if (milestones.data.length === 0) {
+              console.log('There are no milestones, skipping.');
+              return;
+            }
+
+            await github.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              milestone: milestones.data[0].number
+            });


### PR DESCRIPTION
#### Summary
I've been adding the milestone for some time, then now I think it's time to a bot assumes this 😄 

This PR adds a GitHub action that will run when we merge pull requests.

- it will add the milestone if the PR is merged and there is no milestone already associated 


If you find this useful, let's get this in and test and then I will add in the other repositories as well

#### Ticket Link

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
