### PR TITLE
Start building `internal/oci/static.New{Signature,File}`

### DIFF
--- a/internal/oci/static/options.go
+++ b/internal/oci/static/options.go
@@ -1,0 +1,89 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package static
+
+import (
+	"github.com/go-openapi/swag"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/internal/oci"
+	ctypes "github.com/sigstore/cosign/pkg/types"
+)
+
+// Option is a functional option for customizing static signatures.
+type Option func(*options)
+
+type options struct {
+	MediaType   types.MediaType
+	Bundle      *oci.Bundle
+	Cert        []byte
+	Chain       []byte
+	Annotations map[string]string
+}
+
+func makeOptions(opts ...Option) (*options, error) {
+	o := &options{
+		MediaType:   ctypes.SimpleSigningMediaType,
+		Annotations: make(map[string]string),
+	}
+
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	if o.Cert != nil {
+		o.Annotations[CertificateAnnotationKey] = string(o.Cert)
+		o.Annotations[ChainAnnotationKey] = string(o.Chain)
+	}
+
+	if o.Bundle != nil {
+		b, err := swag.WriteJSON(o.Bundle)
+		if err != nil {
+			return nil, err
+		}
+		o.Annotations[BundleAnnotationKey] = string(b)
+	}
+
+	return o, nil
+}
+
+// WithMediaType sets the media type of the signature.
+func WithMediaType(mt types.MediaType) Option {
+	return func(o *options) {
+		o.MediaType = mt
+	}
+}
+
+// WithAnnotations sets the annotations that will be associated.
+func WithAnnotations(ann map[string]string) Option {
+	return func(o *options) {
+		o.Annotations = ann
+	}
+}
+
+// WithBundle sets the bundle to attach to the signature
+func WithBundle(b *oci.Bundle) Option {
+	return func(o *options) {
+		o.Bundle = b
+	}
+}
+
+// WithCertChain sets the certificate chain for this signature.
+func WithCertChain(cert, chain []byte) Option {
+	return func(o *options) {
+		o.Cert = cert
+		o.Chain = chain
+	}
+}

--- a/internal/oci/static/options_test.go
+++ b/internal/oci/static/options_test.go
@@ -1,0 +1,93 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package static
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/sigstore/cosign/internal/oci"
+	ctypes "github.com/sigstore/cosign/pkg/types"
+)
+
+func TestOptions(t *testing.T) {
+	bundle := &oci.Bundle{}
+
+	tests := []struct {
+		name string
+		opts []Option
+		want *options
+	}{{
+		name: "no options",
+		want: &options{
+			MediaType:   ctypes.SimpleSigningMediaType,
+			Annotations: make(map[string]string),
+		},
+	}, {
+		name: "with media type",
+		opts: []Option{WithMediaType("foo")},
+		want: &options{
+			MediaType:   "foo",
+			Annotations: make(map[string]string),
+		},
+	}, {
+		name: "with annotations",
+		opts: []Option{WithAnnotations(map[string]string{
+			"foo": "bar",
+		})},
+		want: &options{
+			MediaType: ctypes.SimpleSigningMediaType,
+			Annotations: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}, {
+		name: "with cert chain",
+		opts: []Option{WithCertChain([]byte("a"), []byte("b"))},
+		want: &options{
+			MediaType: ctypes.SimpleSigningMediaType,
+			Annotations: map[string]string{
+				CertificateAnnotationKey: "a",
+				ChainAnnotationKey:       "b",
+			},
+			Cert:  []byte("a"),
+			Chain: []byte("b"),
+		},
+	}, {
+		name: "with bundle",
+		opts: []Option{WithBundle(bundle)},
+		want: &options{
+			MediaType: ctypes.SimpleSigningMediaType,
+			Annotations: map[string]string{
+				BundleAnnotationKey: "{\"SignedEntryTimestamp\":\"\",\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"}}",
+			},
+			Bundle: bundle,
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := makeOptions(test.opts...)
+			if err != nil {
+				t.Fatalf("makeOptions() = %v", err)
+			}
+
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("makeOptions() = %#v, wanted %#v", got, test.want)
+			}
+		})
+	}
+}

