### PR TITLE
Drop option that only passes default behavior.

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -167,11 +167,6 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 		if err != nil {
 			return errors.Wrapf(err, "resolving attachment type %s for image %s", c.Attachment, img)
 		}
-		sigRepo, err := TargetRepositoryForImage(ref)
-		if err != nil {
-			return err
-		}
-		co.SignatureRepo = sigRepo
 		//TODO: this is really confusing, it's actually a return value for the printed verification below
 		co.VerifyBundle = false
 

--- a/cmd/cosign/cli/verify_attestation.go
+++ b/cmd/cosign/cli/verify_attestation.go
@@ -158,11 +158,6 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 		if err != nil {
 			return err
 		}
-		sigRepo, err := TargetRepositoryForImage(ref)
-		if err != nil {
-			return err
-		}
-		co.SignatureRepo = sigRepo
 		//TODO: this is really confusing, it's actually a return value for the printed verification below
 		co.VerifyBundle = false
 

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -178,10 +178,6 @@ func main() {
 			if err != nil {
 				return nil, err
 			}
-			sigRepo, err := cli.TargetRepositoryForImage(ref)
-			if err != nil {
-				return nil, err
-			}
 
 			pubKey, err := cli.LoadPublicKey(bctx.Context, key)
 			if err != nil {
@@ -196,7 +192,6 @@ func main() {
 				RootCerts:          fulcio.GetRoots(),
 				RegistryClientOpts: regOpts.GetRegistryClientOpts(bctx.Context),
 				RekorURL:           *rekorURL,
-				SignatureRepo:      sigRepo,
 			}
 			sps, err := cosign.Verify(bctx.Context, ref, co)
 			if err != nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -44,9 +44,6 @@ import (
 
 // CheckOpts are the options for checking signatures.
 type CheckOpts struct {
-	// SignatureRepo, if set, designates the repository where image signatures are stored.
-	// Otherwise, it is assumed that signatures reside in the same repo as the image itself.
-	SignatureRepo name.Repository
 	// SigTagSuffixOverride overrides the suffix of the derived signature image tag. Default: ".sig"
 	SigTagSuffixOverride string
 	// RegistryClientOpts are the options for interacting with the container registry.
@@ -94,9 +91,6 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 	}
 
 	// These are all the signatures attached to our image that we know how to parse.
-	if (co.SignatureRepo != name.Repository{}) {
-		opts = append(opts, ociremote.WithTargetRepository(co.SignatureRepo))
-	}
 	if co.SigTagSuffixOverride != "" {
 		opts = append(opts, ociremote.WithSignatureSuffix(co.SigTagSuffixOverride))
 	}

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -73,11 +73,6 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 
 	if co.SigVerifier != nil || cli.EnableExperimental() {
 		co.RootCerts = fulcio.GetRoots()
-		sigRepo, err := cli.TargetRepositoryForImage(ref)
-		if err != nil {
-			return err
-		}
-		co.SignatureRepo = sigRepo
 
 		sp, err := cosign.Verify(ctx, ref, co)
 		if err != nil {


### PR DESCRIPTION
I noticed that the only places we ever pass SignatureRepo to CheckOpts matches the default behavior that is already present within the library.

This drops that option, and cleans up the callers that were doing superfluous work.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note
```release-note
Removed the SignatureRepo from CheckOpts.  You can get the original behavior through the environment variable.
```
