### PR TITLE
move `verify-manifest` to `manifest verify`

### DIFF
--- a/cmd/cosign/cli/manifest/manifest.go
+++ b/cmd/cosign/cli/manifest/manifest.go
@@ -1,0 +1,39 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifest
+
+import (
+	"context"
+	"flag"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+func Manifest() *ffcli.Command {
+	var (
+		flagset = flag.NewFlagSet("cosign manifest", flag.ExitOnError)
+	)
+
+	return &ffcli.Command{
+		Name:        "manifest",
+		ShortUsage:  "cosign manifest",
+		ShortHelp:   "Provides utilities for discovering images in and performing operations on Kubernetes manifests",
+		FlagSet:     flagset,
+		Subcommands: []*ffcli.Command{VerifyManifest()},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}

--- a/cmd/cosign/cli/manifest/verify.go
+++ b/cmd/cosign/cli/manifest/verify.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli
+package manifest
 
 import (
 	"bytes"
@@ -27,54 +27,55 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/pkg/errors"
+	"github.com/sigstore/cosign/cmd/cosign/cli"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // VerifyManifestCommand verifies all image signatures on a supplied k8s resource
 type VerifyManifestCommand struct {
-	VerifyCommand
+	cli.VerifyCommand
 }
 
 // VerifyManifest builds and returns an ffcli command
 func VerifyManifest() *ffcli.Command {
-	cmd := VerifyManifestCommand{VerifyCommand: VerifyCommand{}}
-	flagset := flag.NewFlagSet("cosign verify-manifest", flag.ExitOnError)
-	ApplyVerifyFlags(&cmd.VerifyCommand, flagset)
+	cmd := VerifyManifestCommand{}
+	flagset := flag.NewFlagSet("cosign manifest verify", flag.ExitOnError)
+	cli.ApplyVerifyFlags(&cmd.VerifyCommand, flagset)
 
 	return &ffcli.Command{
-		Name:       "verify-manifest",
-		ShortUsage: "cosign verify-manifest -key <key path>|<key url>|<kms uri> <path/to/manifest>",
+		Name:       "verify",
+		ShortUsage: "cosign manifest verify -key <key path>|<key url>|<kms uri> <path/to/manifest>",
 		ShortHelp:  "Verify all signatures of images specified in the manifest",
 		LongHelp: `Verify all signature of images in a Kubernetes resource manifest by checking claims
 against the transparency log.
 
 EXAMPLES
   # verify cosign claims and signing certificates on images in the manifest
-  cosign verify-manifest <path/to/my-deployment.yaml>
+  cosign manifest verify <path/to/my-deployment.yaml>
 
   # additionally verify specified annotations
-  cosign verify-manifest -a key1=val1 -a key2=val2 <path/to/my-deployment.yaml>
+  cosign manifest verify -a key1=val1 -a key2=val2 <path/to/my-deployment.yaml>
 
   # (experimental) additionally, verify with the transparency log
-  COSIGN_EXPERIMENTAL=1 cosign verify-manifest <path/to/my-deployment.yaml>
+  COSIGN_EXPERIMENTAL=1 cosign manifest verify <path/to/my-deployment.yaml>
 
   # verify images with public key
-  cosign verify-manifest -key cosign.pub <path/to/my-deployment.yaml>
+  cosign manifest verify -key cosign.pub <path/to/my-deployment.yaml>
 
   # verify images with public key provided by URL
-  cosign verify-manifest -key https://host.for/<FILE> <path/to/my-deployment.yaml>
+  cosign manifest verify -key https://host.for/<FILE> <path/to/my-deployment.yaml>
 
   # verify images with public key stored in Azure Key Vault
-  cosign verify-manifest -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <path/to/my-deployment.yaml>
+  cosign manifest verify -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <path/to/my-deployment.yaml>
 
   # verify images with public key stored in AWS KMS
-  cosign verify-manifest -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <path/to/my-deployment.yaml>
+  cosign manifest verify -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <path/to/my-deployment.yaml>
 
   # verify images with public key stored in Google Cloud KMS
-  cosign verify-manifest -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <path/to/my-deployment.yaml>
+  cosign manifest verify -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <path/to/my-deployment.yaml>
 
   # verify images with public key stored in Hashicorp Vault
-  cosign verify-manifest -key hashivault://[KEY] <path/to/my-deployment.yaml>`,
+  cosign manifest verify -key hashivault://[KEY] <path/to/my-deployment.yaml>`,
 
 		FlagSet: flagset,
 		Exec:    cmd.Exec,

--- a/cmd/cosign/cli/manifest/verify_test.go
+++ b/cmd/cosign/cli/manifest/verify_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cli
+package manifest
 
 import (
 	"reflect"

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/attach"
 	"github.com/sigstore/cosign/cmd/cosign/cli/dockerfile"
 	"github.com/sigstore/cosign/cmd/cosign/cli/download"
+	"github.com/sigstore/cosign/cmd/cosign/cli/manifest"
 	"github.com/sigstore/cosign/cmd/cosign/cli/pivcli"
 	"github.com/sigstore/cosign/cmd/cosign/cli/upload"
 )
@@ -56,7 +57,8 @@ func main() {
 			cli.SignBlob(),
 			cli.VerifyAttestation(),
 			cli.VerifyBlob(),
-			cli.VerifyManifest(),
+			// Manifest sub-tree
+			manifest.Manifest(),
 			// Upload sub-tree
 			upload.Upload(),
 			// Download sub-tree

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -58,9 +58,9 @@ test_image="gcr.io/distroless/base" ./cosign dockerfile verify -key ${DISTROLESS
 if (test_image="ubuntu" ./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile); then false; fi
 ./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_lowercase.Dockerfile
 
-# Test `cosign verify-manifest`
-./cosign verify-manifest -key ${DISTROLESS_PUB_KEY} ./test/testdata/signed_manifest.yaml
-if (./cosign verify-manifest -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_manifest.yaml); then false; fi
+# Test `cosign manifest verify`
+./cosign manifest verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/signed_manifest.yaml
+if (./cosign manifest verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_manifest.yaml); then false; fi
 
 # Run the built container to make sure it doesn't crash
 make ko-local


### PR DESCRIPTION
A follow up to https://github.com/sigstore/cosign/pull/662 regarding the concerns brought up in https://github.com/sigstore/cosign/issues/437

```release-note
BREAKING: `verify-manifest` is now `manifest verify`
```
