### PR TITLE
Return better errors from `cosigned`

### DIFF
--- a/pkg/cosign/kubernetes/webhook/validator.go
+++ b/pkg/cosign/kubernetes/webhook/validator.go
@@ -138,8 +138,8 @@ func (v *Validator) validatePodSpec(ctx context.Context, ps *corev1.PodSpec, opt
 				continue
 			}
 
-			if !valid(ctx, ref, keys, ociremote.WithRemoteOptions(remote.WithAuthFromKeychain(kc))) {
-				errorField := apis.ErrGeneric("invalid image signature", "image").ViaFieldIndex(field, i)
+			if err := valid(ctx, ref, keys, ociremote.WithRemoteOptions(remote.WithAuthFromKeychain(kc))); err != nil {
+				errorField := apis.ErrGeneric(err.Error(), "image").ViaFieldIndex(field, i)
 				errorField.Details = c.Image
 				errs = errs.Also(errorField)
 				continue


### PR DESCRIPTION
This drops the `bool` on `valid()` so that when internal errors occur they can be surfaced back through the webhook to better indicate what problems the webhook is having.

To illustrate these better diagnostics, I've added unit tests that simulate errors looking up secrets and service accounts in k8schain.

Signed-off-by: Matt Moore <mattomata@gmail.com>
cc @blackcat-lin

#### Ticket Link

Fixes: https://github.com/sigstore/cosign/issues/963


#### Release Note

```release-note
Improve the error messages exposed by the `cosigned` webhook on internal errors (don't make it seem like images are unsigned, if that's not why we failed).
```
