### PR TITLE
Try out `Attestations()`

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -209,27 +209,22 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 		opts = append(opts, static.WithBundle(bundle))
 	}
 
-	clientOpts := append(
-		regOpts.ClientOpts(ctx),
-		ociremote.WithSignatureSuffix(ociremote.AttestationTagSuffix),
-	)
-
 	sig, err := static.NewAttestation(signedPayload, opts...)
 	if err != nil {
 		return err
 	}
 
-	se, err := ociremote.SignedEntity(digest, clientOpts...)
+	se, err := ociremote.SignedEntity(digest, regOpts.ClientOpts(ctx)...)
 	if err != nil {
 		return err
 	}
 
-	// Attach the signature to the entity.
-	newSE, err := mutate.AttachSignatureToEntity(se, sig, mutate.WithDupeDetector(dd))
+	// Attach the attestation to the entity.
+	newSE, err := mutate.AttachAttestationToEntity(se, sig, mutate.WithDupeDetector(dd))
 	if err != nil {
 		return err
 	}
 
-	// Publish the signatures associated with this entity
-	return ociremote.WriteSignatures(digest.Repository, newSE, clientOpts...)
+	// Publish the attestations associated with this entity
+	return ociremote.WriteAttestations(digest.Repository, newSE, regOpts.ClientOpts(ctx)...)
 }

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -163,6 +163,8 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 			return err
 		}
 
+		// TODO(mattmoor): Add some sort of configuration to have this
+		// use Attestations() in place of Signatures().
 		verified, bundleVerified, err := cosign.Verify(ctx, ref, co)
 		if err != nil {
 			return err

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -82,9 +82,7 @@ func Verify(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (ch
 		}
 	}
 
-	opts := co.RegistryClientOpts
-
-	se, err := ociremote.SignedEntity(signedImgRef, opts...)
+	se, err := ociremote.SignedEntity(signedImgRef, co.RegistryClientOpts...)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/oci/interface.go
+++ b/pkg/oci/interface.go
@@ -19,4 +19,8 @@ type SignedEntity interface {
 	// Signatures returns the set of signatures currently associated with this
 	// entity, or the empty equivalent if none are found.
 	Signatures() (Signatures, error)
+
+	// Attestations returns the set of attestations currently associated with this
+	// entity, or the empty equivalent if none are found.
+	Attestations() (Signatures, error)
 }

--- a/pkg/oci/remote/image.go
+++ b/pkg/oci/remote/image.go
@@ -48,3 +48,8 @@ var _ oci.SignedImage = (*image)(nil)
 func (i *image) Signatures() (oci.Signatures, error) {
 	return signatures(i, i.opt)
 }
+
+// Attestations implements oic.SignedImage
+func (i *image) Attestations() (oci.Signatures, error) {
+	return attestations(i, i.opt)
+}

--- a/pkg/oci/remote/image_test.go
+++ b/pkg/oci/remote/image_test.go
@@ -56,4 +56,15 @@ func TestSignedImage(t *testing.T) {
 	} else if got := int64(len(sl)); got != wantLayers {
 		t.Errorf("len(Get()) = %d, wanted %d", got, wantLayers)
 	}
+
+	atts, err := si.Attestations()
+	if err != nil {
+		t.Fatalf("Signatures() = %v", err)
+	}
+
+	if al, err := atts.Get(); err != nil {
+		t.Errorf("Get() = %v", err)
+	} else if got := int64(len(al)); got != wantLayers {
+		t.Errorf("len(Get()) = %d, wanted %d", got, wantLayers)
+	}
 }

--- a/pkg/oci/remote/index.go
+++ b/pkg/oci/remote/index.go
@@ -55,6 +55,11 @@ func (i *index) Signatures() (oci.Signatures, error) {
 	return signatures(i, i.opt)
 }
 
+// Attestations implements oic.SignedImageIndex
+func (i *index) Attestations() (oci.Signatures, error) {
+	return attestations(i, i.opt)
+}
+
 // SignedImage implements oic.SignedImageIndex
 func (i *index) SignedImage(h v1.Hash) (oci.SignedImage, error) {
 	img, err := i.Image(h)

--- a/pkg/oci/remote/index_test.go
+++ b/pkg/oci/remote/index_test.go
@@ -118,5 +118,16 @@ func TestSignedImageIndex(t *testing.T) {
 		} else if got := int64(len(sl)); got != wantLayers {
 			t.Errorf("len(Get()) = %d, wanted %d", got, wantLayers)
 		}
+
+		atts, err := se.Attestations()
+		if err != nil {
+			t.Fatalf("Signatures() = %v", err)
+		}
+
+		if al, err := atts.Get(); err != nil {
+			t.Errorf("Get() = %v", err)
+		} else if got := int64(len(al)); got != wantLayers {
+			t.Errorf("len(Get()) = %d, wanted %d", got, wantLayers)
+		}
 	}
 }

