### PR TITLE
find and fix examples where we are using the single dash style flags.

### DIFF
--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -66,13 +66,13 @@ jobs:
           COSIGN_PASSWORD: ${{secrets[matrix.COSIGN_PASSWORD]}}
         if: github.event_name != 'pull_request'
         run: |
-          ./${{matrix.COSIGN_TARGET}} sign-blob -key ./.github/workflows/cosign.key ./${{matrix.COSIGN_TARGET}} > ${{matrix.COSIGN_TARGET}}.sig
-          ./${{matrix.COSIGN_TARGET}} sign-blob -key ./.github/workflows/cosign.key ./${{matrix.SGET_TARGET}} > ${{matrix.SGET_TARGET}}.sig
+          ./${{matrix.COSIGN_TARGET}} sign-blob --key ./.github/workflows/cosign.key ./${{matrix.COSIGN_TARGET}} > ${{matrix.COSIGN_TARGET}}.sig
+          ./${{matrix.COSIGN_TARGET}} sign-blob --key ./.github/workflows/cosign.key ./${{matrix.SGET_TARGET}} > ${{matrix.SGET_TARGET}}.sig
       - name: verify
         if: github.event_name != 'pull_request'
         run: |
-          ./${{matrix.COSIGN_TARGET}} verify-blob -key ./.github/workflows/cosign.pub -signature ${{matrix.COSIGN_TARGET}}.sig ./${{matrix.COSIGN_TARGET}}
-          ./${{matrix.COSIGN_TARGET}} verify-blob -key ./.github/workflows/cosign.pub -signature ${{matrix.SGET_TARGET}}.sig ./${{matrix.SGET_TARGET}}
+          ./${{matrix.COSIGN_TARGET}} verify-blob --key ./.github/workflows/cosign.pub --signature ${{matrix.COSIGN_TARGET}}.sig ./${{matrix.COSIGN_TARGET}}
+          ./${{matrix.COSIGN_TARGET}} verify-blob --key ./.github/workflows/cosign.pub --signature ${{matrix.SGET_TARGET}}.sig ./${{matrix.SGET_TARGET}}
       - name: Upload artifacts
         if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -128,19 +128,19 @@ signs:
   - id: cosign
     signature: "${artifact}.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "-output", "${artifact}.sig", "-key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    args: ["sign-blob", "--output", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
   - id: cosigned
     signature: "${artifact}.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "-output", "${artifact}.sig", "-key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    args: ["sign-blob", "--output", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
     ids:
       - linux-cosigned
   - id: sget
     signature: "${artifact}.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "-output", "${artifact}.sig", "-key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    args: ["sign-blob", "--output", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
     ids:
       - sget
@@ -219,7 +219,7 @@ docker_manifests:
 
 docker_signs:
   - artifacts: all
-    args: [ "sign", "-key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}" ]
+    args: [ "sign", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}" ]
 
 archives:
 - format: binary

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -8,7 +8,7 @@ Use `cosign` to generate the payload, sign it with `gcloud kms`, then use `cosig
 $ cosign generate us-central1-docker.pkg.dev/dlorenc-vmtest2/test/taskrun > payload.json
 $ gcloud kms asymmetric-sign --digest-algorithm=sha256 --input-file=payload.json --signature-file=gcpkms.sig --key=foo --keyring=foo --version=1 --location=us-central
 # We have to base64 encode the signature
-$ cat gcpkms.sig | base64 | cosign attach signature -signature - us-central1-docker.pkg.dev/dlorenc-vmtest2/test/taskrun
+$ cat gcpkms.sig | base64 | cosign attach signature --signature - us-central1-docker.pkg.dev/dlorenc-vmtest2/test/taskrun
 ```
 
 Now (on another machine) download the public key, payload, signatures and verify it!
@@ -36,9 +36,9 @@ $ cosign generate us.gcr.io/dlorenc-vmtest2/demo > payload.json
 $ openssl dgst -sha256 -sign openssl.key -out payload.sig payload.json
 $ cat payload.sig | base64 > payloadbase64.sig
 # Upload the signature
-$ cosign attach signature -payload payload.json -signature payloadbase64.sig  us.gcr.io/dlorenc-vmtest2/demo
+$ cosign attach signature --payload payload.json --signature payloadbase64.sig us.gcr.io/dlorenc-vmtest2/demo
 # Verify!
-$ cosign verify -key openssl.pub us.gcr.io/dlorenc-vmtest2/demo
+$ cosign verify --key openssl.pub us.gcr.io/dlorenc-vmtest2/demo
 Verification for us.gcr.io/dlorenc-vmtest2/demo --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated

--- a/FUN.md
+++ b/FUN.md
@@ -10,13 +10,13 @@ Think again!
 Sign the commits and store the signatures and public keys somewhere else.
 
 ```
-$ ./cosign sign-blob -key cosign.key <(git rev-parse HEAD)
+$ ./cosign sign-blob --key cosign.key <(git rev-parse HEAD)
 Using payload from: /dev/fd/63
 Enter password for private key:
 MEUCIQDLtTbCRCW+o7Gt3WKR4b2UqT947L8JtYzQJk+R8PItxgIgXoYQg1YXw8xDmGWun6wIG2t+/J0HJs9SbscnSLMNWsM=
 $ git rev-parse HEAD
 455d1988360dcfdcf0fa17b0736fbbc33b4924c0
-$ ./cosign verify-blob -key cosign.pub -signature MEUCIQDLtTbCRCW+o7Gt3WKR4b2UqT947L8JtYzQJk+R8PItxgIgXoYQg1YXw8xDmGWun6wIG2t+/J0HJs9SbscnSLMNWsM= <(git rev-parse HEAD)
+$ ./cosign verify-blob --key cosign.pub --signature MEUCIQDLtTbCRCW+o7Gt3WKR4b2UqT947L8JtYzQJk+R8PItxgIgXoYQg1YXw8xDmGWun6wIG2t+/J0HJs9SbscnSLMNWsM= <(git rev-parse HEAD)
 Verified OK
 ```
 
@@ -25,12 +25,12 @@ Verified OK
 Store the signature in the repo as notes, store the public key somewhere else.
 
 ```
-$ ./cosign sign-blob -key cosign.key <(git rev-parse HEAD)
+$ ./cosign sign-blob --key cosign.key <(git rev-parse HEAD)
 Using payload from: /dev/fd/63
 Enter password for private key:
 MEQCIHXN31pDrZBxs+m/HrcFruavv++oMc+pBZKgl7Hps9jjAiA9QE5uzpFNC5SGpdr4TJuCwh47C24Hwt4yHICae0J1bw==
 $ git notes add -m "MEQCIHXN31pDrZBxs+m/HrcFruavv++oMc+pBZKgl7Hps9jjAiA9QE5uzpFNC5SGpdr4TJuCwh47C24Hwt4yHICae0J1bw==" HEAD
-$ ./cosign verify-blob -key cosign.pub -signature <(git notes show HEAD) <(git rev-parse HEAD)
+$ ./cosign verify-blob --key cosign.pub --signature <(git notes show HEAD) <(git rev-parse HEAD)
 Verified OK
 ```
 
@@ -40,7 +40,7 @@ Verified OK
 Store the signature in the Transparency Log, and store the public key somewhere else.
 
 ```
-$ COSIGN_EXPERIMENTAL=1 ./cosign sign-blob -key cosign.key <(git rev-parse HEAD)
+$ COSIGN_EXPERIMENTAL=1 ./cosign sign-blob --key cosign.key <(git rev-parse HEAD)
 Using payload from: /dev/fd/63
 Enter password for private key:
 MEYCIQDWX6RjU0Z2ynd1CdiAwo/JaC2Z5+vdx8H5spuDNu/r5wIhAPnP+87+knFEwbE8FgeXCrgkjWal3aBsNR3IVaBDT2XU
@@ -52,7 +52,7 @@ Now find it from the log:
 ```
 $ uuid=$(rekor-cli search --artifact <(git rev-parse HEAD) | tail -n 1)
 $ sig=$(rekor-cli get --uuid=$uuid --format=json | jq -r .Body.RekordObj.signature.content)
-$ cosign verify-blob -key cosign.pub -signature <(echo $sig) <(git rev-parse HEAD)
+$ cosign verify-blob --key cosign.pub --signature <(echo $sig) <(git rev-parse HEAD)
 Verified OK
 ```
 

--- a/KMS.md
+++ b/KMS.md
@@ -14,17 +14,17 @@ The URI path syntax is provider specific and explained in the section for each p
 
 ### Key Generation and Management
 
-To generate keys using a KMS provider, you can use the `cosign generate-key-pair` command with the `-kms` flag.
+To generate keys using a KMS provider, you can use the `cosign generate-key-pair` command with the `--kms` flag.
 For example:
 
 ```shell
-$ cosign generate-key-pair -kms <some provider>://<some key>
+$ cosign generate-key-pair --kms <some provider>://<some key>
 ```
 
 The public key can be retrieved with:
 
 ```shell
-$ cosign public-key -key <some provider>://<some key>
+$ cosign public-key --key <some provider>://<some key>
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXc+DQU8Pb7Xo2RWCjFG/f6qbdABN
 jnVtSyKZxNzBfNMLLtVxdu8q+AigrGCS2KPmejda9bICTcHQCRUrD5OLGQ==
@@ -33,13 +33,13 @@ jnVtSyKZxNzBfNMLLtVxdu8q+AigrGCS2KPmejda9bICTcHQCRUrD5OLGQ==
 
 ### Signing and Verification
 
-To sign and verify using a key managed by a KMS provider, you can pass a provider-specific URI to the `-key` command:
+To sign and verify using a key managed by a KMS provider, you can pass a provider-specific URI to the `--key` command:
 
 ```shell
-$ cosign sign -key <some provider>://<some key> gcr.io/dlorenc-vmtest2/demo
+$ cosign sign --key <some provider>://<some key> gcr.io/dlorenc-vmtest2/demo
 Pushing signature to: gcr.io/dlorenc-vmtest2/demo:sha256-410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd.cosign
 
-$ cosign verify -key <some provider>://<some key> gcr.io/dlorenc-vmtest2/demo
+$ cosign verify --key <some provider>://<some key> gcr.io/dlorenc-vmtest2/demo
 
 Verification for gcr.io/dlorenc-vmtest2/demo --
 The following checks were performed on each of these signatures:
@@ -53,8 +53,8 @@ The following checks were performed on each of these signatures:
 You can also export the public key and verify against that file:
 
 ```shell
-$ cosign public-key -key <some provider>://<some key> > kms.pub
-$ cosign verify -key kms.pub gcr.io/dlorenc-vmtest2/demo
+$ cosign public-key --key <some provider>://<some key> > kms.pub
+$ cosign verify --key kms.pub gcr.io/dlorenc-vmtest2/demo
 ```
 
 ### Providers
@@ -173,5 +173,5 @@ $ vault secrets enable transit
 If you enabled `transit` secret engine at different path with the use of `-path` flag (i.e., `$ vault secrets enable -path="someotherpath" transit`), you can use `TRANSIT_SECRET_ENGINE_PATH` environment variable to specify this path while generating a key pair like the following:
 
 ```shell
-$ TRANSIT_SECRET_ENGINE_PATH="someotherpath" cosign generate-key-pair -kms hashivault://testkey
+$ TRANSIT_SECRET_ENGINE_PATH="someotherpath" cosign generate-key-pair --kms hashivault://testkey
 ```

--- a/Makefile
+++ b/Makefile
@@ -108,11 +108,11 @@ ko-local:
 
 .PHONY: sign-container
 sign-container: ko
-	cosign sign -key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosign:$(GIT_HASH)
+	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosign:$(GIT_HASH)
 
 .PHONY: sign-cosigned
 sign-cosigned:
-	cosign sign -key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosigned:$(GIT_HASH)
+	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosigned:$(GIT_HASH)
 
 # used when releasing together with GCP CloudBuild
 .PHONY: release

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Public key written to cosign.pub
 ### Sign a container and store the signature in the registry
 
 ```shell
-$ cosign sign -key cosign.key dlorenc/demo
+$ cosign sign --key cosign.key dlorenc/demo
 Enter password for private key:
 Pushing signature to: index.docker.io/dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 ```
@@ -136,7 +136,7 @@ Note that these signed payloads include the digest of the container image, which
 sure these "detached" signatures cover the correct image.
 
 ```shell
-$ cosign verify -key cosign.pub dlorenc/demo
+$ cosign verify --key cosign.pub dlorenc/demo
 The following checks were performed on these signatures:
   - The cosign claims were validated
   - The signatures were verified against the specified public key
@@ -221,7 +221,7 @@ curl -L gcr.io/v2/dlorenc-vmtest2/artifact/blobs/sha256:97f16c28f6478f3c02d7fff4
 You can sign it with the normal `cosign sign` command and flags:
 
 ```shell
-cosign sign -key cosign.key gcr.io/dlorenc-vmtest2/artifact
+cosign sign --key cosign.key gcr.io/dlorenc-vmtest2/artifact
 Enter password for private key:
 Pushing signature to: gcr.io/dlorenc-vmtest2/artifact:sha256-3f612a4520b2c245d620d0cca029f1173f6bea76819dde8543f5b799ea3c696c.sig
 ```
@@ -271,7 +271,7 @@ Creating Tekton Bundle:
         - Added TaskRun:  to image
 
 Pushed Tekton Bundle to us.gcr.io/dlorenc-vmtest2/pipeline@sha256:124e1fdee94fe5c5f902bc94da2d6e2fea243934c74e76c2368acdc8d3ac7155
-$ cosign sign -key cosign.key us.gcr.io/dlorenc-vmtest2/pipeline:latest
+$ cosign sign --key cosign.key us.gcr.io/dlorenc-vmtest2/pipeline:latest
 Enter password for private key:
 tlog entry created with index: 5086
 Pushing signature to: us.gcr.io/dlorenc-vmtest2/demo:sha256-124e1fdee94fe5c5f902bc94da2d6e2fea243934c74e76c2368acdc8d3ac7155.sig
@@ -285,7 +285,7 @@ Cosign can upload these using the `cosign wasm upload` command:
 
 ```shell
 $ cosign upload wasm -f hello.wasm us.gcr.io/dlorenc-vmtest2/wasm
-$ cosign sign -key cosign.key us.gcr.io/dlorenc-vmtest2/wasm
+$ cosign sign --key cosign.key us.gcr.io/dlorenc-vmtest2/wasm
 Enter password for private key:
 tlog entry created with index: 5198
 Pushing signature to: us.gcr.io/dlorenc-vmtest2/wasm:sha256-9e7a511fb3130ee4641baf1adc0400bed674d4afc3f1b81bb581c3c8f613f812.sig
@@ -299,7 +299,7 @@ The specification for these is defined [here](https://github.com/in-toto/attesta
 You can create and sign one from a local predicate file using the following commands:
 
 ```shell
-$ cosign attest -predicate <file> -key cosign.pub <image>
+$ cosign attest --predicate <file> --key cosign.pub <image>
 ```
 
 All of the standard key management systems are supported.
@@ -308,7 +308,7 @@ Payloads are signed using the DSSE signing spec, defined [here](https://github.c
 To verify:
 
 ```shell
-$ cosign verify-attestation -key cosign.pub <image>
+$ cosign verify-attestation --key cosign.pub <image>
 ```
 
 ## Detailed Usage
@@ -345,7 +345,7 @@ Today, `cosign` has been tested and works against the following registries:
 
 We aim for wide registry support. To `sign` images in registries which do not yet fully support [OCI media types](https://github.com/sigstore/cosign/blob/main/SPEC.md#object-types), one may need to use `COSIGN_DOCKER_MEDIA_TYPES` to fall back to legacy equivalents. For example:
 ```shell
-COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign -key cosign.key legacy-registry.example.com/my/image
+COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign --key cosign.key legacy-registry.example.com/my/image
 ```
 
 Please help test and file bugs if you see issues!
@@ -358,8 +358,8 @@ To publish signed artifacts to a Rekor transparency log and verify their existen
 set the `COSIGN_EXPERIMENTAL=1` environment variable.
 
 ```shell
-COSIGN_EXPERIMENTAL=1 cosign sign -key cosign.key dlorenc/demo
-COSIGN_EXPERIMENTAL=1 cosign verify -key cosign.pub dlorenc/demo
+COSIGN_EXPERIMENTAL=1 cosign sign --key cosign.key dlorenc/demo
+COSIGN_EXPERIMENTAL=1 cosign verify --key cosign.pub dlorenc/demo
 ```
 
 `cosign` defaults to using the public instance of rekor at [rekor.sigstore.dev](https://rekor.sigstore.dev).
@@ -508,7 +508,7 @@ Digest: sha256:551e6cce7ed2e5c914998f931b277bc879e675b74843e6f29bc17f3b5f692bef
 Now sign it! Using `cosign` of course:
 
 ```shell
-$ cosign sign -key cosign.key us-central1-docker.pkg.dev/dlorenc-vmtest2/test/artifact@sha256:551e6cce7ed2e5c914998f931b277bc879e675b74843e6f29bc17f3b5f692bef
+$ cosign sign --key cosign.key us-central1-docker.pkg.dev/dlorenc-vmtest2/test/artifact@sha256:551e6cce7ed2e5c914998f931b277bc879e675b74843e6f29bc17f3b5f692bef
 Enter password for private key:
 Pushing signature to: us-central1-docker.pkg.dev/dlorenc-vmtest2/test/artifact:sha256-551e6cce7ed2e5c914998f931b277bc879e675b74843e6f29bc17f3b5f692bef.sig
 ```
@@ -516,7 +516,7 @@ Pushing signature to: us-central1-docker.pkg.dev/dlorenc-vmtest2/test/artifact:s
 Finally, verify `cosign` with `cosign` again:
 
 ```shell
-$ cosign verify -key cosign.pub  us-central1-docker.pkg.dev/dlorenc-vmtest2/test/artifact@sha256:551e6cce7ed2e5c914998f931b277bc879e675b74843e6f29bc17f3b5f692bef
+$ cosign verify --key cosign.pub  us-central1-docker.pkg.dev/dlorenc-vmtest2/test/artifact@sha256:551e6cce7ed2e5c914998f931b277bc879e675b74843e6f29bc17f3b5f692bef
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - The claims were present in the transparency log
@@ -599,17 +599,17 @@ run something like:
 ```shell
 $ TAG=sign-me
 $ DGST=$(crane digest dlorenc/demo:$TAG)
-$ cosign sign -key cosign.key -a tag=$TAG dlorenc/demo@$DGST
+$ cosign sign --key cosign.key -a tag=$TAG dlorenc/demo@$DGST
 Enter password for private key:
 Pushing signature to: dlorenc/demo:sha256-97fc222cee7991b5b061d4d4afdb5f3428fcb0c9054e1690313786befa1e4e36.sig
 ```
 
 Then you can verify that the tag->digest mapping is also covered in the signature, using the `-a` flag to `cosign verify`.
-This example verifes that the digest `$TAG` points to (`sha256:97fc222cee7991b5b061d4d4afdb5f3428fcb0c9054e1690313786befa1e4e36`)
+This example verifies that the digest `$TAG` points to (`sha256:97fc222cee7991b5b061d4d4afdb5f3428fcb0c9054e1690313786befa1e4e36`)
 has been signed, **and also** that the `$TAG`:
 
 ```shell
-$ cosign verify -key cosign.pub -a tag=$TAG dlorenc/demo:$TAG | jq .
+$ cosign verify --key cosign.pub -a tag=$TAG dlorenc/demo:$TAG | jq .
 {
   "Critical": {
     "Identity": {
@@ -693,10 +693,10 @@ it to act as an attestation to the **signature(s) themselves**.
 Before we sign the signature artifact, we first give it a memorable name so we can find it later.
 
 ```shell
-$ cosign sign -key cosign.key -a sig=original dlorenc/demo
+$ cosign sign --key cosign.key -a sig=original dlorenc/demo
 Enter password for private key:
 Pushing signature to: dlorenc/demo:sha256-97fc222cee7991b5b061d4d4afdb5f3428fcb0c9054e1690313786befa1e4e36.sig
-$ cosign verify -key cosign.pub dlorenc/demo | jq .
+$ cosign verify --key cosign.pub dlorenc/demo | jq .
 {
   "Critical": {
     "Identity": {
@@ -718,10 +718,10 @@ Now give that signature a memorable name, then sign that:
 ```shell
 $ crane tag $(cosign triangulate dlorenc/demo) mysignature
 2021/02/15 20:22:55 dlorenc/demo:mysignature: digest: sha256:71f70e5d29bde87f988740665257c35b1c6f52dafa20fab4ba16b3b1f4c6ba0e size: 556
-$ cosign sign -key cosign.key -a sig=counter dlorenc/demo:mysignature
+$ cosign sign --key cosign.key -a sig=counter dlorenc/demo:mysignature
 Enter password for private key:
 Pushing signature to: dlorenc/demo:sha256-71f70e5d29bde87f988740665257c35b1c6f52dafa20fab4ba16b3b1f4c6ba0e.sig
-$ cosign verify -key cosign.pub dlorenc/demo:mysignature
+$ cosign verify --key cosign.pub dlorenc/demo:mysignature
 {"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"71f70e5d29bde87f988740665257c35b1c6f52dafa20fab4ba16b3b1f4c6ba0e"},"Type":"cosign container image signature"},"Optional":{"sig":"counter"}}
 ```
 
@@ -751,5 +751,5 @@ $ crane manifest dlorenc/demo@sha256:71f70e5d29bde87f988740665257c35b1c6f52dafa2
 
 ## Security
 
-Should you discover any security issues, please refer to sigstores [security
+Should you discover any security issues, please refer to sigstore's [security
 process](https://github.com/sigstore/community/blob/main/SECURITY.md)

--- a/TOKENS.md
+++ b/TOKENS.md
@@ -91,7 +91,7 @@ You can then use the normal `cosign` commands to sign images and blobs with your
 **NOTE**: The default PIN is `123456`.
 
 ```shell
-$ cosign sign -sk gcr.io/dlorenc-vmtest2/demo
+$ cosign sign --sk gcr.io/dlorenc-vmtest2/demo
 Enter PIN for security key:
 Please tap security key...
 Pushing signature to: gcr.io/dlorenc-vmtest2/demo:sha256-410a07f17151ffffb513f942a01748dfdb921de915ea6427d61d60b0357c1dcd.sig
@@ -100,7 +100,7 @@ Pushing signature to: gcr.io/dlorenc-vmtest2/demo:sha256-410a07f17151ffffb513f94
 To verify, you can either use the hardware key directly:
 
 ```shell
-$ cosign verify -sk gcr.io/dlorenc-vmtest2/demo
+$ cosign verify --sk gcr.io/dlorenc-vmtest2/demo
 
 Verification for gcr.io/dlorenc-vmtest2/demo --
 The following checks were performed on each of these signatures:
@@ -114,9 +114,9 @@ The following checks were performed on each of these signatures:
 Or export the public key and verify against that:
 
 ```shell
-$ cosign public-key -sk > pub.key
+$ cosign public-key --sk > pub.key
 
-$ cosign verify -key pub.key gcr.io/dlorenc-vmtest2/demo
+$ cosign verify --key pub.key gcr.io/dlorenc-vmtest2/demo
 
 Verification for gcr.io/dlorenc-vmtest2/demo --
 The following checks were performed on each of these signatures:

--- a/USAGE.md
+++ b/USAGE.md
@@ -5,11 +5,11 @@
 Multiple signatures can be "attached" to a single container image:
 
 ```shell
-$ cosign sign -key cosign.key dlorenc/demo
+$ cosign sign --key cosign.key dlorenc/demo
 Enter password for private key:
 Pushing signature to: index.docker.io/dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 
-$ cosign sign -key other.key dlorenc/demo
+$ cosign sign --key other.key dlorenc/demo
 Enter password for private key:
 Pushing signature to: index.docker.io/dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 ```
@@ -20,7 +20,7 @@ The `-a` flag can be used to add annotations to the generated, signed payload.
 This flag can be repeated:
 
 ```shell
-$ cosign sign -key other.key -a foo=bar dlorenc/demo
+$ cosign sign --key other.key -a foo=bar dlorenc/demo
 Enter password for private key:
 Pushing signature to: index.docker.io/dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 ```
@@ -39,7 +39,7 @@ they can be verified with the `-a` flag to `cosign verify`.
 The payload must be specified as a path to a file:
 
 ```shell
-$ cosign sign -key cosign.key -payload README.md dlorenc/demo
+$ cosign sign --key cosign.key --payload README.md dlorenc/demo
 Using payload from: README.md
 Enter password for private key:
 Pushing signature to: index.docker.io/dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
@@ -100,7 +100,7 @@ The base64 encoded signature is printed to stdout.
 This can be stored somewhere else.
 
 ```shell
-$ cosign sign -key key.pem --upload=false dlorenc/demo
+$ cosign sign --key key.pem --upload=false dlorenc/demo
 Qr883oPOj0dj82PZ0d9mQ2lrdM0lbyLSXUkjt6ejrxtHxwe7bU6Gr27Sysgk1jagf1htO/gvkkg71oJiwWryCQ==
 ```
 
@@ -121,25 +121,25 @@ $ cosign generate dlorenc/demo | openssl...
 
 ## Upload a generated signature
 
-The signature is passed via the -signature flag.
+The signature is passed via the `--signature` flag.
 It can be a file:
 
 ```shell
-$ cosign attach signature -signature file.sig dlorenc/demo
+$ cosign attach signature --signature file.sig dlorenc/demo
 Pushing signature to: dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 ```
 
 the base64-encoded signature:
 
 ```shell
-$ cosign attach signature -signature Qr883oPOj0dj82PZ0d9mQ2lrdM0lbyLSXUkjt6ejrxtHxwe7bU6Gr27Sysgk1jagf1htO/gvkkg71oJiwWryCQ== dlorenc/demo
+$ cosign attach signature --signature Qr883oPOj0dj82PZ0d9mQ2lrdM0lbyLSXUkjt6ejrxtHxwe7bU6Gr27Sysgk1jagf1htO/gvkkg71oJiwWryCQ== dlorenc/demo
 Pushing signature to: dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def.sig
 ```
 
 or, `-` for stdin for chaining from other commands:
 
 ```shell
-$ cosign generate dlorenc/demo | openssl... | cosign attach signature -signature -- dlorenc/demo
+$ cosign generate dlorenc/demo | openssl... | cosign attach signature --signature -- dlorenc/demo
 Pushing signature to: dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def.sig
 ```
 
@@ -150,10 +150,10 @@ Pushing signature to: dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd41
 Signature payloads created by `cosign` included the digest of the container image they are attached to.
 By default, `cosign` validates that this digest matches the container during `cosign verify`.
 
-If you are using other payload formats with `cosign`, you can use the `-check-claims=false` flag:
+If you are using other payload formats with `cosign`, you can use the `--check-claims=false` flag:
 
 ```shell
-$ cosign verify -check-claims=false -key cosign.pub dlorenc/demo
+$ cosign verify --check-claims=false --key cosign.pub dlorenc/demo
 Warning: the following claims have not been verified:
 {"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8"},"Type":"cosign container image signature"},"Optional":null}
 ```
@@ -164,7 +164,7 @@ verify any claims in the payload.
 Annotations made in the original signature (`cosign sign -a foo=bar`) are present under the `Optional` section of the payload:
 
 ```shell
-$ cosign verify -key cosign.pub  dlorenc/demo | jq .
+$ cosign verify --key cosign.pub  dlorenc/demo | jq .
 {
   "Critical": {
     "Identity": {
@@ -187,15 +187,15 @@ The payload may contain other key-value pairs.
 
 ```shell
 # This works
-$ cosign verify -a -key cosign.pub  dlorenc/demo
+$ cosign verify -a --key cosign.pub  dlorenc/demo
 {"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"97fc222cee7991b5b061d4d4afdb5f3428fcb0c9054e1690313786befa1e4e36"},"Type":"cosign container image signature"},"Optional":{"sig":"original"}}
 
 # This works too
-$ cosign verify -a sig=original -key cosign.pub  dlorenc/demo
+$ cosign verify -a sig=original --key cosign.pub  dlorenc/demo
 {"Critical":{"Identity":{"docker-reference":""},"Image":{"Docker-manifest-digest":"97fc222cee7991b5b061d4d4afdb5f3428fcb0c9054e1690313786befa1e4e36"},"Type":"cosign container image signature"},"Optional":{"sig":"original"}}
 
 # This doesn't work
-$ cosign verify -a sig=original -a=foo=bar -key cosign.pub  dlorenc/demo
+$ cosign verify -a sig=original -a=foo=bar --key cosign.pub  dlorenc/demo
 error: no matching claims:
 invalid or missing annotation in claim: map[sig:original]
 ```
@@ -215,14 +215,14 @@ $ cosign download signature us-central1-docker.pkg.dev/dlorenc-vmtest2/test/task
 KMS:
 ```shell
 # Retrieve from Google Cloud KMS
-$ cosign public-key -key gcpkms://projects/someproject/locations/us-central1/keyRings/foo/cryptoKeys/bug/versions/1
+$ cosign public-key --key gcpkms://projects/someproject/locations/us-central1/keyRings/foo/cryptoKeys/bug/versions/1
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgrKKtyws86/APoULh/zXk4LONqII
 AcxvLtLEgRjRI4TKnMAXtIGp8K4X4CTWPEXMqSYZZUa2I1YvHyLLY2bEzA==
 -----END PUBLIC KEY-----
 
 # Retrieve from HashiCorp Vault
-$ cosign public-key -key hashivault://transit
+$ cosign public-key --key hashivault://transit
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgrKKtyws86/APoULh/zXk4LONqII
 AcxvLtLEgRjRI4TKnMAXtIGp8K4X4CTWPEXMqSYZZUa2I1YvHyLLY2bEzA==
@@ -231,7 +231,7 @@ AcxvLtLEgRjRI4TKnMAXtIGp8K4X4CTWPEXMqSYZZUa2I1YvHyLLY2bEzA==
 
 Private Key:
 ```shell
-$ ./cosign public-key -key cosign.key
+$ ./cosign public-key --key cosign.key
 Enter password for private key:
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjCxhhvb1KmIfe1J2ceT25kHepstb

--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -34,7 +34,7 @@ func addCopy(topLevel *cobra.Command) {
   cosign copy example.com/src:latest example.com/dest:latest
 
   # copy the signatures only
-  cosign copy -sig-only example.com/src example.com/dest
+  cosign copy --sig-only example.com/src example.com/dest
 
   # overwrite destination image and signatures
   cosign copy -f example.com/src example.com/dest`,

--- a/cmd/cosign/cli/manifest.go
+++ b/cmd/cosign/cli/manifest.go
@@ -44,7 +44,7 @@ func manifestVerify() *cobra.Command {
 		Short: "Verify all signatures of images specified in the manifest",
 		Long: `Verify all signature of images in a Kubernetes resource manifest by checking claims
 against the transparency log.`,
-		Example: `  cosign manifest verify -key <key path>|<key url>|<kms uri> <path/to/manifest>
+		Example: `  cosign manifest verify --key <key path>|<key url>|<kms uri> <path/to/manifest>
 
   # verify cosign claims and signing certificates on images in the manifest
   cosign manifest verify <path/to/my-deployment.yaml>
@@ -56,22 +56,22 @@ against the transparency log.`,
   COSIGN_EXPERIMENTAL=1 cosign manifest verify <path/to/my-deployment.yaml>
 
   # verify images with public key
-  cosign manifest verify -key cosign.pub <path/to/my-deployment.yaml>
+  cosign manifest verify --key cosign.pub <path/to/my-deployment.yaml>
 
   # verify images with public key provided by URL
-  cosign manifest verify -key https://host.for/<FILE> <path/to/my-deployment.yaml>
+  cosign manifest verify --key https://host.for/<FILE> <path/to/my-deployment.yaml>
 
   # verify images with public key stored in Azure Key Vault
-  cosign manifest verify -key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <path/to/my-deployment.yaml>
+  cosign manifest verify --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <path/to/my-deployment.yaml>
 
   # verify images with public key stored in AWS KMS
-  cosign manifest verify -key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <path/to/my-deployment.yaml>
+  cosign manifest verify --key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <path/to/my-deployment.yaml>
 
   # verify images with public key stored in Google Cloud KMS
-  cosign manifest verify -key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <path/to/my-deployment.yaml>
+  cosign manifest verify --key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <path/to/my-deployment.yaml>
 
   # verify images with public key stored in Hashicorp Vault
-  cosign manifest verify -key hashivault://[KEY] <path/to/my-deployment.yaml>`,
+  cosign manifest verify --key hashivault://[KEY] <path/to/my-deployment.yaml>`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			annotations, err := o.AnnotationsMap()

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -30,7 +30,7 @@ func addSignBlob(topLevel *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "sign-blob",
 		Short: "Sign the supplied blob, outputting the base64-encoded signature to stdout.",
-		Example: `  cosign sign-blob -key <key path>|<kms uri> [-sig <sig path>] <blob>
+		Example: `  cosign sign-blob --key <key path>|<kms uri> <blob>
 
   # sign a blob with Google sign-in (experimental)
   COSIGN_EXPERIMENTAL=1 cosign sign-blob <FILE>

--- a/cmd/sget/cli/commands.go
+++ b/cmd/sget/cli/commands.go
@@ -34,7 +34,7 @@ var (
 func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sget <image reference>",
-		Short: "sget [-key <key reference>] <image reference>",
+		Short: "sget [--key <key reference>] <image reference>",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("a single image reference is required")

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -49,18 +49,18 @@ go test -tags=e2e -race ./...
 # Test `cosign dockerfile verify`
 export DISTROLESS_PUB_KEY=distroless.pub
 wget -O ${DISTROLESS_PUB_KEY} https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub
-./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/single_stage.Dockerfile
-if (./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_build_stage.Dockerfile); then false; fi
-./cosign dockerfile verify -base-image-only -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_build_stage.Dockerfile
-./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/fancy_from.Dockerfile
-test_image="gcr.io/distroless/base" ./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile
+./cosign dockerfile verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/single_stage.Dockerfile
+if (./cosign dockerfile verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_build_stage.Dockerfile); then false; fi
+./cosign dockerfile verify --base-image-only --key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_build_stage.Dockerfile
+./cosign dockerfile verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/fancy_from.Dockerfile
+test_image="gcr.io/distroless/base" ./cosign dockerfile verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile
 # Image exists, but is unsigned
-if (test_image="ubuntu" ./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile); then false; fi
-./cosign dockerfile verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/with_lowercase.Dockerfile
+if (test_image="ubuntu" ./cosign dockerfile verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/with_arg.Dockerfile); then false; fi
+./cosign dockerfile verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/with_lowercase.Dockerfile
 
 # Test `cosign manifest verify`
-./cosign manifest verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/signed_manifest.yaml
-if (./cosign manifest verify -key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_manifest.yaml); then false; fi
+./cosign manifest verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/signed_manifest.yaml
+if (./cosign manifest verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigned_manifest.yaml); then false; fi
 
 # Run the built container to make sure it doesn't crash
 make ko-local

--- a/test/e2e_test_cosigned.sh
+++ b/test/e2e_test_cosigned.sh
@@ -132,7 +132,7 @@ fi
 echo '::endgroup::'
 
 echo '::group:: sign test image'
-cosign sign -key k8s://cosign-system/verification-key $DIGEST
+cosign sign --key k8s://cosign-system/verification-key $DIGEST
 echo '::endgroup::'
 
 

--- a/test/e2e_test_insecure_registry.sh
+++ b/test/e2e_test_insecure_registry.sh
@@ -37,10 +37,10 @@ img="${INSECURE_REGISTRY_NAME}:${INSECURE_REGISTRY_PORT}/test"
 crane cp gcr.io/distroless/static $img --insecure
 
 # Operations with insecure registries should fail by default, then succeed
-# with `-allow-insecure-registry`
-if (./cosign sign -key ${signing_key} $img); then false; fi
-./cosign sign -allow-insecure-registry -key ${signing_key} $img
-if (./cosign verify -key ${verification_key} $img); then false; fi
-./cosign verify -allow-insecure-registry -key ${verification_key} $img
+# with `--allow-insecure-registry`
+if (./cosign sign --key ${signing_key} $img); then false; fi
+./cosign sign --allow-insecure-registry --key ${signing_key} $img
+if (./cosign verify --key ${verification_key} $img); then false; fi
+./cosign verify --allow-insecure-registry --key ${verification_key} $img
 
 echo "SUCCESS"

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -100,16 +100,16 @@ echo "myblob2" > myblob2
 ./cosign sign-blob --key ${signing_key} myblob > myblob.sig
 ./cosign sign-blob --key ${signing_key} myblob2 > myblob2.sig
 
-./cosign verify-blob --key ${verification_key} -signature myblob.sig myblob
-if (./cosign verify-blob --key ${verification_key} -signature myblob.sig myblob2); then false; fi
+./cosign verify-blob --key ${verification_key} --signature myblob.sig myblob
+if (./cosign verify-blob --key ${verification_key} --signature myblob.sig myblob2); then false; fi
 
-if (./cosign verify-blob --key ${verification_key} -signature myblob2.sig myblob); then false; fi
-./cosign verify-blob --key ${verification_key} -signature myblob2.sig myblob2
+if (./cosign verify-blob --key ${verification_key} --signature myblob2.sig myblob); then false; fi
+./cosign verify-blob --key ${verification_key} --signature myblob2.sig myblob2
 
 ## sign and verify multiple blobs
 ./cosign sign-blob --key ${signing_key} myblob myblob2 > sigs
-./cosign verify-blob --key ${verification_key} -signature <(head -n 1 sigs) myblob
-./cosign verify-blob --key ${verification_key} -signature <(tail -n 1 sigs) myblob2
+./cosign verify-blob --key ${verification_key} --signature <(head -n 1 sigs) myblob
+./cosign verify-blob --key ${verification_key} --signature <(tail -n 1 sigs) myblob2
 
 ## upload blob/sget
 blobimg="${BASE_TEST_REPO}/blob"
@@ -145,7 +145,7 @@ if ( ! cmp -s randomblob randomblob_from_digest ); then false; fi
 ## KMS!
 TEST_KMS=${TEST_KMS:-gcpkms://projects/projectsigstore/locations/global/keyRings/e2e-test/cryptoKeys/test}
 (crane delete $(./cosign triangulate $img)) || true
-./cosign generate-key-pair -kms $TEST_KMS
+./cosign generate-key-pair --kms $TEST_KMS
 signing_key=$TEST_KMS
 
 if (./cosign verify --key ${verification_key} $img); then false; fi


### PR DESCRIPTION
#### Summary

find and fix examples where we are using the single dash style flags.

#### Ticket Link

Related to #706 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
`cosign` now uses POXIS style flags.
```
