### PR TITLE
Have `GetAttachedImageRef` take `name.Reference`.

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -198,11 +198,7 @@ EXAMPLES
 	}
 }
 
-func GetAttachedImageRef(imageRef string, attachment string, remoteOpts ...remote.Option) (name.Reference, error) {
-	ref, err := name.ParseReference(imageRef)
-	if err != nil {
-		return nil, errors.Wrap(err, "parsing reference")
-	}
+func GetAttachedImageRef(ref name.Reference, attachment string, remoteOpts ...remote.Option) (name.Reference, error) {
 	if attachment == "" {
 		return ref, nil
 	}
@@ -249,7 +245,11 @@ func SignCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOpts, anno
 	}
 
 	for _, inputImg := range imgs {
-		ref, err := GetAttachedImageRef(inputImg, attachment, remoteOpts...)
+		ref, err := name.ParseReference(inputImg)
+		if err != nil {
+			return errors.Wrap(err, "parsing reference")
+		}
+		ref, err = GetAttachedImageRef(ref, attachment, remoteOpts...)
 		if err != nil {
 			return fmt.Errorf("unable to resolve attachment %s for image %s", attachment, inputImg)
 		}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/peterbourgon/ff/v3/ffcli"
 	"github.com/pkg/errors"
 
@@ -166,7 +167,11 @@ func (c *VerifyCommand) Exec(ctx context.Context, args []string) (err error) {
 	co.SigVerifier = pubKey
 
 	for _, img := range args {
-		ref, err := sign.GetAttachedImageRef(img, c.Attachment, c.RegistryOpts.GetRegistryClientOpts(ctx)...)
+		ref, err := name.ParseReference(img)
+		if err != nil {
+			return errors.Wrap(err, "parsing reference")
+		}
+		ref, err = sign.GetAttachedImageRef(ref, c.Attachment, c.RegistryOpts.GetRegistryClientOpts(ctx)...)
 		if err != nil {
 			return errors.Wrapf(err, "resolving attachment type %s for image %s", c.Attachment, img)
 		}


### PR DESCRIPTION
Generally I prefer to have functions take/return structured types where possible, so this changes `GetAttachedImageRef` to require the caller to sanitize the input and pass the `name.Reference`.

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link

N/A

#### Release Note
```release-note
NONE
```
