### PR TITLE
Add digest resolution to `cosigned`.

### DIFF
--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -64,6 +64,10 @@ jobs:
         sudo mv ko /usr/local/bin
         echo '::endgroup::'
 
+        echo '::group:: install yq'
+        go get github.com/mikefarah/yq/v4
+        echo '::endgroup::'
+
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
       with:

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -21,12 +21,12 @@ rules:
     resources: ["events"]
     verbs: ["create"]
 
-  # Allow the reconciliation of exactly our validating webhook.
+  # Allow the reconciliation of exactly our validating and mutating webhooks.
   - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["validatingwebhookconfigurations"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["list", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["validatingwebhookconfigurations"]
+    resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
     verbs: ["get", "update"]
     resourceNames: ["cosigned.sigstore.dev"]
 

--- a/config/500-webhook-configuration.yaml
+++ b/config/500-webhook-configuration.yaml
@@ -33,6 +33,27 @@ webhooks:
   sideEffects: None
 
 ---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: cosigned.sigstore.dev
+webhooks:
+- name: cosigned.sigstore.dev
+  namespaceSelector:
+    # The webhook should only apply to things that opt-in
+    matchExpressions:
+    - key: cosigned.sigstore.dev/include
+      operator: In
+      values: ["true"]
+  admissionReviewVersions: [v1]
+  clientConfig:
+    service:
+      name: webhook
+      namespace: cosign-system
+  failurePolicy: Fail
+  sideEffects: None
+
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/pkg/cosign/kubernetes/webhook/validator_test.go
+++ b/pkg/cosign/kubernetes/webhook/validator_test.go
@@ -20,9 +20,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/oci"
+	"github.com/sigstore/cosign/pkg/oci/remote"
 	"github.com/sigstore/cosign/pkg/oci/static"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,6 +145,146 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 				t.Errorf("validatePodSpec() = %v, wanted %v", got, test.want)
 			} else if got != nil && got.Error() != test.want.Error() {
 				t.Errorf("validatePodSpec() = %v, wanted %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestResolvePodSpec(t *testing.T) {
+	tag := name.MustParseReference("gcr.io/distroless/static:nonroot")
+	// Resolved via crane digest on 2021/09/25
+	digest := name.MustParseReference("gcr.io/distroless/static:nonroot@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4")
+
+	ctx, _ := rtesting.SetupFakeContext(t)
+	si := fakesecret.Get(ctx)
+
+	secretName := "blah"
+
+	si.Informer().GetIndexer().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: system.Namespace(),
+			Name:      secretName,
+		},
+		Data: map[string][]byte{
+			// Random public key (cosign generate-key-pair) 2021-09-25
+			"cosign.pub": []byte(`-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEapTW568kniCbL0OXBFIhuhOboeox
+UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
+-----END PUBLIC KEY-----
+`),
+		},
+	})
+
+	v := NewValidator(ctx, secretName)
+
+	rrd := remoteResolveDigest
+	defer func() {
+		remoteResolveDigest = rrd
+	}()
+	resolve := func(ref name.Reference, opts ...remote.Option) (name.Digest, error) {
+		return digest.(name.Digest), nil
+	}
+
+	tests := []struct {
+		name string
+		ps   *corev1.PodSpec
+		want *corev1.PodSpec
+		wc   func(context.Context) context.Context
+		rrd  func(name.Reference, ...remote.Option) (name.Digest, error)
+	}{{
+		name: "nothing changed (not the right update)",
+		ps: &corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:  "setup-stuff",
+				Image: tag.String(),
+			}},
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+		},
+		want: &corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:  "setup-stuff",
+				Image: tag.String(),
+			}},
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+		},
+		rrd: resolve,
+	}, {
+		name: "nothing changed (bad reference)",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: "in@valid",
+			}},
+		},
+		want: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: "in@valid",
+			}},
+		},
+		wc:  apis.WithinCreate,
+		rrd: resolve,
+	}, {
+		name: "nothing changed (unable to resolve)",
+		ps: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+		},
+		want: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+		},
+		wc: apis.WithinCreate,
+		rrd: func(r name.Reference, o ...remote.Option) (name.Digest, error) {
+			return name.Digest{}, errors.New("boom")
+		},
+	}, {
+		name: "digests resolve (in create)",
+		ps: &corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:  "setup-stuff",
+				Image: tag.String(),
+			}},
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: tag.String(),
+			}},
+		},
+		want: &corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:  "setup-stuff",
+				Image: digest.String(),
+			}},
+			Containers: []corev1.Container{{
+				Name:  "user-container",
+				Image: digest.String(),
+			}},
+		},
+		wc:  apis.WithinCreate,
+		rrd: resolve,
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			remoteResolveDigest = test.rrd
+			got := test.ps.DeepCopy()
+			ctx := context.Background()
+			if test.wc != nil {
+				ctx = test.wc(context.Background())
+			}
+			v.resolvePodSpec(ctx, got)
+			if !cmp.Equal(got, test.want) {
+				t.Errorf("resolvePodSpec = %s", cmp.Diff(got, test.want))
 			}
 		})
 	}


### PR DESCRIPTION
This change introduces a mutating webhook to complement our validating webhook.

The validating webhook in #799 began rejecting tag reference because tags are mutable and can drift between validation and resolution by the kubelet.  This change introduces a mutating webhook that resolves tags to digests as resources are created, so that users aren't necessarily forced to provide digests, but we get the benefits of them nonetheless.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link
Fixes: https://github.com/sigstore/cosign/issues/784

#### Release Note
```release-note
cosigned now includes a mutating webhook that resolves tags to digests
```