--- a/internal/oci/static/signature.go
+++ b/internal/oci/static/signature.go
@@ -1,0 +1,145 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package static
+
+import (
+	"bytes"
+	"crypto/x509"
+	"io"
+	"io/ioutil"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/internal/oci"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"knative.dev/pkg/kmeta"
+)
+
+const (
+	SignatureAnnotationKey   = "dev.cosignproject.cosign/signature"
+	CertificateAnnotationKey = "dev.sigstore.cosign/certificate"
+	ChainAnnotationKey       = "dev.sigstore.cosign/chain"
+	BundleAnnotationKey      = "dev.sigstore.cosign/bundle"
+)
+
+// NewSignature constructs a new oci.Signature from the provided options.
+func NewSignature(payload []byte, b64sig string, opts ...Option) (oci.Signature, error) {
+	o, err := makeOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &staticLayer{
+		b:      payload,
+		b64sig: b64sig,
+		opts:   o,
+	}, nil
+}
+
+// NewFile constructs a new v1.Layer with the provided payload.
+func NewFile(payload []byte, opts ...Option) (v1.Layer, error) {
+	o, err := makeOptions(opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &staticLayer{
+		b:    payload,
+		opts: o,
+	}, nil
+}
+
+type staticLayer struct {
+	b      []byte
+	b64sig string
+	opts   *options
+}
+
+var _ v1.Layer = (*staticLayer)(nil)
+var _ oci.Signature = (*staticLayer)(nil)
+
+// Annotations implements oci.Signature
+func (l *staticLayer) Annotations() (map[string]string, error) {
+	return kmeta.UnionMaps(l.opts.Annotations, map[string]string{
+		SignatureAnnotationKey: l.b64sig,
+	}), nil
+}
+
+// Payload implements oci.Signature
+func (l *staticLayer) Payload() ([]byte, error) {
+	return l.b, nil
+}
+
+// Base64Signature implements oci.Signature
+func (l *staticLayer) Base64Signature() (string, error) {
+	return l.b64sig, nil
+}
+
+// Cert implements oci.Signature
+func (l *staticLayer) Cert() (*x509.Certificate, error) {
+	certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(l.opts.Cert))
+	if err != nil {
+		return nil, err
+	}
+	if len(certs) == 0 {
+		return nil, nil
+	}
+	return certs[0], nil
+}
+
+// Chain implements oci.Signature
+func (l *staticLayer) Chain() ([]*x509.Certificate, error) {
+	certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(l.opts.Chain))
+	if err != nil {
+		return nil, err
+	}
+	return certs, nil
+}
+
+// Bundle implements oci.Signature
+func (l *staticLayer) Bundle() (*oci.Bundle, error) {
+	return l.opts.Bundle, nil
+}
+
+// Digest implements v1.Layer
+func (l *staticLayer) Digest() (v1.Hash, error) {
+	h, _, err := v1.SHA256(bytes.NewReader(l.b))
+	return h, err
+}
+
+// DiffID implements v1.Layer
+func (l *staticLayer) DiffID() (v1.Hash, error) {
+	h, _, err := v1.SHA256(bytes.NewReader(l.b))
+	return h, err
+}
+
+// Compressed implements v1.Layer
+func (l *staticLayer) Compressed() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
+}
+
+// Uncompressed implements v1.Layer
+func (l *staticLayer) Uncompressed() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
+}
+
+// Size implements v1.Layer
+func (l *staticLayer) Size() (int64, error) {
+	return int64(len(l.b)), nil
+}
+
+// MediaType implements v1.Layer
+func (l *staticLayer) MediaType() (types.MediaType, error) {
+	return l.opts.MediaType, nil
+}

