### PR TITLE
Switch `CheckOpts` to take `ociremote.Option`s.

### DIFF
--- a/cmd/cosign/cli/options/flags.go
+++ b/cmd/cosign/cli/options/flags.go
@@ -47,7 +47,7 @@ type RegistryOpts struct {
 	AllowInsecure bool
 }
 
-func (co *RegistryOpts) RemoteOpts(ctx context.Context) []ociremote.Option {
+func (co *RegistryOpts) ClientOpts(ctx context.Context) []ociremote.Option {
 	return []ociremote.Option{ociremote.WithRemoteOptions(co.GetRegistryClientOpts(ctx)...)}
 }
 

--- a/cmd/cosign/cli/options/flags.go
+++ b/cmd/cosign/cli/options/flags.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 )
 
 // OneOf ensures that only one of the supplied interfaces is set to a non-zero value.
@@ -44,6 +45,10 @@ func NOf(args ...interface{}) int {
 
 type RegistryOpts struct {
 	AllowInsecure bool
+}
+
+func (co *RegistryOpts) RemoteOpts(ctx context.Context) []ociremote.Option {
+	return []ociremote.Option{ociremote.WithRemoteOptions(co.GetRegistryClientOpts(ctx)...)}
 }
 
 func (co *RegistryOpts) GetRegistryClientOpts(ctx context.Context) []remote.Option {

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -134,7 +134,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 
 	co := &cosign.CheckOpts{
 		Annotations:        *c.Annotations,
-		RegistryClientOpts: c.RegistryOpts.RemoteOpts(ctx),
+		RegistryClientOpts: c.RegistryOpts.ClientOpts(ctx),
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.SimpleClaimVerifier

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -132,11 +132,9 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 		return &options.KeyParseError{}
 	}
 
-	remoteOpts := c.RegistryOpts.GetRegistryClientOpts(ctx)
-
 	co := &cosign.CheckOpts{
 		Annotations:        *c.Annotations,
-		RegistryClientOpts: remoteOpts,
+		RegistryClientOpts: c.RegistryOpts.RemoteOpts(ctx),
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.SimpleClaimVerifier
@@ -168,7 +166,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 	co.SigVerifier = pubKey
 
 	for _, img := range args {
-		ref, err := sign.GetAttachedImageRef(img, c.Attachment, remoteOpts...)
+		ref, err := sign.GetAttachedImageRef(img, c.Attachment, c.RegistryOpts.GetRegistryClientOpts(ctx)...)
 		if err != nil {
 			return errors.Wrapf(err, "resolving attachment type %s for image %s", c.Attachment, img)
 		}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -122,7 +122,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 	}
 
 	co := &cosign.CheckOpts{
-		RegistryClientOpts:   c.RemoteOpts(ctx),
+		RegistryClientOpts:   c.ClientOpts(ctx),
 		SigTagSuffixOverride: cosign.AttestationTagSuffix,
 	}
 	if c.CheckClaims {

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -122,7 +122,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 	}
 
 	co := &cosign.CheckOpts{
-		RegistryClientOpts:   c.GetRegistryClientOpts(ctx),
+		RegistryClientOpts:   c.RemoteOpts(ctx),
 		SigTagSuffixOverride: cosign.AttestationTagSuffix,
 	}
 	if c.CheckClaims {

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -190,7 +190,7 @@ func main() {
 				PKOpts:             []signature.PublicKeyOption{ctxOpt},
 				ClaimVerifier:      cosign.SimpleClaimVerifier,
 				RootCerts:          fulcio.GetRoots(),
-				RegistryClientOpts: regOpts.RemoteOpts(bctx.Context),
+				RegistryClientOpts: regOpts.ClientOpts(bctx.Context),
 				RekorURL:           *rekorURL,
 			}
 			sps, _, err := cosign.Verify(bctx.Context, ref, co)

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -190,7 +190,7 @@ func main() {
 				PKOpts:             []signature.PublicKeyOption{ctxOpt},
 				ClaimVerifier:      cosign.SimpleClaimVerifier,
 				RootCerts:          fulcio.GetRoots(),
-				RegistryClientOpts: regOpts.GetRegistryClientOpts(bctx.Context),
+				RegistryClientOpts: regOpts.RemoteOpts(bctx.Context),
 				RekorURL:           *rekorURL,
 			}
 			sps, _, err := cosign.Verify(bctx.Context, ref, co)

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -30,7 +30,6 @@ import (
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/pkg/errors"
 
 	"github.com/sigstore/cosign/internal/oci"
@@ -47,7 +46,7 @@ type CheckOpts struct {
 	// SigTagSuffixOverride overrides the suffix of the derived signature image tag. Default: ".sig"
 	SigTagSuffixOverride string
 	// RegistryClientOpts are the options for interacting with the container registry.
-	RegistryClientOpts []remote.Option
+	RegistryClientOpts []ociremote.Option
 
 	// Annotations optionally specifies image signature annotations to verify.
 	Annotations map[string]interface{}
@@ -85,9 +84,8 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (ch
 		}
 	}
 
-	opts := []ociremote.Option{
-		ociremote.WithRemoteOptions(co.RegistryClientOpts...),
-	}
+	opts := co.RegistryClientOpts
+
 	// These are all the signatures attached to our image that we know how to parse.
 	if co.SigTagSuffixOverride != "" {
 		opts = append(opts, ociremote.WithSignatureSuffix(co.SigTagSuffixOverride))


### PR DESCRIPTION
This is as a precursor to starting to fold some other stuff together, e.g. the SigSuffix option.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
