### PR TITLE
Migrate generate-key-pair to cobra

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -119,6 +119,7 @@ func New() *cobra.Command {
 	addPublicKey(cmd)
 	addSign(cmd)
 	addSignBlob(cmd)
+	addGenerateKeyPair(cmd)
 
 	return cmd
 }

--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -38,6 +38,8 @@ var (
 	Read = readPasswordFn
 )
 
+// GenerateKeyPair subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 // nolint
 func GenerateKeyPair() *ffcli.Command {
 	var (
@@ -75,7 +77,8 @@ CAVEATS:
   the COSIGN_PASSWORD environment variable to provide one.`,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			return GenerateKeyPairCmd(ctx, *kmsVal, args)
+			_ = kmsVal
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/cli/generate_key_pair.go
+++ b/cmd/cosign/cli/generate_key_pair.go
@@ -1,0 +1,64 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+)
+
+func addGenerateKeyPair(topLevel *cobra.Command) {
+	o := &options.GenerateKeyPairOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "generate-key-pair",
+		Short: "Generates a key-pair.\ncosign generate-key-pair [--kms KMSPATH]",
+		Long:  "Generates a key-pair for signing.",
+		Example: `
+  # generate key-pair and write to cosign.key and cosign.pub files
+  cosign generate-key-pair
+
+  # generate a key-pair in Azure Key Vault
+  cosign generate-key-pair --kms azurekms://[VAULT_NAME][VAULT_URI]/[KEY]
+
+  # generate a key-pair in AWS KMS
+  cosign generate-key-pair --kms awskms://[ENDPOINT]/[ID/ALIAS/ARN]
+
+  # generate a key-pair in Google Cloud KMS
+  cosign generate-key-pair --kms gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]
+
+  # generate a key-pair in Hashicorp Vault
+  cosign generate-key-pair --kms hashivault://[KEY]
+
+  # generate a key-pair in Kubernetes Secret
+  cosign generate-key-pair k8s://[NAMESPACE]/[NAME]
+
+CAVEATS:
+  This command interactively prompts for a password. You can use
+  the COSIGN_PASSWORD environment variable to provide one.`,
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return generate.GenerateKeyPairCmd(context.Background(), o.KMS, args)
+		},
+	}
+
+	options.AddGenerateKeyPairOptions(cmd, o)
+	topLevel.AddCommand(cmd)
+}

--- a/cmd/cosign/cli/options/generate_key_pair.go
+++ b/cmd/cosign/cli/options/generate_key_pair.go
@@ -1,0 +1,32 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// GenerateKeyPairOptions is the top level wrapper for the generate-key-pair command.
+type GenerateKeyPairOptions struct {
+	// KMS Key Management Service
+	KMS string
+}
+
+// AddGenerateKeyPairOptions adds the generate-key-pair command options to cmd.
+func AddGenerateKeyPairOptions(cmd *cobra.Command, o *GenerateKeyPairOptions) {
+	cmd.Flags().StringVar(&o.KMS, "kms", "",
+		"create key pair in KMS service to use for signing")
+}

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -49,7 +49,7 @@ func main() {
 	// escape the remaining args to let them be passed to cobra.
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
-		case "public-key":
+		case "public-key", "generate-key-pair":
 		case "sign", "sign-blob":
 			// cobra.
 		default:


### PR DESCRIPTION
#### Summary

Migrate `cosign generate-key-pair` to cobra.

#### Ticket Link

Relates to #706 

#### Release Note
```release-note
NONE.
```