--- a/internal/oci/static/signature_test.go
+++ b/internal/oci/static/signature_test.go
@@ -1,0 +1,418 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package static
+
+import (
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/internal/oci"
+)
+
+func TestNewFile(t *testing.T) {
+	payload := "this is the content!"
+	l, err := NewFile([]byte(payload), WithMediaType("foo"))
+	if err != nil {
+		t.Fatalf("NewFile() = %v", err)
+	}
+
+	t.Run("check size", func(t *testing.T) {
+		wantSize := int64(len(payload))
+		gotSize, err := l.Size()
+		if err != nil {
+			t.Fatalf("Size() = %v", err)
+		}
+		if gotSize != wantSize {
+			t.Errorf("Size() = %d, wanted %d", gotSize, wantSize)
+		}
+	})
+
+	t.Run("check media type", func(t *testing.T) {
+		wantMT := types.MediaType("foo")
+		gotMT, err := l.MediaType()
+		if err != nil {
+			t.Fatalf("MediaType() = %v", err)
+		}
+		if gotMT != wantMT {
+			t.Errorf("MediaType() = %s, wanted %s", gotMT, wantMT)
+		}
+	})
+
+	t.Run("check hashes", func(t *testing.T) {
+		wantHash, _, err := v1.SHA256(strings.NewReader(payload))
+		if err != nil {
+			t.Fatalf("SHA256() = %v", err)
+		}
+
+		gotDigest, err := l.Digest()
+		if err != nil {
+			t.Fatalf("Digest() = %v", err)
+		}
+		if !cmp.Equal(gotDigest, wantHash) {
+			t.Errorf("Digest = %s", cmp.Diff(gotDigest, wantHash))
+		}
+
+		gotDiffID, err := l.DiffID()
+		if err != nil {
+			t.Fatalf("DiffID() = %v", err)
+		}
+		if !cmp.Equal(gotDiffID, wantHash) {
+			t.Errorf("DiffID = %s", cmp.Diff(gotDiffID, wantHash))
+		}
+	})
+
+	t.Run("check content", func(t *testing.T) {
+		comp, err := l.Compressed()
+		if err != nil {
+			t.Fatalf("Compressed() = %v", err)
+		}
+		defer comp.Close()
+		compContent, err := io.ReadAll(comp)
+		if err != nil {
+			t.Fatalf("ReadAll() = %v", err)
+		}
+		if got, want := string(compContent), payload; got != want {
+			t.Errorf("Compressed() = %s, wanted %s", got, want)
+		}
+
+		uncomp, err := l.Uncompressed()
+		if err != nil {
+			t.Fatalf("Uncompressed() = %v", err)
+		}
+		defer uncomp.Close()
+		uncompContent, err := io.ReadAll(uncomp)
+		if err != nil {
+			t.Fatalf("ReadAll() = %v", err)
+		}
+		if got, want := string(uncompContent), payload; got != want {
+			t.Errorf("Uncompressed() = %s, wanted %s", got, want)
+		}
+	})
+}
+
+func TestNewSignatureBasic(t *testing.T) {
+	payload := "this is the content!"
+	b64sig := "b64 content=="
+	l, err := NewSignature([]byte(payload), b64sig, WithMediaType("foo"))
+	if err != nil {
+		t.Fatalf("NewSignature() = %v", err)
+	}
+
+	t.Run("check size", func(t *testing.T) {
+		wantSize := int64(len(payload))
+		gotSize, err := l.Size()
+		if err != nil {
+			t.Fatalf("Size() = %v", err)
+		}
+		if gotSize != wantSize {
+			t.Errorf("Size() = %d, wanted %d", gotSize, wantSize)
+		}
+	})
+
+	t.Run("check media type", func(t *testing.T) {
+		wantMT := types.MediaType("foo")
+		gotMT, err := l.MediaType()
+		if err != nil {
+			t.Fatalf("MediaType() = %v", err)
+		}
+		if gotMT != wantMT {
+			t.Errorf("MediaType() = %s, wanted %s", gotMT, wantMT)
+		}
+	})
+
+	t.Run("check hashes", func(t *testing.T) {
+		wantHash, _, err := v1.SHA256(strings.NewReader(payload))
+		if err != nil {
+			t.Fatalf("SHA256() = %v", err)
+		}
+
+		gotDigest, err := l.Digest()
+		if err != nil {
+			t.Fatalf("Digest() = %v", err)
+		}
+		if !cmp.Equal(gotDigest, wantHash) {
+			t.Errorf("Digest = %s", cmp.Diff(gotDigest, wantHash))
+		}
+
+		gotDiffID, err := l.DiffID()
+		if err != nil {
+			t.Fatalf("DiffID() = %v", err)
+		}
+		if !cmp.Equal(gotDiffID, wantHash) {
+			t.Errorf("DiffID = %s", cmp.Diff(gotDiffID, wantHash))
+		}
+	})
+
+	t.Run("check content", func(t *testing.T) {
+		comp, err := l.Compressed()
+		if err != nil {
+			t.Fatalf("Compressed() = %v", err)
+		}
+		defer comp.Close()
+		compContent, err := io.ReadAll(comp)
+		if err != nil {
+			t.Fatalf("ReadAll() = %v", err)
+		}
+		if got, want := string(compContent), payload; got != want {
+			t.Errorf("Compressed() = %s, wanted %s", got, want)
+		}
+
+		uncomp, err := l.Uncompressed()
+		if err != nil {
+			t.Fatalf("Uncompressed() = %v", err)
+		}
+		defer uncomp.Close()
+		uncompContent, err := io.ReadAll(uncomp)
+		if err != nil {
+			t.Fatalf("ReadAll() = %v", err)
+		}
+		if got, want := string(uncompContent), payload; got != want {
+			t.Errorf("Uncompressed() = %s, wanted %s", got, want)
+		}
+
+		gotPayload, err := l.Payload()
+		if err != nil {
+			t.Fatalf("Payload() = %v", err)
+		}
+		if got, want := string(gotPayload), payload; got != want {
+			t.Errorf("Payload() = %s, wanted %s", got, want)
+		}
+
+		gotSig, err := l.Base64Signature()
+		if err != nil {
+			t.Fatalf("Base64Signature() = %v", err)
+		}
+		if got, want := gotSig, b64sig; got != want {
+			t.Errorf("Base64Signature() = %s, wanted %s", got, want)
+		}
+
+		gotBundle, err := l.Bundle()
+		if err != nil {
+			t.Fatalf("Bundle() = %v", err)
+		}
+		if gotBundle != nil {
+			t.Errorf("Bundle() = %#v, wanted nil", gotBundle)
+		}
+	})
+
+	t.Run("check annotations", func(t *testing.T) {
+		want := map[string]string{
+			SignatureAnnotationKey: b64sig,
+		}
+		got, err := l.Annotations()
+		if err != nil {
+			t.Fatalf("Annotations() = %v", err)
+		}
+		if !cmp.Equal(got, want) {
+			t.Errorf("Annotations = %s", cmp.Diff(got, want))
+		}
+	})
+
+	t.Run("check signature accessors", func(t *testing.T) {
+		gotPayload, err := l.Payload()
+		if err != nil {
+			t.Fatalf("Payload() = %v", err)
+		}
+		if got, want := string(gotPayload), payload; got != want {
+			t.Errorf("Payload() = %s, wanted %s", got, want)
+		}
+
+		gotSig, err := l.Base64Signature()
+		if err != nil {
+			t.Fatalf("Base64Signature() = %v", err)
+		}
+		if got, want := gotSig, b64sig; got != want {
+			t.Errorf("Base64Signature() = %s, wanted %s", got, want)
+		}
+
+		if got, err := l.Bundle(); err != nil {
+			t.Fatalf("Bundle() = %v", err)
+		} else if got != nil {
+			t.Errorf("Bundle() = %#v, wanted nil", got)
+		}
+
+		if got, err := l.Cert(); err != nil {
+			t.Fatalf("Cert() = %v", err)
+		} else if got != nil {
+			t.Errorf("Cert() = %#v, wanted nil", got)
+		}
+
+		if got, err := l.Chain(); err != nil {
+			t.Fatalf("Chain() = %v", err)
+		} else if len(got) != 0 {
+			t.Errorf("len(Chain()) = %d, wanted 0", len(got))
+		}
+	})
+}
+
+func TestNewSignatureCertChainAndBundle(t *testing.T) {
+	payload := "this is the other content!"
+	b64sig := "b64 content="
+
+	// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16
+	var (
+		cert = []byte(`
+-----BEGIN CERTIFICATE-----
+MIICjzCCAhSgAwIBAgITV2heiswW9YldtVEAu98QxDO8TTAKBggqhkjOPQQDAzAq
+MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
+MDkxNDE5MTI0MFoXDTIxMDkxNDE5MzIzOVowADBZMBMGByqGSM49AgEGCCqGSM49
+AwEHA0IABMF1AWZcfvubslc4ABNnvGbRjm6GWVHxrJ1RRthTHMCE4FpFmiHQBfGt
+6n80DqszGj77Whb35O33+Dal4Y2po+CjggFBMIIBPTAOBgNVHQ8BAf8EBAMCB4Aw
+EwYDVR0lBAwwCgYIKwYBBQUHAwMwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQU340G
+3G1ozVNmFC5TBFV0yNuouvowHwYDVR0jBBgwFoAUyMUdAEGaJCkyUSTrDa5K7UoG
+0+wwgY0GCCsGAQUFBwEBBIGAMH4wfAYIKwYBBQUHMAKGcGh0dHA6Ly9wcml2YXRl
+Y2EtY29udGVudC02MDNmZTdlNy0wMDAwLTIyMjctYmY3NS1mNGY1ZTgwZDI5NTQu
+c3RvcmFnZS5nb29nbGVhcGlzLmNvbS9jYTM2YTFlOTYyNDJiOWZjYjE0Ni9jYS5j
+cnQwOAYDVR0RAQH/BC4wLIEqa2V5bGVzc0BkaXN0cm9sZXNzLmlhbS5nc2Vydmlj
+ZWFjY291bnQuY29tMAoGCCqGSM49BAMDA2kAMGYCMQDcH9cdkxW6ugsbPHqX9qrM
+wlMaprcwnlktS3+5xuABr5icuqwrB/Fj5doFtS7AnM0CMQD9MjSaUmHFFF7zoLMx
+uThR1Z6JuA21HwxtL3GyJ8UQZcEPOlTBV593HrSAwBhiCoY=
+-----END CERTIFICATE-----
+`)
+		chain = []byte(`
+-----BEGIN CERTIFICATE-----
+MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAq
+MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
+MDMwNzAzMjAyOVoXDTMxMDIyMzAzMjAyOVowKjEVMBMGA1UEChMMc2lnc3RvcmUu
+ZGV2MREwDwYDVQQDEwhzaWdzdG9yZTB2MBAGByqGSM49AgEGBSuBBAAiA2IABLSy
+A7Ii5k+pNO8ZEWY0ylemWDowOkNa3kL+GZE5Z5GWehL9/A9bRNA3RbrsZ5i0Jcas
+taRL7Sp5fp/jD5dxqc/UdTVnlvS16an+2Yfswe/QuLolRUCrcOE2+2iA5+tzd6Nm
+MGQwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB/wQIMAYBAf8CAQEwHQYDVR0OBBYE
+FMjFHQBBmiQpMlEk6w2uSu1KBtPsMB8GA1UdIwQYMBaAFMjFHQBBmiQpMlEk6w2u
+Su1KBtPsMAoGCCqGSM49BAMDA2gAMGUCMH8liWJfMui6vXXBhjDgY4MwslmN/TJx
+Ve/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uup
+Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
+-----END CERTIFICATE-----
+`)
+		bundle = &oci.Bundle{
+			SignedEntryTimestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+			Payload: oci.BundlePayload{
+				Body:           "REMOVED",
+				IntegratedTime: 1631646761,
+				LogIndex:       693591,
+				LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+			},
+		}
+	)
+
+	l, err := NewSignature([]byte(payload), b64sig,
+		WithCertChain(cert, chain), WithBundle(bundle))
+	if err != nil {
+		t.Fatalf("NewSignature() = %v", err)
+	}
+
+	t.Run("check signature accessors", func(t *testing.T) {
+		gotPayload, err := l.Payload()
+		if err != nil {
+			t.Fatalf("Payload() = %v", err)
+		}
+		if got, want := string(gotPayload), payload; got != want {
+			t.Errorf("Payload() = %s, wanted %s", got, want)
+		}
+
+		gotSig, err := l.Base64Signature()
+		if err != nil {
+			t.Fatalf("Base64Signature() = %v", err)
+		}
+		if got, want := gotSig, b64sig; got != want {
+			t.Errorf("Base64Signature() = %s, wanted %s", got, want)
+		}
+
+		if got, err := l.Bundle(); err != nil {
+			t.Fatalf("Bundle() = %v", err)
+		} else if got != bundle {
+			t.Errorf("Bundle() = %#v, wanted %#v", got, bundle)
+		}
+
+		if got, err := l.Cert(); err != nil {
+			t.Fatalf("Cert() = %v", err)
+		} else if got == nil {
+			t.Error("Cert() = nil, wanted non-nil")
+		}
+
+		if got, err := l.Chain(); err != nil {
+			t.Fatalf("Chain() = %v", err)
+		} else if len(got) != 1 {
+			t.Errorf("len(Chain()) = %d, wanted 1", len(got))
+		}
+	})
+
+	t.Run("check annotations", func(t *testing.T) {
+		want := map[string]string{
+			SignatureAnnotationKey:   b64sig,
+			CertificateAnnotationKey: string(cert),
+			ChainAnnotationKey:       string(chain),
+			// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16.
+			// The Body has been removed for brevity
+			BundleAnnotationKey: `{"SignedEntryTimestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
+		}
+		got, err := l.Annotations()
+		if err != nil {
+			t.Fatalf("Annotations() = %v", err)
+		}
+		if !cmp.Equal(got, want) {
+			t.Errorf("Annotations = %s", cmp.Diff(got, want))
+		}
+	})
+}
+
+func TestNewSignatureBadCertChain(t *testing.T) {
+	payload := "this is the other content!"
+	b64sig := "b64 content="
+
+	// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16
+	var (
+		cert = []byte(`
+-----BEGIN CERTIFICATE-----
+garbage in
+-----END CERTIFICATE-----
+`)
+		chain = []byte(`
+-----BEGIN CERTIFICATE-----
+garbage out
+-----END CERTIFICATE-----
+`)
+	)
+
+	l, err := NewSignature([]byte(payload), b64sig,
+		WithCertChain(cert, chain))
+	if err != nil {
+		t.Fatalf("NewSignature() = %v", err)
+	}
+
+	t.Run("check signature accessors", func(t *testing.T) {
+		if got, err := l.Cert(); err == nil {
+			t.Fatalf("Cert() = %#v, wanted error", got)
+		}
+
+		if got, err := l.Chain(); err == nil {
+			t.Fatalf("Chain() = %#v, wanted error", got)
+		}
+	})
+}
+
+func mustDecode(s string) []byte {
+	b, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		panic(err.Error())
+	}
+	return b
+}

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/theupdateframework/go-tuf/encrypted"
 
-	"github.com/sigstore/cosign/pkg/cosign/remote"
+	"github.com/sigstore/cosign/internal/oci/static"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
@@ -36,7 +36,7 @@ import (
 const (
 	PrivakeKeyPemType = "ENCRYPTED COSIGN PRIVATE KEY"
 
-	BundleKey = remote.BundleKey
+	BundleKey = static.BundleAnnotationKey
 )
 
 type PassFunc func(bool) ([]byte, error)

--- a/pkg/cosign/remote/index.go
+++ b/pkg/cosign/remote/index.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/internal/oci/static"
 )
 
 type Digester interface {
@@ -139,10 +140,10 @@ func UploadFiles(ref name.Reference, files []File, getMt MediaTypeGetter, remote
 	return img, nil
 }
 
-func UploadFile(b []byte, ref name.Reference, layerMt, configMt types.MediaType, remoteOpts ...remote.Option) (v1.Image, error) {
-	l := &staticLayer{
-		b:  b,
-		mt: layerMt,
+func UploadFile(b []byte, ref name.Reference, layerMT, configMt types.MediaType, remoteOpts ...remote.Option) (v1.Image, error) {
+	l, err := static.NewFile(b, static.WithMediaType(layerMT))
+	if err != nil {
+		return nil, err
 	}
 
 	emptyOci := mutate.MediaType(empty.Image, types.OCIManifestSchema1)


### PR DESCRIPTION
This is to encapsulate the `staticLayer` functionality that lived alongside `Upload{Signature,File}`, which my previous change refactored a bunch.

This change really just moves stuff, but a subsequent change will likely try to start taking more advantage of this encapsulation.

Signed-off-by: Matt Moore <mattomata@gmail.com>



#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
