### PR TITLE
[cosign] Disable usage on errors

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -33,6 +33,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "cosign",
 		DisableAutoGenTag: true,
+		SilenceUsage:      true, // Don't show usage on errors
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if ro.OutputFile != "" {
 				out, err := os.Create(ro.OutputFile)


### PR DESCRIPTION
#### Summary

Tell cobra to not output usage on errors. 

#### Ticket Link
Fixes https://github.com/sigstore/cosign/issues/874

#### Release Note
```release-note
None.
```
