### PR TITLE
Make `UploadSignature` take an `oci.Signature`.

### DIFF
--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	ociremote "github.com/sigstore/cosign/internal/oci/remote"
+	"github.com/sigstore/cosign/internal/oci/static"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
 	"github.com/sigstore/cosign/pkg/image"
 	sigPayload "github.com/sigstore/sigstore/pkg/signature/payload"
@@ -99,7 +100,12 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOpts, sigRef, pay
 		return err
 	}
 
-	return cremote.UploadSignature(sigBytes, payload, dstRef, cremote.UploadOpts{RemoteOpts: remoteOpts})
+	sig, err := static.NewSignature(payload, base64.StdEncoding.EncodeToString(sigBytes))
+	if err != nil {
+		return err
+	}
+
+	return cremote.UploadSignature(sig, dstRef, cremote.UploadOpts{RemoteOpts: remoteOpts})
 }
 
 type SignatureArgType uint8

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
 
 	"github.com/sigstore/cosign/internal/oci"
@@ -127,34 +126,11 @@ LayerLoop:
 }
 
 type UploadOpts struct {
-	Cert                  []byte
-	Chain                 []byte
-	DupeDetector          signature.Verifier
-	Bundle                *oci.Bundle
-	AdditionalAnnotations map[string]string
-	RemoteOpts            []remote.Option
-	MediaType             string
+	DupeDetector signature.Verifier
+	RemoteOpts   []remote.Option
 }
 
-func UploadSignature(signature, payload []byte, dst name.Reference, opts UploadOpts) error {
-	b64sig := base64.StdEncoding.EncodeToString(signature)
-	var options []static.Option
-	// Preserve the default
-	if opts.MediaType != "" {
-		options = append(options, static.WithMediaType(types.MediaType(opts.MediaType)))
-	}
-	if opts.Cert != nil {
-		options = append(options, static.WithCertChain(opts.Cert, opts.Chain))
-	}
-	if opts.Bundle != nil {
-		options = append(options, static.WithBundle(opts.Bundle))
-	}
-
-	l, err := static.NewSignature(payload, b64sig, options...)
-	if err != nil {
-		return err
-	}
-
+func UploadSignature(l oci.Signature, dst name.Reference, opts UploadOpts) error {
 	base, err := SignatureImage(dst, opts.RemoteOpts...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Now that we have `static.NewSignature`, this shifts the construction out of `UploadSignature` and removes the elements passed via `UploadOpts` to simply be a part of the `NewSignature` call on the caller's side.

With this `UploadSignature` is starting to look pretty lean!

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
