### PR TITLE
Allow both lower and upper cases in transparency commit confirmation

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -75,7 +76,7 @@ func ShouldUploadToTlog(ref name.Reference, force bool, url string) (bool, error
 		if _, err := fmt.Scanln(&tlogConfirmResponse); err != nil {
 			return false, err
 		}
-		if tlogConfirmResponse != "Y" {
+		if strings.ToUpper(tlogConfirmResponse) != "Y" {
 			fmt.Fprintln(os.Stderr, "not uploading to transparency log")
 			return false, nil
 		}


### PR DESCRIPTION
allow to answer both "Y" and "y" when signing a docker image using cosign

before

```
warning: uploading to the transparency log at https://rekor.example.com for a private image, please confirm [Y/N]: Y
tlog entry created with index:  1
```

```
warning: uploading to the transparency log at https://rekor.example.com for a private image, please confirm [Y/N]: y
not uploading to transparency log
```

after


```
warning: uploading to the transparency log at https://rekor.example.com for a private image, please confirm [Y/N]: Y
tlog entry created with index:  1
```

```
warning: uploading to the transparency log at https://rekor.example.com for a private image, please confirm [Y/N]: y
tlog entry created with index:  2
```

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
