### PR TITLE
Fix the release

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -50,7 +50,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -w /go/src/sigstore/cosign \
             --entrypoint="" \
-            ghcr.io/gythialy/golang-cross:v1.17.2@sha256:24bb133da23e0d21a8e8a54416f652d753c7cb2ad8efb3e6a3ef652f597ada8f \
+            ghcr.io/gythialy/golang-cross:v1.17.2-1@sha256:51f3c71079f6e1d7d0732b33bcc54ebd310f6ea155ac7dbe244a8695334bd50a \
             make snapshot
 
       - name: check binaries

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -168,55 +168,67 @@ dockers:
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-amd64"
     dockerfile: Dockerfile
+    goos: linux
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--no-cache"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=amd64"
+      - "--build-arg=TARGETARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-arm64v8"
+    goos: linux
     goarch: arm64
     dockerfile: Dockerfile
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--no-cache"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=arm64"
+      - "--build-arg=TARGETARCH=arm64"
 
   # cosigned Image
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-amd64"
     dockerfile: Dockerfile.cosigned
+    goos: linux
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--no-cache"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=amd64"
+      - "--build-arg=TARGETARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-arm64v8"
+    goos: linux
     goarch: arm64
     dockerfile: Dockerfile.cosigned
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--no-cache"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=arm64"
+      - "--build-arg=TARGETARCH=arm64"
 
   # sget Image
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-amd64"
     dockerfile: Dockerfile.sget
+    goos: linux
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
+      - "--no-cache"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=amd64"
+      - "--build-arg=TARGETARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8"
+    goos: linux
     goarch: arm64
     dockerfile: Dockerfile.sget
     build_flag_templates:
       - "--platform=linux/arm64/v8"
+      - "--no-cache"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
-      - "--build-arg=ARCH=arm64"
+      - "--build-arg=TARGETARCH=arm64"
 
 docker_manifests:
   - name_template: gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,7 @@ project_name: cosign
 env:
   - GO111MODULE=on
   - CGO_ENABLED=1
+  - DOCKER_CLI_EXPERIMENTAL=enabled
 
 # Prevents parallel builds from stepping on eachothers toes downloading modules
 before:
@@ -166,15 +167,14 @@ dockers:
   # cosign Image
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-amd64"
-    use: buildx
     dockerfile: Dockerfile
+    goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
       - "--build-arg=ARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-arm64v8"
-    use: buildx
     goarch: arm64
     dockerfile: Dockerfile
     build_flag_templates:
@@ -185,15 +185,14 @@ dockers:
   # cosigned Image
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-amd64"
-    use: buildx
     dockerfile: Dockerfile.cosigned
+    goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
       - "--build-arg=ARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-arm64v8"
-    use: buildx
     goarch: arm64
     dockerfile: Dockerfile.cosigned
     build_flag_templates:
@@ -204,15 +203,14 @@ dockers:
   # sget Image
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-amd64"
-    use: buildx
     dockerfile: Dockerfile.sget
+    goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
       - "--build-arg=ARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8"
-    use: buildx
     goarch: arm64
     dockerfile: Dockerfile.sget
     build_flag_templates:
@@ -236,6 +234,7 @@ docker_manifests:
 
 docker_signs:
   - artifacts: all
+    cmd: ./dist/cosign-linux-amd64
     args: [ "sign", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}" ]
 
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -172,8 +172,8 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--no-cache"
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      # TODO(dekkagaijin): remove suffix when race condition fixed
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-amd64"
       - "--build-arg=TARGETARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-arm64v8"
@@ -182,8 +182,8 @@ dockers:
     dockerfile: Dockerfile
     build_flag_templates:
       - "--platform=linux/arm64/v8"
-      - "--no-cache"
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      # TODO(dekkagaijin): remove suffix when race condition fixed
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-arm64"
       - "--build-arg=TARGETARCH=arm64"
 
   # cosigned Image
@@ -194,8 +194,8 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--no-cache"
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      # TODO(dekkagaijin): remove suffix when race condition fixed
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-amd64"
       - "--build-arg=TARGETARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-arm64v8"
@@ -204,8 +204,8 @@ dockers:
     dockerfile: Dockerfile.cosigned
     build_flag_templates:
       - "--platform=linux/arm64/v8"
-      - "--no-cache"
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      # TODO(dekkagaijin): remove suffix when race condition fixed
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-arm64"
       - "--build-arg=TARGETARCH=arm64"
 
   # sget Image
