### PR TITLE
Eliminate `cremote.UploadFile`.

### DIFF
--- a/cmd/cosign/cli/upload/wasm.go
+++ b/cmd/cosign/cli/upload/wasm.go
@@ -23,10 +23,11 @@ import (
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/peterbourgon/ff/v3/ffcli"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
+	"github.com/sigstore/cosign/pkg/oci/static"
 	"github.com/sigstore/cosign/pkg/types"
 )
 
@@ -63,6 +64,9 @@ func WasmCmd(ctx context.Context, regOpts options.RegistryOpts, wasmPath, imageR
 		return err
 	}
 	fmt.Fprintf(os.Stderr, "Uploading wasm file from [%s] to [%s].\n", wasmPath, ref.Name())
-	_, err = cremote.UploadFile(b, ref, types.WasmLayerMediaType, types.WasmConfigMediaType, regOpts.GetRegistryClientOpts(ctx)...)
-	return err
+	img, err := static.NewFile(b, static.WithLayerMediaType(types.WasmLayerMediaType), static.WithConfigMediaType(types.WasmConfigMediaType))
+	if err != nil {
+		return err
+	}
+	return remote.Write(ref, img, regOpts.GetRegistryClientOpts(ctx)...)
 }


### PR DESCRIPTION
This can now be done in terms of `static.NewFile` and `remote.Write`, which is simply enough to just inline.

_WIP until https://github.com/sigstore/cosign/pull/796 merges and this is rebased._

#### Ticket Link

Related #666

#### Release Note
```release-note
Remove cremote.UploadFile in favor of static.NewFile and remote.Write
```
