### PR TITLE
fix `x509: unsupported public key type: *crypto.PublicKey`

### DIFF
--- a/pkg/cosign/pivkey/pivkey.go
+++ b/pkg/cosign/pivkey/pivkey.go
@@ -214,7 +214,7 @@ func (k *Key) Verifier() (signature.Verifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	k.Pub = (*crypto.PublicKey)(&cert.PublicKey)
+	k.Pub = cert.PublicKey
 
 	return k, nil
 }
@@ -241,7 +241,7 @@ func (k *Key) SignerVerifier() (signature.SignerVerifier, error) {
 	if err != nil {
 		return nil, err
 	}
-	k.Pub = (*crypto.PublicKey)(&cert.PublicKey)
+	k.Pub = cert.PublicKey
 
 	var auth piv.KeyAuth
 	if k.pin == "" {


### PR DESCRIPTION
https://pkg.go.dev/crypto#PublicKey
`type PublicKey interface{}` 😢

```release-note
Bugfix: `cosign public-key -sk` causing  `error: x509: unsupported public key type: *crypto.PublicKey`
```
