### PR TITLE
Ship multi-arch images for all the cosign components.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,17 +91,17 @@ clean:
 ko:
 	# We can't pass more than one LDFLAG via GOFLAGS, you can't have spaces in there.
 	KO_DOCKER_REPO=${KO_PREFIX}/cosign CGO_ENABLED=0 GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
-		--tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		github.com/sigstore/cosign/cmd/cosign
 
 	# cosigned
 	KO_DOCKER_REPO=${KO_PREFIX}/cosigned CGO_ENABLED=0 GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
-		--tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		github.com/sigstore/cosign/cmd/cosign/webhook
 
 	# sget
 	KO_DOCKER_REPO=${KO_PREFIX}/sget CGO_ENABLED=0 GOFLAGS="-ldflags=-X=$(PKG).gitCommit=$(GIT_HASH)" ko publish --bare \
-		--tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		github.com/sigstore/cosign/cmd/sget
 
 .PHONY: ko-local


### PR DESCRIPTION
This will direct `ko` to build `cosign` et al for all of the platforms and architectures that the configured base image ships, so for distroless that should include arm, arm64, ppc64le, s390z, and ofc amd64.

Signed-off-by: Matt Moore <mattomata@gmail.com>

#### Ticket Link

#### Release Note
```release-note
The cosign images are now shipped for every architecture distroless ships on (currently: amd64, arm64, arm, s390x, ppc64le)
```
