### PR TITLE
Move sget -key to --key

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Fetching contents without verifying them is dangerous, so we require the artifac
 $ sget gcr.io/dlorenc-vmtest2/artifact
 error: public key must be specified when fetching by tag, you must fetch by digest or supply a public key
 
-$ sget -key cosign.pub us.gcr.io/dlorenc-vmtest2/readme > foo
+$ sget --key cosign.pub us.gcr.io/dlorenc-vmtest2/readme > foo
 
 Verification for us.gcr.io/dlorenc-vmtest2/readme --
 The following checks were performed on each of these signatures:

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -124,11 +124,11 @@ dgst=$(./cosign upload blob -f randomblob ${blobimg})
 ./cosign verify -key ${verification_key} ${dgst} # For sanity
 
 # sget w/ signature verification should work via tag or digest
-./sget -key ${verification_key} -o verified_randomblob_from_digest $dgst
-./sget -key ${verification_key} -o verified_randomblob_from_tag $blobimg
+./sget --key ${verification_key} -o verified_randomblob_from_digest $dgst
+./sget --key ${verification_key} -o verified_randomblob_from_tag $blobimg
 
 # sget w/o signature verification should only work for ref by digest
-./sget -key ${verification_key} -o randomblob_from_digest $dgst
+./sget --key ${verification_key} -o randomblob_from_digest $dgst
 if (./sget -o randomblob_from_tag $blobimg); then false; fi
 
 # clean up a bit


### PR DESCRIPTION
#### Summary

In accordance with https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html POSIX flags and arguments are to be single dash short code, or double dash long code. `-key` is not a valid option. Replaced with `--key`

#### Ticket Link

Related to #709 

#### Release Note

```release-note
BREAKING API CHANGE: sget flags have been migrated to POXIS style, `-key` --> `--key`; `-output` --> `--output` or `-o`.
```
