### PR TITLE
Rename `RemoteOpts` to `RegistryClientOpts` for consistency.

### DIFF
--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -101,7 +101,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOpts, sigRef, pay
 		return err
 	}
 
-	return cremote.UploadSignature(sig, dstRef, cremote.UploadOpts{RemoteOpts: regOpts.GetRegistryClientOpts(ctx)})
+	return cremote.UploadSignature(sig, dstRef, cremote.UploadOpts{RegistryClientOpts: regOpts.GetRegistryClientOpts(ctx)})
 }
 
 type SignatureArgType uint8

--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -217,7 +217,7 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 	// An attestation represents both the signature and payload. So store the entire thing
 	// in the payload field since they can get large
 	return cremote.UploadSignature(sig, attRef, cremote.UploadOpts{
-		DupeDetector: cremote.NewDupeDetector(sv),
-		RemoteOpts:   regOpts.GetRegistryClientOpts(ctx),
+		DupeDetector:       cremote.NewDupeDetector(sv),
+		RegistryClientOpts: regOpts.GetRegistryClientOpts(ctx),
 	})
 }

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -103,12 +103,12 @@ LayerLoop:
 }
 
 type UploadOpts struct {
-	DupeDetector mutate.DupeDetector
-	RemoteOpts   []remote.Option
+	DupeDetector       mutate.DupeDetector
+	RegistryClientOpts []remote.Option
 }
 
 func UploadSignature(l oci.Signature, dst name.Reference, opts UploadOpts) error {
-	base, err := ociremote.Signatures(dst, ociremote.WithRemoteOptions(opts.RemoteOpts...))
+	base, err := ociremote.Signatures(dst, ociremote.WithRemoteOptions(opts.RegistryClientOpts...))
 	if err != nil {
 		return err
 	}
@@ -124,5 +124,5 @@ func UploadSignature(l oci.Signature, dst name.Reference, opts UploadOpts) error
 		return err
 	}
 
-	return remote.Write(dst, sigs, opts.RemoteOpts...)
+	return remote.Write(dst, sigs, opts.RegistryClientOpts...)
 }


### PR DESCRIPTION
This was raised by Jake on one of my prior PRs that touched the adjacent code.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link


#### Release Note
```release-note

```
