### PR TITLE
Switch most things to use `oci.Signature` directly.

### DIFF
--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -28,6 +28,7 @@ import (
 	"knative.dev/pkg/logging"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio/fulcioroots"
+	"github.com/sigstore/cosign/internal/oci"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
@@ -47,7 +48,7 @@ func valid(ctx context.Context, img string, keys []*ecdsa.PublicKey) bool {
 	return false
 }
 
-func validSignatures(ctx context.Context, img string, key *ecdsa.PublicKey) ([]cosign.SignedPayload, error) {
+func validSignatures(ctx context.Context, img string, key *ecdsa.PublicKey) ([]oci.Signature, error) {
 	ref, err := name.ParseReference(img)
 	if err != nil {
 		return nil, err

--- a/pkg/cosign/verifiers.go
+++ b/pkg/cosign/verifiers.go
@@ -25,13 +25,19 @@ import (
 	"github.com/in-toto/in-toto-golang/pkg/ssl"
 	"github.com/pkg/errors"
 
+	"github.com/sigstore/cosign/internal/oci"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-// SimpleClaimVerifier verifies that SignedPayload.Payload is a SimpleContainerImage payload which references the given image digest and contains the given annotations.
-func SimpleClaimVerifier(sp SignedPayload, imageDigest v1.Hash, annotations map[string]interface{}) error {
+// SimpleClaimVerifier verifies that sig.Payload() is a SimpleContainerImage payload which references the given image digest and contains the given annotations.
+func SimpleClaimVerifier(sig oci.Signature, imageDigest v1.Hash, annotations map[string]interface{}) error {
+	p, err := sig.Payload()
+	if err != nil {
+		return err
+	}
+
 	ss := &payload.SimpleContainerImage{}
-	if err := json.Unmarshal(sp.Payload, ss); err != nil {
+	if err := json.Unmarshal(p, ss); err != nil {
 		return err
 	}
 
@@ -48,11 +54,16 @@ func SimpleClaimVerifier(sp SignedPayload, imageDigest v1.Hash, annotations map[
 	return nil
 }
 
-// IntotoSubjectClaimVerifier verifies that SignedPayload.Payload is an Intoto statement which references the given image digest.
-func IntotoSubjectClaimVerifier(sp SignedPayload, imageDigest v1.Hash, _ map[string]interface{}) error {
+// IntotoSubjectClaimVerifier verifies that sig.Payload() is an Intoto statement which references the given image digest.
+func IntotoSubjectClaimVerifier(sig oci.Signature, imageDigest v1.Hash, _ map[string]interface{}) error {
+	p, err := sig.Payload()
+	if err != nil {
+		return err
+	}
+
 	// The payload here is an envelope. We already verified the signature earlier.
 	e := ssl.Envelope{}
-	if err := json.Unmarshal(sp.Payload, &e); err != nil {
+	if err := json.Unmarshal(p, &e); err != nil {
 		return err
 	}
 	stBytes, err := base64.StdEncoding.DecodeString(e.Payload)


### PR DESCRIPTION
This changes most of the callers of `FetchSignaturesForReference` to use `ociremote.SignedEntity` directly, and eliminates essentially all usage of `SignedPayload` except one specific use case.

The places that remain calling `FetchSignaturesForReference` and using `SignedPayload` are marshalling the `SignedPayload` (one is in the cosign CLI, the other is copasetic and has rego references).

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
