### PR TITLE
Migrate `image.Digest` to `ociremote.ResolveDigest`.

### DIFF
--- a/cmd/cosign/cli/generate/generate.go
+++ b/cmd/cosign/cli/generate/generate.go
@@ -26,7 +26,7 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/pkg/image"
+	ociremote "github.com/sigstore/cosign/internal/oci/remote"
 	"github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
@@ -74,13 +74,12 @@ func GenerateCmd(ctx context.Context, regOpts options.RegistryOpts, imageRef str
 		return err
 	}
 
-	h, err := image.Digest(ref, regOpts.GetRegistryClientOpts(ctx)...)
+	digest, err := ociremote.ResolveDigest(ref, regOpts.ClientOpts(ctx)...)
 	if err != nil {
 		return err
 	}
-	img := ref.Context().Digest(h.String())
 
-	json, err := (&payload.Cosign{Image: img, Annotations: annotations}).MarshalJSON()
+	json, err := (&payload.Cosign{Image: digest, Annotations: annotations}).MarshalJSON()
 	if err != nil {
 		return err
 	}

--- a/internal/oci/remote/digest_test.go
+++ b/internal/oci/remote/digest_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/pkg/errors"
+)
+
+func TestResolveDigest(t *testing.T) {
+	rg := remoteGet
+	defer func() {
+		remoteGet = rg
+	}()
+
+	tag := name.MustParseReference("gcr.io/distroless/static:nonroot")
+	// As of 2021-09-20:
+	// crane digest gcr.io/distroless/static:nonroot
+	digest := name.MustParseReference("gcr.io/distroless/static@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4")
+
+	t.Run("digest doesn't call remote.Get", func(t *testing.T) {
+		remoteGet = func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error) {
+			t.Fatal("ResolveDigest should not call remote.Get.")
+			return nil, nil
+		}
+
+		got, err := ResolveDigest(digest)
+		if err != nil {
+			t.Fatalf("ResolveDigest() = %v", err)
+		}
+		if want := digest; got != want {
+			t.Errorf("ResolveDigest() = %v, wanted %v", got, want)
+		}
+	})
+
+	t.Run("tag calls remote.Get", func(t *testing.T) {
+		remoteGet = func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error) {
+			return &remote.Descriptor{
+				Descriptor: v1.Descriptor{
+					Digest: v1.Hash{
+						Algorithm: "sha256",
+						// As of 2021-09-20:
+						// crane digest gcr.io/distroless/static:nonroot
+						Hex: "be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4",
+					},
+				},
+			}, nil
+		}
+
+		got, err := ResolveDigest(tag)
+		if err != nil {
+			t.Fatalf("ResolveDigest() = %v", err)
+		}
+		if want := digest; got != want {
+			t.Errorf("ResolveDigest() = %v, wanted %v", got, want)
+		}
+	})
+
+	t.Run("remote.Get errors propagate", func(t *testing.T) {
+		want := errors.New("we should propagate this error")
+		remoteGet = func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error) {
+			return nil, want
+		}
+
+		_, got := ResolveDigest(tag)
+		if !errors.Is(got, want) {
+			t.Fatalf("ResolveDigest() = %v, wanted %v", got, want)
+		}
+	})
+}


### PR DESCRIPTION
The only thing left in `pkg/image` was `Digest`, which potentially hits `remote.Get`.

This change introduces `ociremote.ResolveDigest`, which is similar, but takes our options and returns a `name.Digest` instead of a `v1.Hash`.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
