### PR TITLE
Change `UploadFiles` to return a `name.Digest`.

### DIFF
--- a/cmd/cosign/cli/upload/blob.go
+++ b/cmd/cosign/cli/upload/blob.go
@@ -102,19 +102,13 @@ func BlobCmd(ctx context.Context, regOpts options.RegistryOpts, files []cremote.
 		return err
 	}
 
-	dgster, err := cremote.UploadFiles(ref, files, cremote.DefaultMediaTypeGetter, regOpts.GetRegistryClientOpts(ctx)...)
+	dgstAddr, err := cremote.UploadFiles(ref, files, cremote.DefaultMediaTypeGetter, regOpts.GetRegistryClientOpts(ctx)...)
 	if err != nil {
 		return err
 	}
-	if dgster == nil {
-		return errors.New("dgstr is nil, no files uploaded?")
+	if len(files) == 0 {
+		return errors.New("no files uploaded?")
 	}
-	dgst, err := dgster.Digest()
-	if err != nil {
-		return err
-	}
-	dgstAddr := ref.Context().Digest(dgst.String())
-
 	if len(files) > 1 {
 		fmt.Fprintf(os.Stderr, "Uploading multi-platform index to %s\n", dgstAddr)
 	} else {


### PR DESCRIPTION
Previously this defined and returned a `Digester`, and constructed the digest using the ref that was passed in.  It simplifies things a bunch to just have `UploadFiles` return the digest of the thing it uploaded.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link

#### Release Note
```release-note
NONE
```
