### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/cmd/cosign/cli/attach/sbom.go
+++ b/cmd/cosign/cli/attach/sbom.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -64,11 +64,11 @@ func sbomBytes(sbomRef string) ([]byte, error) {
 	// sbomRef can be "-", a string or a file.
 	switch signatureType(sbomRef) {
 	case StdinSignature:
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	case RawSignature:
 		return []byte(sbomRef), nil
 	case FileSignature:
-		return ioutil.ReadFile(filepath.Clean(sbomRef))
+		return os.ReadFile(filepath.Clean(sbomRef))
 	default:
 		return nil, errors.New("unknown SBOM arg type")
 	}

--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -18,7 +18,7 @@ package attach
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -60,7 +60,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 	if payloadRef == "" {
 		payload, err = (&sigPayload.Cosign{Image: digest}).MarshalJSON()
 	} else {
-		payload, err = ioutil.ReadFile(filepath.Clean(payloadRef))
+		payload, err = os.ReadFile(filepath.Clean(payloadRef))
 	}
 	if err != nil {
 		return err
@@ -98,11 +98,11 @@ func signatureBytes(sigRef string) ([]byte, error) {
 	// sigRef can be "-", a string or a file.
 	switch signatureType(sigRef) {
 	case StdinSignature:
-		return ioutil.ReadAll(os.Stdin)
+		return io.ReadAll(os.Stdin)
 	case RawSignature:
 		return []byte(sigRef), nil
 	case FileSignature:
-		return ioutil.ReadFile(filepath.Clean(sigRef))
+		return os.ReadFile(filepath.Clean(sigRef))
 	default:
 		return nil, errors.New("unknown signature arg type")
 	}

--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -52,7 +51,7 @@ func initRoots() *x509.CertPool {
 	cp := x509.NewCertPool()
 	rootEnv := os.Getenv(altRoot)
 	if rootEnv != "" {
-		raw, err := ioutil.ReadFile(rootEnv)
+		raw, err := os.ReadFile(rootEnv)
 		if err != nil {
 			panic(fmt.Sprintf("error reading root PEM file: %s", err))
 		}

--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -19,7 +19,7 @@ import (
 	"context"
 	"crypto"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -55,7 +55,7 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error
 		if err != nil {
 			return err
 		}
-		if err := ioutil.WriteFile("cosign.pub", pemBytes, 0600); err != nil {
+		if err := os.WriteFile("cosign.pub", pemBytes, 0600); err != nil {
 			return err
 		}
 		fmt.Fprintln(os.Stderr, "Public key written to cosign.pub")
@@ -100,12 +100,12 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error
 		}
 	}
 	// TODO: make sure the perms are locked down first.
-	if err := ioutil.WriteFile("cosign.key", keys.PrivateBytes, 0600); err != nil {
+	if err := os.WriteFile("cosign.key", keys.PrivateBytes, 0600); err != nil {
 		return err
 	}
 	fmt.Fprintln(os.Stderr, "Private key written to cosign.key")
 
-	if err := ioutil.WriteFile("cosign.pub", keys.PublicBytes, 0644); err != nil {
+	if err := os.WriteFile("cosign.pub", keys.PublicBytes, 0644); err != nil {
 		return err
 	} // #nosec G306
 	fmt.Fprintln(os.Stderr, "Public key written to cosign.pub")
@@ -131,7 +131,7 @@ func readPasswordFn(confirm bool) func() ([]byte, error) {
 	// Handle piped in passwords.
 	default:
 		return func() ([]byte, error) {
-			return ioutil.ReadAll(os.Stdin)
+			return io.ReadAll(os.Stdin)
 		}
 	}
 }

--- a/cmd/cosign/cli/manifest/verify.go
+++ b/cmd/cosign/cli/manifest/verify.go
@@ -20,7 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -48,7 +47,7 @@ func (c *VerifyManifestCommand) Exec(ctx context.Context, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "check if extension is valid")
 	}
-	manifest, err := ioutil.ReadFile(manifestPath)
+	manifest, err := os.ReadFile(manifestPath)
 	if err != nil {
 		return fmt.Errorf("could not read manifest: %w", err)
 	}

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -20,7 +20,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/mail"
 	"os"
 	"path/filepath"
@@ -131,7 +131,7 @@ func initPolicy() *cobra.Command {
 			var outfile string
 			if o.OutFile != "" {
 				outfile = o.OutFile
-				err = ioutil.WriteFile(o.OutFile, policyFile, 0600)
+				err = os.WriteFile(o.OutFile, policyFile, 0600)
 				if err != nil {
 					return errors.Wrapf(err, "error writing to %s", outfile)
 				}
@@ -213,7 +213,7 @@ func signPolicy() *cobra.Command {
 			if err := sget.New(imgName+"@"+dgst.String(), "", result).Do(cmd.Context()); err != nil {
 				return errors.Wrap(err, "error getting result")
 			}
-			b, err := ioutil.ReadAll(result)
+			b, err := io.ReadAll(result)
 			if err != nil {
 				return errors.Wrap(err, "error reading bytes from root.json")
 			}
@@ -263,7 +263,7 @@ func signPolicy() *cobra.Command {
 			var outfile string
 			if o.OutFile != "" {
 				outfile = o.OutFile
-				err = ioutil.WriteFile(o.OutFile, policyFile, 0600)
+				err = os.WriteFile(o.OutFile, policyFile, 0600)
 				if err != nil {
 					return errors.Wrapf(err, "error writing to %s", outfile)
 				}

--- a/cmd/cosign/cli/publickey/public_key_test.go
+++ b/cmd/cosign/cli/publickey/public_key_test.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -46,7 +46,7 @@ func TestPublicKeyLocation(t *testing.T) {
 
 	td := t.TempDir()
 	f := filepath.Join(td, "private.key")
-	if err := ioutil.WriteFile(f, keys.PrivateBytes, 0644); err != nil {
+	if err := os.WriteFile(f, keys.PrivateBytes, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -74,7 +74,7 @@ func TestPublicKeyBadPrivateKey(t *testing.T) {
 	}
 	td := t.TempDir()
 	f := filepath.Join(td, "private.key")
-	if err := ioutil.WriteFile(f, buf, 0644); err != nil {
+	if err := os.WriteFile(f, buf, 0644); err != nil {
 		t.Fatal(err)
 	}
 	var out bytes.Buffer

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -25,7 +25,6 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -145,7 +144,7 @@ func SignCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOptions, a
 	var staticPayload []byte
 	if payloadPath != "" {
 		fmt.Fprintln(os.Stderr, "Using payload from:", payloadPath)
-		staticPayload, err = ioutil.ReadFile(filepath.Clean(payloadPath))
+		staticPayload, err = os.ReadFile(filepath.Clean(payloadPath))
 		if err != nil {
 			return errors.Wrap(err, "payload from file")
 		}
@@ -340,7 +339,7 @@ func SignerFromKeyOpts(ctx context.Context, certPath string, ko KeyOpts) (*CertS
 			return certSigner, nil
 		}
 
-		certBytes, err := ioutil.ReadFile(certPath)
+		certBytes, err := os.ReadFile(certPath)
 		if err != nil {
 			return nil, errors.Wrap(err, "read certificate")
 		}

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -56,10 +56,10 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOption
 	var err error
 
 	if payloadPath == "-" {
-		payload, err = ioutil.ReadAll(os.Stdin)
+		payload, err = io.ReadAll(os.Stdin)
 	} else {
 		fmt.Fprintln(os.Stderr, "Using payload from:", payloadPath)
-		payload, err = ioutil.ReadFile(filepath.Clean(payloadPath))
+		payload, err = os.ReadFile(filepath.Clean(payloadPath))
 	}
 	if err != nil {
 		return nil, err

--- a/cmd/cosign/cli/upload/wasm.go
+++ b/cmd/cosign/cli/upload/wasm.go
@@ -18,7 +18,6 @@ package upload
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -29,7 +28,7 @@ import (
 )
 
 func WasmCmd(ctx context.Context, regOpts options.RegistryOptions, wasmPath, imageRef string) error {
-	b, err := ioutil.ReadFile(wasmPath)
+	b, err := os.ReadFile(wasmPath)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -24,7 +24,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/pkg/errors"
@@ -75,7 +75,7 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 			return errors.Wrap(err, "loading public key from token")
 		}
 	case certRef != "":
-		pems, err := ioutil.ReadFile(certRef)
+		pems, err := os.ReadFile(certRef)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 
 	var blobBytes []byte
 	if blobRef == "-" {
-		blobBytes, err = ioutil.ReadAll(os.Stdin)
+		blobBytes, err = io.ReadAll(os.Stdin)
 	} else {
 		blobBytes, err = blob.LoadFileOrURL(blobRef)
 	}

--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -128,7 +127,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 
 	fmt.Fprintln(os.Stderr, "Public key written to COSIGN_PUBLIC_KEY environment variable")
 
-	if err := ioutil.WriteFile("cosign.pub", keys.PublicBytes, 0o600); err != nil {
+	if err := os.WriteFile("cosign.pub", keys.PublicBytes, 0o600); err != nil {
 		return err
 	}
 	fmt.Fprintln(os.Stderr, "Public key also written to cosign.pub")

--- a/pkg/cosign/git/gitlab/gitlab.go
+++ b/pkg/cosign/git/gitlab/gitlab.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/pkg/errors"
@@ -117,7 +116,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 
 	fmt.Fprintln(os.Stderr, "Public key written to \"COSIGN_PUBLIC_KEY\" variable")
 
-	if err := ioutil.WriteFile("cosign.pub", keys.PublicBytes, 0o600); err != nil {
+	if err := os.WriteFile("cosign.pub", keys.PublicBytes, 0o600); err != nil {
 		return err
 	}
 	fmt.Fprintln(os.Stderr, "Public key also written to cosign.pub")

--- a/pkg/cosign/kubernetes/secret.go
+++ b/pkg/cosign/kubernetes/secret.go
@@ -17,7 +17,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -86,7 +85,7 @@ func KeyPairSecret(ctx context.Context, k8sRef string, pf cosign.PassFunc) error
 	}
 
 	fmt.Fprintf(os.Stderr, "Successfully created secret %s in namespace %s\n", s.Name, s.Namespace)
-	if err := ioutil.WriteFile("cosign.pub", keys.PublicBytes, 0600); err != nil {
+	if err := os.WriteFile("cosign.pub", keys.PublicBytes, 0600); err != nil {
 		return err
 	}
 	fmt.Fprintln(os.Stderr, "Public key written to cosign.pub")

--- a/pkg/cosign/pivkey/pivkey.go
+++ b/pkg/cosign/pivkey/pivkey.go
@@ -27,7 +27,6 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/go-piv/piv-go/piv"
@@ -166,11 +165,11 @@ func (k *Key) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, er
 }
 
 func (k *Key) VerifySignature(signature, message io.Reader, opts ...signature.VerifyOption) error {
-	sig, err := ioutil.ReadAll(signature)
+	sig, err := io.ReadAll(signature)
 	if err != nil {
 		return errors.Wrap(err, "read signature")
 	}
-	msg, err := ioutil.ReadAll(message)
+	msg, err := io.ReadAll(message)
 	if err != nil {
 		return errors.Wrap(err, "read message")
 	}

--- a/pkg/cosign/remote/index.go
+++ b/pkg/cosign/remote/index.go
@@ -17,7 +17,6 @@ package remote
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"strings"
@@ -73,7 +72,7 @@ func (f *file) Path() string {
 }
 
 func (f *file) Contents() ([]byte, error) {
-	return ioutil.ReadFile(f.path)
+	return os.ReadFile(f.path)
 }
 func (f *file) Platform() *v1.Platform {
 	return f.platform

--- a/pkg/oci/remote/layer.go
+++ b/pkg/oci/remote/layer.go
@@ -19,7 +19,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -53,7 +53,7 @@ func (s *sigLayer) Payload() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	payload, err := ioutil.ReadAll(r)
+	payload, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"crypto/x509"
 	"io"
-	"io/ioutil"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/types"
@@ -122,12 +121,12 @@ func (l *staticLayer) DiffID() (v1.Hash, error) {
 
 // Compressed implements v1.Layer
 func (l *staticLayer) Compressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
+	return io.NopCloser(bytes.NewReader(l.b)), nil
 }
 
 // Uncompressed implements v1.Layer
 func (l *staticLayer) Uncompressed() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader(l.b)), nil
+	return io.NopCloser(bytes.NewReader(l.b)), nil
 }
 
 // Size implements v1.Layer

--- a/pkg/providers/google/google.go
+++ b/pkg/providers/google/google.go
@@ -17,7 +17,6 @@ package google
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -43,7 +42,7 @@ var gceProductNameFile = "/sys/class/dmi/id/product_name"
 // Enabled implements providers.Interface
 // This is based on k8s.io/kubernetes/pkg/credentialprovider/gcp
 func (gwi *googleWorkloadIdentity) Enabled(ctx context.Context) bool {
-	data, err := ioutil.ReadFile(gceProductNameFile)
+	data, err := os.ReadFile(gceProductNameFile)
 	if err != nil {
 		return false
 	}

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -17,7 +17,7 @@ package signature
 import (
 	"context"
 	"crypto"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -55,7 +55,7 @@ func LoadPublicKey(ctx context.Context, keyRef string) (verifier signature.Verif
 }
 
 func loadKey(keyPath string, pf cosign.PassFunc) (*signature.ECDSASignerVerifier, error) {
-	kb, err := ioutil.ReadFile(filepath.Clean(keyPath))
+	kb, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/signature/keys_test.go
+++ b/pkg/signature/keys_test.go
@@ -16,7 +16,7 @@ package signature
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/sigstore/cosign/pkg/cosign"
@@ -25,12 +25,12 @@ import (
 func generateKeyFile(t *testing.T, tmpDir string, pf cosign.PassFunc) (privFile, pubFile string) {
 	t.Helper()
 
-	tmpPrivFile, err := ioutil.TempFile(tmpDir, "cosign_test_*.key")
+	tmpPrivFile, err := os.CreateTemp(tmpDir, "cosign_test_*.key")
 	if err != nil {
 		t.Fatalf("failed to create temp key file: %v", err)
 	}
 	defer tmpPrivFile.Close()
-	tmpPubFile, err := ioutil.TempFile(tmpDir, "cosign_test_*.pub")
+	tmpPubFile, err := os.CreateTemp(tmpDir, "cosign_test_*.pub")
 	if err != nil {
 		t.Fatalf("failed to create temp pub file: %v", err)
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -24,7 +24,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http/httptest"
 	"net/url"
 	"os"
@@ -176,7 +176,7 @@ func TestAttestVerify(t *testing.T) {
 
 	slsaAttestation := `{ "builder": { "id": "2" }, "recipe": {} }`
 	slsaAttestationPath := filepath.Join(td, "attestation.slsa.json")
-	if err := ioutil.WriteFile(slsaAttestationPath, []byte(slsaAttestation), 0600); err != nil {
+	if err := os.WriteFile(slsaAttestationPath, []byte(slsaAttestation), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -191,13 +191,13 @@ func TestAttestVerify(t *testing.T) {
 
 	// Fail case
 	cuePolicy := `builder: id: "1"`
-	if err := ioutil.WriteFile(policyPath, []byte(cuePolicy), 0600); err != nil {
+	if err := os.WriteFile(policyPath, []byte(cuePolicy), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	// Success case
 	cuePolicy = `builder: id: "2"`
-	if err := ioutil.WriteFile(policyPath, []byte(cuePolicy), 0600); err != nil {
+	if err := os.WriteFile(policyPath, []byte(cuePolicy), 0600); err != nil {
 		t.Fatal(err)
 	}
 	must(verifyAttestation.Exec(ctx, []string{imgName}), t)
@@ -384,7 +384,7 @@ func TestSignBlob(t *testing.T) {
 	})
 	bp := filepath.Join(td1, blob)
 
-	if err := ioutil.WriteFile(bp, []byte(blob), 0644); err != nil {
+	if err := os.WriteFile(bp, []byte(blob), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -460,12 +460,12 @@ func keypair(t *testing.T, td string) (*cosign.Keys, string, string) {
 	}
 
 	privKeyPath := filepath.Join(td, "cosign.key")
-	if err := ioutil.WriteFile(privKeyPath, keys.PrivateBytes, 0600); err != nil {
+	if err := os.WriteFile(privKeyPath, keys.PrivateBytes, 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	pubKeyPath := filepath.Join(td, "cosign.pub")
-	if err := ioutil.WriteFile(pubKeyPath, keys.PublicBytes, 0600); err != nil {
+	if err := os.WriteFile(pubKeyPath, keys.PublicBytes, 0600); err != nil {
 		t.Fatal(err)
 	}
 	return keys, privKeyPath, pubKeyPath
@@ -599,7 +599,7 @@ func TestUploadBlob(t *testing.T) {
 	if err := sget.New(imgName+"@"+dgst.String(), "", result).Do(ctx); err != nil {
 		t.Fatal(err)
 	}
-	b, err := ioutil.ReadAll(result)
+	b, err := io.ReadAll(result)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -636,7 +636,7 @@ func TestAttachSBOM(t *testing.T) {
 	if len(sboms) != 1 {
 		t.Fatalf("Expected one sbom, got %d", len(sboms))
 	}
-	want, err := ioutil.ReadFile("./testdata/bom-go-mod.spdx")
+	want, err := os.ReadFile("./testdata/bom-go-mod.spdx")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -726,13 +726,13 @@ func TestGetPublicKeyCustomOut(t *testing.T) {
 	}
 	must(publickey.GetPublicKey(ctx, pk, publickey.NamedWriter{Name: outPath, Writer: outWriter}, passFunc), t)
 
-	output, err := ioutil.ReadFile(outPath)
+	output, err := os.ReadFile(outPath)
 	must(err, t)
 	equals(keys.PublicBytes, output, t)
 }
 
 func mkfile(contents, td string, t *testing.T) string {
-	f, err := ioutil.TempFile(td, "")
+	f, err := os.CreateTemp(td, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### Summary
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
