### PR TITLE
Sign without pulling from the registry

### DIFF
--- a/pkg/oci/empty/signed.go
+++ b/pkg/oci/empty/signed.go
@@ -1,0 +1,65 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package empty
+
+import (
+	"fmt"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/sigstore/cosign/pkg/oci"
+)
+
+type signedImage struct {
+	v1.Image
+	digest       v1.Hash
+	signature    oci.Signatures
+	attestations oci.Signatures
+}
+
+func (se *signedImage) Signatures() (oci.Signatures, error) {
+	return se.signature, nil
+}
+
+func (se *signedImage) Attestations() (oci.Signatures, error) {
+	return se.attestations, nil
+}
+
+func (se *signedImage) Digest() (v1.Hash, error) {
+	if se.digest.Hex == "" {
+		return v1.Hash{}, fmt.Errorf("digest not available")
+	}
+	return se.digest, nil
+}
+
+func SignedImage(ref name.Reference) (oci.SignedImage, error) {
+	var err error
+	d := v1.Hash{}
+	base := empty.Image
+	if digest, ok := ref.(name.Digest); ok {
+		d, err = v1.NewHash(digest.DigestStr())
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &signedImage{
+		Image:        base,
+		digest:       d,
+		signature:    Signatures(),
+		attestations: Signatures(),
+	}, nil
+}

--- a/pkg/oci/empty/signed_test.go
+++ b/pkg/oci/empty/signed_test.go
@@ -1,0 +1,68 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package empty
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func TestSignedImage(t *testing.T) {
+	tests := []struct {
+		ref       string
+		digestStr string
+		digestErr string
+	}{
+		{
+			ref:       "hello-world:latest",
+			digestErr: "digest not available",
+		},
+		{
+			ref:       "hello-world@sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
+			digestStr: "sha256:e1c082e3d3c45cccac829840a25941e679c25d438cc8412c2fa221cf1a824e6a",
+		},
+	}
+	for _, test := range tests {
+		ref, err := name.ParseReference(test.ref)
+		if err != nil {
+			t.Errorf("failed to parse ref \"%s\": %v", test.ref, err)
+			continue
+		}
+		se, err := SignedImage(ref)
+		if err != nil {
+			t.Errorf("failed to create signed image for \"%s\": %v", test.ref, err)
+			continue
+		}
+		d, err := se.Digest()
+		if (err == nil && test.digestErr != "") ||
+			(err != nil && test.digestErr == "") ||
+			(err != nil && test.digestErr != "" && err.Error() != test.digestErr) {
+			t.Errorf("digest error mismatch for \"%s\": expected %s, saw %v", test.ref, test.digestErr, err)
+		}
+		if test.digestStr != "" && d.String() != test.digestStr {
+			t.Errorf("digest mismatch for \"%s\": expected %s, saw %s", test.ref, test.digestStr, d.String())
+		}
+		_, err = se.Signatures()
+		if err != nil {
+			t.Errorf("failed to get signatures for %s: %v", test.ref, err)
+		}
+		_, err = se.Attestations()
+		if err != nil {
+			t.Errorf("failed to get attestations for %s: %v", test.ref, err)
+		}
+	}
+}


### PR DESCRIPTION
This allows signing in a disconnected environment.

Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

This skips registry queries when the reference provided includes the digest and it does not need to recursively resolve an Index or resolve the SBOM digest. The result is the ability to sign images in a disconnected environment without direct access to the registry, or to sign images before they are pushed to the registry (if the digest can be calculated in advance).

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
This is handling issues similar to #596 when you know the digest (but doesn't handle situations when you don't know the digest).

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Do not query the registry when a digest is provided in the reference to sign.
```
