### PR TITLE
Migrate the attach command tree to cobra

### DIFF
--- a/cmd/cosign/cli/attach.go
+++ b/cmd/cosign/cli/attach.go
@@ -1,0 +1,77 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/attach"
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+)
+
+func addAttach(topLevel *cobra.Command) {
+	cmd := &cobra.Command{
+		Use:   "attach",
+		Short: "Provides utilities for attaching artifacts to other artifacts in a registry",
+	}
+
+	cmd.AddCommand(
+		attachSignature(),
+		attachSBOM(),
+	)
+
+	topLevel.AddCommand(cmd)
+}
+
+func attachSignature() *cobra.Command {
+	o := &options.AttachSignatureOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "signature",
+		Short:   "Attach signatures to the supplied container image",
+		Example: "cosign attach signature <image uri>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return attach.SignatureCmd(cmd.Context(), o.Registry, o.Signature, o.Payload, args[0])
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}
+
+func attachSBOM() *cobra.Command {
+	o := &options.AttachSBOMOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "sbom",
+		Short:   "Attach sbom to the supplied container image",
+		Example: "cosign attach sbom <image uri>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mediaType, err := o.MediaType()
+			if err != nil {
+				return err
+			}
+			return attach.SBOMCmd(cmd.Context(), o.Registry, o.SBOM, mediaType, args[0])
+		},
+	}
+
+	o.AddFlags(cmd)
+
+	return cmd
+}

--- a/cmd/cosign/cli/attach/attach.go
+++ b/cmd/cosign/cli/attach/attach.go
@@ -22,6 +22,8 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
+// Attach subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Attach() *ffcli.Command {
 	var (
 		flagset = flag.NewFlagSet("cosign attach", flag.ExitOnError)
@@ -34,7 +36,7 @@ func Attach() *ffcli.Command {
 		FlagSet:     flagset,
 		Subcommands: []*ffcli.Command{Signature(), SBOM()},
 		Exec: func(ctx context.Context, args []string) error {
-			return flag.ErrHelp
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/cli/attach/sbom.go
+++ b/cmd/cosign/cli/attach/sbom.go
@@ -32,14 +32,10 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 	"github.com/sigstore/cosign/pkg/oci/static"
-	ctypes "github.com/sigstore/cosign/pkg/types"
 )
 
-var mediaTypes = map[string]types.MediaType{
-	"cyclonedx": ctypes.CycloneDXMediaType,
-	"spdx":      ctypes.SPDXMediaType,
-}
-
+// SBOM subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func SBOM() *ffcli.Command {
 	var (
 		flagset  = flag.NewFlagSet("cosign attach sbom", flag.ExitOnError)
@@ -54,16 +50,9 @@ func SBOM() *ffcli.Command {
 		ShortHelp:  "Attach sbom to the supplied container image",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-
-			mt, ok := mediaTypes[*sbomType]
-			if !ok {
-				return flag.ErrHelp
-			}
-
-			return SBOMCmd(ctx, regOpts, *sbom, mt, args[0])
+			_ = sbom
+			_ = sbomType
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -33,6 +33,8 @@ import (
 	sigPayload "github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
+// Signature subcommand for ffcli.
+// Deprecated: this will be deleted when the migration from ffcli to cobra is done.
 func Signature() *ffcli.Command {
 	var (
 		flagset   = flag.NewFlagSet("cosign attach signature", flag.ExitOnError)
@@ -47,11 +49,9 @@ func Signature() *ffcli.Command {
 		ShortHelp:  "Attach signatures to the supplied container image",
 		FlagSet:    flagset,
 		Exec: func(ctx context.Context, args []string) error {
-			if len(args) != 1 {
-				return flag.ErrHelp
-			}
-
-			return SignatureCmd(ctx, regOpts, *signature, *payload, args[0])
+			_ = signature
+			_ = payload
+			panic("this command is now implemented in cobra.")
 		},
 	}
 }

--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -131,6 +131,7 @@ func New() *cobra.Command {
 	addAttest(cmd)
 	addUpload(cmd)
 	addDownload(cmd)
+	addAttach(cmd)
 	addCopy(cmd)
 	addClean(cmd)
 	addTriangulate(cmd)

--- a/cmd/cosign/cli/options/attach.go
+++ b/cmd/cosign/cli/options/attach.go
@@ -1,0 +1,76 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/spf13/cobra"
+
+	ctypes "github.com/sigstore/cosign/pkg/types"
+)
+
+// AttachSignatureOptions is the top level wrapper for the attach signature command.
+type AttachSignatureOptions struct {
+	Signature string
+	Payload   string
+	Registry  RegistryOptions
+}
+
+var _ Interface = (*AttachSignatureOptions)(nil)
+
+// AddFlags implements Interface
+func (o *AttachSignatureOptions) AddFlags(cmd *cobra.Command) {
+	o.Registry.AddFlags(cmd)
+
+	cmd.Flags().StringVar(&o.Signature, "signature", "",
+		"the signature, path to the signature, or {-} for stdin")
+
+	cmd.Flags().StringVar(&o.Payload, "payload", "",
+		"path to the payload covered by the signature (if using another format)")
+}
+
+// AttachSBOMOptions is the top level wrapper for the attach sbom command.
+type AttachSBOMOptions struct {
+	SBOM     string
+	SBOMType string
+	Registry RegistryOptions
+}
+
+var _ Interface = (*AttachSBOMOptions)(nil)
+
+// AddFlags implements Interface
+func (o *AttachSBOMOptions) AddFlags(cmd *cobra.Command) {
+	o.Registry.AddFlags(cmd)
+
+	cmd.Flags().StringVar(&o.SBOM, "sbom", "",
+		"path to the sbom, or {-} for stdin")
+
+	cmd.Flags().StringVar(&o.SBOMType, "type", "spdx",
+		"type of sbom (spdx|cyclonedx)")
+}
+
+func (o *AttachSBOMOptions) MediaType() (types.MediaType, error) {
+	switch o.SBOMType {
+	case "cyclonedx":
+		return ctypes.CycloneDXMediaType, nil
+	case "spdx":
+		return ctypes.SPDXMediaType, nil
+	default:
+		return "unknown", fmt.Errorf("unknown SBOM type: %q, expected (spdx|cyclonedx)", o.SBOMType)
+	}
+}

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -51,7 +51,7 @@ func main() {
 		switch os.Args[1] {
 		case "public-key", "policy", "generate-key-pair",
 			"generate", "sign", "sign-blob",
-			"upload", "download",
+			"upload", "download", "attach",
 			"piv-tool",
 			"attest", "copy", "clean", "triangulate",
 			"initialize",


### PR DESCRIPTION
#### Summary

- migrate `cosign attach ...` subtree to cobra.

#### Ticket Link

Related to #706 

#### Release Note
```release-note
NONE.
```
