### PR TITLE
cosigned: add image name to the error messages when having an invalid signature

### DIFF
--- a/pkg/cosign/kubernetes/webhook/validator.go
+++ b/pkg/cosign/kubernetes/webhook/validator.go
@@ -105,7 +105,9 @@ func (v *Validator) validatePodSpec(ctx context.Context, ps *corev1.PodSpec) (er
 			}
 
 			if !valid(ctx, ref, keys) {
-				errs = errs.Also(apis.ErrGeneric("invalid image signature", "image").ViaFieldIndex(field, i))
+				errorField := apis.ErrGeneric("invalid image signature", "image").ViaFieldIndex(field, i)
+				errorField.Details = c.Image
+				errs = errs.Also(errorField)
 				continue
 			}
 		}

--- a/pkg/cosign/kubernetes/webhook/validator_test.go
+++ b/pkg/cosign/kubernetes/webhook/validator_test.go
@@ -139,6 +139,7 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 		want: &apis.FieldError{
 			Message: `invalid image signature`,
 			Paths:   []string{"containers[0].image"},
+			Details: digest.String(),
 		},
 		cvs: fail,
 	}}
@@ -330,6 +331,7 @@ func TestValidateCronJob(t *testing.T) {
 		want: &apis.FieldError{
 			Message: `invalid image signature`,
 			Paths:   []string{"spec.jobTemplate.spec.template.spec.containers[0].image"},
+			Details: digest.String(),
 		},
 		cvs: fail,
 	}}


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

```
invalid image signature: spec.jobTemplate.spec.template.spec.containers[0].image
            gcr.io/distroless/static:nonroot@sha256:be5d77c62dbe7fedfb0a4e5ec2f91078080800ab1f18358e5f31fcc8faa023c4
 ```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

closes https://github.com/sigstore/cosign/issues/873

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Include image name on cosigned rejections
```
