### PR TITLE
conversation starter on what we want standard flags to look like inside of cosign

### DIFF
--- a/cmd/cosign/cli/options/doc.go
+++ b/cmd/cosign/cli/options/doc.go
@@ -1,0 +1,28 @@
+// Package options contains the options used by the cosign cli.
+//
+// Aspirational flag patterns. Not all flags are used for all commands, but no
+// other command may reuse the flag meaning listed here.
+//
+// Boolean types:
+// `-a`, `--all`: All.
+// `-d`, `--debug`: Show debug output. Example: each input and output is printed, each step is detailed.
+// `-q`, `--quiet`: Show less output.
+// `-F`, `--force`: Force an operation.
+// `-v`, `--verbose`: Verbose output. Example: each step is detailed.
+// `-K`, `--security-key`: Whether to use a hardware security key.
+// `-R`, `--recursive`: Apply the operation recursively.
+
+// Single-entry inputs
+// `-o`, `--output`: The output file.
+// `-f`, `--output-format`: The format of the output.
+// `-O`, `--output-file`: The file to output to.
+// `-k`, `--key`: Path to the private key file, KMS URI or Kubernetes Secret.
+// '-s', `--signature`: Path to signature, or content or remote URL.
+// `-c`, `--cert`: Path to the public certificate.
+// `-S`, `--security-key-slot`: The slot of the hardware security key in use.
+//
+// Multi-entry inputs
+// `-a`, `--annotations`: List of annotations.
+//
+//
+package options

--- a/cmd/cosign/cli/options/doc.go
+++ b/cmd/cosign/cli/options/doc.go
@@ -13,9 +13,9 @@
 // `-R`, `--recursive`: Apply the operation recursively.
 
 // Single-entry inputs
-// `-o`, `--output`: The output file.
+// `-o`, `--output`: The output file (payload).
 // `-f`, `--output-format`: The format of the output.
-// `-O`, `--output-file`: The file to output to.
+// `-O`, `--output-file`: The file to redirect stdout to (task steps).
 // `-k`, `--key`: Path to the private key file, KMS URI or Kubernetes Secret.
 // '-s', `--signature`: Path to signature, or content or remote URL.
 // `-c`, `--cert`: Path to the public certificate.


### PR DESCRIPTION

#### Summary

Writing down what we think the flags should look like long term. Let's agree on these and then we can make a plan to move to them long term.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
