### PR TITLE
Use `cmd.Context()` everywhere.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -16,7 +16,6 @@
 package cli
 
 import (
-	"context"
 	"flag"
 
 	"github.com/pkg/errors"
@@ -71,7 +70,7 @@ func addAttest(topLevel *cobra.Command) {
 				FulcioURL: o.Fulcio.URL,
 			}
 			for _, img := range args {
-				if err := attest.AttestCmd(context.Background(), ko, o.RegistryOpts, img, o.Cert, o.Upload, o.Predicate.Path, o.Force, o.Predicate.Type); err != nil {
+				if err := attest.AttestCmd(cmd.Context(), ko, o.RegistryOpts, img, o.Cert, o.Upload, o.Predicate.Path, o.Force, o.Predicate.Type); err != nil {
 					return errors.Wrapf(err, "signing %s", img)
 				}
 			}

--- a/cmd/cosign/cli/generate_key_pair.go
+++ b/cmd/cosign/cli/generate_key_pair.go
@@ -16,8 +16,6 @@
 package cli
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
@@ -55,7 +53,7 @@ CAVEATS:
   the COSIGN_PASSWORD environment variable to provide one.`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return generate.GenerateKeyPairCmd(context.Background(), o.KMS, args)
+			return generate.GenerateKeyPairCmd(cmd.Context(), o.KMS, args)
 		},
 	}
 

--- a/cmd/cosign/cli/init.go
+++ b/cmd/cosign/cli/init.go
@@ -86,7 +86,7 @@ EXAMPLES
 			}
 
 			// Initialize and update the local SigStore root.
-			return ctuf.Init(context.Background(), rootFileBytes, remote, *threshold)
+			return ctuf.Init(ctx, rootFileBytes, remote, *threshold)
 		},
 	}
 }

--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -16,7 +16,6 @@
 package cli
 
 import (
-	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -77,7 +76,7 @@ func addPublicKey(topLevel *cobra.Command) {
 				Sk:     o.SecurityKey.Use,
 				Slot:   o.SecurityKey.Slot,
 			}
-			return publickey.GetPublicKey(context.Background(), pk, writer, generate.GetPass)
+			return publickey.GetPublicKey(cmd.Context(), pk, writer, generate.GetPass)
 		},
 	}
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -16,7 +16,6 @@
 package cli
 
 import (
-	"context"
 	"flag"
 
 	"github.com/pkg/errors"
@@ -91,7 +90,7 @@ func addSign(topLevel *cobra.Command) {
 			if err != nil {
 				return err
 			}
-			if err := sign.SignCmd(context.Background(), ko, o.RegistryOpts, annotationsMap.Annotations, args, o.Cert, o.Upload, o.PayloadPath, o.Force, o.Recursive, o.Attachment); err != nil {
+			if err := sign.SignCmd(cmd.Context(), ko, o.RegistryOpts, annotationsMap.Annotations, args, o.Cert, o.Upload, o.PayloadPath, o.Force, o.Recursive, o.Attachment); err != nil {
 				if o.Attachment == "" {
 					return errors.Wrapf(err, "signing %v", args)
 				}

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -16,7 +16,6 @@
 package cli
 
 import (
-	"context"
 	"flag"
 
 	"github.com/pkg/errors"
@@ -77,7 +76,7 @@ func addSignBlob(topLevel *cobra.Command) {
 				OIDCClientSecret: o.OIDC.ClientSecret,
 			}
 			for _, blob := range args {
-				if _, err := sign.SignBlobCmd(context.Background(), ko, o.RegistryOpts, blob, o.Base64Output, o.Output); err != nil {
+				if _, err := sign.SignBlobCmd(cmd.Context(), ko, o.RegistryOpts, blob, o.Base64Output, o.Output); err != nil {
 					return errors.Wrapf(err, "signing %s", blob)
 				}
 			}

--- a/cmd/sget/cli/commands.go
+++ b/cmd/sget/cli/commands.go
@@ -17,7 +17,6 @@ package cli
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"os"
 
@@ -49,7 +48,7 @@ func New() *cobra.Command {
 				return err
 			}
 			defer wc.Close()
-			return sget.New(ro.ImageRef, ro.PublicKey, wc).Do(context.Background())
+			return sget.New(ro.ImageRef, ro.PublicKey, wc).Do(cmd.Context())
 		},
 	}
 	options.AddRootArgs(cmd, ro)


### PR DESCRIPTION
Cobra provides a context, use it.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

#### Release Note
```release-note
NONE
```
