### PR TITLE
support user customizable predicates

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -74,7 +75,11 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 
 	predicateURI, ok := predicateTypeMap[predicateType]
 	if !ok {
-		return fmt.Errorf("invalid predicate type: %s", predicateType)
+		if _, err := url.ParseRequestURI(predicateType); err != nil {
+			return fmt.Errorf("invalid predicate type: %s", predicateType)
+		} else {
+			predicateURI = predicateType
+		}
 	}
 
 	ref, err := name.ParseReference(imageRef)

--- a/cmd/cosign/cli/options/predicate.go
+++ b/cmd/cosign/cli/options/predicate.go
@@ -33,5 +33,5 @@ func (o *PredicateOptions) AddFlags(cmd *cobra.Command) {
 		"path to the predicate file.")
 
 	cmd.Flags().StringVar(&o.Type, "type", "custom",
-		"specify predicate type (default: custom) (slsaprovenance|link|spdx)")
+		"specify a predicate type (slsaprovenance|link|spdx|custom) or an URI")
 }

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -48,7 +48,7 @@ cosign attest [flags]
       --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sk                        whether to use a hardware security key
       --slot string               security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --type string               specify predicate type (default: custom) (slsaprovenance|link|spdx) (default "custom")
+      --type string               specify a predicate type (slsaprovenance|link|spdx|custom) or an URI (default "custom")
       --upload                    whether to upload the signature (default true)
 ```
 

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -115,14 +115,14 @@ func generateCustomStatement(rawPayload []byte, customType, digest, repo, timest
 
 	return in_toto.Statement{
 		StatementHeader: generateStatementHeader(digest, repo, customType),
-		Predicate: payload,
+		Predicate:       payload,
 	}, nil
 }
 
 func generateCustomPredicate(rawPayload []byte, customType, timestamp string) (interface{}, error) {
 	if customType == CosignCustomProvenanceV01 {
 		return &CosignPredicate{
-			Data: string(rawPayload),
+			Data:      string(rawPayload),
 			Timestamp: timestamp,
 		}, nil
 	}

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -35,7 +35,7 @@ const (
 
 // CosignPredicate specifies the format of the Custom Predicate.
 type CosignPredicate struct {
-	Data      string
+	Data      interface{}
 	Timestamp string
 }
 
@@ -63,13 +63,6 @@ func GenerateStatement(opts GenerateOpts) (interface{}, error) {
 		return nil, err
 	}
 	switch opts.Type {
-	case "custom":
-		if opts.Time == nil {
-			opts.Time = time.Now
-		}
-		now := opts.Time()
-		stamp := now.UTC().Format(time.RFC3339)
-		return generateCustomStatement(rawPayload, opts.Digest, opts.Repo, stamp)
 	case "slsaprovenance":
 		return generateSLSAProvenanceStatement(rawPayload, opts.Digest, opts.Repo)
 	case "spdx":
@@ -77,8 +70,25 @@ func GenerateStatement(opts GenerateOpts) (interface{}, error) {
 	case "link":
 		return generateLinkStatement(rawPayload, opts.Digest, opts.Repo)
 	default:
-		return nil, fmt.Errorf("we don't know this predicate type: %q", opts.Type)
+		stamp := timestamp(opts)
+		predicateType := customType(opts)
+		return generateCustomStatement(rawPayload, predicateType, opts.Digest, opts.Repo, stamp)
 	}
+}
+
+func timestamp(opts GenerateOpts) string {
+	if opts.Time == nil {
+		opts.Time = time.Now
+	}
+	now := opts.Time()
+	return now.UTC().Format(time.RFC3339)
+}
+
+func customType(opts GenerateOpts) string {
+	if opts.Type != "custom" {
+		return opts.Type
+	}
+	return CosignCustomProvenanceV01
 }
 
 func generateStatementHeader(digest, repo, predicateType string) in_toto.StatementHeader {
@@ -97,14 +107,32 @@ func generateStatementHeader(digest, repo, predicateType string) in_toto.Stateme
 }
 
 //
-func generateCustomStatement(rawPayload []byte, digest, repo, timestamp string) (interface{}, error) {
+func generateCustomStatement(rawPayload []byte, customType, digest, repo, timestamp string) (interface{}, error) {
+	payload, err := generateCustomPredicate(rawPayload, customType, timestamp)
+	if err != nil {
+		return nil, err
+	}
+
 	return in_toto.Statement{
-		StatementHeader: generateStatementHeader(digest, repo, CosignCustomProvenanceV01),
-		Predicate: CosignPredicate{
-			Data:      string(rawPayload),
-			Timestamp: timestamp,
-		},
+		StatementHeader: generateStatementHeader(digest, repo, customType),
+		Predicate: payload,
 	}, nil
+}
+
+func generateCustomPredicate(rawPayload []byte, customType, timestamp string) (interface{}, error) {
+	if customType == CosignCustomProvenanceV01 {
+		return &CosignPredicate{
+			Data: string(rawPayload),
+			Timestamp: timestamp,
+		}, nil
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(rawPayload, &result); err != nil {
+		return nil, errors.Wrapf(err, "invalid JSON payload for predicate type %s", customType)
+	}
+
+	return result, nil
 }
 
 func generateSLSAProvenanceStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {


### PR DESCRIPTION
Signed-off-by: Jim Bugwadia <jim@nirmata.com>

Fixes https://github.com/sigstore/cosign/issues/846.

#### Summary

This PR allows users to specify a custom predicate and supply any JSON data:

```sh
./cosign attest --predicate ~/predicate.json --type https://example.com/CodeReview/v1 --key ~/cosign.key <image>
```

where `predicate.json` is:

```json
{                                                       
    "repo": {                                           
      "type": "git",                                    
      "uri": "https://github.com/example/my-project",   
      "branch": "main"                                  
    },                                                  
    "author": "mailto:alice@example.com",               
    "reviewers": ["mailto:bob@example.com"]             
}                                                       
```

The resulting verify-attest results look like this:

```sh
Verification for ghcr.io/jimbugwadia/pause2 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - The signatures were verified against the specified public key
  - Any certificates were verified against the Fulcio roots.
{"payloadType":"https://example.com/CodeReview/v1","payload":"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL2V4YW1wbGUuY29tL0NvZGVSZXZpZXcvdjEiLCJzdWJqZWN0IjpbeyJuYW1lIjoiZ2hjci5pby9qaW1idWd3YWRpYS9wYXVzZTIiLCJkaWdlc3QiOnsic2hhMjU2IjoiYjMxYmZiNGQwMjEzZjI1NGQzNjFlMDA3OWRlYWFlYmVmYTRmODJiYTdhYTc2ZWY4MmU5MGI0OTM1YWQ1YjEwNSJ9fV0sInByZWRpY2F0ZSI6eyJhdXRob3IiOiJtYWlsdG86YWxpY2VAZXhhbXBsZS5jb20iLCJyZXBvIjp7ImJyYW5jaCI6Im1haW4iLCJ0eXBlIjoiZ2l0IiwidXJpIjoiaHR0cHM6Ly9naXRodWIuY29tL2V4YW1wbGUvbXktcHJvamVjdCJ9LCJyZXZpZXdlcnMiOlsibWFpbHRvOmJvYkBleGFtcGxlLmNvbSJdfX0=","signatures":[{"keyid":"","sig":"MEYCIQCrEr+vgPDmNCrqGDE/4z9iMLmCXMXcDlGKtSoiuMTSFgIhAN2riBaGk4accWzVl7ypi1XTRxyrPYHst8DesugPXgOf"}]}
```

The base64 decodes to:

```json
{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://example.com/CodeReview/v1","subject":[{"name":"ghcr.io/jimbugwadia/pause2","digest":{"sha256":"b31bfb4d0213f254d361e0079deaaebefa4f82ba7aa76ef82e90b4935ad5b105"}}],"predicate":{"author":"mailto:alice@example.com","repo":{"branch":"main","type":"git","uri":"https://github.com/example/my-project"},"reviewers":["mailto:bob@example.com"]}}
```




