### PR TITLE
make `COSIGN_REPOSITORY` use explicit again

### DIFF
--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -43,7 +43,11 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 	if err != nil {
 		return err
 	}
-	digest, err := ociremote.ResolveDigest(ref, regOpts.ClientOpts(ctx)...)
+	ociremoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return err
+	}
+	digest, err := ociremote.ResolveDigest(ref, ociremoteOpts...)
 	if err != nil {
 		return err
 	}
@@ -67,7 +71,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 		return err
 	}
 
-	se, err := ociremote.SignedEntity(digest, regOpts.ClientOpts(ctx)...)
+	se, err := ociremote.SignedEntity(digest, ociremoteOpts...)
 	if err != nil {
 		return err
 	}
@@ -79,7 +83,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 	}
 
 	// Publish the signatures associated with this entity
-	return ociremote.WriteSignatures(digest.Repository, newSE, regOpts.ClientOpts(ctx)...)
+	return ociremote.WriteSignatures(digest.Repository, newSE, ociremoteOpts...)
 }
 
 type SignatureArgType uint8

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -86,7 +86,11 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 	if err != nil {
 		return errors.Wrap(err, "parsing reference")
 	}
-	digest, err := ociremote.ResolveDigest(ref, regOpts.ClientOpts(ctx)...)
+	ociremoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return err
+	}
+	digest, err := ociremote.ResolveDigest(ref, ociremoteOpts...)
 	if err != nil {
 		return err
 	}
@@ -151,7 +155,7 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 		return err
 	}
 
-	se, err := ociremote.SignedEntity(digest, regOpts.ClientOpts(ctx)...)
+	se, err := ociremote.SignedEntity(digest, ociremoteOpts...)
 	if err != nil {
 		return err
 	}
@@ -163,5 +167,5 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 	}
 
 	// Publish the attestations associated with this entity
-	return ociremote.WriteAttestations(digest.Repository, newSE, regOpts.ClientOpts(ctx)...)
+	return ociremote.WriteAttestations(digest.Repository, newSE, ociremoteOpts...)
 }

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/pkg/oci/remote"
+	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 )
 
 func SBOMCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef string, out io.Writer) ([]string, error) {
@@ -32,12 +32,16 @@ func SBOMCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef stri
 		return nil, err
 	}
 
-	opts := append(regOpts.ClientOpts(ctx),
+	ociremoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return nil, err
+	}
+	ociremoteOpts = append(ociremoteOpts,
 		// TODO(mattmoor): This isn't really "signatures", consider shifting to
 		// an SBOMs accessor?
-		remote.WithSignatureSuffix(remote.SBOMTagSuffix))
+		ociremote.WithSignatureSuffix(ociremote.SBOMTagSuffix))
 
-	se, err := remote.SignedEntity(ref, opts...)
+	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cosign/cli/download/signature.go
+++ b/cmd/cosign/cli/download/signature.go
@@ -30,7 +30,11 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef
 	if err != nil {
 		return err
 	}
-	signatures, err := cosign.FetchSignaturesForReference(ctx, ref, regOpts.ClientOpts(ctx)...)
+	ociremoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return err
+	}
+	signatures, err := cosign.FetchSignaturesForReference(ctx, ref, ociremoteOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/generate/generate.go
+++ b/cmd/cosign/cli/generate/generate.go
@@ -32,7 +32,11 @@ func GenerateCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef 
 	if err != nil {
 		return err
 	}
-	digest, err := ociremote.ResolveDigest(ref, regOpts.ClientOpts(ctx)...)
+	ociremoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return err
+	}
+	digest, err := ociremote.ResolveDigest(ref, ociremoteOpts...)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/triangulate/triangulate.go
+++ b/cmd/cosign/cli/triangulate/triangulate.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/pkg/cosign"
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
@@ -31,14 +32,19 @@ func MungeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef str
 		return err
 	}
 
+	ociremoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "constructing client options")
+	}
+
 	var dstRef name.Tag
 	switch attachmentType {
 	case cosign.Signature:
-		dstRef, err = ociremote.SignatureTag(ref, regOpts.ClientOpts(ctx)...)
+		dstRef, err = ociremote.SignatureTag(ref, ociremoteOpts...)
 	case cosign.SBOM:
-		dstRef, err = ociremote.SBOMTag(ref, regOpts.ClientOpts(ctx)...)
+		dstRef, err = ociremote.SBOMTag(ref, ociremoteOpts...)
 	case cosign.Attestation:
-		dstRef, err = ociremote.AttestationTag(ref, regOpts.ClientOpts(ctx)...)
+		dstRef, err = ociremote.AttestationTag(ref, ociremoteOpts...)
 	default:
 		err = fmt.Errorf("unknown attachment type %s", attachmentType)
 	}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -68,10 +68,13 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	if !options.OneOf(c.KeyRef, c.Sk) && !options.EnableExperimental() {
 		return &options.KeyParseError{}
 	}
