### PR TITLE
Allow disabling `verifySCT`.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -57,16 +57,17 @@ func Attest() *cobra.Command {
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ko := sign.KeyOpts{
-				KeyRef:           o.Key,
-				PassFunc:         generate.GetPass,
-				Sk:               o.SecurityKey.Use,
-				Slot:             o.SecurityKey.Slot,
-				FulcioURL:        o.Fulcio.URL,
-				IDToken:          o.Fulcio.IdentityToken,
-				RekorURL:         o.Rekor.URL,
-				OIDCIssuer:       o.OIDC.Issuer,
-				OIDCClientID:     o.OIDC.ClientID,
-				OIDCClientSecret: o.OIDC.ClientSecret,
+				KeyRef:                   o.Key,
+				PassFunc:                 generate.GetPass,
+				Sk:                       o.SecurityKey.Use,
+				Slot:                     o.SecurityKey.Slot,
+				FulcioURL:                o.Fulcio.URL,
+				IDToken:                  o.Fulcio.IdentityToken,
+				InsecureSkipFulcioVerify: o.Fulcio.InsecureSkipFulcioVerify,
+				RekorURL:                 o.Rekor.URL,
+				OIDCIssuer:               o.OIDC.Issuer,
+				OIDCClientID:             o.OIDC.ClientID,
+				OIDCClientSecret:         o.OIDC.ClientSecret,
 			}
 			for _, img := range args {
 				if err := attest.AttestCmd(cmd.Context(), ko, o.Registry, img, o.Cert, o.Upload, o.Predicate.Path, o.Force, o.Predicate.Type); err != nil {

--- a/cmd/cosign/cli/options/fulcio.go
+++ b/cmd/cosign/cli/options/fulcio.go
@@ -22,8 +22,9 @@ import (
 
 // FulcioOptions is the wrapper for Fulcio related options.
 type FulcioOptions struct {
-	URL           string
-	IdentityToken string
+	URL                      string
+	IdentityToken            string
+	InsecureSkipFulcioVerify bool
 }
 
 var _ Interface = (*FulcioOptions)(nil)
@@ -35,4 +36,7 @@ func (o *FulcioOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.IdentityToken, "identity-token", "",
 		"[EXPERIMENTAL] identity token to use for certificate from fulcio")
+
+	cmd.Flags().BoolVar(&o.InsecureSkipFulcioVerify, "insecure-skip-verify", false,
+		"[EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).")
 }

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -167,12 +167,13 @@ func signPolicy() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Get Fulcio signer
 			sv, err := sign.SignerFromKeyOpts(cmd.Context(), "", sign.KeyOpts{
-				FulcioURL:        o.Fulcio.URL,
-				IDToken:          o.Fulcio.IdentityToken,
-				RekorURL:         o.Rekor.URL,
-				OIDCIssuer:       o.OIDC.Issuer,
-				OIDCClientID:     o.OIDC.ClientID,
-				OIDCClientSecret: o.OIDC.ClientSecret,
+				FulcioURL:                o.Fulcio.URL,
+				IDToken:                  o.Fulcio.IdentityToken,
+				InsecureSkipFulcioVerify: o.Fulcio.InsecureSkipFulcioVerify,
+				RekorURL:                 o.Rekor.URL,
+				OIDCIssuer:               o.OIDC.Issuer,
+				OIDCClientID:             o.OIDC.ClientID,
+				OIDCClientSecret:         o.OIDC.ClientSecret,
 			})
 			if err != nil {
 				return err

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -73,16 +73,17 @@ func Sign() *cobra.Command {
 				return flag.ErrHelp
 			}
 			ko := sign.KeyOpts{
-				KeyRef:           o.Key,
-				PassFunc:         generate.GetPass,
-				Sk:               o.SecurityKey.Use,
-				Slot:             o.SecurityKey.Slot,
-				FulcioURL:        o.Fulcio.URL,
-				IDToken:          o.Fulcio.IdentityToken,
-				RekorURL:         o.Rekor.URL,
-				OIDCIssuer:       o.OIDC.Issuer,
-				OIDCClientID:     o.OIDC.ClientID,
-				OIDCClientSecret: o.OIDC.ClientSecret,
+				KeyRef:                   o.Key,
+				PassFunc:                 generate.GetPass,
+				Sk:                       o.SecurityKey.Use,
+				Slot:                     o.SecurityKey.Slot,
+				FulcioURL:                o.Fulcio.URL,
+				IDToken:                  o.Fulcio.IdentityToken,
+				InsecureSkipFulcioVerify: o.Fulcio.InsecureSkipFulcioVerify,
+				RekorURL:                 o.Rekor.URL,
+				OIDCIssuer:               o.OIDC.Issuer,
+				OIDCClientID:             o.OIDC.ClientID,
+				OIDCClientSecret:         o.OIDC.ClientSecret,
 			}
 			annotationsMap, err := o.AnnotationsMap()
 			if err != nil {

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -44,6 +44,10 @@ type KeyOpts struct {
 	OIDCIssuer       string
 	OIDCClientID     string
 	OIDCClientSecret string
+
+	// Modeled after InsecureSkipVerify in tls.Config, this disables
+	// verifying the SCT.
+	InsecureSkipFulcioVerify bool
 }
 
 // nolint

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -61,16 +61,17 @@ func SignBlob() *cobra.Command {
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ko := sign.KeyOpts{
-				KeyRef:           o.Key,
-				PassFunc:         generate.GetPass,
-				Sk:               o.SecurityKey.Use,
-				Slot:             o.SecurityKey.Slot,
-				FulcioURL:        o.Fulcio.URL,
-				IDToken:          o.Fulcio.IdentityToken,
-				RekorURL:         o.Rekor.URL,
-				OIDCIssuer:       o.OIDC.Issuer,
-				OIDCClientID:     o.OIDC.ClientID,
-				OIDCClientSecret: o.OIDC.ClientSecret,
+				KeyRef:                   o.Key,
+				PassFunc:                 generate.GetPass,
+				Sk:                       o.SecurityKey.Use,
+				Slot:                     o.SecurityKey.Slot,
+				FulcioURL:                o.Fulcio.URL,
+				IDToken:                  o.Fulcio.IdentityToken,
+				InsecureSkipFulcioVerify: o.Fulcio.InsecureSkipFulcioVerify,
+				RekorURL:                 o.Rekor.URL,
+				OIDCIssuer:               o.OIDC.Issuer,
+				OIDCClientID:             o.OIDC.ClientID,
+				OIDCClientSecret:         o.OIDC.ClientSecret,
 			}
 			for _, blob := range args {
 				if _, err := sign.SignBlobCmd(cmd.Context(), ko, o.Registry, blob, o.Base64Output, o.Output); err != nil {

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -43,6 +43,7 @@ cosign attest [flags]
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for attest
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -20,6 +20,7 @@ cosign policy sign [flags]
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -39,6 +39,7 @@ cosign sign-blob [flags]
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign-blob
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -58,6 +58,7 @@ cosign sign [flags]
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -56,6 +56,7 @@ cosign verify-attestation [flags]
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for verify-attestation
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --policy strings                                                                           specify CUE or Rego files will be using for validation


### PR DESCRIPTION
This adds a new flag to the Fulcio options to allow disabling `verifySCT` on keyless signing paths.

The option is modeled after `InsecureSkipVerify` in `tls.Config` to convey the severity of disabling this verification, and the flag indicates that this is intended only for testing.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link
This is related to my work here: https://github.com/sigstore/fulcio/pull/216

#### Release Note
```release-note
Allow disabling SCT verification during keyless signing (only intended for testing purposes)
```
