### PR TITLE
fix panic on creating annotation maps.

### DIFF
--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -51,6 +51,9 @@ func (s *SignOptions) AnnotationsMap() (sigs.AnnotationsMap, error) {
 		if len(kv) != 2 {
 			return ann, fmt.Errorf("unable to parse annotation: %s", a)
 		}
+		if ann.Annotations == nil {
+			ann.Annotations = map[string]interface{}{}
+		}
 		ann.Annotations[kv[0]] = kv[1]
 	}
 	return ann, nil

--- a/cmd/cosign/cli/options/sign_test.go
+++ b/cmd/cosign/cli/options/sign_test.go
@@ -1,0 +1,63 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/sigstore/cosign/pkg/signature"
+)
+
+func TestSignOptions_AnnotationsMap(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations []string
+		want        signature.AnnotationsMap
+		wantErr     bool
+	}{{
+		name: "nil",
+	}, {
+		name:        "valid key",
+		annotations: []string{"key=value"},
+		want: signature.AnnotationsMap{
+			Annotations: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}, {
+		name:        "invalid key",
+		annotations: []string{"key value"},
+		wantErr:     true,
+		want:        signature.AnnotationsMap{},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &SignOptions{
+				Annotations: tt.annotations,
+			}
+			got, err := s.AnnotationsMap()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("AnnotationsMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("AnnoxtationsMap() got = %v, want %v\n diff: %s", got, tt.want, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION

#### Summary

When parsing annotations, there was a panic on new cobra codepath, fixing.

#### Ticket Link

Related to #762 

#### Release Note
```release-note
NONE
```
