### PR TITLE
Start to sketch `internal/oci/remote.SignedImage[Index]`.

### DIFF
--- a/cmd/cosign/cli/download/signature.go
+++ b/cmd/cosign/cli/download/signature.go
@@ -25,6 +25,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli"
+	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 	"github.com/sigstore/cosign/pkg/cosign"
 )
 
@@ -53,12 +54,8 @@ func SignatureCmd(ctx context.Context, regOpts cli.RegistryOpts, imageRef string
 	if err != nil {
 		return err
 	}
-	sigRepo, err := cli.TargetRepositoryForImage(ref)
-	if err != nil {
-		return err
-	}
 	regClientOpts := regOpts.GetRegistryClientOpts(ctx)
-	signatures, err := cosign.FetchSignaturesForImage(ctx, ref, sigRepo, cosign.SignatureTagSuffix, regClientOpts...)
+	signatures, err := cosign.FetchSignaturesForImage(ctx, ref, ociremote.WithRemoteOptions(regClientOpts...))
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/util.go
+++ b/cmd/cosign/cli/util.go
@@ -32,11 +32,12 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/kms"
+
+	oremote "github.com/sigstore/cosign/internal/oci/remote"
 )
 
 const (
 	ExperimentalEnv = "COSIGN_EXPERIMENTAL"
-	repoEnv         = "COSIGN_REPOSITORY"
 )
 
 func EnableExperimental() bool {
@@ -47,7 +48,7 @@ func EnableExperimental() bool {
 }
 
 func TargetRepositoryForImage(img name.Reference) (name.Repository, error) {
-	wantRepo := os.Getenv(repoEnv)
+	wantRepo := os.Getenv(oremote.RepoOverrideKey)
 	if wantRepo == "" {
 		return img.Context(), nil
 	}

--- a/cmd/cosign/cli/util_test.go
+++ b/cmd/cosign/cli/util_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 )
 
 func TestTargetRepositoryForImage(t *testing.T) {
@@ -68,8 +69,8 @@ func TestTargetRepositoryForImage(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			os.Setenv(repoEnv, test.envRepo)
-			defer os.Unsetenv(repoEnv)
+			os.Setenv(ociremote.RepoOverrideKey, test.envRepo)
+			defer os.Unsetenv(ociremote.RepoOverrideKey)
 
 			got, err := TargetRepositoryForImage(test.image)
 			if err != nil {

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli"
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
+	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
@@ -136,16 +137,12 @@ func main() {
 			if err != nil {
 				return nil, err
 			}
-			sigRepo, err := cli.TargetRepositoryForImage(ref)
-			if err != nil {
-				return nil, err
-			}
 			registryOpts := []remote.Option{
 				remote.WithAuthFromKeychain(authn.DefaultKeychain),
 				remote.WithContext(bctx.Context),
 			}
 
-			sps, err := cosign.FetchSignaturesForImage(bctx.Context, ref, sigRepo, cosign.SignatureTagSuffix, registryOpts...)
+			sps, err := cosign.FetchSignaturesForImage(bctx.Context, ref, ociremote.WithRemoteOptions(registryOpts...))
 			if err != nil {
 				return nil, err
 			}

--- a/internal/oci/remote/options.go
+++ b/internal/oci/remote/options.go
@@ -1,0 +1,120 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"os"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+const (
+	SignatureTagSuffix   = ".sig"
+	SBOMTagSuffix        = ".sbom"
+	AttestationTagSuffix = ".att"
+
+	RepoOverrideKey = "COSIGN_REPOSITORY"
+)
+
+// Option is a functional option for remote operations.
+type Option func(*options) error
+
+type options struct {
+	SignatureSuffix   string
+	AttestationSuffix string
+	SBOMSuffix        string
+	TargetRepository  name.Repository
+	ROpt              []remote.Option
+}
+
+var defaultOptions = []remote.Option{
+	remote.WithAuthFromKeychain(authn.DefaultKeychain),
+	// TODO(mattmoor): Incorporate user agent.
+}
+
+func makeOptions(target name.Repository, opts ...Option) (*options, error) {
+	o := &options{
+		SignatureSuffix:   SignatureTagSuffix,
+		AttestationSuffix: AttestationTagSuffix,
+		SBOMSuffix:        SBOMTagSuffix,
+		TargetRepository:  target,
+		ROpt:              defaultOptions,
+	}
+
+	// Before applying options, allow the environment to override things.
+	if ro := os.Getenv(RepoOverrideKey); ro != "" {
+		repo, err := name.NewRepository(ro)
+		if err != nil {
+			return nil, err
+		}
+		o.TargetRepository = repo
+	}
+
+	for _, option := range opts {
+		if err := option(o); err != nil {
+			return nil, err
+		}
+	}
+
+	return o, nil
+}
+
+// WithSignatureSuffix is a functional option for overriding the default
+// signature tag suffix.
+func WithSignatureSuffix(suffix string) Option {
+	return func(o *options) error {
+		o.SignatureSuffix = suffix
+		return nil
+	}
+}
+
+// WithAttestationSuffix is a functional option for overriding the default
+// attestation tag suffix.
+func WithAttestationSuffix(suffix string) Option {
+	return func(o *options) error {
+		o.AttestationSuffix = suffix
+		return nil
+	}
+}
+
+// WithSBOMSuffix is a functional option for overriding the default
+// SBOM tag suffix.
+func WithSBOMSuffix(suffix string) Option {
+	return func(o *options) error {
+		o.SBOMSuffix = suffix
+		return nil
+	}
+}
+
+// WithRemoteOptions is a functional option for overriding the default
+// remote options passed to GGCR.
+func WithRemoteOptions(opts ...remote.Option) Option {
+	return func(o *options) error {
+		o.ROpt = opts
+		return nil
+	}
+}
+
+// WithTargetRepository is a functional option for overriding the default
+// target repository hosting the signature and attestation tags.
+func WithTargetRepository(repo name.Repository) Option {
+	return func(o *options) error {
+		o.TargetRepository = repo
+		return nil
+	}
+}

--- a/internal/oci/remote/options_test.go
+++ b/internal/oci/remote/options_test.go
@@ -1,0 +1,157 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/pkg/errors"
+)
+
+func TestOptions(t *testing.T) {
+	ev := os.Getenv(RepoOverrideKey)
+	defer os.Setenv(RepoOverrideKey, ev)
+	os.Setenv(RepoOverrideKey, "gcr.io/distroless")
+
+	repo, err := name.NewRepository("gcr.io/projectsigstore")
+	if err != nil {
+		t.Errorf("NewRepository() = %v", err)
+	}
+
+	overrideRepo, err := name.NewRepository("gcr.io/distroless")
+	if err != nil {
+		t.Errorf("NewRepository() = %v", err)
+	}
+
+	otherRepo, err := name.NewRepository("ghcr.io/distroful")
+	if err != nil {
+		t.Errorf("NewRepository() = %v", err)
+	}
+
+	otherROpt := []remote.Option{
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		// TODO(mattmoor): Incorporate user agent.
+	}
+
+	tests := []struct {
+		name string
+		opts []Option
+		want *options
+	}{{
+		name: "no options",
+		want: &options{
+			SignatureSuffix:   SignatureTagSuffix,
+			AttestationSuffix: AttestationTagSuffix,
+			SBOMSuffix:        SBOMTagSuffix,
+			TargetRepository:  overrideRepo,
+			ROpt:              defaultOptions,
+		},
+	}, {
+		name: "signature option",
+		opts: []Option{WithSignatureSuffix(".pig")},
+		want: &options{
+			SignatureSuffix:   ".pig",
+			AttestationSuffix: AttestationTagSuffix,
+			SBOMSuffix:        SBOMTagSuffix,
+			TargetRepository:  overrideRepo,
+			ROpt:              defaultOptions,
+		},
+	}, {
+		name: "attestation option",
+		opts: []Option{WithAttestationSuffix(".pig")},
+		want: &options{
+			SignatureSuffix:   SignatureTagSuffix,
+			AttestationSuffix: ".pig",
+			SBOMSuffix:        SBOMTagSuffix,
+			TargetRepository:  overrideRepo,
+			ROpt:              defaultOptions,
+		},
+	}, {
+		name: "sbom option",
+		opts: []Option{WithSBOMSuffix(".pig")},
+		want: &options{
+			SignatureSuffix:   SignatureTagSuffix,
+			AttestationSuffix: AttestationTagSuffix,
+			SBOMSuffix:        ".pig",
+			TargetRepository:  overrideRepo,
+			ROpt:              defaultOptions,
+		},
+	}, {
+		name: "target repo option",
+		opts: []Option{WithTargetRepository(otherRepo)},
+		want: &options{
+			SignatureSuffix:   SignatureTagSuffix,
+			AttestationSuffix: AttestationTagSuffix,
+			SBOMSuffix:        SBOMTagSuffix,
+			TargetRepository:  otherRepo,
+			ROpt:              defaultOptions,
+		},
+	}, {
+		name: "remote options option",
+		opts: []Option{WithRemoteOptions(otherROpt...)},
+		want: &options{
+			SignatureSuffix:   SignatureTagSuffix,
+			AttestationSuffix: AttestationTagSuffix,
+			SBOMSuffix:        SBOMTagSuffix,
+			TargetRepository:  overrideRepo,
+			ROpt:              otherROpt,
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := makeOptions(repo, test.opts...)
+			if err != nil {
+				t.Fatalf("makeOptions() = %v", err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("makeOptions() = %#v, wanted %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestOptionsErrors(t *testing.T) {
+	repo, err := name.NewRepository("gcr.io/projectsigstore")
+	if err != nil {
+		t.Errorf("NewRepository() = %v", err)
+	}
+
+	want := errors.New("you should expect this error")
+
+	_, got := makeOptions(repo, func(*options) error {
+		return want
+	})
+	if !errors.Is(got, want) {
+		t.Fatalf("makeOptions() = %#v, wanted %v", got, want)
+	}
+
+	ev := os.Getenv(RepoOverrideKey)
+	defer os.Setenv(RepoOverrideKey, ev)
+	os.Setenv(RepoOverrideKey, "gcr.io/illegal@character")
+
+	want = errors.New("repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: illegal@character")
+	_, got = makeOptions(repo)
+	if got.Error() != want.Error() {
+		t.Fatalf("makeOptions() = %v, wanted %v", got, want)
+	}
+}

--- a/internal/oci/remote/remote.go
+++ b/internal/oci/remote/remote.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/internal/oci"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -37,10 +38,167 @@ const (
 	BundleKey = "dev.sigstore.cosign/bundle"
 )
 
-// This enables mocking for unit testing without faking an entire registry.
-var remoteImage = remote.Image
+// These enable mocking for unit testing without faking an entire registry.
+var (
+	remoteImage = remote.Image
+	remoteIndex = remote.Index
+	remoteGet   = remote.Get
+)
+
+// SignedEntity provides access to a remote reference, and its signatures.
+// The SignedEntity will be one of SignedImage or SignedImageIndex.
+func SignedEntity(ref name.Reference, options ...Option) (oci.SignedEntity, error) {
+	o, err := makeOptions(ref.Context(), options...)
+	if err != nil {
+		return nil, err
+	}
+
+	got, err := remoteGet(ref, o.ROpt...)
+	if err != nil {
+		return nil, err
+	}
+
+	switch got.MediaType {
+	case types.OCIImageIndex, types.DockerManifestList:
+		ii, err := got.ImageIndex()
+		if err != nil {
+			return nil, err
+		}
+		return &index{
+			v1Index: ii,
+			ref:     ref.Context().Digest(got.Digest.String()),
+			opt:     o,
+		}, nil
+
+	case types.OCIManifestSchema1, types.DockerManifestSchema2:
+		i, err := got.Image()
+		if err != nil {
+			return nil, err
+		}
+		return &image{
+			Image: i,
+			opt:   o,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf("unknown mime type: %v", got.MediaType)
+	}
+}
+
+// SignedImageIndex provides access to a remote index reference, and its signatures.
+func SignedImageIndex(ref name.Reference, options ...Option) (oci.SignedImageIndex, error) {
+	o, err := makeOptions(ref.Context(), options...)
+	if err != nil {
+		return nil, err
+	}
+	ri, err := remoteIndex(ref, o.ROpt...)
+	if err != nil {
+		return nil, err
+	}
+	return &index{
+		v1Index: ri,
+		ref:     ref,
+		opt:     o,
+	}, nil
+}
+
+// We alias ImageIndex so that we can inline it without the type
+// name colliding with the name of a method it had to implement.
+type v1Index v1.ImageIndex
+
+type index struct {
+	v1Index
+	ref name.Reference
+	opt *options
+}
+
+var _ oci.SignedImageIndex = (*index)(nil)
+
+func normalize(h v1.Hash, suffix string) string {
+	// sha256:d34db33f -> sha256-d34db33f.suffix
+	return strings.ReplaceAll(h.String(), ":", "-") + suffix
+}
+
+// signatures is a shared implementation of the oci.Signed* Signatures method.
+func signatures(digestable interface{ Digest() (v1.Hash, error) }, o *options) (oci.Signatures, error) {
+	h, err := digestable.Digest()
+	if err != nil {
+		return nil, err
+	}
+	return Signatures(o.TargetRepository.Tag(normalize(h, o.SignatureSuffix)), o.ROpt...)
+}
+
+// Signatures implements oic.SignedImageIndex
+func (i *index) Signatures() (oci.Signatures, error) {
+	return signatures(i, i.opt)
+}
+
+// Attestations implements oic.SignedImageIndex
+func (i *index) Attestations() (oci.Attestations, error) {
+	// TODO(mattmoor): allow accessing attestations.
+	return nil, errors.New("NYI")
+}
+
+// SignedImage implements oic.SignedImageIndex
+func (i *index) SignedImage(h v1.Hash) (oci.SignedImage, error) {
+	img, err := i.Image(h)
+	if err != nil {
+		return nil, err
+	}
+	return &image{
+		Image: img,
+		opt:   i.opt,
+	}, nil
+}
+
+// SignedImageIndex implements oic.SignedImageIndex
+func (i *index) SignedImageIndex(h v1.Hash) (oci.SignedImageIndex, error) {
+	ii, err := i.ImageIndex(h)
+	if err != nil {
+		return nil, err
+	}
+	return &index{
+		v1Index: ii,
+		opt:     i.opt,
+	}, nil
+}
+
+// SignedImage provides access to a remote image reference, and its signatures.
+func SignedImage(ref name.Reference, options ...Option) (oci.SignedImage, error) {
+	o, err := makeOptions(ref.Context(), options...)
+	if err != nil {
+		return nil, err
+	}
+	ri, err := remoteImage(ref, o.ROpt...)
+	if err != nil {
+		return nil, err
+	}
+	return &image{
+		Image: ri,
+		opt:   o,
+	}, nil
+}
+
+type image struct {
+	v1.Image
+	opt *options
+}
+
+var _ oci.SignedImage = (*image)(nil)
+
+// Signatures implements oic.SignedImage
+func (i *image) Signatures() (oci.Signatures, error) {
+	return signatures(i, i.opt)
+}
+
+// Attestations implements oic.SignedImage
+func (i *image) Attestations() (oci.Attestations, error) {
+	// TODO(mattmoor): allow accessing attestations.
+	return nil, errors.New("NYI")
+}
 
 // Signatures fetches the signatures image represented by the named reference.
+// TODO(mattmoor): Consider changing to take our Options
 func Signatures(ref name.Reference, opts ...remote.Option) (oci.Signatures, error) {
 	img, err := remoteImage(ref, opts...)
 	if err != nil {


### PR DESCRIPTION
This follows the pattern GGCR uses for functional `remote.Options`, and starts to define `SignedImage[Index]` methods, which build upon the `Signatures` implementation from a prior change.

This also tries to start adopting this pattern a few places, which drops bits of boilerplate (or changes them to functional options).

As part of this, I'm combining `FetchSignaturesForImage[Digest]` and tweaking it's signature a bit (no pun intended!), but I think long term we'll just want folks to consume the `remote` package directly themselves.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
