### PR TITLE
`TagOptions` -> `ReferenceOptions`

### DIFF
--- a/cmd/cosign/cli/options/reference.go
+++ b/cmd/cosign/cli/options/reference.go
@@ -19,16 +19,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TagOptions is a wrapper for the tag options.
-type TagOptions struct {
+// ReferenceOptions is a wrapper for image reference options.
+type ReferenceOptions struct {
 	TagPrefix string
-	TagSuffix string
 }
 
-var _ Interface = (*TagOptions)(nil)
+var _ Interface = (*ReferenceOptions)(nil)
 
 // AddFlags implements Interface
-func (o *TagOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.TagPrefix, "tag-prefix", "", "custom prefix to use for tags")
-	cmd.Flags().StringVar(&o.TagSuffix, "tag-suffix", "", "custom suffix to use for tags")
+func (o *ReferenceOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.TagPrefix, "attachment-tag-prefix", "", "optional custom prefix to use for attached image tags. Attachment images are tagged as: `[AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]`")
 }

--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -28,7 +28,7 @@ import (
 // RegistryOptions is the wrapper for the registry options.
 type RegistryOptions struct {
 	AllowInsecure bool
-	Tags          TagOptions
+	RefOpts       ReferenceOptions
 }
 
 var _ Interface = (*RegistryOptions)(nil)
@@ -37,11 +37,15 @@ var _ Interface = (*RegistryOptions)(nil)
 func (o *RegistryOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.AllowInsecure, "allow-insecure-registry", false,
 		"whether to allow insecure connections to registries. Don't use this for anything but testing")
-	o.Tags.AddFlags(cmd)
+	o.RefOpts.AddFlags(cmd)
 }
 
 func (o *RegistryOptions) ClientOpts(ctx context.Context) []ociremote.Option {
-	return []ociremote.Option{ociremote.WithRemoteOptions(o.GetRegistryClientOpts(ctx)...), ociremote.WithPrefix(o.Tags.TagPrefix), ociremote.WithSuffix(o.Tags.TagSuffix)}
+	opts := []ociremote.Option{ociremote.WithRemoteOptions(o.GetRegistryClientOpts(ctx)...)}
+	if o.RefOpts.TagPrefix != "" {
+		opts = append(opts, ociremote.WithPrefix(o.RefOpts.TagPrefix))
+	}
+	return opts
 }
 
 func (o *RegistryOptions) GetRegistryClientOpts(ctx context.Context) []remote.Option {

--- a/doc/cosign_attach_sbom.md
+++ b/doc/cosign_attach_sbom.md
@@ -15,12 +15,11 @@ cosign attach sbom [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -h, --help                      help for sbom
-      --sbom string               path to the sbom, or {-} for stdin
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
-      --type string               type of sbom (spdx|cyclonedx) (default "spdx")
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for sbom
+      --sbom string                                                                              path to the sbom, or {-} for stdin
+      --type string                                                                              type of sbom (spdx|cyclonedx) (default "spdx")
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -15,12 +15,11 @@ cosign attach signature [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -h, --help                      help for signature
-      --payload string            path to the payload covered by the signature (if using another format)
-      --signature string          the signature, path to the signature, or {-} for stdin
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for signature
+      --payload string                                                                           path to the payload covered by the signature (if using another format)
+      --signature string                                                                         the signature, path to the signature, or {-} for stdin
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -36,22 +36,21 @@ cosign attest [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-      --cert string               path to the x509 certificate to include in the Signature
-  -f, --force                     skip warnings and confirmations
-      --fulcio-url string         [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
-  -h, --help                      help for attest
-      --identity-token string     [EXPERIMENTAL] identity token to use for certificate from fulcio
-      --key string                path to the private key file, KMS URI or Kubernetes Secret
-      --predicate string          path to the predicate file.
-  -r, --recursive                 if a multi-arch image is specified, additionally sign each discrete image
-      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sk                        whether to use a hardware security key
-      --slot string               security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
-      --type string               specify a predicate type (slsaprovenance|link|spdx|custom) or an URI (default "custom")
-      --upload                    whether to upload the signature (default true)
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --cert string                                                                              path to the x509 certificate to include in the Signature
+  -f, --force                                                                                    skip warnings and confirmations
+      --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
+  -h, --help                                                                                     help for attest
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+      --predicate string                                                                         path to the predicate file.
+  -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
+      --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|custom) or an URI (default "custom")
+      --upload                                                                                   whether to upload the signature (default true)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -14,10 +14,9 @@ cosign clean [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -h, --help                      help for clean
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for clean
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -24,12 +24,11 @@ cosign copy [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -f, --force                     overwrite destination image(s), if necessary
-  -h, --help                      help for copy
-      --sig-only                  only copy the image signature
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -f, --force                                                                                    overwrite destination image(s), if necessary
+  -h, --help                                                                                     help for copy
+      --sig-only                                                                                 only copy the image signature
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -52,20 +52,19 @@ cosign dockerfile verify [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -a, --annotations strings       extra key=value pairs to sign
-      --attachment string         related image attachment to sign (sbom), default none
-      --base-image-only           only verify the base image (the last FROM image in the Dockerfile)
-      --cert-email string         the email expected in a valid fulcio cert
-      --check-claims              whether to check the claims found (default true)
-  -h, --help                      help for verify
-      --key string                path to the private key file, KMS URI or Kubernetes Secret
-  -o, --output string             output format for the signing image information (json|text) (default "json")
-      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sk                        whether to use a hardware security key
-      --slot string               security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+  -a, --annotations strings                                                                      extra key=value pairs to sign
+      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --base-image-only                                                                          only verify the base image (the last FROM image in the Dockerfile)
+      --cert-email string                                                                        the email expected in a valid fulcio cert
+      --check-claims                                                                             whether to check the claims found (default true)
+  -h, --help                                                                                     help for verify
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+  -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -15,10 +15,9 @@ cosign download sbom [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -h, --help                      help for sbom
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for sbom
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_download_signature.md
+++ b/doc/cosign_download_signature.md
@@ -15,10 +15,9 @@ cosign download signature [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -h, --help                      help for signature
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for signature
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_generate.md
+++ b/doc/cosign_generate.md
@@ -30,11 +30,10 @@ cosign generate [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -a, --annotations strings       extra key=value pairs to sign
-  -h, --help                      help for generate
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+  -a, --annotations strings                                                                      extra key=value pairs to sign
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for generate
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -47,19 +47,18 @@ cosign manifest verify [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -a, --annotations strings       extra key=value pairs to sign
-      --attachment string         related image attachment to sign (sbom), default none
-      --cert-email string         the email expected in a valid fulcio cert
-      --check-claims              whether to check the claims found (default true)
-  -h, --help                      help for verify
-      --key string                path to the private key file, KMS URI or Kubernetes Secret
-  -o, --output string             output format for the signing image information (json|text) (default "json")
-      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sk                        whether to use a hardware security key
-      --slot string               security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+  -a, --annotations strings                                                                      extra key=value pairs to sign
+      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --cert-email string                                                                        the email expected in a valid fulcio cert
+      --check-claims                                                                             whether to check the claims found (default true)
+  -h, --help                                                                                     help for verify
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+  -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_policy_init.md
+++ b/doc/cosign_policy_init.md
@@ -23,14 +23,13 @@ cosign policy init [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -h, --help                      help for init
-  -m, --maintainers strings       list of maintainers to add to the root policy
-      --namespace string          registry namespace that the root policy belongs to (default "ns")
-      --out string                output policy locally (default "o")
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
-      --threshold int             threshold for root policy signers (default 1)
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for init
+  -m, --maintainers strings                                                                      list of maintainers to add to the root policy
+      --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")
+      --out string                                                                               output policy locally (default "o")
+      --threshold int                                                                            threshold for root policy signers (default 1)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -15,18 +15,17 @@ cosign policy sign [flags]
 ### Options
 
 ```
-      --allow-insecure-registry     whether to allow insecure connections to registries. Don't use this for anything but testing
-      --fulcio-url string           [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
-  -h, --help                        help for sign
-      --identity-token string       [EXPERIMENTAL] identity token to use for certificate from fulcio
-      --namespace string            registry namespace that the root policy belongs to (default "ns")
-      --oidc-client-id string       [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret string   [EXPERIMENTAL] OIDC client secret for application
-      --oidc-issuer string          [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
-      --out string                  output policy locally (default "o")
-      --rekor-url string            [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --tag-prefix string           custom prefix to use for tags
-      --tag-suffix string           custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
+  -h, --help                                                                                     help for sign
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")
+      --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
+      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
+      --out string                                                                               output policy locally (default "o")
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -33,21 +33,20 @@ cosign sign-blob [flags]
 ### Options
 
 ```
-      --allow-insecure-registry     whether to allow insecure connections to registries. Don't use this for anything but testing
-      --b64                         whether to base64 encode the output (default true)
-      --fulcio-url string           [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
-  -h, --help                        help for sign-blob
-      --identity-token string       [EXPERIMENTAL] identity token to use for certificate from fulcio
-      --key string                  path to the private key file, KMS URI or Kubernetes Secret
-      --oidc-client-id string       [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret string   [EXPERIMENTAL] OIDC client secret for application
-      --oidc-issuer string          [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
-      --output string               write the signature to FILE
-      --rekor-url string            [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sk                          whether to use a hardware security key
-      --slot string                 security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string           custom prefix to use for tags
-      --tag-suffix string           custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --b64                                                                                      whether to base64 encode the output (default true)
+      --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
+  -h, --help                                                                                     help for sign-blob
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+      --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
+      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
+      --output string                                                                            write the signature to FILE
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -49,26 +49,25 @@ cosign sign [flags]
 ### Options
 
 ```
-      --allow-insecure-registry     whether to allow insecure connections to registries. Don't use this for anything but testing
-  -a, --annotations strings         extra key=value pairs to sign
-      --attachment string           related image attachment to sign (sbom), default none
-      --cert string                 path to the x509 certificate to include in the Signature
-  -f, --force                       skip warnings and confirmations
-      --fulcio-url string           [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
-  -h, --help                        help for sign
-      --identity-token string       [EXPERIMENTAL] identity token to use for certificate from fulcio
-      --key string                  path to the private key file, KMS URI or Kubernetes Secret
-      --oidc-client-id string       [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret string   [EXPERIMENTAL] OIDC client secret for application
-      --oidc-issuer string          [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
-      --payload string              path to a payload file to use rather than generating one
-  -r, --recursive                   if a multi-arch image is specified, additionally sign each discrete image
-      --rekor-url string            [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sk                          whether to use a hardware security key
-      --slot string                 security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string           custom prefix to use for tags
-      --tag-suffix string           custom suffix to use for tags
-      --upload                      whether to upload the signature (default true)
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+  -a, --annotations strings                                                                      extra key=value pairs to sign
+      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --cert string                                                                              path to the x509 certificate to include in the Signature
+  -f, --force                                                                                    skip warnings and confirmations
+      --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
+  -h, --help                                                                                     help for sign
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+      --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
+      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
+      --payload string                                                                           path to a payload file to use rather than generating one
+  -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
+      --upload                                                                                   whether to upload the signature (default true)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -14,11 +14,10 @@ cosign triangulate [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -h, --help                      help for triangulate
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
-      --type string               related attachment to triangulate (attestation|sbom|signature), default signature (default "signature")
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for triangulate
+      --type string                                                                              related attachment to triangulate (attestation|sbom|signature), default signature (default "signature")
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_upload_blob.md
+++ b/doc/cosign_upload_blob.md
@@ -27,12 +27,11 @@ cosign upload blob [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-      --ct string                 content type to set
-  -f, --files strings             <filepath>:[platform/arch]
-  -h, --help                      help for blob
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --ct string                                                                                content type to set
+  -f, --files strings                                                                            <filepath>:[platform/arch]
+  -h, --help                                                                                     help for blob
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_upload_wasm.md
+++ b/doc/cosign_upload_wasm.md
@@ -15,11 +15,10 @@ cosign upload wasm [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -f, --file string               path to the wasm file to upload
-  -h, --help                      help for wasm
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -f, --file string                                                                              path to the wasm file to upload
+  -h, --help                                                                                     help for wasm
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -44,18 +44,17 @@ cosign verify-attestation [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-      --check-claims              whether to check the claims found (default true)
-      --fulcio-url string         [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
-  -h, --help                      help for verify-attestation
-      --identity-token string     [EXPERIMENTAL] identity token to use for certificate from fulcio
-      --key string                path to the private key file, KMS URI or Kubernetes Secret
-  -o, --output string             output format for the signing image information (json|text) (default "json")
-      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sk                        whether to use a hardware security key
-      --slot string               security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --check-claims                                                                             whether to check the claims found (default true)
+      --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
+  -h, --help                                                                                     help for verify-attestation
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+  -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -51,16 +51,15 @@ cosign verify-blob [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-      --cert string               path to the public certificate
-  -h, --help                      help for verify-blob
-      --key string                path to the private key file, KMS URI or Kubernetes Secret
-      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --signature string          signature content or path or remote URL
-      --sk                        whether to use a hardware security key
-      --slot string               security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --cert string                                                                              path to the public certificate
+  -h, --help                                                                                     help for verify-blob
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --signature string                                                                         signature content or path or remote URL
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -47,19 +47,18 @@ cosign verify [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries. Don't use this for anything but testing
-  -a, --annotations strings       extra key=value pairs to sign
-      --attachment string         related image attachment to sign (sbom), default none
-      --cert-email string         the email expected in a valid fulcio cert
-      --check-claims              whether to check the claims found (default true)
-  -h, --help                      help for verify
-      --key string                path to the private key file, KMS URI or Kubernetes Secret
-  -o, --output string             output format for the signing image information (json|text) (default "json")
-      --rekor-url string          [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --sk                        whether to use a hardware security key
-      --slot string               security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --tag-prefix string         custom prefix to use for tags
-      --tag-suffix string         custom suffix to use for tags
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+  -a, --annotations strings                                                                      extra key=value pairs to sign
+      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --cert-email string                                                                        the email expected in a valid fulcio cert
+      --check-claims                                                                             whether to check the claims found (default true)
+  -h, --help                                                                                     help for verify
+      --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+  -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
+      --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sk                                                                                       whether to use a hardware security key
+      --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/oci/remote/options.go
+++ b/pkg/oci/remote/options.go
@@ -89,18 +89,6 @@ func WithPrefix(prefix string) Option {
 	}
 }
 
-// WithSuffix is a functional option for overriding the default
-// tag suffix.
-func WithSuffix(suffix string) Option {
-	return func(o *options) {
-		if suffix != "" {
-			o.SignatureSuffix = suffix
-			o.AttestationSuffix = suffix
-			o.SBOMSuffix = suffix
-		}
-	}
-}
-
 // WithSignatureSuffix is a functional option for overriding the default
 // signature tag suffix.
 func WithSignatureSuffix(suffix string) Option {


### PR DESCRIPTION
We don't have a use-case for a blanket override of tag suffixes, so eliminated `ociremote.WithSuffix` for now.
