### PR TITLE
Remove the preallocation of signatures slice.

### DIFF
--- a/pkg/cosign/tuf/policy.go
+++ b/pkg/cosign/tuf/policy.go
@@ -174,7 +174,7 @@ func (s *Signed) AddOrUpdateSignature(signature Signature) error {
 	if !root.ValidKey(signature.KeyID, "root") {
 		return errors.New("invalid root key")
 	}
-	signatures := make([]Signature, 0, len(s.Signatures)+1)
+	signatures := []Signature{}
 	for _, sig := range s.Signatures {
 		if sig.KeyID != signature.KeyID {
 			signatures = append(signatures, sig)


### PR DESCRIPTION
This was making codeql upset. I don't think there's a real issue, but better safe
than sorry.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
