### PR TITLE
Replace predicate file path with io.Reader

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -89,11 +89,17 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 	dd := cremote.NewDupeDetector(sv)
 
 	fmt.Fprintln(os.Stderr, "Using payload from:", predicatePath)
+	predicate, err := os.Open(predicatePath)
+	if err != nil {
+		return err
+	}
+	defer predicate.Close()
+
 	sh, err := attestation.GenerateStatement(attestation.GenerateOpts{
-		Path:   predicatePath,
-		Type:   predicateType,
-		Digest: h.Hex,
-		Repo:   digest.Repository.String(),
+		Predicate: predicate,
+		Type:      predicateType,
+		Digest:    h.Hex,
+		Repo:      digest.Repository.String(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Per a discussion with @dekkagaijin, this PR makes an incremental change to help consumers of cosign's attestation functions, specifically by allowing the caller of `attestation.GenerateStatement` to provide **any** `io.Reader` implementation  as the statement's predicate, rather than having the caller provide a file _path_. This allows consumers to control the source of the predicate bytes, which is particularly valuable for non-file predicate sources, such as bytes existing only in memory.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
(Takes one step forward on sigstore/cosign#844)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```