### PR TITLE
release: update golang-cross image to image tag v1.17.2

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -50,7 +50,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -w /go/src/sigstore/cosign \
             --entrypoint="" \
-            ghcr.io/gythialy/golang-cross:v1.17.1@sha256:d6982c0a6dae690b1f5ac977e377e75ba0db7022483c13b664a130a7934eb393 \
+            ghcr.io/gythialy/golang-cross:v1.17.2@sha256:24bb133da23e0d21a8e8a54416f652d753c7cb2ad8efb3e6a3ef652f597ada8f \
             make snapshot
 
       - name: check binaries

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -58,8 +58,17 @@ steps:
   - './Dockerfile.cosigned'
   waitFor: ['-']
 
+- name: 'gcr.io/projectsigstore/cosign:v1.2.0@sha256:96ef6fb02c5a56901dc3c2e0ca34eec9ed926ab8d936ea30ec38f9ec9db017a5'
+  dir: "go/src/sigstore/cosign"
+  args:
+  - 'verify'
+  - '-key'
+  - 'https://raw.githubusercontent.com/gythialy/golang-cross/master/cosign.pub'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.2@sha256:24bb133da23e0d21a8e8a54416f652d753c7cb2ad8efb3e6a3ef652f597ada8f'
+  waitFor: ['-']
+
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.1@sha256:d6982c0a6dae690b1f5ac977e377e75ba0db7022483c13b664a130a7934eb393
+- name: ghcr.io/gythialy/golang-cross:v1.17.2@sha256:24bb133da23e0d21a8e8a54416f652d753c7cb2ad8efb3e6a3ef652f597ada8f
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION
#### Summary
Now the image `ghcr.io/gythialy/golang-cross` is signed with cosign and we can verify that in the release pipeline.

Also we update the image tag and that contains in high-level:
- update to go 1.17.2
- latest goreleaser 0.181.1

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
release: update golang-cross image to image tag v1.17.2
```
