### PR TITLE
Have `Signatures` take `ociremote.Options`.

### DIFF
--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -63,7 +63,7 @@ func SBOMCmd(ctx context.Context, regOpts cli.RegistryOpts, imageRef string, out
 	if err != nil {
 		return nil, err
 	}
-	img, err := remote.Signatures(dstRef, remoteOpts...)
+	img, err := remote.Signatures(dstRef, remote.WithRemoteOptions(remoteOpts...))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oci/remote/options.go
+++ b/internal/oci/remote/options.go
@@ -40,6 +40,8 @@ type options struct {
 	SBOMSuffix        string
 	TargetRepository  name.Repository
 	ROpt              []remote.Option
+
+	OriginalOptions []Option
 }
 
 var defaultOptions = []remote.Option{
@@ -54,6 +56,10 @@ func makeOptions(target name.Repository, opts ...Option) (*options, error) {
 		SBOMSuffix:        SBOMTagSuffix,
 		TargetRepository:  target,
 		ROpt:              defaultOptions,
+
+		// Keep the original options around for things that want
+		// to call something that takes options!
+		OriginalOptions: opts,
 	}
 
 	// Before applying options, allow the environment to override things.

--- a/internal/oci/remote/options_test.go
+++ b/internal/oci/remote/options_test.go
@@ -122,6 +122,7 @@ func TestOptions(t *testing.T) {
 			if err != nil {
 				t.Fatalf("makeOptions() = %v", err)
 			}
+			test.want.OriginalOptions = test.opts
 
 			if !reflect.DeepEqual(got, test.want) {
 				t.Errorf("makeOptions() = %#v, wanted %#v", got, test.want)

--- a/internal/oci/remote/remote.go
+++ b/internal/oci/remote/remote.go
@@ -91,5 +91,5 @@ func signatures(digestable interface{ Digest() (v1.Hash, error) }, o *options) (
 	if err != nil {
 		return nil, err
 	}
-	return Signatures(o.TargetRepository.Tag(normalize(h, o.SignatureSuffix)), o.ROpt...)
+	return Signatures(o.TargetRepository.Tag(normalize(h, o.SignatureSuffix)), o.OriginalOptions...)
 }

--- a/internal/oci/remote/signatures.go
+++ b/internal/oci/remote/signatures.go
@@ -18,14 +18,16 @@ package remote
 import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/internal/oci"
 )
 
 // Signatures fetches the signatures image represented by the named reference.
-// TODO(mattmoor): Consider changing to take our Options
-func Signatures(ref name.Reference, opts ...remote.Option) (oci.Signatures, error) {
-	img, err := remoteImage(ref, opts...)
+func Signatures(ref name.Reference, opts ...Option) (oci.Signatures, error) {
+	o, err := makeOptions(ref.Context(), opts...)
+	if err != nil {
+		return nil, err
+	}
+	img, err := remoteImage(ref, o.ROpt...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This was a TODO in the previous PR that introduces `ociremote.Option`.  This is mostly for consistency of these interfaces.

Signed-off-by: Matt Moore <mattomata@gmail.com>



#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
