### PR TITLE
Only run CI on PRs and push to main or releases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,11 @@
 
 name: CI-Tests
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main', 'release-*']
+  pull_request:
 
 jobs:
   unit-tests:

--- a/.github/workflows/verify-docgen.yaml
+++ b/.github/workflows/verify-docgen.yaml
@@ -15,7 +15,11 @@
 
 name: Docgen
 
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  push:
+    branches: ['main', 'release-*']
+  pull_request:
 
 jobs:
   docgen:


### PR DESCRIPTION
Signed-off-by: Jason Hall <jasonhall@redhat.com>

Noticed while developing #839 

With the previous config, CI would run in my forked repo on any push to a branch while iterating on a PR. Since this also ran CI while the PR was open on this repo, any failure would result in two notifications.

With this change, CI tests will only run on pushes to `main` or release branches, and on PRs to this repo or forked repos. Since most pushes to forked repos are (presumably) to non-`main` branches, this should only cause runs on active PRs.

#### Ticket Link

n/a

#### Release Note

```release-note
NONE
```