### PR TITLE
Create a `NewAttestation` constructor.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -214,7 +214,7 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 		ociremote.WithSignatureSuffix(ociremote.AttestationTagSuffix),
 	)
 
-	sig, err := static.NewSignature(signedPayload, "", opts...)
+	sig, err := static.NewAttestation(signedPayload, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -48,16 +48,14 @@ func NewSignature(payload []byte, b64sig string, opts ...Option) (oci.Signature,
 	}, nil
 }
 
+// NewAttestation constructs a new oci.Signature from the provided options.
+func NewAttestation(payload []byte, opts ...Option) (oci.Signature, error) {
+	return NewSignature(payload, "", opts...)
+}
+
 // NewFile constructs a new v1.Layer with the provided payload.
 func NewFile(payload []byte, opts ...Option) (v1.Layer, error) {
-	o, err := makeOptions(opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &staticLayer{
-		b:    payload,
-		opts: o,
-	}, nil
+	return NewSignature(payload, "", opts...)
 }
 
 type staticLayer struct {


### PR DESCRIPTION
For attestations, the payload holds the signature, so we use an empty signature field.  This exposes a new constructor to hide that detail.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link


#### Release Note
```release-note
NONE
```
