### PR TITLE
Migrate download subtree to cobra

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -20,8 +20,6 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/sigstore/cosign/cmd/cosign/cli/triangulate"
-
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/logs"
@@ -41,6 +39,7 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/pivcli"
 	"github.com/sigstore/cosign/cmd/cosign/cli/publickey"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
+	"github.com/sigstore/cosign/cmd/cosign/cli/triangulate"
 	"github.com/sigstore/cosign/cmd/cosign/cli/upload"
 	"github.com/sigstore/cosign/cmd/cosign/cli/verify"
 )
@@ -131,6 +130,7 @@ func New() *cobra.Command {
 	addGenerateKeyPair(cmd)
 	addAttest(cmd)
 	addUpload(cmd)
+	addDownload(cmd)
 	addCopy(cmd)
 	addClean(cmd)
 	addTriangulate(cmd)

--- a/cmd/cosign/cli/download.go
+++ b/cmd/cosign/cli/download.go
@@ -1,0 +1,74 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/download"
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+)
+
+func addDownload(topLevel *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "download",
+		Short: "Provides utilities for downloading artifacts and attached artifacts in a registry",
+	}
+
+	cmd.AddCommand(
+		downloadSignature(),
+		downloadSBOM(),
+	)
+
+	topLevel.AddCommand(cmd)
+}
+
+func downloadSignature() *cobra.Command {
+	o := &options.RegistryOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "signature",
+		Short:   "Download signatures from the supplied container image",
+		Example: "cosign download signature <image uri>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return download.SignatureCmd(cmd.Context(), *o, args[0])
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}
+
+func downloadSBOM() *cobra.Command {
+	o := &options.RegistryOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "sbom",
+		Short:   "Download SBOMs from the supplied container image",
+		Example: "cosign download sbom <image uri>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			_, err := download.SBOMCmd(cmd.Context(), *o, args[0], cmd.OutOrStdout())
+			return err
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/cmd/cosign/cli/download/download.go
+++ b/cmd/cosign/cli/download/download.go
@@ -22,6 +22,8 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
+// Download subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Download() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign download", flag.ExitOnError)
@@ -34,7 +36,7 @@ func Download() *ffcli.Command {
 		FlagSet:     flagset,
 		Subcommands: []*ffcli.Command{Signature(), SBOM()},
 		Exec: func(ctx context.Context, args []string) error {
-			return flag.ErrHelp
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -29,6 +29,8 @@ import (
 	"github.com/sigstore/cosign/pkg/oci/remote"
 )
 
+// SBOM subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func SBOM() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign download sbom", flag.ExitOnError)
@@ -41,11 +43,7 @@ func SBOM() *ffcli.Command {
 		ShortHelp:  "Download SBOMs from the supplied container image",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-			_, err := SBOMCmd(ctx, regOpts, args[0], os.Stdout)
-			return err
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/cli/download/signature.go
+++ b/cmd/cosign/cli/download/signature.go
@@ -28,6 +28,8 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign"
 )
 
+// Signature subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Signature() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign download signature", flag.ExitOnError)
@@ -40,10 +42,7 @@ func Signature() *ffcli.Command {
 		ShortHelp:  "Download signatures from the supplied container image",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-			return SignatureCmd(ctx, regOpts, args[0])
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -51,7 +51,7 @@ func main() {
 		switch os.Args[1] {
 		case "public-key", "policy", "generate-key-pair",
 			"generate", "sign", "sign-blob",
-			"upload",
+			"upload", "download",
 			"piv-tool",
 			"attest", "copy", "clean", "triangulate",
 			"initialize",


### PR DESCRIPTION
#### Summary

- Migrates `cosign download ...` subtree to cobra.

#### Ticket Link

Relates to #706 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
