### PR TITLE
added `Attachment()` method to `oci.SignedEntity`

### DIFF
--- a/pkg/oci/interface.go
+++ b/pkg/oci/interface.go
@@ -23,4 +23,7 @@ type SignedEntity interface {
 	// Attestations returns the set of attestations currently associated with this
 	// entity, or the empty equivalent if none are found.
 	Attestations() (Signatures, error)
+
+	// Attachment returns a named entity associated with this entity, or error if not found.
+	Attachment(name string) (File, error)
 }

--- a/pkg/oci/mutate/mutate.go
+++ b/pkg/oci/mutate/mutate.go
@@ -16,6 +16,7 @@
 package mutate
 
 import (
+	"errors"
 	"fmt"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -75,6 +76,11 @@ func (i *indexWrapper) Signatures() (oci.Signatures, error) {
 // Attestations implements oci.SignedImageIndex
 func (i *indexWrapper) Attestations() (oci.Signatures, error) {
 	return empty.Signatures(), nil
+}
+
+// Attachment implements oci.SignedImage
+func (*indexWrapper) Attachment(name string) (oci.File, error) {
+	return nil, errors.New("unimplemented")
 }
 
 // SignedImage implements oci.SignedImageIndex
@@ -208,6 +214,11 @@ func (si *signedImage) Attestations() (oci.Signatures, error) {
 	return AppendSignatures(base, si.att)
 }
 
+// Attachment implements oci.SignedImage
+func (si *signedImage) Attachment(attName string) (oci.File, error) {
+	return nil, errors.New("unimplemented")
+}
+
 // AttachSignatureToImageIndex attaches the provided signature to the provided image index.
 func AttachSignatureToImageIndex(sii oci.SignedImageIndex, sig oci.Signature, opts ...SignOption) (oci.SignedImageIndex, error) {
 	return &signedImageIndex{
@@ -271,4 +282,9 @@ func (sii *signedImageIndex) Attestations() (oci.Signatures, error) {
 		}
 	}
 	return AppendSignatures(base, sii.att)
+}
+
+// Attachment implements oci.SignedImageIndex
+func (sii *signedImageIndex) Attachment(attName string) (oci.File, error) {
+	return nil, errors.New("unimplemented")
 }

--- a/pkg/oci/remote/image.go
+++ b/pkg/oci/remote/image.go
@@ -50,3 +50,8 @@ func (i *image) Signatures() (oci.Signatures, error) {
 func (i *image) Attestations() (oci.Signatures, error) {
 	return attestations(i, i.opt)
 }
+
+// Attestations implements oci.SignedImage
+func (i *image) Attachment(name string) (oci.File, error) {
+	return attachment(i, name, i.opt)
+}

--- a/pkg/oci/remote/index.go
+++ b/pkg/oci/remote/index.go
@@ -57,6 +57,11 @@ func (i *index) Attestations() (oci.Signatures, error) {
 	return attestations(i, i.opt)
 }
 
+// Attestations implements oci.SignedImage
+func (i *index) Attachment(name string) (oci.File, error) {
+	return attachment(i, name, i.opt)
+}
+
 // SignedImage implements oci.SignedImageIndex
 func (i *index) SignedImage(h v1.Hash) (oci.SignedImage, error) {
 	img, err := i.Image(h)

--- a/pkg/oci/signed/image.go
+++ b/pkg/oci/signed/image.go
@@ -16,6 +16,8 @@
 package signed
 
 import (
+	"errors"
+
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/sigstore/cosign/pkg/oci"
@@ -43,4 +45,9 @@ func (*image) Signatures() (oci.Signatures, error) {
 // Attestations implements oci.SignedImage
 func (*image) Attestations() (oci.Signatures, error) {
 	return empty.Signatures(), nil
+}
+
+// Attestations implements oci.SignedImage
+func (*image) Attachment(name string) (oci.File, error) {
+	return nil, errors.New("unimplemented")
 }

--- a/pkg/oci/signed/index.go
+++ b/pkg/oci/signed/index.go
@@ -16,6 +16,8 @@
 package signed
 
 import (
+	"errors"
+
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
 	"github.com/sigstore/cosign/pkg/oci"
@@ -64,4 +66,9 @@ func (*index) Signatures() (oci.Signatures, error) {
 // Attestations implements oci.SignedImageIndex
 func (*index) Attestations() (oci.Signatures, error) {
 	return empty.Signatures(), nil
+}
+
+// Attestations implements oci.SignedImage
+func (*index) Attachment(name string) (oci.File, error) {
+	return nil, errors.New("unimplemented")
 }


### PR DESCRIPTION
This allows for users to easily fetch named File "attachments" associated with an image.

#### Ticket Link

https://github.com/sigstore/cosign/issues/844

#### Release Note

```release-note
[pkg/]: Added `Attachment()` method to `oci.SignedEntity` to retrieve arbitrary named "attachments"
```
