### PR TITLE
Ensure we resolve tags once.

### DIFF
--- a/cmd/cosign/cli/attach/sbom.go
+++ b/cmd/cosign/cli/attach/sbom.go
@@ -86,11 +86,8 @@ func SBOMCmd(ctx context.Context, regOpts options.RegistryOpts, sbomRef, sbomTyp
 	}
 
 	fmt.Fprintf(os.Stderr, "Uploading SBOM file for [%s] to [%s] with mediaType [%s].\n", ref.Name(), dstRef.Name(), sbomType)
-	if _, err := cremote.UploadFile(b, dstRef, types.MediaType(sbomType), types.OCIConfigJSON, remoteOpts...); err != nil {
-		return err
-	}
-
-	return nil
+	_, err = cremote.UploadFile(b, dstRef, types.MediaType(sbomType), types.OCIConfigJSON, remoteOpts...)
+	return err
 }
 
 func sbomBytes(sbomRef string) ([]byte, error) {

--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -69,11 +69,14 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOpts, sigRef, pay
 	if err != nil {
 		return err
 	}
-
 	digest, err := ociremote.ResolveDigest(ref, regOpts.ClientOpts(ctx)...)
 	if err != nil {
 		return err
 	}
+	// Overwrite "ref" with a digest to avoid a race where we use a tag
+	// multiple times, and it potentially points to different things at
+	// each access.
+	ref = digest // nolint
 
 	var payload []byte
 	if payloadRef == "" {

--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -154,6 +154,10 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 		return err
 	}
 	h, _ := v1.NewHash(digest.Identifier())
+	// Overwrite "ref" with a digest to avoid a race where we use a tag
+	// multiple times, and it potentially points to different things at
+	// each access.
+	ref = digest // nolint
 
 	sv, err := sign.SignerFromKeyOpts(ctx, certPath, ko)
 	if err != nil {

--- a/cmd/cosign/cli/generate/generate.go
+++ b/cmd/cosign/cli/generate/generate.go
@@ -73,11 +73,14 @@ func GenerateCmd(ctx context.Context, regOpts options.RegistryOpts, imageRef str
 	if err != nil {
 		return err
 	}
-
 	digest, err := ociremote.ResolveDigest(ref, regOpts.ClientOpts(ctx)...)
 	if err != nil {
 		return err
 	}
+	// Overwrite "ref" with a digest to avoid a race where we use a tag
+	// multiple times, and it potentially points to different things at
+	// each access.
+	ref = digest
 
 	json, err := (&payload.Cosign{Image: digest, Annotations: annotations}).MarshalJSON()
 	if err != nil {

--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -49,6 +49,7 @@ func valid(ctx context.Context, img string, keys []*ecdsa.PublicKey) bool {
 }
 
 func validSignatures(ctx context.Context, img string, key *ecdsa.PublicKey) ([]oci.Signature, error) {
+	// TODO(mattmoor): take the name.Reference as the param?
 	ref, err := name.ParseReference(img)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
As I've been refactoring things, I noticed a handful of places where a single command potentially used a `name.Tag` multiple times for remote access.  There is an exceedingly small window here for a race to happen where the first tag access points to one image, and the subsequent access points to another.

I've already fixed a handful of these, and this change fixes one more (in `sget` IIRC), but also tries to add some defensive logic in a few places where we were already doing the right thing.

The defensive logic I added is to clobber `ref` with `digest` after resolving the reference:
```go
       digest, err := ociremote.ResolveDigest(ref, regOpts.ClientOpts(ctx)...)
       if err != nil {
               return err
       }
       // Overwrite "ref" with a digest to avoid a race where we use a tag
       // multiple times, and it potentially points to different things at
       // each access.
       ref = digest // nolint
```

This ensures that regardless of which reference is used below resolution, we always get what we resolved at this point.

There are some other superficial cleanups lumped in, which I noticed as I skimmed the code.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link


#### Release Note
```release-note
NONE
```
