### PR TITLE
Add a `DupeDetector` interface, implement using `signature.Verifier`.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -237,7 +237,7 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 	// An attestation represents both the signature and payload. So store the entire thing
 	// in the payload field since they can get large
 	return cremote.UploadSignature(sig, attRef, cremote.UploadOpts{
-		DupeDetector: sv,
+		DupeDetector: cremote.NewDupeDetector(sv),
 		RemoteOpts:   remoteOpts,
 	})
 }

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -356,7 +356,7 @@ func SignCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOpts, anno
 
 		fmt.Fprintln(os.Stderr, "Pushing signature to:", sigRef.String())
 		if err := cremote.UploadSignature(sig, sigRef, cremote.UploadOpts{
-			DupeDetector: sv,
+			DupeDetector: cremote.NewDupeDetector(sv),
 			RemoteOpts:   remoteOpts,
 		}); err != nil {
 			return errors.Wrap(err, "uploading")


### PR DESCRIPTION
This is one final bit of encapsulation to try and separate duplication detection from how it's consumed.

I'm flexible on where this now separable logic lives.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
