### PR TITLE
Move the `empty.Signatures()` on 404 semantic into the lib.

### DIFF
--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -70,6 +70,10 @@ func SBOMCmd(ctx context.Context, regOpts options.RegistryOpts, imageRef string,
 	if err != nil {
 		return nil, err
 	}
+	if len(sigs) == 0 {
+		return nil, fmt.Errorf("no signatures associated with %v", ref)
+	}
+
 	sboms := make([]string, 0, len(sigs))
 	for _, l := range sigs {
 		mt, err := l.MediaType()

--- a/internal/oci/remote/signatures_test.go
+++ b/internal/oci/remote/signatures_test.go
@@ -1,0 +1,78 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/pkg/errors"
+)
+
+func TestSignaturesErrors(t *testing.T) {
+	ri := remote.Image
+	t.Cleanup(func() {
+		remoteImage = ri
+	})
+
+	t.Run("404 returns empty", func(t *testing.T) {
+		remoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, &transport.Error{
+				StatusCode: http.StatusNotFound,
+			}
+		}
+
+		sigs, err := Signatures(name.MustParseReference("gcr.io/distroless/static:sha256-deadbeef.sig"))
+		if err != nil {
+			t.Fatalf("Signatures() = %v", err)
+		}
+		if sl, err := sigs.Get(); err != nil {
+			t.Fatalf("Get() = %v", err)
+		} else if len(sl) != 0 {
+			t.Fatalf("len(Get()) = %d, wanted 0", len(sl))
+		}
+	})
+
+	t.Run("other transport errors propagate", func(t *testing.T) {
+		want := &transport.Error{
+			StatusCode: http.StatusInternalServerError,
+		}
+		remoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, want
+		}
+
+		_, err := Signatures(name.MustParseReference("gcr.io/distroless/static:sha256-deadbeef.sig"))
+		if !errors.Is(err, want) {
+			t.Fatalf("Signatures() = %v, wanted %v", err, want)
+		}
+	})
+
+	t.Run("other errors propagate", func(t *testing.T) {
+		want := errors.New("it's my error, I can cry if I want to")
+		remoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, want
+		}
+
+		_, err := Signatures(name.MustParseReference("gcr.io/distroless/static:sha256-deadbeef.sig"))
+		if !errors.Is(err, want) {
+			t.Fatalf("Signatures() = %v, wanted %v", err, want)
+		}
+	})
+}

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -18,6 +18,7 @@ package cosign
 import (
 	"context"
 	"crypto/x509"
+	"fmt"
 	"runtime"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -61,6 +62,9 @@ func FetchSignaturesForReference(ctx context.Context, ref name.Reference, opts .
 	l, err := sigs.Get()
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching signatures")
+	}
+	if len(l) == 0 {
+		return nil, fmt.Errorf("no signatures associated with %v", ref)
 	}
 
 	g := pool.New(runtime.NumCPU())

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -506,15 +506,15 @@ func TestUploadDownload(t *testing.T) {
 			se, err := ociremote.SignedEntity(ref, ociremote.WithRemoteOptions(registryClientOpts(ctx)...))
 			must(err, t)
 			sigs, err := se.Signatures()
+			must(err, t)
+			signatures, err := sigs.Get()
+			must(err, t)
 
 			if testCase.expectedErr {
-				mustErr(err, t)
+				if len(signatures) != 0 {
+					t.Fatalf("unexpected signatures %d, wanted 0", len(signatures))
+				}
 			} else {
-				must(err, t)
-
-				signatures, err := sigs.Get()
-				must(err, t)
-
 				if len(signatures) != 1 {
 					t.Fatalf("unexpected signatures %d, wanted 1", len(signatures))
 				}


### PR DESCRIPTION
The more I think about this semantics, the more I think it makes sense for it to be a native part of the library.

In places that are dealing with `SignedEntity` today, we more or less expect this semantic when we access their `Signatures`, and other places sort of do this already (e.g. `mutate.AppendManifests` implements `Signatures()` by returning `empty.Signatures()`).

Hopefully this will improve the DevX of the library a bit.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link
Related: https://github.com/sigstore/cosign/issues/666


#### Release Note

```release-note
NONE
```
