### PR TITLE
output the url to check the rekor entry

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -51,6 +51,7 @@ import (
 	fulcioClient "github.com/sigstore/fulcio/pkg/client"
 	rekorclient "github.com/sigstore/rekor/pkg/client"
 	"github.com/sigstore/rekor/pkg/generated/client"
+	"github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -107,6 +108,19 @@ func UploadToTlog(ctx context.Context, sv *CertSignVerifier, rekorURL string, up
 		return nil, err
 	}
 	fmt.Fprintln(os.Stderr, "tlog entry created with index:", *entry.LogIndex)
+
+	params := entries.NewGetLogEntryByIndexParams()
+	params.LogIndex = *entry.LogIndex
+
+	resp, err := rekorClient.Entries.GetLogEntryByIndex(params)
+	if err != nil {
+		return nil, err
+	}
+
+	for entryIndex := range resp.Payload {
+		fmt.Fprintf(os.Stderr, "Rekor URL: %s/api/v1/log/entries/%s \n", rekorURL, entryIndex)
+	}
+
 	return Bundle(entry), nil
 }
 


### PR DESCRIPTION
#### Summary
For some release automation will be good to have the rekor URL in the output and then we can avoid some running extra commands, also this might be good to have as information for the users

demo:
```
$ COSIGN_EXPERIMENTAL=1 ./cosign sign  ctadeu/test:123
Generating ephemeral keys...
Retrieving signed certificate...
Your browser will now be opened to:
https://oauth2.sigstore.dev/auth/auth?access_type=online&client_id=sigstore&code_challenge=J5cQxIcmLX1umh8uifJJ5DtLawnkw72APCplUT8WS-M&code_challenge_method=S256&nonce=1z31suPSxbuM0Ok87fYcUIWtjyR&redirect_uri=http%3A%2F%2Flocalhost%3A5556%2Fauth%2Fcallback&response_type=code&scope=openid+email&state=1z31suNVKc3jSsz5EHzI7bN6LNP
Successfully verified SCT...
tlog entry created with index: 734594
Rekor URL: https://rekor.sigstore.dev/api/v1/log/entries/2fbfdf45e8bcf7a014b1ed37dd9043db285c4bf1b0f84622a1a2a4fde7446be7
```

using the rekor-cli

```
$ rekor-cli get --log-index 734594 --format json|jq ".UUID"
"2fbfdf45e8bcf7a014b1ed37dd9043db285c4bf1b0f84622a1a2a4fde7446be7"
```

let me know if that is ok :)

#### Ticket Link
N/A

#### Release Note
```release-note
output the url to check the rekor entry
```
