### PR TITLE
Rename `FetchSignaturesForImage` to `Reference`

### DIFF
--- a/cmd/cosign/cli/download/signature.go
+++ b/cmd/cosign/cli/download/signature.go
@@ -55,7 +55,7 @@ func SignatureCmd(ctx context.Context, regOpts cli.RegistryOpts, imageRef string
 		return err
 	}
 	regClientOpts := regOpts.GetRegistryClientOpts(ctx)
-	signatures, err := cosign.FetchSignaturesForImage(ctx, ref, ociremote.WithRemoteOptions(regClientOpts...))
+	signatures, err := cosign.FetchSignaturesForReference(ctx, ref, ociremote.WithRemoteOptions(regClientOpts...))
 	if err != nil {
 		return err
 	}

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -141,7 +141,7 @@ func main() {
 			}
 			registryOpts := regOpts.GetRegistryClientOpts(bctx.Context)
 
-			sps, err := cosign.FetchSignaturesForImage(bctx.Context, ref, ociremote.WithRemoteOptions(registryOpts...))
+			sps, err := cosign.FetchSignaturesForReference(bctx.Context, ref, ociremote.WithRemoteOptions(registryOpts...))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -66,7 +66,7 @@ func AttachedImageTag(repo name.Repository, digest v1.Hash, tagSuffix string) na
 	return repo.Tag(tagStr)
 }
 
-func FetchSignaturesForImage(ctx context.Context, ref name.Reference, opts ...ociremote.Option) ([]SignedPayload, error) {
+func FetchSignaturesForReference(ctx context.Context, ref name.Reference, opts ...ociremote.Option) ([]SignedPayload, error) {
 	simg, err := ociremote.SignedEntity(ref, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -103,7 +103,7 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 
 	// TODO(mattmoor): If we change this code to interact with the SignedImage directly,
 	// then we could shed the `remote.Get` above.
-	allSignatures, err := FetchSignaturesForImage(ctx, signedImgRef, opts...)
+	allSignatures, err := FetchSignaturesForReference(ctx, signedImgRef, opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching signatures")
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -245,7 +245,7 @@ func TestDuplicateSign(t *testing.T) {
 	// Signing again should work just fine...
 	must(cli.SignCmd(ctx, ko, cli.RegistryOpts{}, nil, []string{imgName}, "", true, "", false, false, ""), t)
 
-	signatures, err := cosign.FetchSignaturesForImage(ctx, ref, ociremote.WithRemoteOptions(registryClientOpts(ctx)...))
+	signatures, err := cosign.FetchSignaturesForReference(ctx, ref, ociremote.WithRemoteOptions(registryClientOpts(ctx)...))
 	if err != nil {
 		t.Fatalf("failed to fetch signatures: %v", err)
 	}
@@ -497,7 +497,7 @@ func TestUploadDownload(t *testing.T) {
 
 			// Now download it!
 			regClientOpts := registryClientOpts(ctx)
-			signatures, err := cosign.FetchSignaturesForImage(ctx, ref, ociremote.WithRemoteOptions(regClientOpts...))
+			signatures, err := cosign.FetchSignaturesForReference(ctx, ref, ociremote.WithRemoteOptions(regClientOpts...))
 			if testCase.expectedErr {
 				mustErr(err, t)
 			} else {


### PR DESCRIPTION
This is sort of a throwaway, since I want to kill this method, but I realized staring at it that it's a misnomer since it actually needs to handle `ImageIndex` as well today.  The name misled me into using `ociremote.SignedImage` here where I really wanted `ociremote.SignedEntity`.  Anyways, VS Code made it easy to change, so I changed it :D

Signed-off-by: Matt Moore <mattomata@gmail.com>



#### Ticket Link
N/A it's a nit

#### Release Note

```release-note
NONe
```
