### PR TITLE
Migrate cosign version to cobra

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -125,6 +125,7 @@ func New() *cobra.Command {
 	addSignBlob(cmd)
 	addGenerateKeyPair(cmd)
 	addAttest(cmd)
+	addVersion(cmd)
 
 	return cmd
 }

--- a/cmd/cosign/cli/version.go
+++ b/cmd/cosign/cli/version.go
@@ -22,10 +22,13 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 )
 
+// Version subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Version() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign version", flag.ExitOnError)
@@ -51,4 +54,33 @@ func Version() *ffcli.Command {
 			return nil
 		},
 	}
+}
+
+func addVersion(topLevel *cobra.Command) {
+	var outputJSON bool
+
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints the cosign version",
+		Long:  "Prints the cosign version",
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := options.VersionInfo()
+			res := v.String()
+			if outputJSON {
+				j, err := v.JSONString()
+				if err != nil {
+					return errors.Wrap(err, "unable to generate JSON from version info")
+				}
+				res = j
+			}
+			fmt.Println(res)
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&outputJSON, "json", false,
+		"print JSON instead of text")
+
+	topLevel.AddCommand(cmd)
 }

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -51,7 +51,8 @@ func main() {
 		switch os.Args[1] {
 		case "public-key", "generate-key-pair",
 			"generate", "sign", "sign-blob",
-			"attest":
+			"attest",
+			"version":
 			// cobra.
 		default:
 			// ffcli


### PR DESCRIPTION
#### Summary

Migrate `cosign version` to cobra.

#### Ticket Link

Related to #706 

#### Release Note

```release-note
NONE
```
