### PR TITLE
Fix `cosign attach sbom` with `COSIGN_REPOSITORY`.

### DIFF
--- a/cmd/cosign/cli/attach/sbom.go
+++ b/cmd/cosign/cli/attach/sbom.go
@@ -42,9 +42,12 @@ func SBOMCmd(ctx context.Context, regOpts options.RegistryOptions, sbomRef strin
 		return err
 	}
 
-	remoteOpts := regOpts.GetRegistryClientOpts(ctx)
+	remoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return err
+	}
 
-	dstRef, err := ociremote.SBOMTag(ref, ociremote.WithRemoteOptions(remoteOpts...))
+	dstRef, err := ociremote.SBOMTag(ref, remoteOpts...)
 	if err != nil {
 		return err
 	}
@@ -54,7 +57,7 @@ func SBOMCmd(ctx context.Context, regOpts options.RegistryOptions, sbomRef strin
 	if err != nil {
 		return err
 	}
-	return remote.Write(dstRef, img, remoteOpts...)
+	return remote.Write(dstRef, img, regOpts.GetRegistryClientOpts(ctx)...)
 }
 
 func sbomBytes(sbomRef string) ([]byte, error) {


### PR DESCRIPTION
Currently the env var is ignored by this command because it directly uses GGCR registry options instead of the `ociremote` options (which include the default override).

This fixes things by passing the `ociremote` options from `regOpts` to `SBOMTag`.

Signed-off-by: Matt Moore <mattomata@gmail.com>

Thanks to @vaikas for finding this.

#### Ticket Link


#### Release Note
```release-note
Fixes COSIGN_REPOSITORY with `cosign attach sbom`
```
