### PR TITLE
Hook up k8schain to verification.

### DIFF
--- a/pkg/cosign/kubernetes/webhook/validator_test.go
+++ b/pkg/cosign/kubernetes/webhook/validator_test.go
@@ -65,6 +65,13 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 		},
 	})
 
+	kc := fakekube.Get(ctx)
+	kc.CoreV1().ServiceAccounts("default").Create(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}, metav1.CreateOptions{})
+
 	v := NewValidator(ctx, secretName)
 
 	cvs := cosignVerifySignatures
@@ -149,7 +156,7 @@ UoJou2P8sbDxpLiE/v3yLw1/jyOrCPWYHWFXnyyeGlkgSVefG54tNoK7Uw==
 			cosignVerifySignatures = test.cvs
 
 			// Check the core mechanics
-			got := v.validatePodSpec(context.Background(), test.ps)
+			got := v.validatePodSpec(context.Background(), test.ps, k8schain.Options{})
 			if (got != nil) != (test.want != nil) {
 				t.Errorf("validatePodSpec() = %v, wanted %v", got, test.want)
 			} else if got != nil && got.Error() != test.want.Error() {
@@ -216,6 +223,13 @@ func TestValidateCronJob(t *testing.T) {
 			// No data should make us verify against Fulcio.
 		},
 	})
+
+	kc := fakekube.Get(ctx)
+	kc.CoreV1().ServiceAccounts("default").Create(ctx, &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "default",
+		},
+	}, metav1.CreateOptions{})
 
 	v := NewValidator(ctx, secretName)
 


### PR DESCRIPTION
This wires up k8schain to the verification path, in addition to the resolution path.

I was beating my head against the well wondering why my GKE identity configuration was wrong, but it was fine.  It wasn't using it because it was using the default keychain instead of k8schain!

Signed-off-by: Matt Moore <mattomata@gmail.com>


#### Ticket Link


#### Release Note
```release-note
Fixes the verification webhook to work properly with private images using k8schain.
```
