### PR TITLE
Have `download sbom` use the `Attachment` API.

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -174,35 +174,35 @@ func SignCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOptions, a
 		if digest, ok := ref.(name.Digest); ok && !recursive {
 			se, err := ociempty.SignedImage(ref)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "accessing image")
 			}
 			err = signDigest(ctx, digest, staticPayload, ko, regOpts, annotations, upload, force, dd, sv, se)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "signing digest")
 			}
 			continue
 		}
 
 		se, err := ociremote.SignedEntity(ref, opts...)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "accessing entity")
 		}
 
 		if err := walk.SignedEntity(ctx, se, func(ctx context.Context, se oci.SignedEntity) error {
 			// Get the digest for this entity in our walk.
 			d, err := se.(interface{ Digest() (v1.Hash, error) }).Digest()
 			if err != nil {
-				return err
+				return errors.Wrap(err, "computing digest")
 			}
 			digest := ref.Context().Digest(d.String())
 
 			err = signDigest(ctx, digest, staticPayload, ko, regOpts, annotations, upload, force, dd, sv, se)
 			if err != nil {
-				return err
+				return errors.Wrap(err, "signing digest")
 			}
 			return ErrDone
 		}); err != nil {
-			return err
+			return errors.Wrap(err, "recursively signing")
 		}
 	}
 

--- a/pkg/oci/file.go
+++ b/pkg/oci/file.go
@@ -15,9 +15,16 @@
 
 package oci
 
+import "github.com/google/go-containerregistry/pkg/v1/types"
+
 // File is a degenerate form of SignedImage that stores a single file as a v1.Layer
 type File interface {
 	SignedImage
 
-	// TODO(mattmoor): Consider adding useful helpers.
+	// FileMediaType retrieves the media type of the File
+	FileMediaType() (types.MediaType, error)
+
+	// Payload fetches the opaque data that is being signed.
+	// This will always return data when there is no error.
+	Payload() ([]byte, error)
 }

--- a/pkg/oci/static/file_test.go
+++ b/pkg/oci/static/file_test.go
@@ -27,12 +27,12 @@ import (
 
 func TestNewFile(t *testing.T) {
 	payload := "this is the content!"
-	img, err := NewFile([]byte(payload), WithLayerMediaType("foo"))
+	file, err := NewFile([]byte(payload), WithLayerMediaType("foo"))
 	if err != nil {
 		t.Fatalf("NewFile() = %v", err)
 	}
 
-	layers, err := img.Layers()
+	layers, err := file.Layers()
 	if err != nil {
 		t.Fatalf("Layers() = %v", err)
 	} else if got, want := len(layers), 1; got != want {
@@ -53,7 +53,7 @@ func TestNewFile(t *testing.T) {
 
 	t.Run("check media type", func(t *testing.T) {
 		wantMT := types.MediaType("foo")
-		gotMT, err := l.MediaType()
+		gotMT, err := file.FileMediaType()
 		if err != nil {
 			t.Fatalf("MediaType() = %v", err)
 		}
@@ -110,6 +110,14 @@ func TestNewFile(t *testing.T) {
 		}
 		if got, want := string(uncompContent), payload; got != want {
 			t.Errorf("Uncompressed() = %s, wanted %s", got, want)
+		}
+
+		gotPayload, err := file.Payload()
+		if err != nil {
+			t.Fatalf("Payload() = %v", err)
+		}
+		if got, want := string(gotPayload), payload; got != want {
+			t.Errorf("Payload() = %s, wanted %s", got, want)
 		}
 	})
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -622,7 +622,7 @@ func TestAttachSBOM(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error")
 	}
-	t.Log(out)
+	t.Log(out.String())
 	out.Reset()
 
 	// Upload it!
@@ -632,7 +632,7 @@ func TestAttachSBOM(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(out)
+	t.Log(out.String())
 	if len(sboms) != 1 {
 		t.Fatalf("Expected one sbom, got %d", len(sboms))
 	}


### PR DESCRIPTION
This changes the `download sbom` command to use the `Attachment("sbom")` accessor, and expands `oci.File` with several useful methods for interacting with the underlying data.

Signed-off-by: Matt Moore <mattomata@gmail.com>

cc @vaikas 

#### Ticket Link
Sorta related to #666

#### Release Note
```release-note

```
