### PR TITLE
ci/operations: fixing milestone workflow, when running a fork the temp token is not set

### DIFF
--- a/.github/workflows/milestone.yaml
+++ b/.github/workflows/milestone.yaml
@@ -1,12 +1,27 @@
 name: Milestone
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
+    branches:
+      - main
 
 jobs:
   milestone:
     runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      checks: none
+      contents: read
+      deployments: none
+      issues: write
+      packages: none
+      pull-requests: write
+      repository-projects: none
+      security-events: none
+      statuses: none
+
     steps:
       - uses: actions/github-script@v4
         with:


### PR DESCRIPTION
#### Summary
the milestone workflow is not working because the PRs are from a fork and then the tempo token is not set, if we use the `pull_request_target` and limit the permissions for this workflow then this works



#### Ticket Link
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
