### PR TITLE
fix codeql workflow permission

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,12 +19,15 @@ on:
   push:
     branches: [ main ]
 
-permissions: read-all
-
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
#### Summary
Followup of https://github.com/sigstore/cosign/pull/949 that broke the codeql workflow

this PR fixes that and using the recommended permission from https://github.com/github/codeql-action#usage

sorry for breaking ci
#### Ticket Link


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
