### PR TITLE
Remove commented out sections in CI configs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,9 +34,6 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17.x'
-      # Required for `make cosign-pivkey`
-      # - name: deps
-      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - uses: imjasonh/setup-ko@v0.4
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master

--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -47,10 +47,6 @@ jobs:
           go-version: '1.17.x'
       - name: Checkout code
         uses: actions/checkout@v2
-      # Required for `make cosign-pivkey`
-      # - name: install deps
-      #   if: matrix.os == 'ubuntu-latest'
-      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: build cosign
         run: |
           make cosign && mv ./cosign ./${{matrix.COSIGN_TARGET}}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -54,9 +54,6 @@ jobs:
           # Used to test: cosign generate-key-pair k8s://...
           go install sigs.k8s.io/kind@v0.11.1
           kind create cluster
-      # Required for `make cosign-pivkey`
-      # - name: deps
-      #   run: sudo apt-get update && sudo apt-get install -yq libpcsclite-dev
       - name: Run Go tests
         run: go test ./...
 


### PR DESCRIPTION
#### Summary

This PR removes some potentially confusing commented out sections in some CI configs.

These sections were commented out in https://github.com/sigstore/cosign/pull/332

#### Release Note
```release-note
NONE
```
