### PR TITLE
Add sget to the goreleaser release pipeline

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -1,0 +1,66 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: CI-Validate-Release-Job
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request:
+
+jobs:
+  validate-release-job:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: none
+      checks: none
+      contents: none
+      deployments: none
+      issues: none
+      packages: none
+      pull-requests: none
+      repository-projects: none
+      security-events: none
+      statuses: none
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: goreleaser snapshot
+        run: |
+          docker run --rm --privileged \
+            -e PROJECT_ID=honk-fake-project \
+            -e RUNTIME_IMAGE=gcr.io/distroless/static:debug-nonroot \
+            -v ${PWD}:/go/src/sigstore/cosign \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -w /go/src/sigstore/cosign \
+            --entrypoint="" \
+            ghcr.io/gythialy/golang-cross:v1.17.1@sha256:d6982c0a6dae690b1f5ac977e377e75ba0db7022483c13b664a130a7934eb393 \
+            make snapshot
+
+      - name: check binaries
+        run: |
+          ./dist/cosign-linux-amd64 version
+          ./dist/cosigned-linux-amd64 --help
+          ./dist/sget-linux-amd64 --help
+
+      - name: check images
+        run: |
+          docker run ghcr.io/honk-fake-project/cosign:SNAPSHOT-${GITHUB_SHA:0:7}-amd64 version
+          docker run ghcr.io/honk-fake-project/cosigned:SNAPSHOT-${GITHUB_SHA:0:7}-amd64 --help
+          docker run ghcr.io/honk-fake-project/sget:SNAPSHOT-${GITHUB_SHA:0:7}-amd64 --help

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,18 +18,6 @@ builds:
     - linux
   goarch:
     - amd64
-  ldflags:
-    - "{{ .Env.LDFLAGS }}"
-  env:
-    - CGO_ENABLED=0
-
-- id: linux-arm64
-  binary: cosign-linux-{{ .Arch }}
-  no_unique_dist_dir: true
-  main: ./cmd/cosign
-  goos:
-    - linux
-  goarch:
     - arm64
   ldflags:
     - "{{ .Env.LDFLAGS }}"
@@ -111,19 +99,26 @@ builds:
     - linux
   goarch:
     - amd64
+    - arm64
   ldflags:
     - "{{ .Env.LDFLAGS }}"
   env:
     - CGO_ENABLED=0
 
-- id: linux-cosigned-arm64
-  binary: cosigned-linux-{{ .Arch }}
+- id: sget
+  binary: sget-{{ .Os }}-{{ .Arch }}
   no_unique_dist_dir: true
-  main: ./cmd/cosign/webhook
+  main: ./cmd/sget
   goos:
     - linux
+    - darwin
+    - windows
   goarch:
+    - amd64
     - arm64
+  ignore:
+    - goos: windows
+      goarch: arm64
   ldflags:
     - "{{ .Env.LDFLAGS }}"
   env:
@@ -142,8 +137,16 @@ signs:
     artifacts: binary
     ids:
       - linux-cosigned
+  - id: sget
+    signature: "${artifact}.sig"
+    cmd: ./dist/cosign-linux-amd64
+    args: ["sign-blob", "-output", "${artifact}.sig", "-key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    artifacts: binary
+    ids:
+      - sget
 
 dockers:
+  # cosign Image
   - image_templates:
       - "ghcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-amd64"
     use: buildx
@@ -162,6 +165,7 @@ dockers:
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
       - "--build-arg=ARCH=arm64"
 
+  # cosigned Image
   - image_templates:
       - "ghcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-amd64"
     use: buildx
@@ -180,6 +184,25 @@ dockers:
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
       - "--build-arg=ARCH=arm64"
 
+  # sget Image
+  - image_templates:
+      - "ghcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-amd64"
+    use: buildx
+    dockerfile: Dockerfile.sget
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      - "--build-arg=ARCH=amd64"
+  - image_templates:
+      - "ghcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8"
+    use: buildx
+    goarch: arm64
+    dockerfile: Dockerfile.sget
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      - "--build-arg=ARCH=arm64"
+
 docker_manifests:
   - name_template: ghcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}
     image_templates:
@@ -189,6 +212,10 @@ docker_manifests:
     image_templates:
       - ghcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-amd64
       - ghcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-arm64v8
+  - name_template: ghcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}
+    image_templates:
+      - ghcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-amd64
+      - ghcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8
 
 docker_signs:
   - artifacts: all
@@ -203,7 +230,7 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: SNAPSHOT-{{.ShortCommit}}
+  name_template: SNAPSHOT-{{ .ShortCommit }}
 
 release:
   prerelease: allow # remove this when we start publishing non-prerelease or set to auto

--- a/Dockerfile.sget
+++ b/Dockerfile.sget
@@ -1,0 +1,23 @@
+# Copyright 2021 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
+
+FROM $RUNTIME_IMAGE
+
+ARG ARCH
+COPY sget-linux-${ARCH} /bin/sget
+
+USER nobody
+ENTRYPOINT [ "/bin/sget" ]


### PR DESCRIPTION
#### Summary
Follow up of: https://github.com/sigstore/cosign/pull/745

Now we add the sget in the goreleaser config to release officially `sget`

- Include also the container image
- and a github action to validate the goreleaser config

#### Ticket Link
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Add sget to the goreleaser release pipeline
```
