### PR TITLE
`-d` -> `-v` for verbose logging

### DIFF
--- a/cmd/cosign/cli/options/root.go
+++ b/cmd/cosign/cli/options/root.go
@@ -32,6 +32,6 @@ func (o *RootOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.OutputFile, "output-file", "",
 		"log output to a file")
 
-	cmd.PersistentFlags().BoolVarP(&o.Verbose, "verbose", "d", false,
-		"log debug output")
+	cmd.PersistentFlags().BoolVarP(&o.Verbose, "verbose", "v", false,
+		"log verbose debug output")
 }

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -7,7 +7,7 @@
 ```
   -h, --help                 help for cosign
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach.md
+++ b/doc/cosign_attach.md
@@ -12,7 +12,7 @@ Provides utilities for attaching artifacts to other artifacts in a registry
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach_sbom.md
+++ b/doc/cosign_attach_sbom.md
@@ -25,7 +25,7 @@ cosign attach sbom [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -25,7 +25,7 @@ cosign attach signature [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -56,7 +56,7 @@ cosign attest [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -22,7 +22,7 @@ cosign clean [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_completion.md
+++ b/doc/cosign_completion.md
@@ -44,7 +44,7 @@ cosign completion [bash|zsh|fish|powershell]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -34,7 +34,7 @@ cosign copy [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_dockerfile.md
+++ b/doc/cosign_dockerfile.md
@@ -12,7 +12,7 @@ Provides utilities for discovering images in and performing operations on Docker
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -70,7 +70,7 @@ cosign dockerfile verify [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download.md
+++ b/doc/cosign_download.md
@@ -12,7 +12,7 @@ Provides utilities for downloading artifacts and attached artifacts in a registr
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -23,7 +23,7 @@ cosign download sbom [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download_signature.md
+++ b/doc/cosign_download_signature.md
@@ -23,7 +23,7 @@ cosign download signature [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_generate-key-pair.md
+++ b/doc/cosign_generate-key-pair.md
@@ -49,7 +49,7 @@ CAVEATS:
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_generate.md
+++ b/doc/cosign_generate.md
@@ -39,7 +39,7 @@ cosign generate [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -50,7 +50,7 @@ cosign initialize [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_manifest.md
+++ b/doc/cosign_manifest.md
@@ -12,7 +12,7 @@ Provides utilities for discovering images in and performing operations on Kubern
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -64,7 +64,7 @@ cosign manifest verify [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy.md
+++ b/doc/cosign_policy.md
@@ -22,7 +22,7 @@ cosign policy [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy_init.md
+++ b/doc/cosign_policy_init.md
@@ -34,7 +34,7 @@ cosign policy init [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_public-key.md
+++ b/doc/cosign_public-key.md
@@ -48,7 +48,7 @@ cosign public-key [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -52,7 +52,7 @@ cosign sign-blob [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -73,7 +73,7 @@ cosign sign [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -23,7 +23,7 @@ cosign triangulate [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload.md
+++ b/doc/cosign_upload.md
@@ -12,7 +12,7 @@ Provides utilities for uploading artifacts to a registry
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload_blob.md
+++ b/doc/cosign_upload_blob.md
@@ -37,7 +37,7 @@ cosign upload blob [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload_wasm.md
+++ b/doc/cosign_upload_wasm.md
@@ -24,7 +24,7 @@ cosign upload wasm [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -60,7 +60,7 @@ cosign verify-attestation [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -65,7 +65,7 @@ cosign verify-blob [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -64,7 +64,7 @@ cosign verify [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_version.md
+++ b/doc/cosign_version.md
@@ -21,7 +21,7 @@ cosign version [flags]
 
 ```
       --output-file string   log output to a file
-  -d, --verbose              log debug output
+  -v, --verbose              log verbose debug output
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
`-v` seems to be universal shorthand for `--verbose`