-
+	ociremoteOpts, err := c.ClientOpts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "constructing client options")
+	}
 	co := &cosign.CheckOpts{
 		Annotations:        c.Annotations.Annotations,
-		RegistryClientOpts: c.RegistryOptions.ClientOpts(ctx),
+		RegistryClientOpts: ociremoteOpts,
 		CertEmail:          c.CertEmail,
 	}
 	if c.CheckClaims {
@@ -108,7 +111,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		if err != nil {
 			return errors.Wrap(err, "parsing reference")
 		}
-		ref, err = sign.GetAttachedImageRef(ref, c.Attachment, c.RegistryOptions.GetRegistryClientOpts(ctx)...)
+		ref, err = sign.GetAttachedImageRef(ref, c.Attachment, ociremoteOpts...)
 		if err != nil {
 			return errors.Wrapf(err, "resolving attachment type %s for image %s", c.Attachment, img)
 		}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -66,8 +66,13 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		return &options.KeyParseError{}
 	}
 
+	ociremoteOpts, err := c.ClientOpts(ctx)
+	if err != nil {
+		return errors.Wrap(err, "constructing client options")
+	}
+
 	co := &cosign.CheckOpts{
-		RegistryClientOpts: c.ClientOpts(ctx),
+		RegistryClientOpts: ociremoteOpts,
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier

--- a/pkg/oci/remote/digest.go
+++ b/pkg/oci/remote/digest.go
@@ -23,10 +23,7 @@ import (
 // If the reference is by digest already, it simply extracts the digest.
 // Otherwise, it looks up the digest from the registry.
 func ResolveDigest(ref name.Reference, opts ...Option) (name.Digest, error) {
-	o, err := makeOptions(ref.Context(), opts...)
-	if err != nil {
-		return name.Digest{}, err
-	}
+	o := makeOptions(ref.Context(), opts...)
 	if d, ok := ref.(name.Digest); ok {
 		return d, nil
 	}

--- a/pkg/oci/remote/image.go
+++ b/pkg/oci/remote/image.go
@@ -23,10 +23,7 @@ import (
 
 // SignedImage provides access to a remote image reference, and its signatures.
 func SignedImage(ref name.Reference, options ...Option) (oci.SignedImage, error) {
-	o, err := makeOptions(ref.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	o := makeOptions(ref.Context(), options...)
 	ri, err := remoteImage(ref, o.ROpt...)
 	if err != nil {
 		return nil, err

--- a/pkg/oci/remote/index.go
+++ b/pkg/oci/remote/index.go
@@ -23,10 +23,7 @@ import (
 
 // SignedImageIndex provides access to a remote index reference, and its signatures.
 func SignedImageIndex(ref name.Reference, options ...Option) (oci.SignedImageIndex, error) {
-	o, err := makeOptions(ref.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	o := makeOptions(ref.Context(), options...)
 	ri, err := remoteIndex(ref, o.ROpt...)
 	if err != nil {
 		return nil, err

--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -43,10 +43,7 @@ var (
 // SignedEntity provides access to a remote reference, and its signatures.
 // The SignedEntity will be one of SignedImage or SignedImageIndex.
 func SignedEntity(ref name.Reference, options ...Option) (oci.SignedEntity, error) {
-	o, err := makeOptions(ref.Context(), options...)
-	if err != nil {
-		return nil, err
-	}
+	o := makeOptions(ref.Context(), options...)
 
 	got, err := remoteGet(ref, o.ROpt...)
 	if err != nil {
@@ -91,28 +88,19 @@ func normalize(h v1.Hash, prefix string, suffix string) string {
 
 // SignatureTag returns the name.Tag that associated signatures with a particular digest.
 func SignatureTag(ref name.Reference, opts ...Option) (name.Tag, error) {
-	o, err := makeOptions(ref.Context(), opts...)
-	if err != nil {
-		return name.Tag{}, err
-	}
+	o := makeOptions(ref.Context(), opts...)
 	return suffixTag(ref, o.SignatureSuffix, o)
 }
 
 // AttestationTag returns the name.Tag that associated attestations with a particular digest.
 func AttestationTag(ref name.Reference, opts ...Option) (name.Tag, error) {
-	o, err := makeOptions(ref.Context(), opts...)
-	if err != nil {
-		return name.Tag{}, err
-	}
+	o := makeOptions(ref.Context(), opts...)
 	return suffixTag(ref, o.AttestationSuffix, o)
 }
 
 // SBOMTag returns the name.Tag that associated SBOMs with a particular digest.
 func SBOMTag(ref name.Reference, opts ...Option) (name.Tag, error) {
-	o, err := makeOptions(ref.Context(), opts...)
-	if err != nil {
-		return name.Tag{}, err
-	}
+	o := makeOptions(ref.Context(), opts...)
 	return suffixTag(ref, o.SBOMSuffix, o)
 }
 

--- a/pkg/oci/remote/remote_test.go
+++ b/pkg/oci/remote/remote_test.go
@@ -17,7 +17,6 @@ package remote
 
 import (
 	"encoding/base64"
-	"os"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -139,42 +138,21 @@ func TestTagMethodErrors(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		setenv bool
-		fn     func(name.Reference, ...Option) (name.Tag, error)
-		ref    name.Reference
-		want   error
-	}{{
-		name: "signature passed a tag",
-		fn:   SignatureTag,
-		ref:  name.MustParseReference("gcr.io/distroless/static:nonroot"),
-		want: errRemoteGet,
-	}, {
-		name:   "signature with bad target env var",
-		fn:     SignatureTag,
-		setenv: true,
-		ref:    name.MustParseReference("gcr.io/distroless/static:nonroot"),
-		want:   errors.New("repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: bad$repo"),
-	}, {
-		name:   "attestation with bad target env var",
-		fn:     AttestationTag,
-		setenv: true,
-		ref:    name.MustParseReference("gcr.io/distroless/static:nonroot"),
-		want:   errors.New("repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: bad$repo"),
-	}, {
-		name:   "sbom with bad target env var",
-		fn:     SBOMTag,
-		setenv: true,
-		ref:    name.MustParseReference("gcr.io/distroless/static:nonroot"),
-		want:   errors.New("repository can only contain the runes `abcdefghijklmnopqrstuvwxyz0123456789_-./`: bad$repo"),
-	}}
+		name string
+		fn   func(name.Reference, ...Option) (name.Tag, error)
+		ref  name.Reference
+		want error
+	}{
+		{
+			name: "signature passed a tag",
+			fn:   SignatureTag,
+			ref:  name.MustParseReference("gcr.io/distroless/static:nonroot"),
+			want: errRemoteGet,
+		},
+	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if test.setenv {
-				os.Setenv(RepoOverrideKey, "bad$repo")
-				defer os.Unsetenv(RepoOverrideKey)
-			}
 			tag, got := test.fn(test.ref)
 			if got == nil {
 				t.Fatalf("fn() = %v, wanted %v", tag, test.want)

--- a/pkg/oci/remote/signatures.go
+++ b/pkg/oci/remote/signatures.go
@@ -29,10 +29,7 @@ import (
 // Signatures fetches the signatures image represented by the named reference.
 // If the tag is not found, this returns an empty oci.Signatures.
 func Signatures(ref name.Reference, opts ...Option) (oci.Signatures, error) {
-	o, err := makeOptions(ref.Context(), opts...)
-	if err != nil {
-		return nil, err
-	}
+	o := makeOptions(ref.Context(), opts...)
 	img, err := remoteImage(ref, o.ROpt...)
 	var te *transport.Error
 	if errors.As(err, &te) {

--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -23,10 +23,7 @@ import (
 // WriteSignature publishes the signatures attached to the given entity
 // into the provided repository.
 func WriteSignatures(repo name.Repository, se oci.SignedEntity, opts ...Option) error {
-	o, err := makeOptions(repo, opts...)
-	if err != nil {
-		return err
-	}
+	o := makeOptions(repo, opts...)
 
 	// Access the signature list to publish
 	sigs, err := se.Signatures()
@@ -48,10 +45,7 @@ func WriteSignatures(repo name.Repository, se oci.SignedEntity, opts ...Option) 
 // WriteAttestations publishes the attestations attached to the given entity
 // into the provided repository.
 func WriteAttestations(repo name.Repository, se oci.SignedEntity, opts ...Option) error {
-	o, err := makeOptions(repo, opts...)
-	if err != nil {
-		return err
-	}
+	o := makeOptions(repo, opts...)
 
 	// Access the signature list to publish
 	atts, err := se.Attestations()


### PR DESCRIPTION
At some point in the refactoring `COSIGN_REPOSITORY` magic was reintroduced to `pkg/`. This change makes its usage explicit for library users again.