### PR TITLE
Add support for using k8schain under a flag.

### DIFF
--- a/cmd/cosign/cli/options/flags.go
+++ b/cmd/cosign/cli/options/flags.go
@@ -16,11 +16,7 @@
 package options
 
 import (
-	"context"
 	"reflect"
-
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // OneOf ensures that only one of the supplied interfaces is set to a non-zero value.
@@ -37,12 +33,4 @@ func NOf(args ...interface{}) int {
 		}
 	}
 	return n
-}
-
-func defaultRegistryClientOpts(ctx context.Context) []remote.Option {
-	return []remote.Option{
-		remote.WithAuthFromKeychain(authn.DefaultKeychain),
-		remote.WithContext(ctx),
-		remote.WithUserAgent("cosign/" + VersionInfo().GitVersion),
-	}
 }

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -5,9 +5,10 @@
 ### Options
 
 ```
-  -h, --help                 help for cosign
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -h, --help                                     help for cosign
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach.md
+++ b/doc/cosign_attach.md
@@ -11,8 +11,9 @@ Provides utilities for attaching artifacts to other artifacts in a registry
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach_sbom.md
+++ b/doc/cosign_attach_sbom.md
@@ -18,6 +18,7 @@ cosign attach sbom [flags]
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for sbom
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --sbom string                                                                              path to the sbom, or {-} for stdin
       --type string                                                                              type of sbom (spdx|cyclonedx) (default "spdx")
 ```
