### PR TITLE
Fixed modtime for reproducible goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,7 @@ builds:
   main: ./cmd/cosign
   flags:
     - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
   goos:
     - linux
   goarch:
@@ -31,6 +32,7 @@ builds:
   main: ./cmd/cosign
   flags:
     - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
   goos:
     - linux
   goarch:
@@ -55,6 +57,7 @@ builds:
   main: ./cmd/cosign
   flags:
     - -trimpath
+  mod_timestamp: '{{ .CommitTimestamp }}'
   goos:
     - darwin
   goarch:


### PR DESCRIPTION
The modtime setting was missing that was required for making goreleaser builds consistent.

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
