### PR TITLE
Add `ociremote.WriteSignatures`.

### DIFF
--- a/internal/oci/remote/remote.go
+++ b/internal/oci/remote/remote.go
@@ -37,6 +37,7 @@ var (
 	remoteImage = remote.Image
 	remoteIndex = remote.Index
 	remoteGet   = remote.Get
+	remoteWrite = remote.Write
 )
 
 // SignedEntity provides access to a remote reference, and its signatures.
@@ -129,8 +130,12 @@ func suffixTag(ref name.Reference, suffix string, o *options) (name.Tag, error) 
 	return o.TargetRepository.Tag(normalize(h, suffix)), nil
 }
 
+type digestable interface {
+	Digest() (v1.Hash, error)
+}
+
 // signatures is a shared implementation of the oci.Signed* Signatures method.
-func signatures(digestable interface{ Digest() (v1.Hash, error) }, o *options) (oci.Signatures, error) {
+func signatures(digestable digestable, o *options) (oci.Signatures, error) {
 	h, err := digestable.Digest()
 	if err != nil {
 		return nil, err

--- a/internal/oci/remote/write.go
+++ b/internal/oci/remote/write.go
@@ -1,0 +1,46 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sigstore/cosign/internal/oci"
+)
+
+// WriteSignature publishes the signatures attaches to the given entity
+// into the provided repository.
+func WriteSignatures(repo name.Repository, se oci.SignedEntity, opts ...Option) error {
+	o, err := makeOptions(repo, opts...)
+	if err != nil {
+		return err
+	}
+
+	// Access the signature list to publish
+	sigs, err := se.Signatures()
+	if err != nil {
+		return err
+	}
+
+	// Determine the tag to which these signatures should be published.
+	h, err := se.(digestable).Digest()
+	if err != nil {
+		return err
+	}
+	tag := o.TargetRepository.Tag(normalize(h, o.SignatureSuffix))
+
+	// Write the Signatures image to the tag, with the provided remote.Options
+	return remoteWrite(tag, sigs, o.ROpt...)
+}

--- a/internal/oci/remote/write_test.go
+++ b/internal/oci/remote/write_test.go
@@ -1,0 +1,71 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/sigstore/cosign/internal/oci/mutate"
+	"github.com/sigstore/cosign/internal/oci/signed"
+	"github.com/sigstore/cosign/internal/oci/static"
+)
+
+func TestWriteSignatures(t *testing.T) {
+	rw := remote.Write
+	t.Cleanup(func() {
+		remoteWrite = rw
+	})
+	i, err := random.Image(300 /* byteSize */, 7 /* layers */)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	si := signed.Image(i)
+
+	want := 6 // Add 6 signatures
+	for i := 0; i < want; i++ {
+		sig, err := static.NewSignature(nil, fmt.Sprintf("%d", i))
+		if err != nil {
+			t.Fatalf("static.NewSignature() = %v", err)
+		}
+		si, err = mutate.AttachSignatureToImage(si, sig)
+		if err != nil {
+			t.Fatalf("SignEntity() = %v", err)
+		}
+	}
+
+	ref := name.MustParseReference("gcr.io/bistroless/static:nonroot")
+
+	remoteWrite = func(ref name.Reference, img v1.Image, options ...remote.Option) error {
+		l, err := img.Layers()
+		if err != nil {
+			return err
+		}
+
+		if got := len(l); got != want {
+			t.Errorf("got %d layers, wanted %d", got, want)
+		}
+
+		return nil
+	}
+	if err := WriteSignatures(ref.Context(), si); err != nil {
+		t.Fatalf("WriteSignature() = %v", err)
+	}
+}


### PR DESCRIPTION

This new method publishes the signatures associated with an `oci.SignedEntity` to a particular `name.Repository` in accordance with the `ociremote.Option`s, and the digest of the `oci.SignedEntity` with which it is affiliated.

Signed-off-by: Matt Moore <mattomata@gmail.com>

WIP until https://github.com/sigstore/cosign/pull/761 lands

#### Ticket Link
Related: https://github.com/sigstore/cosign/issues/666

#### Release Note
```release-note
NONE
```
