### PR TITLE
Return k8schain error.

### DIFF
--- a/pkg/cosign/kubernetes/webhook/validator.go
+++ b/pkg/cosign/kubernetes/webhook/validator.go
@@ -107,7 +107,7 @@ func (v *Validator) validatePodSpec(ctx context.Context, ps *corev1.PodSpec, opt
 	kc, err := k8schain.New(ctx, v.client, opt)
 	if err != nil {
 		logging.FromContext(ctx).Warnf("Unable to build k8schain: %v", err)
-		return
+		return apis.ErrGeneric(err.Error(), apis.CurrentField)
 	}
 
 	s, err := v.lister.Secrets(system.Namespace()).Get(v.secretName)


### PR DESCRIPTION
The k8schain error path wasn't returning the error!  This means that when k8schain is improperly configured, images will be let through.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Release Note
```release-note

```