--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -142,3 +142,12 @@ func signatures(digestable digestable, o *options) (oci.Signatures, error) {
 	}
 	return Signatures(o.TargetRepository.Tag(normalize(h, o.SignatureSuffix)), o.OriginalOptions...)
 }
+
+// attestations is a shared implementation of the oci.Signed* Signatures method.
+func attestations(digestable digestable, o *options) (oci.Signatures, error) {
+	h, err := digestable.Digest()
+	if err != nil {
+		return nil, err
+	}
+	return Signatures(o.TargetRepository.Tag(normalize(h, o.AttestationSuffix)), o.OriginalOptions...)
+}

--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sigstore/cosign/pkg/oci"
 )
 
-// WriteSignature publishes the signatures attaches to the given entity
+// WriteSignature publishes the signatures attached to the given entity
 // into the provided repository.
 func WriteSignatures(repo name.Repository, se oci.SignedEntity, opts ...Option) error {
 	o, err := makeOptions(repo, opts...)
@@ -43,4 +43,29 @@ func WriteSignatures(repo name.Repository, se oci.SignedEntity, opts ...Option) 
 
 	// Write the Signatures image to the tag, with the provided remote.Options
 	return remoteWrite(tag, sigs, o.ROpt...)
+}
+
+// WriteAttestations publishes the attestations attached to the given entity
+// into the provided repository.
+func WriteAttestations(repo name.Repository, se oci.SignedEntity, opts ...Option) error {
+	o, err := makeOptions(repo, opts...)
+	if err != nil {
+		return err
+	}
+
+	// Access the signature list to publish
+	atts, err := se.Attestations()
+	if err != nil {
+		return err
+	}
+
+	// Determine the tag to which these signatures should be published.
+	h, err := se.(digestable).Digest()
+	if err != nil {
+		return err
+	}
+	tag := o.TargetRepository.Tag(normalize(h, o.AttestationSuffix))
+
+	// Write the Signatures image to the tag, with the provided remote.Options
+	return remoteWrite(tag, atts, o.ROpt...)
 }

--- a/pkg/oci/signed/image.go
+++ b/pkg/oci/signed/image.go
@@ -39,3 +39,8 @@ var _ oci.SignedImage = (*image)(nil)
 func (*image) Signatures() (oci.Signatures, error) {
 	return empty.Signatures(), nil
 }
+
+// Attestations implements oci.SignedImage
+func (*image) Attestations() (oci.Signatures, error) {
+	return empty.Signatures(), nil
+}

--- a/pkg/oci/signed/image_test.go
+++ b/pkg/oci/signed/image_test.go
@@ -39,4 +39,15 @@ func TestImage(t *testing.T) {
 	} else if got, want := len(sl), 0; got != want {
 		t.Errorf("len(Get()) = %d, wanted %d", got, want)
 	}
+
+	atts, err := si.Attestations()
+	if err != nil {
+		t.Fatalf("Attestations() = %v", err)
+	}
+
+	if al, err := atts.Get(); err != nil {
+		t.Errorf("Get() = %v", err)
+	} else if got, want := len(al), 0; got != want {
+		t.Errorf("len(Get()) = %d, wanted %d", got, want)
+	}
 }

--- a/pkg/oci/signed/index.go
+++ b/pkg/oci/signed/index.go
@@ -60,3 +60,8 @@ func (ii *index) SignedImageIndex(h v1.Hash) (oci.SignedImageIndex, error) {
 func (*index) Signatures() (oci.Signatures, error) {
 	return empty.Signatures(), nil
 }
+
+// Attestations implements oci.SignedImageIndex
+func (*index) Attestations() (oci.Signatures, error) {
+	return empty.Signatures(), nil
+}

--- a/pkg/oci/signed/index_test.go
+++ b/pkg/oci/signed/index_test.go
@@ -86,5 +86,16 @@ func TestImageIndex(t *testing.T) {
 		} else if got, want := len(sl), 0; got != want {
 			t.Errorf("len(Get()) = %d, wanted %d", got, want)
 		}
+
+		atts, err := se.Attestations()
+		if err != nil {
+			t.Fatalf("Attestations() = %v", err)
+		}
+
+		if al, err := atts.Get(); err != nil {
+			t.Errorf("Get() = %v", err)
+		} else if got, want := len(al), 0; got != want {
+			t.Errorf("len(Get()) = %d, wanted %d", got, want)
+		}
 	}
 }


### PR DESCRIPTION
I know I just killed this off for being NYI, but I don't like the fact that we need `WithSignatureSuffix` to access things.

#### Ticket Link

Related #666 

#### Release Note
```release-note
NONE
```
