### PR TITLE
Introduce `signed.Image[Index]` to cast unsigned entities.

### DIFF
--- a/internal/oci/signed/image.go
+++ b/internal/oci/signed/image.go
@@ -1,0 +1,49 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signed
+
+import (
+	"errors"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/sigstore/cosign/internal/oci"
+	"github.com/sigstore/cosign/internal/oci/empty"
+)
+
+// Image returns an oci.SignedImage form of the v1.Image with no signatures
+// or attestations.
+func Image(i v1.Image) oci.SignedImage {
+	return &image{
+		Image: i,
+	}
+}
+
+type image struct {
+	v1.Image
+}
+
+var _ oci.SignedImage = (*image)(nil)
+
+// Signatures implements oci.SignedImage
+func (*image) Signatures() (oci.Signatures, error) {
+	return empty.Signatures(), nil
+}
+
+// Attestations implements oci.SignedImage
+func (*image) Attestations() (oci.Attestations, error) {
+	return nil, errors.New("NYI")
+}

--- a/internal/oci/signed/image_test.go
+++ b/internal/oci/signed/image_test.go
@@ -1,0 +1,46 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signed
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/random"
+)
+
+func TestImage(t *testing.T) {
+	i, err := random.Image(300 /* bytes */, 5 /* layers */)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+
+	si := Image(i)
+
+	sigs, err := si.Signatures()
+	if err != nil {
+		t.Fatalf("Signatures() = %v", err)
+	}
+
+	if sl, err := sigs.Get(); err != nil {
+		t.Errorf("Get() = %v", err)
+	} else if got, want := len(sl), 0; got != want {
+		t.Errorf("len(Get()) = %d, wanted %d", got, want)
+	}
+
+	if _, err := si.Attestations(); err == nil {
+		t.Error("Need coverage for attestations!")
+	}
+}

--- a/internal/oci/signed/index.go
+++ b/internal/oci/signed/index.go
@@ -1,0 +1,69 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signed
+
+import (
+	"errors"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/sigstore/cosign/internal/oci"
+	"github.com/sigstore/cosign/internal/oci/empty"
+)
+
+// ImageIndex returns an oci.SignedImageIndex form of the v1.ImageIndex with
+// no signatures or attestations.
+func ImageIndex(i v1.ImageIndex) oci.SignedImageIndex {
+	return &index{
+		v1Index: i,
+	}
+}
+
+type v1Index v1.ImageIndex
+
+type index struct {
+	v1Index
+}
+
+var _ oci.SignedImageIndex = (*index)(nil)
+
+// SignedImage implements oci.SignedImageIndex
+func (ii *index) SignedImage(h v1.Hash) (oci.SignedImage, error) {
+	i, err := ii.Image(h)
+	if err != nil {
+		return nil, err
+	}
+	return Image(i), nil
+}
+
+// SignedImageIndex implements oci.SignedImageIndex
+func (ii *index) SignedImageIndex(h v1.Hash) (oci.SignedImageIndex, error) {
+	i, err := ii.ImageIndex(h)
+	if err != nil {
+		return nil, err
+	}
+	return ImageIndex(i), nil
+}
+
+// Signatures implements oci.SignedImageIndex
+func (*index) Signatures() (oci.Signatures, error) {
+	return empty.Signatures(), nil
+}
+
+// Attestations implements oci.SignedImageIndex
+func (*index) Attestations() (oci.Attestations, error) {
+	return nil, errors.New("NYI")
+}

--- a/internal/oci/signed/index_test.go
+++ b/internal/oci/signed/index_test.go
@@ -1,0 +1,94 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signed
+
+import (
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/internal/oci"
+)
+
+func TestImageIndex(t *testing.T) {
+	ii, err := random.Index(300 /* bytes */, 5 /* layers */, 3 /* images */)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+
+	ni, err := random.Index(300 /* bytes */, 5 /* layers */, 3 /* images */)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	ni = mutate.AppendManifests(ni, mutate.IndexAddendum{
+		Add: ii,
+	})
+
+	im, err := ni.IndexManifest()
+	if err != nil {
+		t.Fatalf("IndexManifest() = %v", err)
+	}
+
+	sii := ImageIndex(ni)
+
+	sel := make([]oci.SignedEntity, 0, len(im.Manifests)+1)
+	sel = append(sel, sii)
+
+	for _, desc := range im.Manifests {
+		switch desc.MediaType {
+		case types.OCIImageIndex, types.DockerManifestList:
+			se, err := sii.SignedImageIndex(desc.Digest)
+			if err != nil {
+				t.Fatalf("SignedImageIndex() = %v", err)
+			}
+			sel = append(sel, se)
+		case types.OCIManifestSchema1, types.DockerManifestSchema2:
+			se, err := sii.SignedImage(desc.Digest)
+			if err != nil {
+				t.Fatalf("SignedImage() = %v", err)
+			}
+			sel = append(sel, se)
+		default:
+			t.Errorf("Unsupported media type: %v", desc.MediaType)
+		}
+	}
+
+	if se, err := sii.SignedImageIndex(v1.Hash{}); err == nil {
+		t.Errorf("SignedImageIndex() = %#v, wanted error", se)
+	}
+	if se, err := sii.SignedImage(v1.Hash{}); err == nil {
+		t.Errorf("SignedImage() = %#v, wanted error", se)
+	}
+
+	for _, se := range sel {
+		sigs, err := se.Signatures()
+		if err != nil {
+			t.Fatalf("Signatures() = %v", err)
+		}
+
+		if sl, err := sigs.Get(); err != nil {
+			t.Errorf("Get() = %v", err)
+		} else if got, want := len(sl), 0; got != want {
+			t.Errorf("len(Get()) = %d, wanted %d", got, want)
+		}
+
+		if _, err := se.Attestations(); err == nil {
+			t.Error("Need coverage for attestations!")
+		}
+	}
+}


### PR DESCRIPTION
This package lets us cast (for lack of a better term) unsigned entities as signed entities with no signatures.

So with this, a user can write:
```go
  si := signed.Image(img)
```

... and interact with the degenerate form of `oci.SignedImage` that has no signatures.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link
https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
