### PR TITLE
Hoist the `name.ParseReference` to avoid passing strings.

### DIFF
--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -33,9 +33,9 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-func valid(ctx context.Context, img string, keys []*ecdsa.PublicKey) bool {
+func valid(ctx context.Context, ref name.Reference, keys []*ecdsa.PublicKey) bool {
 	for _, k := range keys {
-		sps, err := validSignatures(ctx, img, k)
+		sps, err := validSignatures(ctx, ref, k)
 		if err != nil {
 			logging.FromContext(ctx).Errorf("error validating signatures: %v", err)
 			return false
@@ -48,13 +48,7 @@ func valid(ctx context.Context, img string, keys []*ecdsa.PublicKey) bool {
 	return false
 }
 
-func validSignatures(ctx context.Context, img string, key *ecdsa.PublicKey) ([]oci.Signature, error) {
-	// TODO(mattmoor): take the name.Reference as the param?
-	ref, err := name.ParseReference(img)
-	if err != nil {
-		return nil, err
-	}
-
+func validSignatures(ctx context.Context, ref name.Reference, key *ecdsa.PublicKey) ([]oci.Signature, error) {
 	ecdsaVerifier, err := signature.LoadECDSAVerifier(key, crypto.SHA256)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I noticed this triaging our `name.ParseReference` calls, at a minimum this gets the call out of a loop, but I think it helps us surface better errors as well.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```
