### PR TITLE
fix: safer way to install google/ko

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,9 +39,7 @@ jobs:
       #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: install ko
         run: |
-          curl -L https://github.com/google/ko/releases/download/v${{ env.KO_VERSION }}/ko_${{ env.KO_VERSION }}_Linux_x86_64.tar.gz | tar xzf - ko && \
-          chmod +x ./ko && sudo mv ko /usr/local/bin/
-
+          GOBIN=/usr/local/bin go install github.com/google/ko@v${{ .Env.KO_VERSION }}
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -43,6 +43,7 @@ jobs:
       INSECURE_REGISTRY_NAME: insecure-registry.notlocal
       INSECURE_REGISTRY_PORT: 5001
       KO_DOCKER_REPO: registry.local:5000/cosigned
+      KO_VERSION: 0.9.3
 
     steps:
     - name: Set up Go 1.16.x
@@ -50,18 +51,11 @@ jobs:
       with:
         go-version: 1.16.x
 
-    - name: Install Dependencies
-      working-directory: ./
-      run: |
-        echo '::group:: install ko'
-        curl -L https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_Linux_x86_64.tar.gz | tar xzf - ko
-        chmod +x ./ko
-        sudo mv ko /usr/local/bin
-        echo '::endgroup::'
+    - name: Install ko
+      run: GOBIN=/usr/local/bin go install github.com/google/ko@v${{ .Env.KO_VERSION }}
 
-        echo '::group:: install yq'
-        go get github.com/mikefarah/yq/v4
-        echo '::endgroup::'
+    - name: Install yq
+      uses: mikefarah/yq@master
 
     - name: Check out code onto GOPATH
       uses: actions/checkout@v2
@@ -177,12 +171,12 @@ jobs:
 
         # Wait for the webhook to come up and become Ready
         kubectl rollout status --timeout 5m --namespace cosign-system deployments/webhook
-    
+
     - name: Run Insecure Registry Tests
       run: |
         go install github.com/google/go-containerregistry/cmd/crane
         ./test/e2e_test_insecure_registry.sh
-    
+
     - name: Run Cosigned Tests
       run: |
         ./test/e2e_test_cosigned.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,6 +25,9 @@ jobs:
   unit-tests:
     name: Run tests
     runs-on: ubuntu-latest
+    env:
+      KO_VERSION: 0.9.3
+
 
     steps:
       - uses: actions/checkout@v2
@@ -48,9 +51,7 @@ jobs:
         with:
           go-version: '1.17.x'
       - name: install ko
-        run: |
-          curl -L https://github.com/google/ko/releases/download/v0.8.3/ko_0.8.3_Linux_x86_64.tar.gz | tar xzf - ko && \
-          chmod +x ./ko && sudo mv ko /usr/local/bin/
+        run: GOBIN=/usr/local/bin go install github.com/google/ko@v${{ .Env.KO_VERSION }}
       - name: setup kind cluster
         run: |
           go install sigs.k8s.io/kind@v0.11.1


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

we can use the `go install` with the `GOBIN` option to install ko under `/usr/local/bin` safelly.

QA Test Steps:

```shell
$ GOOGLE_KO_DIR=$(pwd)/bin 
$ GOOGLE_KO_BIN=$GOOGLE_KO_DIR/ko
$ GOBIN=$(GOOGLE_KO_BIN) go install github.com/google/ko@v0.9.3
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #888 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
fix: safer way to install google/ko
```
