### PR TITLE
Drop VerifyOpts from CheckOpts

### DIFF
--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -186,7 +186,6 @@ func main() {
 			ctxOpt := options.WithContext(bctx.Context)
 			co := &cosign.CheckOpts{
 				SigVerifier:        pubKey,
-				VerifyOpts:         []signature.VerifyOption{ctxOpt},
 				PKOpts:             []signature.PublicKeyOption{ctxOpt},
 				ClaimVerifier:      cosign.SimpleClaimVerifier,
 				RootCerts:          fulcio.GetRoots(),


### PR DESCRIPTION
These were only ever used to pass `options.WithContext(ctx)` and we have `ctx`, so we simply pass `ctx` to `VerifySignature` and pass `options.WithContext(ctx)` directly.

We were also inconsistent about whether we even passed `VerifyOpts` to `VerifySignature`, so now things are both simpler and more consistent.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note

```release-note
Retire VerifyOpts in CheckOpts, which was only used to pass `options.WithContext`
```
