### PR TITLE
Fix e2e postsubmit

### DIFF
--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -89,9 +89,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 	}
 
 	if !sigOnly {
-		if err := copyImage(srcRef, dstRef, force, remoteOpts...); err != nil {
-			return err
-		}
+		return copyImage(srcRef, dstRef, force, remoteOpts...)
 	}
 
 	return nil

--- a/cmd/cosign/cli/options/copy.go
+++ b/cmd/cosign/cli/options/copy.go
@@ -32,7 +32,7 @@ var _ Interface = (*CopyOptions)(nil)
 func (o *CopyOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 
-	cmd.Flags().BoolVar(&o.SignatureOnly, "sig-only", true,
+	cmd.Flags().BoolVar(&o.SignatureOnly, "sig-only", false,
 		"only copy the image signature")
 
 	cmd.Flags().BoolVarP(&o.Force, "force", "f", false,


### PR DESCRIPTION
* Fixed regression in `copy`
* `-key` -> `--key`. Prevents the e2e script from throwing a ton of warnings

```release-note
NONE
```
