### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -1,16 +1,24 @@
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Cosigned KinD E2E
 
 on:
   pull_request:
     branches: [ 'main', 'release-*' ]
 
-defaults:
-  run:
-    shell: bash
-    working-directory: ./src/github.com/sigstore/cosign
-
 jobs:
-
   e2e-tests:
     name: e2e tests
     runs-on: ubuntu-latest
@@ -35,7 +43,6 @@ jobs:
           cluster-suffix: c${{ github.run_id }}.local
 
     env:
-      GOPATH: ${{ github.workspace }}
       # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for
       # '*.local' hostnames.
       REGISTRY_NAME: registry.local
@@ -46,21 +53,16 @@ jobs:
       KO_VERSION: 0.9.3
 
     steps:
-    - name: Set up Go 1.16.x
-      uses: actions/setup-go@v2
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
       with:
-        go-version: 1.16.x
+        go-version: 1.17.x
 
     - name: Install ko
-      run: GOBIN=/usr/local/bin go install github.com/google/ko@v${{ .Env.KO_VERSION }}
+      run: go install github.com/google/ko@v${KO_VERSION}
 
     - name: Install yq
       uses: mikefarah/yq@master
-
-    - name: Check out code onto GOPATH
-      uses: actions/checkout@v2
-      with:
-        path: ./src/github.com/sigstore/cosign
 
     - name: Install Cosign
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,3 @@
-#
 # Copyright 2021 The Sigstore Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +27,6 @@ jobs:
     env:
       KO_VERSION: 0.9.3
 
-
     steps:
       - uses: actions/checkout@v2
       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
@@ -51,7 +49,7 @@ jobs:
         with:
           go-version: '1.17.x'
       - name: install ko
-        run: GOBIN=/usr/local/bin go install github.com/google/ko@v${{ .Env.KO_VERSION }}
+        run: go install github.com/google/ko@v${KO_VERSION}
       - name: setup kind cluster
         run: |
           go install sigs.k8s.io/kind@v0.11.1


### PR DESCRIPTION
The ${{ Env.KO_VERSION }} placeholder appears to be invalid. Instead,
just reference the environment variable normally.

Signed-off-by: Jason Hall <jasonhall@redhat.com>


#### Release Note

```release-note
NONE
```