### PR TITLE
Rework `cosign.Verify` to specify what's verified.

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -171,7 +171,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 			return errors.Wrapf(err, "resolving attachment type %s for image %s", c.Attachment, img)
 		}
 
-		verified, bundleVerified, err := cosign.Verify(ctx, ref, co)
+		verified, bundleVerified, err := cosign.VerifySignatures(ctx, ref, co)
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/pivkey"
-	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
@@ -123,7 +122,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 	}
 
 	co := &cosign.CheckOpts{
-		RegistryClientOpts: append(c.ClientOpts(ctx), ociremote.WithSignatureSuffix(cosign.AttestationTagSuffix)),
+		RegistryClientOpts: c.ClientOpts(ctx),
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
@@ -163,9 +162,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, args []string) (err
 			return err
 		}
 
-		// TODO(mattmoor): Add some sort of configuration to have this
-		// use Attestations() in place of Signatures().
-		verified, bundleVerified, err := cosign.Verify(ctx, ref, co)
+		verified, bundleVerified, err := cosign.VerifyAttestations(ctx, ref, co)
 		if err != nil {
 			return err
 		}

--- a/copasetic/main.go
+++ b/copasetic/main.go
@@ -193,7 +193,7 @@ func main() {
 				RegistryClientOpts: regOpts.ClientOpts(bctx.Context),
 				RekorURL:           *rekorURL,
 			}
-			sps, _, err := cosign.Verify(bctx.Context, ref, co)
+			sps, _, err := cosign.VerifySignatures(bctx.Context, ref, co)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -60,7 +60,7 @@ func validSignatures(ctx context.Context, img string, key *ecdsa.PublicKey) ([]o
 		return nil, err
 	}
 
-	sigs, _, err := cosign.Verify(ctx, ref, &cosign.CheckOpts{
+	sigs, _, err := cosign.VerifySignatures(ctx, ref, &cosign.CheckOpts{
 		RootCerts:     fulcioroots.Get(),
 		SigVerifier:   ecdsaVerifier,
 		ClaimVerifier: cosign.SimpleClaimVerifier,

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -85,7 +85,7 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 	if co.SigVerifier != nil || options.EnableExperimental() {
 		co.RootCerts = fulcio.GetRoots()
 
-		sp, bundleVerified, err := cosign.Verify(ctx, ref, co)
+		sp, bundleVerified, err := cosign.VerifySignatures(ctx, ref, co)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously, this was always `Signatures()`, but which sense of "signature" was nebulous (e.g. `.sig`, `.att`).

With this change, the interface here changes to take and accessor so folks explicitly specify which one they want, and I exposed `Verify{Signatures,Attestations}` methods with identical function signatures to what we exposed previously.

After this change, the only usage of `ociremote.WithSignatureSuffix` is some logic that deals with SBOMs, which it abusing things a bit, and the whole "attachment" thing is one of the next things I'm going to look at adding some abstraction for.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link

Related: #666 

#### Release Note
```release-note
Changes the function signature of `cosign.Verify` so callers must be explicit about which signatures (or attestations) to verify.  For matching signatures, see also `cosign.Verify{Signatures,Attestations}`.
```
