### PR TITLE
Do a pass cleaning up `regOpts.GetRegistryClientOpts`

### DIFF
--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -56,13 +56,11 @@ func SBOMCmd(ctx context.Context, regOpts options.RegistryOpts, imageRef string,
 		return nil, err
 	}
 
-	remoteOpts := regOpts.GetRegistryClientOpts(ctx)
-
-	dstRef, err := remote.SBOMTag(ref, remote.WithRemoteOptions(remoteOpts...))
+	dstRef, err := remote.SBOMTag(ref, regOpts.ClientOpts(ctx)...)
 	if err != nil {
 		return nil, err
 	}
-	img, err := remote.Signatures(dstRef, remote.WithRemoteOptions(remoteOpts...))
+	img, err := remote.Signatures(dstRef, regOpts.ClientOpts(ctx)...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cosign/cli/download/signature.go
+++ b/cmd/cosign/cli/download/signature.go
@@ -25,7 +25,6 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 	"github.com/sigstore/cosign/pkg/cosign"
 )
 
@@ -54,8 +53,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOpts, imageRef st
 	if err != nil {
 		return err
 	}
-	regClientOpts := regOpts.GetRegistryClientOpts(ctx)
-	signatures, err := cosign.FetchSignaturesForReference(ctx, ref, ociremote.WithRemoteOptions(regClientOpts...))
+	signatures, err := cosign.FetchSignaturesForReference(ctx, ref, regOpts.ClientOpts(ctx)...)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/generate/generate.go
+++ b/cmd/cosign/cli/generate/generate.go
@@ -23,10 +23,10 @@ import (
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/pkg/image"
 	"github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
@@ -74,12 +74,11 @@ func GenerateCmd(ctx context.Context, regOpts options.RegistryOpts, imageRef str
 		return err
 	}
 
-	get, err := remote.Get(ref, regOpts.GetRegistryClientOpts(ctx)...)
+	h, err := image.Digest(ref, regOpts.GetRegistryClientOpts(ctx)...)
 	if err != nil {
 		return err
 	}
-	repo := ref.Context()
-	img := repo.Digest(get.Digest.String())
+	img := ref.Context().Digest(h.String())
 
 	json, err := (&payload.Cosign{Image: img, Annotations: annotations}).MarshalJSON()
 	if err != nil {

--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -55,15 +55,14 @@ func MungeCmd(ctx context.Context, regOpts options.RegistryOpts, imageRef string
 		return err
 	}
 
-	remoteOpts := regOpts.GetRegistryClientOpts(ctx)
 	var dstRef name.Tag
 	switch attachmentType {
 	case cosign.Signature:
-		dstRef, err = ociremote.SignatureTag(ref, ociremote.WithRemoteOptions(remoteOpts...))
+		dstRef, err = ociremote.SignatureTag(ref, regOpts.ClientOpts(ctx)...)
 	case cosign.SBOM:
-		dstRef, err = ociremote.SBOMTag(ref, ociremote.WithRemoteOptions(remoteOpts...))
+		dstRef, err = ociremote.SBOMTag(ref, regOpts.ClientOpts(ctx)...)
 	case cosign.Attestation:
-		dstRef, err = ociremote.AttestationTag(ref, ociremote.WithRemoteOptions(remoteOpts...))
+		dstRef, err = ociremote.AttestationTag(ref, regOpts.ClientOpts(ctx)...)
 	default:
 		err = fmt.Errorf("unknown attachment type %s", attachmentType)
 	}

--- a/cmd/cosign/cli/upload/wasm.go
+++ b/cmd/cosign/cli/upload/wasm.go
@@ -62,7 +62,6 @@ func WasmCmd(ctx context.Context, regOpts options.RegistryOpts, wasmPath, imageR
 	if err != nil {
 		return err
 	}
-	regOpts.GetRegistryClientOpts(ctx)
 	fmt.Fprintf(os.Stderr, "Uploading wasm file from [%s] to [%s].\n", wasmPath, ref.Name())
 	if _, err := cremote.UploadFile(b, ref, types.WasmLayerMediaType, types.WasmConfigMediaType, regOpts.GetRegistryClientOpts(ctx)...); err != nil {
 		return err


### PR DESCRIPTION
I noticed a bunch of places were just reimplementing `regOpts.ClientOpts`, and noticed a couple other little cleanups as I was auditing calls:
 * Have `GenerateCmd` call `image.Digest`
 * Remove dead call in `wasm.go`

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
