### PR TITLE
Eliminate methods on `SignedPayload`.

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -173,7 +173,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 		}
 
 		//TODO: this is really confusing, it's actually a return value for the printed verification below
-		co.VerifyBundle = false
+		co.BundleVerified = false
 
 		verified, err := cosign.Verify(ctx, ref, co)
 		if err != nil {
@@ -196,7 +196,7 @@ func PrintVerificationHeader(imgRef string, co *cosign.CheckOpts) {
 		}
 		fmt.Fprintln(os.Stderr, "  - The cosign claims were validated")
 	}
-	if co.VerifyBundle {
+	if co.BundleVerified {
 		fmt.Fprintln(os.Stderr, "  - Existence of the claims in the transparency log was verified offline")
 	} else if co.RekorURL != "" {
 		fmt.Fprintln(os.Stderr, "  - The claims were present in the transparency log")

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -164,7 +164,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 		}
 
 		//TODO: this is really confusing, it's actually a return value for the printed verification below
-		co.VerifyBundle = false
+		co.BundleVerified = false
 
 		verified, err := cosign.Verify(ctx, ref, co)
 		if err != nil {

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -36,17 +36,7 @@ type SignedPayload struct {
 	Cert            *x509.Certificate
 	Chain           []*x509.Certificate
 	Bundle          *oci.Bundle
-	bundleVerified  bool
 }
-
-// TODO: marshal the cert correctly.
-// func (sp *SignedPayload) MarshalJSON() ([]byte, error) {
-// 	x509.Certificate.
-// 	pem.EncodeToMemory(&pem.Block{
-// 		Type: "CERTIFICATE",
-// 		Bytes:
-// 	})
-// }
 
 const (
 	SignatureTagSuffix   = ".sig"

--- a/pkg/cosign/verifiers.go
+++ b/pkg/cosign/verifiers.go
@@ -18,6 +18,7 @@ package cosign
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/in-toto/in-toto-golang/in_toto"
@@ -34,8 +35,9 @@ func SimpleClaimVerifier(sp SignedPayload, imageDigest v1.Hash, annotations map[
 		return err
 	}
 
-	if err := sp.VerifyClaims(imageDigest, ss); err != nil {
-		return err
+	foundDgst := ss.Critical.Image.DockerManifestDigest
+	if foundDgst != imageDigest.String() {
+		return fmt.Errorf("invalid or missing digest in claim: %s", foundDgst)
 	}
 
 	if annotations != nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -52,8 +52,8 @@ type CheckOpts struct {
 	// Annotations optionally specifies image signature annotations to verify.
 	Annotations map[string]interface{}
 	// ClaimVerifier, if provided, verifies claims present in the SignedPayload.
-	ClaimVerifier func(sigPayload SignedPayload, imageDigest v1.Hash, annotations map[string]interface{}) error
-	VerifyBundle  bool //TODO: remove in favor of SignedPayload.BundleVerified
+	ClaimVerifier  func(sigPayload SignedPayload, imageDigest v1.Hash, annotations map[string]interface{}) error
+	BundleVerified bool //TODO: remove in favor of SignedPayload.BundleVerified
 
 	// RekorURL is the URL for the rekor server to use to verify signatures and public keys.
 	RekorURL string
@@ -171,7 +171,7 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 			validationErrs = append(validationErrs, "unable to verify bundle: "+err.Error())
 			continue
 		}
-		co.VerifyBundle = verified
+		co.BundleVerified = verified
 
 		if !verified && co.RekorURL != "" {
 			if rekorClient == nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -40,7 +40,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
-	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
 // CheckOpts are the options for checking signatures.
@@ -108,7 +107,12 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 		switch {
 		// We have a public key to check against.
 		case co.SigVerifier != nil:
-			if err := sp.VerifySignature(ctx, co.SigVerifier); err != nil {
+			signature, err := base64.StdEncoding.DecodeString(sp.Base64Signature)
+			if err != nil {
+				validationErrs = append(validationErrs, err.Error())
+				continue
+			}
+			if err := co.SigVerifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(sp.Payload), options.WithContext(ctx)); err != nil {
 				validationErrs = append(validationErrs, err.Error())
 				continue
 			}
@@ -125,11 +129,17 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 				continue
 			}
 			// Now verify the cert, then the signature.
-			if err := sp.TrustedCert(co.RootCerts); err != nil {
+			if err := TrustedCert(sp.Cert, co.RootCerts); err != nil {
 				validationErrs = append(validationErrs, err.Error())
 				continue
 			}
-			if err := sp.VerifySignature(ctx, pub); err != nil {
+
+			signature, err := base64.StdEncoding.DecodeString(sp.Base64Signature)
+			if err != nil {
+				validationErrs = append(validationErrs, err.Error())
+				continue
+			}
+			if err := pub.VerifySignature(bytes.NewReader(signature), bytes.NewReader(sp.Payload), options.WithContext(ctx)); err != nil {
 				validationErrs = append(validationErrs, err.Error())
 				continue
 			}
@@ -156,7 +166,7 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 			}
 		}
 
-		verified, err := sp.VerifyBundle()
+		verified, err := VerifyBundle(sp)
 		if err != nil && co.RekorURL == "" {
 			validationErrs = append(validationErrs, "unable to verify bundle: "+err.Error())
 			continue
@@ -190,7 +200,7 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) ([]
 			}
 
 			// Find the uuid then the entry.
-			uuid, _, err := sp.VerifyTlog(rekorClient, pemBytes)
+			uuid, _, err := FindTlogEntry(rekorClient, sp.Base64Signature, sp.Payload, pemBytes)
 			if err != nil {
 				validationErrs = append(validationErrs, err.Error())
 				continue
@@ -237,32 +247,9 @@ func checkExpiry(cert *x509.Certificate, it time.Time) error {
 	return nil
 }
 
-func (sp *SignedPayload) VerifySignature(ctx context.Context, verifier signature.Verifier) error {
-	signature, err := base64.StdEncoding.DecodeString(sp.Base64Signature)
-	if err != nil {
-		return err
-	}
-	return verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(sp.Payload), options.WithContext(ctx))
-}
-
-func (sp *SignedPayload) VerifyClaims(digest v1.Hash, ss *payload.SimpleContainerImage) error {
-	foundDgst := ss.Critical.Image.DockerManifestDigest
-	if foundDgst != digest.String() {
-		return fmt.Errorf("invalid or missing digest in claim: %s", foundDgst)
-	}
-	return nil
-}
-
-func (sp *SignedPayload) BundleVerified() bool {
-	return sp.bundleVerified
-}
-
-func (sp *SignedPayload) VerifyBundle() (bool, error) {
+func VerifyBundle(sp SignedPayload) (bool, error) {
 	if sp.Bundle == nil {
 		return false, nil
-	}
-	if sp.bundleVerified {
-		return true, nil
 	}
 	rekorPubKey, err := PemToECDSAKey([]byte(GetRekorPub()))
 	if err != nil {
@@ -274,7 +261,6 @@ func (sp *SignedPayload) VerifyBundle() (bool, error) {
 	}
 
 	if sp.Cert == nil {
-		sp.bundleVerified = true
 		return true, nil
 	}
 
@@ -282,7 +268,6 @@ func (sp *SignedPayload) VerifyBundle() (bool, error) {
 	if err := checkExpiry(sp.Cert, time.Unix(sp.Bundle.Payload.IntegratedTime, 0)); err != nil {
 		return false, errors.Wrap(err, "checking expiry on cert")
 	}
-	sp.bundleVerified = true
 	return true, nil
 }
 
@@ -302,14 +287,6 @@ func VerifySET(bundlePayload oci.BundlePayload, signature []byte, pub *ecdsa.Pub
 		return errors.New("unable to verify")
 	}
 	return nil
-}
-
-func (sp *SignedPayload) VerifyTlog(rc *client.Rekor, publicKeyPem []byte) (uuid string, index int64, err error) {
-	return FindTlogEntry(rc, sp.Base64Signature, sp.Payload, publicKeyPem)
-}
-
-func (sp *SignedPayload) TrustedCert(roots *x509.CertPool) error {
-	return TrustedCert(sp.Cert, roots)
 }
 
 func TrustedCert(cert *x509.Certificate, roots *x509.CertPool) error {

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -58,8 +58,8 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 	}
 
 	co := &cosign.CheckOpts{
-		ClaimVerifier: cosign.SimpleClaimVerifier,
-		VerifyBundle:  true,
+		ClaimVerifier:  cosign.SimpleClaimVerifier,
+		BundleVerified: true,
 		RegistryClientOpts: []remote.Option{
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 			remote.WithContext(ctx),


### PR DESCRIPTION
There are a few cases here:
1. A few places these were simple enough "thunks" that it made sense to just inline them at the cost of a bit of redundancy.
2. I eliminated the unused `BundleVerified()` accessor and the backing state.
3. For `VerifyBundle` I made it take a `SignedPayload` instead (now that it had no state to mutate!).

Now that `SignedPayload` is *just* data, which is almost entirely a projection of accessors on `oci.Signatures`, a following change should be relatively trivial to eliminate `SignedPayload` entirely in favor of `oci.Signatures` :tada:

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
SignedPayload's methods have been retired in favor of available helpers, and this type will be removed in a subsequent change.
```
