### PR TITLE
Eliminate `BundleVerified` from `CheckOpts` in favor of new return value.

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -173,22 +173,19 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 			return errors.Wrapf(err, "resolving attachment type %s for image %s", c.Attachment, img)
 		}
 
-		//TODO: this is really confusing, it's actually a return value for the printed verification below
-		co.BundleVerified = false
-
-		verified, err := cosign.Verify(ctx, ref, co)
+		verified, bundleVerified, err := cosign.Verify(ctx, ref, co)
 		if err != nil {
 			return err
 		}
 
-		PrintVerificationHeader(ref.Name(), co)
+		PrintVerificationHeader(ref.Name(), co, bundleVerified)
 		PrintVerification(ref.Name(), verified, c.Output)
 	}
 
 	return nil
 }
 
-func PrintVerificationHeader(imgRef string, co *cosign.CheckOpts) {
+func PrintVerificationHeader(imgRef string, co *cosign.CheckOpts, bundleVerified bool) {
 	fmt.Fprintf(os.Stderr, "\nVerification for %s --\n", imgRef)
 	fmt.Fprintln(os.Stderr, "The following checks were performed on each of these signatures:")
 	if co.ClaimVerifier != nil {
@@ -197,7 +194,7 @@ func PrintVerificationHeader(imgRef string, co *cosign.CheckOpts) {
 		}
 		fmt.Fprintln(os.Stderr, "  - The cosign claims were validated")
 	}
-	if co.BundleVerified {
+	if bundleVerified {
 		fmt.Fprintln(os.Stderr, "  - Existence of the claims in the transparency log was verified offline")
 	} else if co.RekorURL != "" {
 		fmt.Fprintln(os.Stderr, "  - The claims were present in the transparency log")

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -163,15 +163,12 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 			return err
 		}
 
-		//TODO: this is really confusing, it's actually a return value for the printed verification below
-		co.BundleVerified = false
-
-		verified, err := cosign.Verify(ctx, ref, co)
+		verified, bundleVerified, err := cosign.Verify(ctx, ref, co)
 		if err != nil {
 			return err
 		}
 
-		PrintVerificationHeader(imageRef, co)
+		PrintVerificationHeader(imageRef, co, bundleVerified)
 		// The attestations are always JSON, so use the raw "text" mode for outputting them instead of conversion
 		PrintVerification(imageRef, verified, "text")
 	}

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -193,7 +193,7 @@ func main() {
 				RegistryClientOpts: regOpts.GetRegistryClientOpts(bctx.Context),
 				RekorURL:           *rekorURL,
 			}
-			sps, err := cosign.Verify(bctx.Context, ref, co)
+			sps, _, err := cosign.Verify(bctx.Context, ref, co)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -59,11 +59,12 @@ func validSignatures(ctx context.Context, img string, key *ecdsa.PublicKey) ([]o
 		return nil, err
 	}
 
-	return cosign.Verify(ctx, ref, &cosign.CheckOpts{
+	sigs, _, err := cosign.Verify(ctx, ref, &cosign.CheckOpts{
 		RootCerts:     fulcioroots.Get(),
 		SigVerifier:   ecdsaVerifier,
 		ClaimVerifier: cosign.SimpleClaimVerifier,
 	})
+	return sigs, err
 }
 
 func getKeys(ctx context.Context, cfg map[string][]byte) ([]*ecdsa.PublicKey, *apis.FieldError) {

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -58,8 +58,7 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 	}
 
 	co := &cosign.CheckOpts{
-		ClaimVerifier:  cosign.SimpleClaimVerifier,
-		BundleVerified: true,
+		ClaimVerifier: cosign.SimpleClaimVerifier,
 		RegistryClientOpts: []remote.Option{
 			remote.WithAuthFromKeychain(authn.DefaultKeychain),
 			remote.WithContext(ctx),
@@ -76,11 +75,11 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 	if co.SigVerifier != nil || options.EnableExperimental() {
 		co.RootCerts = fulcio.GetRoots()
 
-		sp, err := cosign.Verify(ctx, ref, co)
+		sp, bundleVerified, err := cosign.Verify(ctx, ref, co)
 		if err != nil {
 			return err
 		}
-		verify.PrintVerificationHeader(sg.ImageRef, co)
+		verify.PrintVerificationHeader(sg.ImageRef, co, bundleVerified)
 		verify.PrintVerification(sg.ImageRef, sp, "text")
 	}
 


### PR DESCRIPTION
This out-param is a subtle code smell that had TODOs sprinkled no less than everywhere to remove it.

This adds a return value to `cosign.Verify` that indicates whether any bundles were verified, which is what this tracked, and updates call sites to utilize that.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
