### PR TITLE
Fix the postsubmit failure introduced by #795

### DIFF
--- a/pkg/cosign/remote/index.go
+++ b/pkg/cosign/remote/index.go
@@ -106,6 +106,10 @@ func UploadFiles(ref name.Reference, files []File, getMt MediaTypeGetter, remote
 		if err != nil {
 			return name.Digest{}, err
 		}
+		lastHash, err = img.Digest()
+		if err != nil {
+			return name.Digest{}, err
+		}
 		if err := remote.Write(ref, img, remoteOpts...); err != nil {
 			return name.Digest{}, err
 		}
@@ -113,11 +117,11 @@ func UploadFiles(ref name.Reference, files []File, getMt MediaTypeGetter, remote
 		if err != nil {
 			return name.Digest{}, err
 		}
-		lastHash, err = l[0].Digest()
+		layerHash, err := l[0].Digest()
 		if err != nil {
 			return name.Digest{}, err
 		}
-		blobURL := ref.Context().Registry.RegistryStr() + "/v2/" + ref.Context().RepositoryStr() + "/blobs/" + lastHash.String()
+		blobURL := ref.Context().Registry.RegistryStr() + "/v2/" + ref.Context().RepositoryStr() + "/blobs/" + layerHash.String()
 		fmt.Fprintf(os.Stderr, "File [%s] is available directly at [%s]\n", f.Path(), blobURL)
 		if f.Platform() != nil {
 			idx = mutate.AppendManifests(idx, mutate.IndexAddendum{


### PR DESCRIPTION
The logs of a failure are here: https://github.com/sigstore/cosign/runs/3705988573#step:5:492

The problem here is that when I changed the return value to be the `name.Digest`, I was setting `lastHash` to the `v1.Layer` hash, not the `v1.Image` hash, so when the post-submit job tried to sign the resulting digest things exploded.

This change properly sets `lastHash` to the `v1.Image` hash, and uses a separate `layerHash` variable for the layer's digest for the download print statement we print.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

#### Release Note

```release-note
NONE
```
