### PR TITLE
cmd/policy: ability to pass expire days

### DIFF
--- a/cmd/cosign/cli/options/policy.go
+++ b/cmd/cosign/cli/options/policy.go
@@ -24,6 +24,7 @@ type PolicyInitOptions struct {
 	ImageRef    string
 	Maintainers []string
 	Threshold   int
+	Expires     int
 	OutFile     string
 	Registry    RegistryOptions
 }
@@ -43,6 +44,9 @@ func (o *PolicyInitOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringSliceVarP(&o.Maintainers, "maintainers", "m", nil,
 		"list of maintainers to add to the root policy")
+
+	cmd.Flags().IntVar(&o.Expires, "expires", 0,
+		"total expire duration in days")
 
 	o.Registry.AddFlags(cmd)
 }

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -113,6 +114,10 @@ func initPolicy() *cobra.Command {
 			role.AddKeysWithThreshold(publicKeys, o.Threshold)
 			root.Roles["root"] = role
 			root.Namespace = o.ImageRef
+
+			if o.Expires > 0 {
+				root.Expires = time.Now().AddDate(0, 0, o.Expires).UTC().Round(time.Second)
+			}
 
 			policy, err := root.Marshal()
 			if err != nil {

--- a/doc/cosign_policy_init.md
+++ b/doc/cosign_policy_init.md
@@ -25,6 +25,7 @@ cosign policy init [flags]
 ```
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --expires int                                                                              total expire duration in days
   -h, --help                                                                                     help for init
   -m, --maintainers strings                                                                      list of maintainers to add to the root policy
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

#### Summary

Just noticed that we have the following [usage example](https://github.com/sigstore/cosign/blob/9e304d1486c0c8ecfc08ce3f775a88868d0a4356/cmd/cosign/cli/policy_init.go#L83):
```
# extract public key from private key to a specified out file.
  cosign policy init -ns <project_namespace> --maintainers {email_addresses} --threshold <int> --expires <int>(days)
```

I was passed `--expires 7` flag, and it seems does not work as expected: _(It adds [3 months by default](https://github.com/sigstore/cosign/blob/9e304d1486c0c8ecfc08ce3f775a88868d0a4356/pkg/cosign/tuf/policy.go#L82))_

My current date: `2021-10-21T20:52:12Z`

**Before**
```bash
$ cat ./o
{
    "signed": {
        "expires": "2022-01-21T20:54:44Z",
    }
}
```

**After**
```bash
$ cat ./o
{
    "signed": {
        "expires": "2021-10-28T20:58:53Z",
    }
}
```

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->


<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Ability to pass --expire for policy init command
```

cc: @asraa 