### PR TITLE
fix issue 919

### DIFF
--- a/pkg/oci/interface.go
+++ b/pkg/oci/interface.go
@@ -22,6 +22,8 @@ type SignedEntity interface {
 
 	// Attestations returns the set of attestations currently associated with this
 	// entity, or the empty equivalent if none are found.
+	// Attestations are just like a Signature, but they do not contain
+	// Base64Signature because it's baked into the payload.
 	Attestations() (Signatures, error)
 
 	// Attachment returns a named entity associated with this entity, or error if not found.

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -49,6 +49,9 @@ func NewSignature(payload []byte, b64sig string, opts ...Option) (oci.Signature,
 }
 
 // NewAttestation constructs a new oci.Signature from the provided options.
+// Since Attestation is treated just like a Signature but the actual signature
+// is baked into the payload, the Signature does not actually have
+// the Base64Signature.
 func NewAttestation(payload []byte, opts ...Option) (oci.Signature, error) {
 	return NewSignature(payload, "", opts...)
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
Closes #919 
There were couple of issues going on here from what I can tell. One was the actual nil deref, but the other one and seemingly a bigger one was that for Attestations, the signature (at least for keyless case) was always failing because it was using the same codepath for both Signature / Attestation even though they have a different set of assumptions.

I added couple of comments to a few places that I think might have been helpful because lack of them led me a bit astray.

<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #919 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fix verify-attestations for keyless verify-attestation 
```
