### PR TITLE
Add a test/example for signing using GitHub OIDC

### DIFF
--- a/.github/workflows/github-oidc.yaml
+++ b/.github/workflows/github-oidc.yaml
@@ -1,0 +1,52 @@
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test GitHub OIDC
+on:
+  push:
+    branches: [ 'main', 'release-*' ]
+  schedule:
+    - cron: '0 1 * * *' # 1AM UTC
+  workflow_dispatch:
+
+jobs:
+  build:
+    permissions:
+      id-token: write
+      packages: write
+      contents: read
+    env:
+      COSIGN_EXPERIMENTAL: "true"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.x'
+      - uses: sigstore/cosign-installer@main
+
+      - name: Build and sign a container image
+        env:
+          KO_DOCKER_REPO: ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+        run: |
+          set -e
+
+          # Install ko
+          go install github.com/google/ko@v0.9.3
+
+          # Login to ghcr.io
+          echo ${{ github.token }} | ko login ghcr.io --username=${{ github.repository_owner }} --password-stdin
+
+          # Setup ko, publish an image and sign it.
+          cosign sign $(ko publish --preserve-import-paths ./cmd/cosign)


### PR DESCRIPTION
This demonstrates building a container image consisting of a Go binary
(cmd/cosign in this case), pushing it to a registry, and signing it
using ambient GitHub OIDC credentials available in the GitHub Actions
build environment.

This should serve as a runnable/forkable demo, and also a test to guard
against breakages.

Because permission to push packages is not available to workflow runs
started by PRs, this action runs on pushes to main, and on a nightly
basis.

Signed-off-by: Jason Hall <jasonhall@redhat.com>

#### Release Note

```release-note
NONE
```

cc @mattmoor 