### PR TITLE
Add the OIDC options to `AttestOptions`.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -57,13 +57,16 @@ func Attest() *cobra.Command {
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ko := sign.KeyOpts{
-				KeyRef:    o.Key,
-				PassFunc:  generate.GetPass,
-				Sk:        o.SecurityKey.Use,
-				Slot:      o.SecurityKey.Slot,
-				IDToken:   o.Fulcio.IdentityToken,
-				RekorURL:  o.Rekor.URL,
-				FulcioURL: o.Fulcio.URL,
+				KeyRef:           o.Key,
+				PassFunc:         generate.GetPass,
+				Sk:               o.SecurityKey.Use,
+				Slot:             o.SecurityKey.Slot,
+				FulcioURL:        o.Fulcio.URL,
+				IDToken:          o.Fulcio.IdentityToken,
+				RekorURL:         o.Rekor.URL,
+				OIDCIssuer:       o.OIDC.Issuer,
+				OIDCClientID:     o.OIDC.ClientID,
+				OIDCClientSecret: o.OIDC.ClientSecret,
 			}
 			for _, img := range args {
 				if err := attest.AttestCmd(cmd.Context(), ko, o.Registry, img, o.Cert, o.Upload, o.Predicate.Path, o.Force, o.Predicate.Type); err != nil {

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -29,6 +29,7 @@ type AttestOptions struct {
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
+	OIDC        OIDCOptions
 	SecurityKey SecurityKeyOptions
 	Predicate   PredicateLocalOptions
 	Registry    RegistryOptions
@@ -41,6 +42,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 	o.SecurityKey.AddFlags(cmd)
 	o.Predicate.AddFlags(cmd)
 	o.Fulcio.AddFlags(cmd)
+	o.OIDC.AddFlags(cmd)
 	o.Rekor.AddFlags(cmd)
 	o.Registry.AddFlags(cmd)
 

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -24,17 +24,15 @@ type SignOptions struct {
 	Key         string
 	Cert        string
 	Upload      bool
-	SecurityKey SecurityKeyOptions
 	PayloadPath string
 	Force       bool
 	Recursive   bool
+	Attachment  string
 
-	Fulcio FulcioOptions
-	Rekor  RekorOptions
-
-	OIDC       OIDCOptions
-	Attachment string
-
+	Rekor       RekorOptions
+	Fulcio      FulcioOptions
+	OIDC        OIDCOptions
+	SecurityKey SecurityKeyOptions
 	AnnotationOptions
 	Registry RegistryOptions
 }

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -44,6 +44,9 @@ cosign attest [flags]
   -h, --help                                                                                     help for attest
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+      --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
+      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --predicate string                                                                         path to the predicate file.
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")


### PR DESCRIPTION
Without this, I get the following (back to 1.0):
```
Error: signing gcr.io/mattmoor-credit/sbom@sha256:faef0ba9f497e26509d9f72f9ece7016b0e36edcb34ea3d3afe04f4bb2b01c5d: getting signer: getting key from Fulcio: retrieving cert: Get "/.well-known/openid-configuration": unsupported protocol scheme ""
main.go:48: error during command execution: signing gcr.io/mattmoor-credit/sbom@sha256:faef0ba9f497e26509d9f72f9ece7016b0e36edcb34ea3d3afe04f4bb2b01c5d: getting signer: getting key from Fulcio: retrieving cert: Get "/.well-known/openid-configuration": unsupported protocol scheme ""
exit status 1
```

With this change, it gets further, but there are still issues:

```
Error: signing gcr.io/mattmoor-credit/sbom@sha256:faef0ba9f497e26509d9f72f9ece7016b0e36edcb34ea3d3afe04f4bb2b01c5d: [POST /api/v1/log/entries][400] createLogEntryBadRequest  &{Code:400 Message:Error processing entry: unsupported public key type}
main.go:48: error during command execution: signing gcr.io/mattmoor-credit/sbom@sha256:faef0ba9f497e26509d9f72f9ece7016b0e36edcb34ea3d3afe04f4bb2b01c5d: [POST /api/v1/log/entries][400] createLogEntryBadRequest  &{Code:400 Message:Error processing entry: unsupported public key type}
exit status 1
```

Signed-off-by: Matt Moore <mattomata@gmail.com>



#### Release Note
```release-note
NONE
```
