### PR TITLE
Migrate triangulate and initialize to cobra

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -131,6 +131,8 @@ func New() *cobra.Command {
 	addAttest(cmd)
 	addCopy(cmd)
 	addClean(cmd)
+	addTriangulate(cmd)
+	addInitialize(cmd)
 	addVersion(cmd)
 
 	return cmd

--- a/cmd/cosign/cli/initialize.go
+++ b/cmd/cosign/cli/initialize.go
@@ -1,0 +1,60 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/sigstore/cosign/cmd/cosign/cli/initialize"
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+)
+
+func addInitialize(topLevel *cobra.Command) {
+	o := &options.InitializeOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "initialize",
+		Short: "Initializes SigStore root to retrieve trusted certificate and key targets for verification.\ncosign initialize -mirror <url> -out <file>",
+		Long: `Initializes SigStore root to retrieve trusted certificate and key targets for verification.
+
+The following options are used by default:
+	- The initial 1.root.json is embedded inside cosign.
+	- SigStore current TUF repository is pulled from the GCS mirror at sigstore-tuf-root.
+	- A default threshold of 3 root signatures is used.
+
+To provide an out-of-band trusted initial root.json, use the -root flag with a file or URL reference.
+
+The resulting updated TUF repository will be written to $HOME/.sigstore/root/.
+
+Trusted keys and certificate used in cosign verification (e.g. verifying Fulcio issued certificates
+with Fulcio root CA) are pulled form the trusted metadata.`,
+		Example: `
+  # initialize root with distributed root keys, default mirror, and default out path.
+  cosign initialize
+
+  # initialize with an out-of-band root key file.
+  cosign initialize
+
+  # initialize with an out-of-band root key file and custom repository mirror.
+  cosign initialize -mirror <url> -root <url>`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return initialize.DoInitialize(cmd.Context(), o.Root, o.Mirror, o.Threshold)
+		},
+	}
+
+	o.AddFlags(cmd)
+	topLevel.AddCommand(cmd)
+}

--- a/cmd/cosign/cli/initialize/init.go
+++ b/cmd/cosign/cli/initialize/init.go
@@ -29,6 +29,8 @@ import (
 //go:embed 1.root.json
 var initialRoot string
 
+// Initialize subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Initialize() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign initialize", flag.ExitOnError)
@@ -67,26 +69,33 @@ EXAMPLES
   `,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			// Get the initial trusted root contents.
-			var rootFileBytes []byte
-			if *root == "" {
-				rootFileBytes = []byte(initialRoot)
-			} else {
-				var err error
-				rootFileBytes, err = blob.LoadFileOrURL(*root)
-				if err != nil {
-					return err
-				}
-			}
-
-			// Initialize the remote repository.
-			remote, err := ctuf.GcsRemoteStore(ctx, *mirror, nil, nil)
-			if err != nil {
-				return err
-			}
-
-			// Initialize and update the local SigStore root.
-			return ctuf.Init(ctx, rootFileBytes, remote, *threshold)
+			_ = mirror
+			_ = root
+			_ = threshold
+			panic("this command is now implemented in cobra.")
 		},
 	}
+}
+
+func DoInitialize(ctx context.Context, root, mirror string, threshold int) error {
+	// Get the initial trusted root contents.
+	var rootFileBytes []byte
+	if root == "" {
+		rootFileBytes = []byte(initialRoot)
+	} else {
+		var err error
+		rootFileBytes, err = blob.LoadFileOrURL(root)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Initialize the remote repository.
+	remote, err := ctuf.GcsRemoteStore(ctx, mirror, nil, nil)
+	if err != nil {
+		return err
+	}
+
+	// Initialize and update the local SigStore root.
+	return ctuf.Init(ctx, rootFileBytes, remote, threshold)
 }

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -1,0 +1,41 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// InitializeOptions is the top level wrapper for the initialize command.
+type InitializeOptions struct {
+	Mirror    string
+	Root      string
+	Threshold int
+}
+
+var _ Interface = (*InitializeOptions)(nil)
+
+// AddFlags implements Interface
+func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Mirror, "mirror", "sigstore-tuf-root",
+		"GCS bucket to a SigStore TUF repository.")
+
+	cmd.Flags().StringVar(&o.Root, "root", "",
+		"path to trusted initial root. defaults to embedded root")
+
+	cmd.Flags().IntVar(&o.Threshold, "upload", 3,
+		"threshold of root key signers")
+}

--- a/cmd/cosign/cli/options/triangulate.go
+++ b/cmd/cosign/cli/options/triangulate.go
@@ -1,0 +1,36 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// TriangulateOptions is the top level wrapper for the triangulate command.
+type TriangulateOptions struct {
+	Type     string
+	Registry RegistryOptions
+}
+
+var _ Interface = (*TriangulateOptions)(nil)
+
+// AddFlags implements Interface
+func (o *TriangulateOptions) AddFlags(cmd *cobra.Command) {
+	o.Registry.AddFlags(cmd)
+
+	cmd.Flags().StringVar(&o.Type, "type", "signature",
+		"related attachment to triangulate (attestation|sbom|signature), default signature")
+}

--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -1,0 +1,44 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"flag"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/cmd/cosign/cli/triangulate"
+)
+
+func addTriangulate(topLevel *cobra.Command) {
+	o := &options.TriangulateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "triangulate",
+		Short: "Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.\ncosign triangulate <image uri>",
+		Long:  "Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return flag.ErrHelp
+			}
+			return triangulate.MungeCmd(cmd.Context(), o.Registry, args[0], o.Type)
+		},
+	}
+
+	o.AddFlags(cmd)
+	topLevel.AddCommand(cmd)
+}

--- a/cmd/cosign/cli/triangulate/triangulate.go
+++ b/cmd/cosign/cli/triangulate/triangulate.go
@@ -28,6 +28,8 @@ import (
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 )
 
+// Triangulate subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Triangulate() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign triangulate", flag.ExitOnError)
@@ -41,10 +43,8 @@ func Triangulate() *ffcli.Command {
 		ShortHelp:  "Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-			return MungeCmd(ctx, regOpts, args[0], *t)
+			_ = t
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -51,7 +51,8 @@ func main() {
 		switch os.Args[1] {
 		case "public-key", "generate-key-pair",
 			"generate", "sign", "sign-blob",
-			"attest", "copy", "clean",
+			"attest", "copy", "clean", "triangulate",
+			"initialize",
 			"version":
 			// cobra.
 		default:


### PR DESCRIPTION
#### Summary

- Migrate `cosign initialize` to cobra.
- Migrate `cosign triangulate` to cobra.

#### Ticket Link

Relates to #706 

#### Release Note
```release-note
NONE
```
