### PR TITLE
fix(ci): do not need to set no_unique_dist_dir

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -55,9 +55,9 @@ jobs:
 
       - name: check binaries
         run: |
-          ./dist/cosign-linux-amd64 version
-          ./dist/cosigned-linux-amd64 --help
-          ./dist/sget-linux-amd64 --help
+          ./dist/cosign-linux-amd64/cosign version
+          ./dist/cosigned-linux-amd64/cosigned --help
+          ./dist/sget-linux-amd64/sget --help
 
       - name: check images
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -217,7 +217,7 @@ docker_signs:
 
 archives:
 - format: binary
-  name_template: "{{ .Binary }}-{{ .OS }}-{{ .Arch }}"
+  name_template: "{{ .Binary }}-{{ .Os }}-{{ .Arch }}"
   allow_different_binary_count: true
 
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ before:
 
 builds:
 - id: linux
-  binary: cosign-linux-{{ .Arch }}
+  binary: cosign
   main: ./cmd/cosign
   goos:
     - linux
@@ -24,7 +24,7 @@ builds:
     - CGO_ENABLED=0
 
 - id: linux-pivkey-amd64
-  binary: cosign-linux-pivkey-amd64
+  binary: cosign-pivkey
   main: ./cmd/cosign
   goos:
     - linux
@@ -42,7 +42,7 @@ builds:
     - PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/"
 
 - id: darwin-amd64
-  binary: cosign-darwin-amd64
+  binary: cosign
   env:
     - CC=o64-clang
     - CXX=o64-clang++
@@ -57,7 +57,7 @@ builds:
     - pivkey
 
 - id: darwin-arm64
-  binary: cosign-darwin-arm64
+  binary: cosign
   env:
     - CC=aarch64-apple-darwin20.2-clang
     - CXX=aarch64-apple-darwin20.2-clang++
@@ -72,7 +72,7 @@ builds:
     - "{{.Env.LDFLAGS}}"
 
 - id: windows-amd64
-  binary: cosign-windows-amd64
+  binary: cosign
   env:
     - CC=x86_64-w64-mingw32-gcc
     - CXX=x86_64-w64-mingw32-g++
@@ -88,7 +88,7 @@ builds:
     - pivkey
 
 - id: linux-cosigned
-  binary: cosigned-linux-{{ .Arch }}
+  binary: cosigned
   main: ./cmd/cosign/webhook
   goos:
     - linux
@@ -101,7 +101,7 @@ builds:
     - CGO_ENABLED=0
 
 - id: sget
-  binary: sget-{{ .Os }}-{{ .Arch }}
+  binary: sget
   main: ./cmd/sget
   goos:
     - linux
@@ -217,7 +217,7 @@ docker_signs:
 
 archives:
 - format: binary
-  name_template: "{{ .Binary }}"
+  name_template: "{{ .Binary }}-{{ .OS }}-{{ .Arch }}"
   allow_different_binary_count: true
 
 checksum:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,7 +12,6 @@ before:
 builds:
 - id: linux
   binary: cosign-linux-{{ .Arch }}
-  no_unique_dist_dir: true
   main: ./cmd/cosign
   goos:
     - linux
@@ -44,7 +43,6 @@ builds:
 
 - id: darwin-amd64
   binary: cosign-darwin-amd64
-  no_unique_dist_dir: true
   env:
     - CC=o64-clang
     - CXX=o64-clang++
@@ -60,7 +58,6 @@ builds:
 
 - id: darwin-arm64
   binary: cosign-darwin-arm64
-  no_unique_dist_dir: true
   env:
     - CC=aarch64-apple-darwin20.2-clang
     - CXX=aarch64-apple-darwin20.2-clang++
@@ -76,7 +73,6 @@ builds:
 
 - id: windows-amd64
   binary: cosign-windows-amd64
-  no_unique_dist_dir: true
   env:
     - CC=x86_64-w64-mingw32-gcc
     - CXX=x86_64-w64-mingw32-g++
@@ -93,7 +89,6 @@ builds:
 
 - id: linux-cosigned
   binary: cosigned-linux-{{ .Arch }}
-  no_unique_dist_dir: true
   main: ./cmd/cosign/webhook
   goos:
     - linux
@@ -107,7 +102,6 @@ builds:
 
 - id: sget
   binary: sget-{{ .Os }}-{{ .Arch }}
-  no_unique_dist_dir: true
   main: ./cmd/sget
   goos:
     - linux

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -148,7 +148,6 @@ dockers:
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=amd64"
   - image_templates:
       - "ghcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-arm64v8"
     use: buildx
@@ -157,7 +156,6 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=arm64"
 
   # cosigned Image
   - image_templates:
@@ -167,7 +165,6 @@ dockers:
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=amd64"
   - image_templates:
       - "ghcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-arm64v8"
     use: buildx
@@ -176,7 +173,6 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=arm64"
 
   # sget Image
   - image_templates:
@@ -186,7 +182,6 @@ dockers:
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=amd64"
   - image_templates:
       - "ghcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8"
     use: buildx
@@ -195,7 +190,6 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64/v8"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=arm64"
 
 docker_manifests:
   - name_template: ghcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
 
 FROM $RUNTIME_IMAGE
 
-ARG ARCH
-COPY cosign-linux-${ARCH} /bin/cosign
+COPY cosign /bin/cosign
 
 USER nobody
 ENTRYPOINT [ "/bin/cosign" ]

--- a/Dockerfile.cosigned
+++ b/Dockerfile.cosigned
@@ -16,8 +16,7 @@ ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
 
 FROM $RUNTIME_IMAGE
 
-ARG ARCH
-COPY cosigned-linux-${ARCH} /bin/cosigned
+COPY cosigned /bin/cosigned
 
 USER nobody
 ENTRYPOINT [ "/bin/cosigned" ]

--- a/Dockerfile.sget
+++ b/Dockerfile.sget
@@ -16,8 +16,7 @@ ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
 
 FROM $RUNTIME_IMAGE
 
-ARG ARCH
-COPY sget-linux-${ARCH} /bin/sget
+COPY sget /bin/sget
 
 USER nobody
 ENTRYPOINT [ "/bin/sget" ]


### PR DESCRIPTION

#### Summary

Its not really needed to set `no_unique_dist_dir`.
Also simplified the binary naming, with `no_unique_dist_dir: false`, goreleaser auto-creates an unique dir inside dist for each binary, and the archive config handles the "renaming" when uploading to github.

#### Ticket Link

as discussed in https://github.com/sigstore/cosign/pull/854#issuecomment-942841712

#### Release Note

```release-note

```
