### PR TITLE
Convert `empty.Image` to `empty.Signatures`

### DIFF
--- a/internal/oci/empty/empty.go
+++ b/internal/oci/empty/empty.go
@@ -24,8 +24,8 @@ import (
 	"github.com/sigstore/cosign/internal/oci"
 )
 
-// Image constructs an empty image on which to base signature images.
-func Image() v1.Image {
+// Signatures constructs an empty oci.Signatures.
+func Signatures() oci.Signatures {
 	base := empty.Image
 	if !oci.DockerMediaTypes() {
 		base = mutate.MediaType(base, types.OCIManifestSchema1)
@@ -36,5 +36,18 @@ func Image() v1.Image {
 		}
 		m.Config.MediaType = types.OCIConfigJSON
 	}
-	return base
+	return &emptyImage{
+		Image: base,
+	}
+}
+
+type emptyImage struct {
+	v1.Image
+}
+
+var _ oci.Signatures = (*emptyImage)(nil)
+
+// Get implements oci.Signatures
+func (*emptyImage) Get() ([]oci.Signature, error) {
+	return nil, nil
 }

--- a/internal/oci/empty/empty_test.go
+++ b/internal/oci/empty/empty_test.go
@@ -52,7 +52,7 @@ func TestEmptyImage(t *testing.T) {
 				t.Fatalf("Setenv() = %v", err)
 			}
 
-			img := Image()
+			img := Signatures()
 
 			if mt, err := img.MediaType(); err != nil {
 				t.Errorf("MediaType() = %v", err)

--- a/internal/oci/remote/layer_test.go
+++ b/internal/oci/remote/layer_test.go
@@ -56,7 +56,7 @@ func TestSignature(t *testing.T) {
 		name: "just payload and signature",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -70,7 +70,7 @@ func TestSignature(t *testing.T) {
 		name: "with empty other keys",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -87,7 +87,7 @@ func TestSignature(t *testing.T) {
 		name: "bad digest",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: v1.Hash{Algorithm: "bad", Hex: "f00d"},
@@ -102,7 +102,7 @@ func TestSignature(t *testing.T) {
 		name: "missing signature",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -113,7 +113,7 @@ func TestSignature(t *testing.T) {
 		name: "min plus bad bundle",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -129,7 +129,7 @@ func TestSignature(t *testing.T) {
 		name: "min plus bad cert",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -145,7 +145,7 @@ func TestSignature(t *testing.T) {
 		name: "min plus bad chain",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -161,7 +161,7 @@ func TestSignature(t *testing.T) {
 		name: "min plus bundle",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -187,7 +187,7 @@ func TestSignature(t *testing.T) {
 		name: "min plus good cert",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,
@@ -221,7 +221,7 @@ uThR1Z6JuA21HwxtL3GyJ8UQZcEPOlTBV593HrSAwBhiCoY=
 		name: "min plus bad chain",
 		l: &sigLayer{
 			img: &sigs{
-				Image: must(mutate.Append(ociempty.Image(), mutate.Addendum{Layer: layer})),
+				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
 			},
 			desc: v1.Descriptor{
 				Digest: digest,


### PR DESCRIPTION
That's how it's used, and I need it for some of the `mutate` stuff I'm starting to look at.

This also changed `cremote.SignatureImage` to start using `ociremote.Signatures` and the `oci.Signatures` type very slightly (I stopped myself before scope creeping too badly).

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
