### PR TITLE
Add `Annotations` to `oci.Signature`.

### DIFF
--- a/internal/oci/remote/layer.go
+++ b/internal/oci/remote/layer.go
@@ -36,6 +36,11 @@ type sigLayer struct {
 
 var _ oci.Signature = (*sigLayer)(nil)
 
+// Annotations implements oci.Signature
+func (s *sigLayer) Annotations() (map[string]string, error) {
+	return s.desc.Annotations, nil
+}
+
 // Payload implements oci.Signature
 func (s *sigLayer) Payload() ([]byte, error) {
 	l, err := s.img.LayerByDigest(s.desc.Digest)

--- a/internal/oci/signatures.go
+++ b/internal/oci/signatures.go
@@ -39,6 +39,9 @@ type Signatures interface {
 type Signature interface {
 	v1.Layer
 
+	// Annotations returns the annotations associated with this layer.
+	Annotations() (map[string]string, error)
+
 	// Payload fetches the opaque data that is being signed.
 	// This will always return data when there is no error.
 	Payload() ([]byte, error)

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -103,8 +103,12 @@ LayerLoop:
 		if err != nil {
 			continue LayerLoop
 		}
+
 		// if there are any new annotations, then this isn't a duplicate
 		for a, value := range newAnnotations {
+			if a == sigkey {
+				continue // Ignore the signature key, we check it with custom logic below.
+			}
 			if val, ok := existingAnnotations[a]; !ok || val != value {
 				continue LayerLoop
 			}

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -17,10 +17,12 @@ package remote
 
 import (
 	"bytes"
+	"crypto/x509"
 	"encoding/base64"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/go-openapi/swag"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -30,11 +32,13 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
+	"knative.dev/pkg/kmeta"
 
 	"github.com/sigstore/cosign/internal/oci"
 	"github.com/sigstore/cosign/internal/oci/empty"
 	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 	ctypes "github.com/sigstore/cosign/pkg/types"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
@@ -74,40 +78,59 @@ func SignatureImage(ref name.Reference, opts ...remote.Option) (oci.Signatures, 
 	return nil, err
 }
 
-func findDuplicate(sigImage oci.Signatures, payload []byte, dupeDetector signature.Verifier, annotations map[string]string) ([]byte, error) {
-	l := &staticLayer{
-		b:  payload,
-		mt: ctypes.SimpleSigningMediaType,
+func findDuplicate(sigImage oci.Signatures, newSig oci.Signature, dupeDetector signature.Verifier) ([]byte, error) {
+	newDigest, err := newSig.Digest()
+	if err != nil {
+		return nil, err
 	}
-
-	sigDigest, err := l.Digest()
+	newMediaType, err := newSig.MediaType()
+	if err != nil {
+		return nil, err
+	}
+	newAnnotations, err := newSig.Annotations()
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO(mattmoor): Port this to take advantage of the higher-level oci.Signature interface.
-	manifest, err := sigImage.Manifest()
+	sigs, err := sigImage.Get()
 	if err != nil {
 		return nil, err
 	}
 
 LayerLoop:
-	for _, layer := range manifest.Layers {
+	for _, sig := range sigs {
+		existingAnnotations, err := sig.Annotations()
+		if err != nil {
+			continue LayerLoop
+		}
 		// if there are any new annotations, then this isn't a duplicate
-		for a, value := range annotations {
-			if val, ok := layer.Annotations[a]; !ok || val != value {
+		for a, value := range newAnnotations {
+			if val, ok := existingAnnotations[a]; !ok || val != value {
 				continue LayerLoop
 			}
 		}
-		if layer.MediaType == ctypes.SimpleSigningMediaType && layer.Digest == sigDigest && layer.Annotations[sigkey] != "" {
-			uploadedSig, err := base64.StdEncoding.DecodeString(layer.Annotations[sigkey])
-			if err != nil {
-				return nil, err
-			}
-			if err := dupeDetector.VerifySignature(bytes.NewReader(uploadedSig), bytes.NewReader(payload)); err == nil {
-				// An equivalent signature has already been uploaded.
-				return uploadedSig, nil
-			}
+		if existingDigest, err := sig.Digest(); err != nil || existingDigest != newDigest {
+			continue LayerLoop
+		}
+		if existingMediaType, err := sig.MediaType(); err != nil || existingMediaType != newMediaType {
+			continue LayerLoop
+		}
+
+		existingSignature, err := sig.Base64Signature()
+		if err != nil || existingSignature == "" {
+			continue LayerLoop
+		}
+		uploadedSig, err := base64.StdEncoding.DecodeString(existingSignature)
+		if err != nil {
+			continue LayerLoop
+		}
+		r, err := newSig.Uncompressed()
+		if err != nil {
+			return nil, err
+		}
+		if err := dupeDetector.VerifySignature(bytes.NewReader(uploadedSig), r); err == nil {
+			// An equivalent signature has already been uploaded.
+			return uploadedSig, nil
 		}
 	}
 	return nil, nil
@@ -124,13 +147,33 @@ type UploadOpts struct {
 }
 
 func UploadSignature(signature, payload []byte, dst name.Reference, opts UploadOpts) error {
-	// Preserve the default
-	if opts.MediaType == "" {
-		opts.MediaType = ctypes.SimpleSigningMediaType
-	}
+	b64sig := base64.StdEncoding.EncodeToString(signature)
 	l := &staticLayer{
 		b:  payload,
-		mt: types.MediaType(opts.MediaType),
+		mt: ctypes.SimpleSigningMediaType,
+		annotations: kmeta.UnionMaps(opts.AdditionalAnnotations, map[string]string{
+			sigkey: b64sig,
+		}),
+		b64sig:   b64sig,
+		certPEM:  string(opts.Cert),
+		chainPEM: string(opts.Chain),
+		bundle:   opts.Bundle,
+	}
+	// Preserve the default
+	if opts.MediaType != "" {
+		l.mt = types.MediaType(opts.MediaType)
+	}
+
+	if opts.Cert != nil {
+		l.annotations[certkey] = l.certPEM
+		l.annotations[chainkey] = l.chainPEM
+	}
+	if opts.Bundle != nil {
+		b, err := swag.WriteJSON(opts.Bundle)
+		if err != nil {
+			return errors.Wrap(err, "marshaling bundle")
+		}
+		l.annotations[BundleKey] = string(b)
 	}
 
 	base, err := SignatureImage(dst, opts.RemoteOpts...)
@@ -139,71 +182,101 @@ func UploadSignature(signature, payload []byte, dst name.Reference, opts UploadO
 	}
 
 	if opts.DupeDetector != nil {
-		if uploadedSig, err := findDuplicate(base, payload, opts.DupeDetector, opts.AdditionalAnnotations); err != nil || uploadedSig != nil {
+		if uploadedSig, err := findDuplicate(base, l, opts.DupeDetector); err != nil || uploadedSig != nil {
 			return err
 		}
 	}
 
-	annotations := map[string]string{
-		sigkey: base64.StdEncoding.EncodeToString(signature),
-	}
-	if opts.Cert != nil {
-		annotations[certkey] = string(opts.Cert)
-		annotations[chainkey] = string(opts.Chain)
-	}
-	if opts.Bundle != nil {
-		b, err := swag.WriteJSON(opts.Bundle)
-		if err != nil {
-			return errors.Wrap(err, "marshaling bundle")
-		}
-		annotations[BundleKey] = string(b)
-	}
 	img, err := mutate.Append(base, mutate.Addendum{
 		Layer:       l,
-		Annotations: annotations,
+		Annotations: l.annotations,
 	})
 	if err != nil {
 		return err
 	}
 
-	if err := remote.Write(dst, img, opts.RemoteOpts...); err != nil {
-		return err
-	}
-	return nil
+	return remote.Write(dst, img, opts.RemoteOpts...)
 }
 
 type staticLayer struct {
-	b  []byte
-	mt types.MediaType
+	b           []byte
+	mt          types.MediaType
+	annotations map[string]string
+	b64sig      string
+	certPEM     string
+	chainPEM    string
+	bundle      *oci.Bundle
 }
 
+var _ v1.Layer = (*staticLayer)(nil)
+var _ oci.Signature = (*staticLayer)(nil)
+
+// Annotations implements oci.Signature
+func (l *staticLayer) Annotations() (map[string]string, error) {
+	return l.annotations, nil
+}
+
+// Payload implements oci.Signature
+func (l *staticLayer) Payload() ([]byte, error) {
+	return l.b, nil
+}
+
+// Base64Signature implements oci.Signature
+func (l *staticLayer) Base64Signature() (string, error) {
+	return l.b64sig, nil
+}
+
+// Cert implements oci.Signature
+func (l *staticLayer) Cert() (*x509.Certificate, error) {
+	certs, err := cryptoutils.LoadCertificatesFromPEM(strings.NewReader(l.certPEM))
+	if err != nil {
+		return nil, err
+	}
+	return certs[0], nil
+}
+
+// Chain implements oci.Signature
+func (l *staticLayer) Chain() ([]*x509.Certificate, error) {
+	certs, err := cryptoutils.LoadCertificatesFromPEM(strings.NewReader(l.chainPEM))
+	if err != nil {
+		return nil, err
+	}
+	return certs, nil
+}
+
+// Bundle implements oci.Signature
+func (l *staticLayer) Bundle() (*oci.Bundle, error) {
+	return l.bundle, nil
+}
+
+// Digest implements v1.Layer
 func (l *staticLayer) Digest() (v1.Hash, error) {
 	h, _, err := v1.SHA256(bytes.NewReader(l.b))
 	return h, err
 }
 
-// DiffID returns the Hash of the uncompressed layer.
+// DiffID implements v1.Layer
 func (l *staticLayer) DiffID() (v1.Hash, error) {
 	h, _, err := v1.SHA256(bytes.NewReader(l.b))
 	return h, err
 }
 
-// Compressed returns an io.ReadCloser for the compressed layer contents.
+// Compressed implements v1.Layer
 func (l *staticLayer) Compressed() (io.ReadCloser, error) {
 	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
 }
 
-// Uncompressed returns an io.ReadCloser for the uncompressed layer contents.
+// Uncompressed implements v1.Layer
 func (l *staticLayer) Uncompressed() (io.ReadCloser, error) {
 	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
 }
 
-// Size returns the compressed size of the Layer.
+// Size implements v1.Layer
 func (l *staticLayer) Size() (int64, error) {
 	return int64(len(l.b)), nil
 }
 
-// MediaType returns the media type of the Layer.
+// MediaType implements v1.Layer
 func (l *staticLayer) MediaType() (types.MediaType, error) {
 	return l.mt, nil
 }


### PR DESCRIPTION
This change has two main parts, the first is largely as the title indicates, which is to add an `Annotations()` method to `oci.Signature` (and our implementations thereof).  This is largely motivated by the second half of this change.

The second part of this change is starting to orient `UploadSignature` to operate in terms of our `oci` interfaces.  For a much longer-form version of the direction I'd like to drive this towards, see here: https://github.com/sigstore/cosign/issues/666#issuecomment-923609067.  This is a bit messier than I'd like, but I think it is progress towards the final form outlined in the issue since it starts to orient things like deduplication around the `oci.Signature` interface.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link

Related: Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
