### PR TITLE
Add a readonly variant of `mutate.Map`.

### DIFF
--- a/internal/oci/mutate/map.go
+++ b/internal/oci/mutate/map.go
@@ -27,15 +27,15 @@ import (
 	"github.com/sigstore/cosign/internal/oci"
 )
 
-// Mutator is the signature of the callback supplied to Map.
+// Fn is the signature of the callback supplied to Map.
 // The oci.SignedEntity is either an oci.SignedImageIndex or an oci.SignedImage.
 // This callback is called on oci.SignedImageIndex *before* its children are
 // processed with a context that returns IsBeforeChildren(ctx) == true.
 // If the images within the SignedImageIndex change after the Before pass, then
-// the Mutator will be invoked again on the new SignedImageIndex with a context
+// the Fn will be invoked again on the new SignedImageIndex with a context
 // that returns IsAfterChildren(ctx) == true.
 // If the returned entity is nil, it is filtered from the result of Map.
-type Mutator func(context.Context, oci.SignedEntity) (oci.SignedEntity, error)
+type Fn func(context.Context, oci.SignedEntity) (oci.SignedEntity, error)
 
 // ErrSkipChildren is a special error that may be returned from a Mutator
 // to skip processing of an index's child entities.
@@ -44,7 +44,7 @@ var ErrSkipChildren = errors.New("skip child entities")
 // Map calls `fn` on the signed entity and each of its constituent entities (`SignedImageIndex`
 // or `SignedImage`) transitively.
 // Any errors returned by an `fn` are returned by `Map`.
-func Map(ctx context.Context, parent oci.SignedEntity, fn Mutator) (oci.SignedEntity, error) {
+func Map(ctx context.Context, parent oci.SignedEntity, fn Fn) (oci.SignedEntity, error) {
 	parent, err := fn(before(ctx), parent)
 	switch {
 	case errors.Is(err, ErrSkipChildren):

--- a/internal/oci/walk/walk.go
+++ b/internal/oci/walk/walk.go
@@ -1,0 +1,41 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package walk
+
+import (
+	"context"
+
+	"github.com/sigstore/cosign/internal/oci"
+	"github.com/sigstore/cosign/internal/oci/mutate"
+)
+
+// Fn is the signature of the callback supplied to SignedEntity.
+// The oci.SignedEntity is either an oci.SignedImageIndex or an oci.SignedImage.
+// This callback is called on oci.SignedImageIndex *before* its children.
+type Fn func(context.Context, oci.SignedEntity) error
+
+// SignedEntity calls `fn` on the signed entity and each of its constituent entities
+// (`SignedImageIndex` or `SignedImage`) transitively.
+// Any errors returned by an `fn` are returned by `Walk`.
+func SignedEntity(ctx context.Context, parent oci.SignedEntity, fn Fn) error {
+	_, err := mutate.Map(ctx, parent, func(ctx context.Context, se oci.SignedEntity) (oci.SignedEntity, error) {
+		if err := fn(ctx, se); err != nil {
+			return nil, err
+		}
+		return se, nil
+	})
+	return err
+}

--- a/internal/oci/walk/walk_test.go
+++ b/internal/oci/walk/walk_test.go
@@ -1,0 +1,87 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package walk
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/sigstore/cosign/internal/oci"
+	"github.com/sigstore/cosign/internal/oci/signed"
+)
+
+func TestMapImage(t *testing.T) {
+	i, err := random.Image(300 /* bytes */, 3 /* layers */)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	si := signed.Image(i)
+
+	t.Run("walk image, no errors", func(t *testing.T) {
+		calls := 0
+		err := SignedEntity(context.Background(), si, func(c context.Context, se oci.SignedEntity) error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Map() = %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("Map called %d times, wanted 1", calls)
+		}
+	})
+
+	t.Run("error propagates", func(t *testing.T) {
+		want := errors.New("this is the error I expect")
+		got := SignedEntity(context.Background(), si, func(c context.Context, se oci.SignedEntity) error {
+			return want
+		})
+		if !errors.Is(got, want) {
+			t.Fatalf("Map() = %v, wanted %v", got, want)
+		}
+	})
+}
+
+func TestMapImageIndex(t *testing.T) {
+	ii, err := random.Index(300 /* bytes */, 3 /* layers */, 2 /* images */)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	ii2, err := random.Index(300 /* bytes */, 3 /* layers */, 2 /* images */)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	sii := signed.ImageIndex(mutate.AppendManifests(ii, mutate.IndexAddendum{
+		Add: ii2,
+	}))
+
+	t.Run("six calls to identity mutator", func(t *testing.T) {
+		calls := 0
+		err := SignedEntity(context.Background(), sii, func(ctx context.Context, se oci.SignedEntity) error {
+			calls++
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("Map() = %v", err)
+		}
+		if calls != 6 {
+			t.Fatalf("Map called %d times, wanted 6", calls)
+		}
+	})
+}


### PR DESCRIPTION
This adds a trivial `walk.SignedEntity` method that makes it easier to author read-only walks using `mutate.Map`.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link


#### Release Note
```release-note
NONE
```
