### PR TITLE
Migrate upload tree to cobra

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -16,8 +16,6 @@
 package cli
 
 import (
-	"flag"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -56,11 +54,8 @@ func addAttest(topLevel *cobra.Command) {
   # attach an attestation to a container image which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign attest --predicate <FILE> --type <TYPE> --key cosign.key legacy-registry.example.com/my/image`,
 
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return flag.ErrHelp
-			}
-
 			ko := sign.KeyOpts{
 				KeyRef:    o.Key,
 				PassFunc:  generate.GetPass,

--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -37,12 +37,8 @@ func addClean(topLevel *cobra.Command) {
 		Use:   "clean",
 		Short: "Remove all signatures from an image.\ncosign clean <image uri>",
 		Long:  "Remove all signatures from an image.",
-
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-
 			return CleanCmd(cmd.Context(), *o, args[0])
 		},
 	}

--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -129,6 +129,7 @@ func New() *cobra.Command {
 	addSignBlob(cmd)
 	addGenerateKeyPair(cmd)
 	addAttest(cmd)
+	addUpload(cmd)
 	addCopy(cmd)
 	addClean(cmd)
 	addTriangulate(cmd)

--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -16,8 +16,6 @@
 package cli
 
 import (
-	"flag"
-
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/copy"
@@ -41,10 +39,8 @@ func addCopy(topLevel *cobra.Command) {
   # overwrite destination image and signatures
   cosign copy -f example.com/src example.com/dest`,
 
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 2 {
-				return flag.ErrHelp
-			}
 			return copy.CopyCmd(cmd.Context(), o.Registry, args[0], args[1], o.SignatureOnly, o.Force)
 		},
 	}

--- a/cmd/cosign/cli/generate.go
+++ b/cmd/cosign/cli/generate.go
@@ -16,8 +16,6 @@
 package cli
 
 import (
-	"flag"
-
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
@@ -43,10 +41,8 @@ to sign payloads with your own tooling or algorithms.`,
 	# Use this payload in another tool
 	gpg --output image.sig --detach-sig <(cosign generate <IMAGE>)`,
 
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
 			annotationMap, err := o.AnnotationsMap()
 			if err != nil {
 				return err

--- a/cmd/cosign/cli/options/annotations.go
+++ b/cmd/cosign/cli/options/annotations.go
@@ -46,7 +46,7 @@ func (o *AnnotationOptions) AnnotationsMap() (sigs.AnnotationsMap, error) {
 	return ann, nil
 }
 
-// AddFlags implements Inteface
+// AddFlags implements Interface
 func (o *AnnotationOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&o.Annotations, "annotations", "a", nil,
 		"extra key=value pairs to sign")

--- a/cmd/cosign/cli/options/files.go
+++ b/cmd/cosign/cli/options/files.go
@@ -1,0 +1,57 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
+)
+
+// FilesOptions is the wrapper for the files.
+type FilesOptions struct {
+	Files []string
+}
+
+var _ Interface = (*FilesOptions)(nil)
+
+func (o *FilesOptions) Parse() ([]cremote.File, error) {
+	fs := cremote.FilesFromFlagList(o.Files)
+
+	// If we have multiple files, each file must have a platform.
+	if len(fs) > 1 {
+		for _, f := range fs {
+			if f.Platform() == nil {
+				return nil, fmt.Errorf("each file must include a unique platform, %s had no platform", f.Path())
+			}
+		}
+	}
+
+	return fs, nil
+}
+
+func (o *FilesOptions) String() string {
+	return strings.Join(o.Files, ",")
+}
+
+// AddFlags implements Interface
+func (o *FilesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSliceVarP(&o.Files, "files", "f", nil,
+		"<filepath>:[platform/arch]")
+}

--- a/cmd/cosign/cli/options/upload.go
+++ b/cmd/cosign/cli/options/upload.go
@@ -1,0 +1,55 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// UploadBlobOptions is the top level wrapper for the `upload blob` command.
+type UploadBlobOptions struct {
+	ContentType string
+	Files       FilesOptions
+	Registry    RegistryOptions
+}
+
+var _ Interface = (*UploadBlobOptions)(nil)
+
+// AddFlags implements Interface
+func (o *UploadBlobOptions) AddFlags(cmd *cobra.Command) {
+	o.Registry.AddFlags(cmd)
+	o.Files.AddFlags(cmd)
+
+	cmd.Flags().StringVar(&o.ContentType, "ct", "",
+		"content type to set")
+}
+
+// UploadWASMOptions is the top level wrapper for the `upload wasm` command.
+type UploadWASMOptions struct {
+	File     string
+	Registry RegistryOptions
+}
+
+var _ Interface = (*UploadWASMOptions)(nil)
+
+// AddFlags implements Interface
+func (o *UploadWASMOptions) AddFlags(cmd *cobra.Command) {
+	o.Registry.AddFlags(cmd)
+
+	cmd.Flags().StringVarP(&o.File, "file", "f", "",
+		"path to the wasm file to upload")
+	_ = cmd.MarkFlagRequired("file")
+}

--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -50,12 +50,13 @@ func addPublicKey(topLevel *cobra.Command) {
 
   # extract public key from Hashicorp Vault KMS
   cosign public-key --key hashivault://[KEY]`,
-
-		RunE: func(cmd *cobra.Command, args []string) error {
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			if !options.OneOf(o.Key, o.SecurityKey.Use) {
 				return &options.KeyParseError{}
 			}
-
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			writer := publickey.NamedWriter{Name: "", Writer: nil}
 			var f *os.File
 			// Open output file for public key if specified.

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -63,11 +63,8 @@ func addSign(topLevel *cobra.Command) {
 
   # sign a container in a registry which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign --key cosign.key legacy-registry.example.com/my/image`,
-
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return flag.ErrHelp
-			}
 			switch o.Attachment {
 			case "sbom", "":
 				break

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -16,8 +16,6 @@
 package cli
 
 import (
-	"flag"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
@@ -51,18 +49,17 @@ func addSignBlob(topLevel *cobra.Command) {
 
   # sign a blob with a key pair stored in Hashicorp Vault
   cosign sign-blob --key hashivault://[KEY] <FILE>`,
-
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Args: cobra.MinimumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// A key file is required unless we're in experimental mode!
 			if !options.EnableExperimental() {
 				if !options.OneOf(o.Key, o.SecurityKey.Use) {
 					return &options.KeyParseError{}
 				}
 			}
-
-			if len(args) == 0 {
-				return flag.ErrHelp
-			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ko := sign.KeyOpts{
 				KeyRef:           o.Key,
 				PassFunc:         generate.GetPass,

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -1,0 +1,99 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"flag"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/cmd/cosign/cli/upload"
+)
+
+func addUpload(topLevel *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "upload",
+		Short: "Provides utilities for uploading artifacts to a registry",
+	}
+
+	cmd.AddCommand(
+		uploadBlob(),
+		uploadWASM(),
+	)
+
+	topLevel.AddCommand(cmd)
+}
+
+func uploadBlob() *cobra.Command {
+	o := &options.UploadBlobOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "blob",
+		Short: "Upload one or more blobs to the supplied container image address.",
+		Long:  "Upload one or more blobs to the supplied container image address.\ncosign upload blob -f <blob ref> <image uri>",
+		Example: `
+  # upload a blob named foo to the location specified by <IMAGE>
+  cosign upload blob -f foo <IMAGE>
+
+  # upload a blob named foo to the location specified by <IMAGE>, setting the os field to "MYOS".
+  cosign upload blob -f foo:MYOS <IMAGE>
+
+  # upload a blob named foo to the location specified by <IMAGE>, setting the os field to "MYOS" and the platform field to "MYPLATFORM".
+  cosign upload blob -f foo:MYOS/MYPLATFORM <IMAGE>
+
+  # upload two blobs named foo-darwin and foo-linux to the location specified by <IMAGE>, setting the os fields
+  cosign upload blob -f foo-darwin:darwin -f foo-linux:linux <IMAGE>`,
+		Args: cobra.ExactArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(o.Files.Files) < 1 {
+				return flag.ErrHelp
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			files, err := o.Files.Parse()
+			if err != nil {
+				return err
+			}
+
+			return upload.BlobCmd(cmd.Context(), o.Registry, files, o.ContentType, args[0])
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}
+
+func uploadWASM() *cobra.Command {
+	o := &options.UploadWASMOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "wasm",
+		Short:   "Upload a wasm module to the supplied container image reference",
+		Long:    "Upload a wasm module to the supplied container image reference",
+		Example: "cosign upload wasm -f foo.wasm <image uri>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return upload.WasmCmd(cmd.Context(), o.Registry, o.File, args[0])
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/cmd/cosign/cli/upload/blob.go
+++ b/cmd/cosign/cli/upload/blob.go
@@ -57,6 +57,8 @@ func (fs *Files) String() string {
 	return strings.Join(s, ",")
 }
 
+// Blob subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Blob() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign upload blob", flag.ExitOnError)
@@ -87,16 +89,14 @@ EXAMPLES
   `,
 		FlagSet: flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 || len(fmap.Files) < 1 {
-				return flag.ErrHelp
-			}
-
-			return BlobCmd(ctx, regOpts, fmap.Files, *ct, args[0])
+			_ = ct
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }
 
 func BlobCmd(ctx context.Context, regOpts options.RegistryOptions, files []cremote.File, contentType, imageRef string) error {
+	// TODO: use contentType.
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return err

--- a/cmd/cosign/cli/upload/upload.go
+++ b/cmd/cosign/cli/upload/upload.go
@@ -22,6 +22,8 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
+// Upload subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Upload() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign upload", flag.ExitOnError)
@@ -34,7 +36,7 @@ func Upload() *ffcli.Command {
 		FlagSet:     flagset,
 		Subcommands: []*ffcli.Command{Blob(), Wasm()},
 		Exec: func(ctx context.Context, args []string) error {
-			return flag.ErrHelp
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/cli/upload/wasm.go
+++ b/cmd/cosign/cli/upload/wasm.go
@@ -31,6 +31,8 @@ import (
 	"github.com/sigstore/cosign/pkg/types"
 )
 
+// Wasm subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Wasm() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign upload wasm", flag.ExitOnError)
@@ -44,11 +46,8 @@ func Wasm() *ffcli.Command {
 		ShortHelp:  "Upload a wasm module to the supplied container image reference",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-
-			return WasmCmd(ctx, regOpts, *f, args[0])
+			_ = f
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -51,6 +51,7 @@ func main() {
 		switch os.Args[1] {
 		case "public-key", "generate-key-pair",
 			"generate", "sign", "sign-blob",
+			"upload",
 			"attest", "copy", "clean", "triangulate",
 			"initialize",
 			"version":

--- a/pkg/cosign/remote/index.go
+++ b/pkg/cosign/remote/index.go
@@ -38,6 +38,14 @@ type File interface {
 	Path() string
 }
 
+func FilesFromFlagList(sl []string) []File {
+	files := make([]File, len(sl))
+	for i, s := range sl {
+		files[i] = FileFromFlag(s)
+	}
+	return files
+}
+
 func FileFromFlag(s string) File {
 	split := strings.Split(s, ":")
 	f := file{

--- a/pkg/cosign/remote/index_test.go
+++ b/pkg/cosign/remote/index_test.go
@@ -22,33 +22,69 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+func TestFilesFromFlagList(t *testing.T) {
+	tests := []struct {
+		name string
+		sl   []string
+		want []File
+	}{{
+		name: "empty",
+		sl:   []string{},
+		want: []File{},
+	}, {
+		name: "nil",
+		sl:   nil,
+		want: []File{},
+	}, {
+		name: "plain",
+		sl:   []string{"foo"},
+		want: []File{&file{path: "foo"}},
+	}, {
+		name: "three",
+		sl:   []string{"foo", "foo:darwin", "foo:darwin/amd64"},
+		want: []File{
+			&file{path: "foo"},
+			&file{path: "foo", platform: &v1.Platform{
+				OS: "darwin",
+			}},
+			&file{path: "foo", platform: &v1.Platform{
+				OS:           "darwin",
+				Architecture: "amd64",
+			}},
+		},
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FilesFromFlagList(tt.sl); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("fileFromFlag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFileFromFlag(t *testing.T) {
 	tests := []struct {
 		name string
 		s    string
 		want File
-	}{
-		{
-			name: "plain",
-			s:    "foo",
-			want: &file{path: "foo"},
-		},
-		{
-			name: "os",
-			s:    "foo:darwin",
-			want: &file{path: "foo", platform: &v1.Platform{
-				OS: "darwin",
-			}},
-		},
-		{
-			name: "os",
-			s:    "foo:darwin/amd64",
-			want: &file{path: "foo", platform: &v1.Platform{
-				OS:           "darwin",
-				Architecture: "amd64",
-			}},
-		},
-	}
+	}{{
+		name: "plain",
+		s:    "foo",
+		want: &file{path: "foo"},
+	}, {
+		name: "os",
+		s:    "foo:darwin",
+		want: &file{path: "foo", platform: &v1.Platform{
+			OS: "darwin",
+		}},
+	}, {
+		name: "os amd64",
+		s:    "foo:darwin/amd64",
+		want: &file{path: "foo", platform: &v1.Platform{
+			OS:           "darwin",
+			Architecture: "amd64",
+		}},
+	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := FileFromFlag(tt.s); !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
#### Summary

- Migrate `cosign upload ...` to cobra.
- Leverage cobra input validation on all other commands.

#### Ticket Link

Relates to #706 

#### Release Note
```release-note
NONE
```
