### PR TITLE
Add `sget` to the release artifacts

### DIFF
--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -46,7 +46,7 @@ jobs:
       # - name: install deps
       #   if: matrix.os == 'ubuntu-latest'
       #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
-      - name: build
+      - name: build cosign
         run: make cosign && mv ./cosign ./${{matrix.TARGET}}
       - name: Print Info
         shell: pwsh
@@ -72,3 +72,52 @@ jobs:
             cosign-*
             cosign.-*sha256
             cosign-*.sig
+
+  build-sget:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - os: macos-latest
+            TARGET: sget-darwin-amd64
+            COSIGN_PASSWORD: COSIGN_PASSWORD
+          - os: ubuntu-latest
+            TARGET: sget-linux-amd64
+            COSIGN_PASSWORD: COSIGN_PASSWORD
+          - os: windows-latest
+            TARGET: sget-windows-amd64.exe
+            COSIGN_PASSWORD: COSIGN_PASSWORD
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.x'
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: build sget
+        run: make sget && mv ./sget ./${{matrix.TARGET}}
+      - name: Print sget info
+        shell: pwsh
+        run: |
+          $hash=Get-FileHash -Path ./${{matrix.TARGET}}
+          Write-Output $($hash.Hash + " " + $(([io.fileinfo]$hash.path).basename)) | Tee-Object -Path ${{matrix.TARGET}}.sha256
+      - name: sign sget
+        shell: bash
+        env:
+          COSIGN_PASSWORD: ${{secrets[matrix.COSIGN_PASSWORD]}}
+        if: github.event_name != 'pull_request'
+        run: |
+          ./${{matrix.TARGET}} sign-blob -key ./.github/workflows/cosign.key ./${{matrix.TARGET}} > ${{matrix.TARGET}}.sig
+      - name: verify sget binary
+        if: github.event_name != 'pull_request'
+        run: ./${{matrix.TARGET}} verify-blob -key ./.github/workflows/cosign.pub -signature ${{matrix.TARGET}}.sig ./${{matrix.TARGET}}
+      - name: Upload sget artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v2
+        with:
+          name: artifacts
+          path: |
+            sget-*
+            sget.-*sha256
+            sget-*.sig


### PR DESCRIPTION
During the release process, builds `sget` along cosign, signs, verifies
and publishes the binaries.

Fixes sigstore/cosign#725
