### PR TITLE
Remove `SigSuffixOverride` fold into `ociremote.Option`.

### DIFF
--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/pivkey"
 	sigs "github.com/sigstore/cosign/pkg/signature"
@@ -122,8 +123,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 	}
 
 	co := &cosign.CheckOpts{
-		RegistryClientOpts:   c.ClientOpts(ctx),
-		SigTagSuffixOverride: cosign.AttestationTagSuffix,
+		RegistryClientOpts: append(c.ClientOpts(ctx), ociremote.WithSignatureSuffix(cosign.AttestationTagSuffix)),
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -43,8 +43,6 @@ import (
 
 // CheckOpts are the options for checking signatures.
 type CheckOpts struct {
-	// SigTagSuffixOverride overrides the suffix of the derived signature image tag. Default: ".sig"
-	SigTagSuffixOverride string
 	// RegistryClientOpts are the options for interacting with the container registry.
 	RegistryClientOpts []ociremote.Option
 
@@ -85,11 +83,6 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (ch
 	}
 
 	opts := co.RegistryClientOpts
-
-	// These are all the signatures attached to our image that we know how to parse.
-	if co.SigTagSuffixOverride != "" {
-		opts = append(opts, ociremote.WithSignatureSuffix(co.SigTagSuffixOverride))
-	}
 
 	se, err := ociremote.SignedEntity(signedImgRef, opts...)
 	if err != nil {


### PR DESCRIPTION
As the title suggests, now that we take `ociremote.Option`, the `SigSuffix` option in CheckOpts is redundant.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link
Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
