### PR TITLE
Skip empty values, not just missing keys.

### DIFF
--- a/internal/oci/remote/remote.go
+++ b/internal/oci/remote/remote.go
@@ -116,8 +116,8 @@ func (s *sigLayer) Base64Signature() (string, error) {
 
 // Cert implements oci.Signature
 func (s *sigLayer) Cert() (*x509.Certificate, error) {
-	certPEM, ok := s.desc.Annotations[certkey]
-	if !ok {
+	certPEM := s.desc.Annotations[certkey]
+	if certPEM == "" {
 		return nil, nil
 	}
 	certs, err := cryptoutils.LoadCertificatesFromPEM(strings.NewReader(certPEM))
@@ -129,8 +129,8 @@ func (s *sigLayer) Cert() (*x509.Certificate, error) {
 
 // Chain implements oci.Signature
 func (s *sigLayer) Chain() ([]*x509.Certificate, error) {
-	chainPEM, ok := s.desc.Annotations[chainkey]
-	if !ok {
+	chainPEM := s.desc.Annotations[chainkey]
+	if chainPEM == "" {
 		return nil, nil
 	}
 	certs, err := cryptoutils.LoadCertificatesFromPEM(strings.NewReader(chainPEM))

--- a/internal/oci/remote/remote_test.go
+++ b/internal/oci/remote/remote_test.go
@@ -70,6 +70,23 @@ func TestSignature(t *testing.T) {
 		},
 		wantSig: "blah",
 	}, {
+		name: "with empty other keys",
+		l: &sigLayer{
+			img: &sigs{
+				Image: must(mutate.Append(empty.Image(), mutate.Addendum{Layer: layer})),
+			},
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:    "blah",
+					certkey:   "",
+					chainkey:  "",
+					BundleKey: "",
+				},
+			},
+		},
+		wantSig: "blah",
+	}, {
 		name: "bad digest",
 		l: &sigLayer{
 			img: &sigs{


### PR DESCRIPTION
One of my previous changes switch from skipping `""` fetched from the map to using this syntax:

```go
blah, ok := themap[thekey]
if !ok {
...
}
```

However, it seems like there may be paths where we actually have these keys, but they contain empty string.

I'm seeing an index-out-of-bounds with both open PRs and HEAD trying to `cosign verify dockerfile` with `gcr.io/distroless/base`.

I'm sending this while I do a big more digging into the signatures there, but wanted to eliminate this delta quickly to avoid tripping others up.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

#### Release Note
```release-note
NONE
```
