### PR TITLE
Add `mutate.SignEntity` and friends.

### DIFF
--- a/internal/oci/mutate/mutate.go
+++ b/internal/oci/mutate/mutate.go
@@ -123,20 +123,20 @@ func (i *indexWrapper) SignedImageIndex(h v1.Hash) (oci.SignedImageIndex, error)
 	}
 }
 
-// SignEntity attaches the provided signature to the provided entity.
-func SignEntity(se oci.SignedEntity, sig oci.Signature, opts ...SignOption) (oci.SignedEntity, error) {
+// AttachSignatureToEntity attaches the provided signature to the provided entity.
+func AttachSignatureToEntity(se oci.SignedEntity, sig oci.Signature, opts ...SignOption) (oci.SignedEntity, error) {
 	switch obj := se.(type) {
 	case oci.SignedImage:
-		return SignImage(obj, sig, opts...)
+		return AttachSignatureToImage(obj, sig, opts...)
 	case oci.SignedImageIndex:
-		return SignImageIndex(obj, sig, opts...)
+		return AttachSignatureToImageIndex(obj, sig, opts...)
 	default:
 		return nil, fmt.Errorf("unsupported type: %T", se)
 	}
 }
 
-// SignImage attaches the provided signature to the provided image.
-func SignImage(si oci.SignedImage, sig oci.Signature, opts ...SignOption) (oci.SignedImage, error) {
+// AttachSignatureToImage attaches the provided signature to the provided image.
+func AttachSignatureToImage(si oci.SignedImage, sig oci.Signature, opts ...SignOption) (oci.SignedImage, error) {
 	return &signedImage{
 		SignedImage: si,
 		sig:         sig,
@@ -167,8 +167,8 @@ func (si *signedImage) Signatures() (oci.Signatures, error) {
 	return AppendSignatures(base, si.sig)
 }
 
-// SignImage attaches the provided signature to the provided image.
-func SignImageIndex(sii oci.SignedImageIndex, sig oci.Signature, opts ...SignOption) (oci.SignedImageIndex, error) {
+// AttachSignatureToImageIndex attaches the provided signature to the provided image index.
+func AttachSignatureToImageIndex(sii oci.SignedImageIndex, sig oci.Signature, opts ...SignOption) (oci.SignedImageIndex, error) {
 	return &signedImageIndex{
 		ociSignedImageIndex: sii,
 		sig:                 sig,

--- a/internal/oci/mutate/mutate_test.go
+++ b/internal/oci/mutate/mutate_test.go
@@ -163,7 +163,7 @@ func TestSignEntity(t *testing.T) {
 			if err != nil {
 				t.Fatalf("static.NewSignature() = %v", err)
 			}
-			se, err = SignEntity(se, orig)
+			se, err = AttachSignatureToEntity(se, orig)
 			if err != nil {
 				t.Fatalf("SignEntity() = %v", err)
 			}
@@ -174,7 +174,7 @@ func TestSignEntity(t *testing.T) {
 					t.Fatalf("static.NewSignature() = %v", err)
 				}
 
-				se, err = SignEntity(se, sig)
+				se, err = AttachSignatureToEntity(se, sig)
 				if err != nil {
 					t.Fatalf("SignEntity() = %v", err)
 				}
@@ -198,7 +198,7 @@ func TestSignEntity(t *testing.T) {
 			if err != nil {
 				t.Fatalf("static.NewSignature() = %v", err)
 			}
-			se, err = SignEntity(se, orig)
+			se, err = AttachSignatureToEntity(se, orig)
 			if err != nil {
 				t.Fatalf("SignEntity() = %v", err)
 			}
@@ -213,7 +213,7 @@ func TestSignEntity(t *testing.T) {
 					t.Fatalf("static.NewSignature() = %v", err)
 				}
 
-				se, err = SignEntity(se, sig, WithDupeDetector(dd))
+				se, err = AttachSignatureToEntity(se, sig, WithDupeDetector(dd))
 				if err != nil {
 					t.Fatalf("SignEntity() = %v", err)
 				}
@@ -237,7 +237,7 @@ func TestSignEntity(t *testing.T) {
 			if err != nil {
 				t.Fatalf("static.NewSignature() = %v", err)
 			}
-			se, err = SignEntity(se, orig)
+			se, err = AttachSignatureToEntity(se, orig)
 			if err != nil {
 				t.Fatalf("SignEntity() = %v", err)
 			}
@@ -253,7 +253,7 @@ func TestSignEntity(t *testing.T) {
 					t.Fatalf("static.NewSignature() = %v", err)
 				}
 
-				se, err = SignEntity(se, sig, WithDupeDetector(dd))
+				se, err = AttachSignatureToEntity(se, sig, WithDupeDetector(dd))
 				if err != nil {
 					t.Fatalf("SignEntity() = %v", err)
 				}

--- a/internal/oci/mutate/options.go
+++ b/internal/oci/mutate/options.go
@@ -1,0 +1,45 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mutate
+
+import "github.com/sigstore/cosign/internal/oci"
+
+// DupeDetector scans a list of signatures looking for a duplicate.
+type DupeDetector interface {
+	Find(oci.Signatures, oci.Signature) (oci.Signature, error)
+}
+
+type SignOption func(*signOpts)
+
+type signOpts struct {
+	dd DupeDetector
+}
+
+func makeSignOpts(opts ...SignOption) *signOpts {
+	so := &signOpts{}
+	for _, opt := range opts {
+		opt(so)
+	}
+	return so
+}
+
+// WithDupeDetector configures Sign* to use the following DupeDetector
+// to avoid attaching duplicate signatures.
+func WithDupeDetector(dd DupeDetector) SignOption {
+	return func(so *signOpts) {
+		so.dd = dd
+	}
+}

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -29,14 +29,9 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-// DupeDetector scans a list of signatures looking for a duplicate.
-type DupeDetector interface {
-	Find(oci.Signatures, oci.Signature) (oci.Signature, error)
-}
-
 // NewDupeDetector creates a new DupeDetector that looks for matching signatures that
 // can verify the provided signature's payload.
-func NewDupeDetector(v signature.Verifier) DupeDetector {
+func NewDupeDetector(v signature.Verifier) mutate.DupeDetector {
 	return &dd{verifier: v}
 }
 
@@ -44,7 +39,7 @@ type dd struct {
 	verifier signature.Verifier
 }
 
-var _ DupeDetector = (*dd)(nil)
+var _ mutate.DupeDetector = (*dd)(nil)
 
 func (dd *dd) Find(sigImage oci.Signatures, newSig oci.Signature) (oci.Signature, error) {
 	newDigest, err := newSig.Digest()
@@ -108,7 +103,7 @@ LayerLoop:
 }
 
 type UploadOpts struct {
-	DupeDetector DupeDetector
+	DupeDetector mutate.DupeDetector
 	RemoteOpts   []remote.Option
 }
 


### PR DESCRIPTION
These mutators attach a new `oci.Signature` to the `oci.Signatures` hanging off of an `oci.SignedEntity`.

A `DupeDetector` may optionally be passed via functional options, to elide the signature when a "dupe" already exists.

Signed-off-by: Matt Moore <mattomata@gmail.com>



#### Ticket Link
Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