@@ -25,8 +26,9 @@ cosign attach sbom [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -18,6 +18,7 @@ cosign attach signature [flags]
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for signature
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --payload string                                                                           path to the payload covered by the signature (if using another format)
       --signature string                                                                         the signature, path to the signature, or {-} for stdin
 ```
@@ -25,8 +26,9 @@ cosign attach signature [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -44,6 +44,7 @@ cosign attest [flags]
   -h, --help                                                                                     help for attest
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
@@ -60,8 +61,9 @@ cosign attest [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -17,13 +17,15 @@ cosign clean [flags]
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for clean
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_completion.md
+++ b/doc/cosign_completion.md
@@ -43,8 +43,9 @@ cosign completion [bash|zsh|fish|powershell]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -28,14 +28,16 @@ cosign copy [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -f, --force                                                                                    overwrite destination image(s), if necessary
   -h, --help                                                                                     help for copy
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --sig-only                                                                                 only copy the image signature
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_dockerfile.md
+++ b/doc/cosign_dockerfile.md
@@ -11,8 +11,9 @@ Provides utilities for discovering images in and performing operations on Docker
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -60,6 +60,7 @@ cosign dockerfile verify [flags]
       --cert-email string                                                                        the email expected in a valid fulcio cert
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
@@ -70,8 +71,9 @@ cosign dockerfile verify [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download.md
+++ b/doc/cosign_download.md
@@ -11,8 +11,9 @@ Provides utilities for downloading artifacts and attached artifacts in a registr
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -18,13 +18,15 @@ cosign download sbom [flags]
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for sbom
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download_signature.md
+++ b/doc/cosign_download_signature.md
@@ -18,13 +18,15 @@ cosign download signature [flags]
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for signature
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_generate-key-pair.md
+++ b/doc/cosign_generate-key-pair.md
@@ -57,8 +57,9 @@ CAVEATS:
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_generate.md
+++ b/doc/cosign_generate.md
@@ -34,13 +34,15 @@ cosign generate [flags]
   -a, --annotations strings                                                                      extra key=value pairs to sign
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for generate
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -50,8 +50,9 @@ cosign initialize -mirror <url> -root <url>
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_manifest.md
+++ b/doc/cosign_manifest.md
@@ -11,8 +11,9 @@ Provides utilities for discovering images in and performing operations on Kubern
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -54,6 +54,7 @@ cosign manifest verify [flags]
       --cert-email string                                                                        the email expected in a valid fulcio cert
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
@@ -64,8 +65,9 @@ cosign manifest verify [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool.md
+++ b/doc/cosign_piv-tool.md
@@ -12,8 +12,9 @@ Provides utilities for managing a hardware token
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_attestation.md
+++ b/doc/cosign_piv-tool_attestation.md
@@ -17,9 +17,10 @@ cosign piv-tool attestation [flags]
 ### Options inherited from parent commands
 
 ```
-  -f, --no-input             skip warnings and confirmations
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -f, --no-input                                 skip warnings and confirmations
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_generate-key.md
+++ b/doc/cosign_piv-tool_generate-key.md
@@ -20,9 +20,10 @@ cosign piv-tool generate-key [flags]
 ### Options inherited from parent commands
 
 ```
-  -f, --no-input             skip warnings and confirmations
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -f, --no-input                                 skip warnings and confirmations
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_reset.md
+++ b/doc/cosign_piv-tool_reset.md
@@ -15,9 +15,10 @@ cosign piv-tool reset [flags]
 ### Options inherited from parent commands
 
 ```
-  -f, --no-input             skip warnings and confirmations
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -f, --no-input                                 skip warnings and confirmations
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_set-management-key.md
+++ b/doc/cosign_piv-tool_set-management-key.md
@@ -18,9 +18,10 @@ cosign piv-tool set-management-key [flags]
 ### Options inherited from parent commands
 
 ```
-  -f, --no-input             skip warnings and confirmations
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -f, --no-input                                 skip warnings and confirmations
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_set-pin.md
+++ b/doc/cosign_piv-tool_set-pin.md
@@ -17,9 +17,10 @@ cosign piv-tool set-pin [flags]
 ### Options inherited from parent commands
 
 ```
-  -f, --no-input             skip warnings and confirmations
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -f, --no-input                                 skip warnings and confirmations
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_set-puk.md
+++ b/doc/cosign_piv-tool_set-puk.md
@@ -17,9 +17,10 @@ cosign piv-tool set-puk [flags]
 ### Options inherited from parent commands
 
 ```
-  -f, --no-input             skip warnings and confirmations
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -f, --no-input                                 skip warnings and confirmations
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_unblock.md
+++ b/doc/cosign_piv-tool_unblock.md
@@ -17,9 +17,10 @@ cosign piv-tool unblock [flags]
 ### Options inherited from parent commands
 
 ```
-  -f, --no-input             skip warnings and confirmations
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+  -f, --no-input                                 skip warnings and confirmations
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy.md
+++ b/doc/cosign_policy.md
@@ -21,8 +21,9 @@ cosign policy [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy_init.md
+++ b/doc/cosign_policy_init.md
@@ -27,6 +27,7 @@ cosign policy init [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --expires int                                                                              total expire duration in days
   -h, --help                                                                                     help for init
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
   -m, --maintainers strings                                                                      list of maintainers to add to the root policy
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")
       --out string                                                                               output policy locally (default "o")
@@ -36,8 +37,9 @@ cosign policy init [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -21,6 +21,7 @@ cosign policy sign [flags]
   -h, --help                                                                                     help for sign
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
@@ -32,8 +33,9 @@ cosign policy sign [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_public-key.md
+++ b/doc/cosign_public-key.md
@@ -53,8 +53,9 @@ cosign public-key [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -40,6 +40,7 @@ cosign sign-blob [flags]
   -h, --help                                                                                     help for sign-blob
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
@@ -53,8 +54,9 @@ cosign sign-blob [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -59,6 +59,7 @@ cosign sign [flags]
   -h, --help                                                                                     help for sign
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
@@ -74,8 +75,9 @@ cosign sign [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -17,14 +17,16 @@ cosign triangulate [flags]
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for triangulate
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --type string                                                                              related attachment to triangulate (attestation|sbom|signature), default signature (default "signature")
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload.md
+++ b/doc/cosign_upload.md
@@ -11,8 +11,9 @@ Provides utilities for uploading artifacts to a registry
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload_blob.md
+++ b/doc/cosign_upload_blob.md
@@ -32,13 +32,15 @@ cosign upload blob [flags]
       --ct string                                                                                content type to set
   -f, --files strings                                                                            <filepath>:[platform/arch]
   -h, --help                                                                                     help for blob
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload_wasm.md
+++ b/doc/cosign_upload_wasm.md
@@ -19,13 +19,15 @@ cosign upload wasm [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -f, --file string                                                                              path to the wasm file to upload
   -h, --help                                                                                     help for wasm
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```
 
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -57,6 +57,7 @@ cosign verify-attestation [flags]
   -h, --help                                                                                     help for verify-attestation
       --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --policy strings                                                                           specify CUE or Rego files will be using for validation
@@ -69,8 +70,9 @@ cosign verify-attestation [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -61,6 +61,7 @@ cosign verify-blob [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --cert string                                                                              path to the public certificate
   -h, --help                                                                                     help for verify-blob
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL
@@ -71,8 +72,9 @@ cosign verify-blob [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -60,6 +60,7 @@ cosign verify [flags]
       --cert-email string                                                                        the email expected in a valid fulcio cert
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
@@ -70,8 +71,9 @@ cosign verify [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO

--- a/doc/cosign_version.md
+++ b/doc/cosign_version.md
@@ -20,8 +20,9 @@ cosign version [flags]
 ### Options inherited from parent commands
 
 ```
-      --output-file string   log output to a file
-  -d, --verbose              log debug output
+      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
+      --output-file string                       log output to a file
+  -d, --verbose                                  log debug output
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
This will help avoid needing to configure credential helpers in environments supporting ambient authentication.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

#### Release Note
```release-note
Add a --k8s-keychain option that enables cosign to support ambient registry credentials based on the "k8schain" library.
```
