### PR TITLE
Pin crane dependency used in e2e tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -37,6 +37,6 @@ jobs:
           service_account_key: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
           export_default_credentials: true
       - run: |
-          go install github.com/google/go-containerregistry/cmd/crane
+          go install github.com/google/go-containerregistry/cmd/crane@v0.6.0
           gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
           ./test/e2e_test_secrets.sh


### PR DESCRIPTION
#### Summary

`go install` without a version specified installs the latest semver release of the tool. This means that a compromise of the go-containerregistry repo could result in arbitrary code running in this workflow, e.g., when e2e tests invoke `crane ls`.

With a version specified, even if the repo moves the `v0.6.0` tag to another commit, the Go module proxy will serve the previous v0.6.0 code.

v0.6.0 is the latest release of crane: https://github.com/google/go-containerregistry/releases

Signed-off-by: Jason Hall <jasonhall@redhat.com>

#### Release Note

```release-note
NONE
```