### PR TITLE
Fix attest bug with rekor URL

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -62,6 +62,7 @@ func addAttest(topLevel *cobra.Command) {
 				Sk:        o.SecurityKey.Use,
 				Slot:      o.SecurityKey.Slot,
 				IDToken:   o.Fulcio.IdentityToken,
+				RekorURL:  o.Rekor.URL,
 				FulcioURL: o.Fulcio.URL,
 			}
 			for _, img := range args {

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -27,6 +27,7 @@ type AttestOptions struct {
 	Force     bool
 	Recursive bool
 
+	Rekor       RekorOptions
 	Fulcio      FulcioOptions
 	SecurityKey SecurityKeyOptions
 	Predicate   PredicateOptions
@@ -40,6 +41,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 	o.SecurityKey.AddFlags(cmd)
 	o.Predicate.AddFlags(cmd)
 	o.Fulcio.AddFlags(cmd)
+	o.Rekor.AddFlags(cmd)
 	o.Registry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Key, "key", "",


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes
* Fixes a bug with the `attest` command where the rekor URL was not passed in.

Previous behavior:
```
COSIGN_EXPERIMENTAL=1 ./cosign attest --predicate example.txt --key cosign.key --type custom gcr.io/asra-ali/busybox/demo --force
Using payload from: example.txt
Error: signing gcr.io/asra-ali/busybox/demo: Post "http:///api/v1/log/entries": http: no Host in request URL

```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
