### PR TITLE
Add ability for verify-blob to find signing cert in transparency log

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -27,8 +27,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/go-openapi/runtime"
 	"github.com/pkg/errors"
-
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
@@ -37,6 +37,9 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign/pivkey"
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	rekorClient "github.com/sigstore/rekor/pkg/client"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+	rekord "github.com/sigstore/rekor/pkg/types/rekord/v0.0.1"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigstoresigs "github.com/sigstore/sigstore/pkg/signature"
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
@@ -53,8 +56,34 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 	var err error
 	var cert *x509.Certificate
 
-	if !options.OneOf(ko.KeyRef, ko.Sk, certRef) {
+	if !options.OneOf(ko.KeyRef, ko.Sk, certRef) && !options.EnableExperimental() {
 		return &options.PubKeyParseError{}
+	}
+
+	var b64sig string
+	targetSig, err := blob.LoadFileOrURL(sigRef)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// ignore if file does not exist, it can be a base64 encoded string as well
+			return err
+		}
+		targetSig = []byte(sigRef)
+	}
+
+	if isb64(targetSig) {
+		b64sig = string(targetSig)
+	} else {
+		b64sig = base64.StdEncoding.EncodeToString(targetSig)
+	}
+
+	var blobBytes []byte
+	if blobRef == "-" {
+		blobBytes, err = io.ReadAll(os.Stdin)
+	} else {
+		blobBytes, err = blob.LoadFileOrURL(blobRef)
+	}
+	if err != nil {
+		return err
 	}
 
 	// Keys are optional!
@@ -92,32 +121,35 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 		if err != nil {
 			return err
 		}
-	}
-
-	var b64sig string
-	targetSig, err := blob.LoadFileOrURL(sigRef)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			// ignore if file does not exist, it can be a base64 encoded string as well
+	case options.EnableExperimental():
+		rClient, err := rekorClient.GetRekorClient(ko.RekorURL)
+		if err != nil {
 			return err
 		}
-		targetSig = []byte(sigRef)
-	}
 
-	if isb64(targetSig) {
-		b64sig = string(targetSig)
-	} else {
-		b64sig = base64.StdEncoding.EncodeToString(targetSig)
-	}
+		uuids, err := cosign.FindTLogEntriesByPayload(rClient, blobBytes)
+		if err != nil {
+			return err
+		}
 
-	var blobBytes []byte
-	if blobRef == "-" {
-		blobBytes, err = io.ReadAll(os.Stdin)
-	} else {
-		blobBytes, err = blob.LoadFileOrURL(blobRef)
-	}
-	if err != nil {
-		return err
+		if len(uuids) == 0 {
+			return errors.New("could not find a tlog entry for provided blob")
+		}
+
+		tlogEntry, err := cosign.GetTlogEntry(rClient, uuids[0])
+		if err != nil {
+			return err
+		}
+
+		certs, err := extractCerts(tlogEntry)
+		if err != nil {
+			return err
+		}
+		cert = certs[0]
+		pubKey, err = sigstoresigs.LoadECDSAVerifier(cert.PublicKey.(*ecdsa.PublicKey), crypto.SHA256)
+		if err != nil {
+			return err
+		}
 	}
 
 	sig, err := base64.StdEncoding.DecodeString(b64sig)
@@ -164,4 +196,48 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 	}
 
 	return nil
+}
+
+func extractCerts(e *models.LogEntryAnon) ([]*x509.Certificate, error) {
+	b, err := base64.StdEncoding.DecodeString(e.Body.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	pe, err := models.UnmarshalProposedEntry(bytes.NewReader(b), runtime.JSONConsumer())
+	if err != nil {
+		return nil, err
+	}
+
+	eimpl, err := types.NewEntry(pe)
+	if err != nil {
+		return nil, err
+	}
+
+	var v001Entry *rekord.V001Entry
+	var ok bool
+	if v001Entry, ok = eimpl.(*rekord.V001Entry); !ok {
+		return nil, errors.New("unexpected tlog entry type")
+	}
+
+	publicKeyB64, err := v001Entry.RekordObj.Signature.PublicKey.Content.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+
+	publicKey, err := base64.StdEncoding.DecodeString(string(publicKeyB64))
+	if err != nil {
+		return nil, err
+	}
+
+	certs, err := cryptoutils.UnmarshalCertificatesFromPEM(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(certs) == 0 {
+		return nil, errors.New("no certs found in pem tlog")
+	}
+
+	return certs, err
 }

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -260,7 +260,7 @@ func Verify(ctx context.Context, signedImgRef name.Reference, accessor Accessor,
 				// if we have a cert, we should check expiry
 				// The IntegratedTime verified in VerifyTlog
 				if cert != nil {
-					e, err := getTlogEntry(rekorClient, uuid)
+					e, err := GetTlogEntry(rekorClient, uuid)
 					if err != nil {
 						return err
 					}


### PR DESCRIPTION
#### Summary

When a user has opted into keyless mode, and they have signed a blob, allow a user to verify a blob without having to specify a certificate.

questions / concerns:
- Currently, the first certificate found in the tlog (for the blob) is used when verifying. However, this might not be the correct cert to use when verifying. I'm not sure what the *best* ux around this should be. Perhaps a new flag should be introduced to help narrow down which cert is used to verify the blob.  (Allow the user to specify a subject / email address?) or perhaps cosign should loop through all the certificates it finds and attempt to verify the blob + sig against each one (this has performance implications)
- where is a good place to add tests?


#### Ticket Link
Aims to improve https://github.com/sigstore/cosign/issues/676#issuecomment-955102906


#### Release Notes

```release-note
When a user has opted into keyless mode, and they have signed a blob, allow a user to verify a blob without having to specify a certificate.
```
