### PR TITLE
Invert upload flag to allow for not uploading attestation

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -70,7 +70,7 @@ func Attest() *cobra.Command {
 				OIDCClientSecret:         o.OIDC.ClientSecret,
 			}
 			for _, img := range args {
-				if err := attest.AttestCmd(cmd.Context(), ko, o.Registry, img, o.Cert, o.Upload, o.Predicate.Path, o.Force, o.Predicate.Type); err != nil {
+				if err := attest.AttestCmd(cmd.Context(), ko, o.Registry, img, o.Cert, o.NoUpload, o.Predicate.Path, o.Force, o.Predicate.Type); err != nil {
 					return errors.Wrapf(err, "signing %s", img)
 				}
 			}

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"context"
 	_ "crypto/sha256" // for `crypto.SHA256`
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -45,7 +44,7 @@ import (
 
 //nolint
 func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOptions, imageRef string, certPath string,
-	upload bool, predicatePath string, force bool, predicateType string) error {
+	noUpload bool, predicatePath string, force bool, predicateType string) error {
 	// A key file or token is required unless we're in experimental mode!
 	if options.EnableExperimental() {
 		if options.NOf(ko.KeyRef, ko.Sk) > 1 {
@@ -115,8 +114,8 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 		return errors.Wrap(err, "signing")
 	}
 
-	if !upload {
-		fmt.Println(base64.StdEncoding.EncodeToString(signedPayload))
+	if noUpload {
+		fmt.Println(string(signedPayload))
 		return nil
 	}
 

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -23,7 +23,7 @@ import (
 type AttestOptions struct {
 	Key       string
 	Cert      string
-	Upload    bool
+	NoUpload  bool
 	Force     bool
 	Recursive bool
 
@@ -52,8 +52,8 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Cert, "cert", "",
 		"path to the x509 certificate to include in the Signature")
 
-	cmd.Flags().BoolVar(&o.Upload, "upload", true,
-		"whether to upload the signature")
+	cmd.Flags().BoolVar(&o.NoUpload, "no-upload", false,
+		"do not upload the generated attestation")
 
 	cmd.Flags().BoolVarP(&o.Force, "force", "f", false,
 		"skip warnings and confirmations")

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -46,6 +46,7 @@ cosign attest [flags]
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
+      --no-upload                                                                                do not upload the generated attestation
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
@@ -55,7 +56,6 @@ cosign attest [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|custom) or an URI (default "custom")
-      --upload                                                                                   whether to upload the signature (default true)
 ```
 
 ### Options inherited from parent commands

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -182,7 +182,8 @@ func TestAttestVerify(t *testing.T) {
 
 	// Now attest the image
 	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-	must(attest.AttestCmd(ctx, ko, options.RegistryOptions{}, imgName, "", true, slsaAttestationPath, false, "custom"), t)
+	must(attest.AttestCmd(ctx, ko, options.RegistryOptions{}, imgName, "", false, slsaAttestationPath, false,
+		"custom"), t)
 
 	// Use cue to verify attestation
 	policyPath := filepath.Join(td, "policy.cue")


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
The `cosign attest` command has an `--upload` flag, designed to tell cosign to upload the generated attestation to the registry.

However, this bool value is set to `true` by default, which ends up meaning that **there's no way to instruct cosign _not to upload_** the generated attestation (IIUC).

This PR changes the flag to `--no-upload`, which inverts the logic and behaves as you'd expect. Without the flag, the attestation is uploaded. With the flag, the attestation is not uploaded, and instead, the attestation DSSE is sent to stdout.

**Note:** This is a breaking change for the CLI, since it removes an existing flag. The flag hadn't been affecting cosign's execution, so I'm not sure how many folks were using it. But regardless, I'm happy to approach this a different way to make the change _non-breaking_, just let me know!

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
attest: replaces '--upload' flag with a '--no-upload' flag
```