@@ -216,8 +216,8 @@ dockers:
     goarch: amd64
     build_flag_templates:
       - "--platform=linux/amd64"
-      - "--no-cache"
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      # TODO(dekkagaijin): remove suffix when race condition fixed
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-amd64"
       - "--build-arg=TARGETARCH=amd64"
   - image_templates:
       - "gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8"
@@ -226,8 +226,8 @@ dockers:
     dockerfile: Dockerfile.sget
     build_flag_templates:
       - "--platform=linux/arm64/v8"
-      - "--no-cache"
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}"
+      # TODO(dekkagaijin): remove suffix when race condition fixed
+      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-arm64"
       - "--build-arg=TARGETARCH=arm64"
 
 docker_manifests:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
+ARG TARGETARCH
 
-FROM $RUNTIME_IMAGE
+FROM --platform=linux/${TARGETARCH} $RUNTIME_IMAGE
 
-ARG ARCH
-COPY cosign-linux-${ARCH} /bin/cosign
+ARG TARGETARCH
+COPY cosign-linux-${TARGETARCH} /bin/cosign
 
 USER nobody
 ENTRYPOINT [ "/bin/cosign" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
-ARG TARGETARCH
 
-FROM --platform=linux/${TARGETARCH} $RUNTIME_IMAGE
+FROM $RUNTIME_IMAGE
 
 ARG TARGETARCH
 COPY cosign-linux-${TARGETARCH} /bin/cosign

--- a/Dockerfile.cosigned
+++ b/Dockerfile.cosigned
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
+ARG TARGETARCH
 
-FROM $RUNTIME_IMAGE
+FROM --platform=linux/${TARGETARCH} $RUNTIME_IMAGE
 
-ARG ARCH
-COPY cosigned-linux-${ARCH} /bin/cosigned
+ARG TARGETARCH
+COPY cosigned-linux-${TARGETARCH} /bin/cosigned
 
 USER nobody
 ENTRYPOINT [ "/bin/cosigned" ]

--- a/Dockerfile.cosigned
+++ b/Dockerfile.cosigned
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
-ARG TARGETARCH
 
-FROM --platform=linux/${TARGETARCH} $RUNTIME_IMAGE
+FROM $RUNTIME_IMAGE
 
 ARG TARGETARCH
 COPY cosigned-linux-${TARGETARCH} /bin/cosigned

--- a/Dockerfile.sget
+++ b/Dockerfile.sget
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
-ARG TARGETARCH
 
-FROM --platform=linux/${TARGETARCH} $RUNTIME_IMAGE
+FROM $RUNTIME_IMAGE
 
 ARG TARGETARCH
 COPY sget-linux-${TARGETARCH} /bin/sget

--- a/Dockerfile.sget
+++ b/Dockerfile.sget
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 ARG RUNTIME_IMAGE=gcr.io/distroless/base:debug
+ARG TARGETARCH
 
-FROM $RUNTIME_IMAGE
+FROM --platform=linux/${TARGETARCH} $RUNTIME_IMAGE
 
-ARG ARCH
-COPY sget-linux-${ARCH} /bin/sget
+ARG TARGETARCH
+COPY sget-linux-${TARGETARCH} /bin/sget
 
 USER nobody
 ENTRYPOINT [ "/bin/sget" ]

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ ifeq ($(DIFF), 1)
     GIT_TREESTATE = "dirty"
 endif
 
-PKG=github.com/sigstore/cosign/cmd/cosign/cli
+PKG=github.com/sigstore/cosign/cmd/cosign/cli/options
 
 LDFLAGS="-X $(PKG).GitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)"
 

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
     echo "Checking out ${_TOOL_REF}"
     git checkout ${_TOOL_REF}
 
-- name: 'gcr.io/projectsigstore/cosign:v1.2.0@sha256:96ef6fb02c5a56901dc3c2e0ca34eec9ed926ab8d936ea30ec38f9ec9db017a5'
+- name: 'gcr.io/projectsigstore/cosign:v1.2.1@sha256:68801416e6ae0a48820baa3f071146d18846d8cd26ca8ec3a1e87fca8a735498'
   dir: "go/src/sigstore/cosign"
   env:
   - RUNTIME_IMAGE=${_RUNTIME_IMAGE}
@@ -43,9 +43,8 @@ steps:
   - '-key'
   - 'https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub'
   - './Dockerfile'
-  waitFor: ['-']
 
-- name: 'gcr.io/projectsigstore/cosign:v1.2.0@sha256:96ef6fb02c5a56901dc3c2e0ca34eec9ed926ab8d936ea30ec38f9ec9db017a5'
+- name: 'gcr.io/projectsigstore/cosign:v1.2.1@sha256:68801416e6ae0a48820baa3f071146d18846d8cd26ca8ec3a1e87fca8a735498'
   dir: "go/src/sigstore/cosign"
   env:
   - RUNTIME_IMAGE=${_RUNTIME_IMAGE}
@@ -56,16 +55,26 @@ steps:
   - '-key'
   - 'https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub'
   - './Dockerfile.cosigned'
-  waitFor: ['-']
 
-- name: 'gcr.io/projectsigstore/cosign:v1.2.0@sha256:96ef6fb02c5a56901dc3c2e0ca34eec9ed926ab8d936ea30ec38f9ec9db017a5'
+- name: 'gcr.io/projectsigstore/cosign:v1.2.1@sha256:68801416e6ae0a48820baa3f071146d18846d8cd26ca8ec3a1e87fca8a735498'
+  dir: "go/src/sigstore/cosign"
+  env:
+  - RUNTIME_IMAGE=${_RUNTIME_IMAGE}
+  args:
+  - 'dockerfile'
+  - 'verify'
+  - '-base-image-only'
+  - '-key'
+  - 'https://raw.githubusercontent.com/GoogleContainerTools/distroless/main/cosign.pub'
+  - './Dockerfile.sget'
+
+- name: 'gcr.io/projectsigstore/cosign:v1.2.1@sha256:68801416e6ae0a48820baa3f071146d18846d8cd26ca8ec3a1e87fca8a735498'
   dir: "go/src/sigstore/cosign"
   args:
   - 'verify'
   - '-key'
   - 'https://raw.githubusercontent.com/gythialy/golang-cross/master/cosign.pub'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.2@sha256:24bb133da23e0d21a8e8a54416f652d753c7cb2ad8efb3e6a3ef652f597ada8f'
-  waitFor: ['-']
+  - 'ghcr.io/gythialy/golang-cross:v1.17.2-1@sha256:51f3c71079f6e1d7d0732b33bcc54ebd310f6ea155ac7dbe244a8695334bd50a'
 
 # maybe we can build our own image and use that to be more in a safe side
 - name: ghcr.io/gythialy/golang-cross:v1.17.2-1@sha256:51f3c71079f6e1d7d0732b33bcc54ebd310f6ea155ac7dbe244a8695334bd50a

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -68,7 +68,7 @@ steps:
   waitFor: ['-']
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.2@sha256:24bb133da23e0d21a8e8a54416f652d753c7cb2ad8efb3e6a3ef652f597ada8f
+- name: ghcr.io/gythialy/golang-cross:v1.17.2-1@sha256:51f3c71079f6e1d7d0732b33bcc54ebd310f6ea155ac7dbe244a8695334bd50a
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION
* `ghcr.io/gythialy/golang-cross:v1.17.2` -> `v1.17.2-1`
* Fixes the release maybe?

Release is getting the error:

```
...
Step #5:       • signing                   artifact=sget-darwin-arm64 cmd=./dist/cosign-linux-amd64
Step #5:    • docker images            
Step #5:       • building docker image     image=gcr.io/projectsigstore/cosigned:1.3.0-arm64v8
Step #5:       • building docker image     image=gcr.io/projectsigstore/sget:1.3.0-arm64v8
Step #5:       • building docker image     image=gcr.io/projectsigstore/cosign:1.3.0-arm64v8
Step #5:       • building docker image     image=gcr.io/projectsigstore/sget:1.3.0-amd64
Step #5:       • building docker image     image=gcr.io/projectsigstore/cosigned:1.3.0-amd64
Step #5:       • building docker image     image=gcr.io/projectsigstore/cosign:1.3.0-amd64
Step #5:    ⨯ release failed after 460.13s error=failed to build gcr.io/projectsigstore/cosigned:1.3.0-arm64v8: exit status 125: unknown flag: --load
Step #5: See 'docker --help'.
Step #5: 
Step #5: Usage:  docker [OPTIONS] COMMAND
Step #5: 
Step #5: A self-sufficient runtime for containers
Step #5: 
Step #5: Options:
Step #5:       --config string      Location of client config files (default
...
```

See https://github.com/sigstore/cosign/issues/988