### PR TITLE
root policy: add optional issuer to maintainer keys

### DIFF
--- a/cmd/cosign/cli/options/policy.go
+++ b/cmd/cosign/cli/options/policy.go
@@ -23,6 +23,7 @@ import (
 type PolicyInitOptions struct {
 	ImageRef    string
 	Maintainers []string
+	Issuer      string
 	Threshold   int
 	Expires     int
 	OutFile     string
@@ -38,6 +39,9 @@ func (o *PolicyInitOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.OutFile, "out", "o",
 		"output policy locally")
+
+	cmd.Flags().StringVar(&o.Issuer, "issuer", "",
+		"trusted issuer to use for identity tokens, e.g. https://accounts.google.com")
 
 	cmd.Flags().IntVar(&o.Threshold, "threshold", 1,
 		"threshold for root policy signers")

--- a/doc/cosign_policy_init.md
+++ b/doc/cosign_policy_init.md
@@ -27,6 +27,7 @@ cosign policy init [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --expires int                                                                              total expire duration in days
   -h, --help                                                                                     help for init
+      --issuer string                                                                            trusted issuer to use for identity tokens, e.g. https://accounts.google.com
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
   -m, --maintainers strings                                                                      list of maintainers to add to the root policy
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")

--- a/pkg/cosign/tuf/signer.go
+++ b/pkg/cosign/tuf/signer.go
@@ -30,7 +30,7 @@ var (
 
 type FulcioKeyVal struct {
 	Identity string `json:"identity"`
-	Issuer   string `json:"issuer"`
+	Issuer   string `json:"issuer,omitempty"`
 }
 
 func FulcioVerificationKey(email string, issuer string) *Key {
@@ -41,4 +41,10 @@ func FulcioVerificationKey(email string, issuer string) *Key {
 		Algorithms: KeyAlgorithms,
 		Value:      keyValBytes,
 	}
+}
+
+func GetFulcioKeyVal(key *Key) (*FulcioKeyVal, error) {
+	fulcioKeyVal := &FulcioKeyVal{}
+	err := json.Unmarshal(key.Value, fulcioKeyVal)
+	return fulcioKeyVal, err
 }

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -17,6 +17,7 @@ package signature
 import (
 	"context"
 	"crypto"
+	"crypto/x509"
 	"os"
 	"path/filepath"
 	"strings"
@@ -160,4 +161,23 @@ func PublicKeyPem(key signature.PublicKeyProvider, pkOpts ...signature.PublicKey
 		return nil, err
 	}
 	return cryptoutils.MarshalPublicKeyToPEM(pub)
+}
+
+func CertSubject(c *x509.Certificate) string {
+	switch {
+	case c.EmailAddresses != nil:
+		return c.EmailAddresses[0]
+	case c.URIs != nil:
+		return c.URIs[0].String()
+	}
+	return ""
+}
+
+func CertIssuerExtension(cert *x509.Certificate) string {
+	for _, ext := range cert.Extensions {
+		if ext.Id.String() == "1.3.6.1.4.1.57264.1.1" {
+			return string(ext.Value)
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
* Adds an optional issuer to the trusted maintainer keys (e.g. we trust asraa@google.com with issuer https://accounts.google.com) now that the issuer is added to the Fulcio certificate. If a maintainer signs with a different issuer than one specified, then signing fails (test added). If no issuer is specified, then anything goes.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```

Sample root policy:
```
{
	"signatures": [
		{
			"cert": "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNuakNDQWlXZ0F3SUJBZ0lUZXZRcVc2NEFZb0ZqcE9Zc2l6eGxrenAzNHpBS0JnZ3Foa2pPUFFRREF6QXEKTVJVd0V3WURWUVFLRXd4emFXZHpkRzl5WlM1a1pYWXhFVEFQQmdOVkJBTVRDSE5wWjNOMGIzSmxNQjRYRFRJeApNVEV3TkRFNU1UVXlPVm9YRFRJeE1URXdOREU1TXpVeU9Gb3dBREJaTUJNR0J5cUdTTTQ5QWdFR0NDcUdTTTQ5CkF3RUhBMElBQk1TZ0o3WGR0K00wcmgwa2VHTERZaWlCUjBiRWRQSXhYak1VcUR0T1RjMEJZd0RUa1ZCWlZPeW0KcSsvYW9YUjQ5L3Nud3dadnlSOVQzTjJMY1E2aXdJcWpnZ0ZTTUlJQlRqQU9CZ05WSFE4QkFmOEVCQU1DQjRBdwpFd1lEVlIwbEJBd3dDZ1lJS3dZQkJRVUhBd013REFZRFZSMFRBUUgvQkFJd0FEQWRCZ05WSFE0RUZnUVU0cUpJCjEza0w5V0NzbUI5MzRHV1lkNTZTQkpRd0h3WURWUjBqQkJnd0ZvQVV5TVVkQUVHYUpDa3lVU1RyRGE1SzdVb0cKMCt3d2dZMEdDQ3NHQVFVRkJ3RUJCSUdBTUg0d2ZBWUlLd1lCQlFVSE1BS0djR2gwZEhBNkx5OXdjbWwyWVhSbApZMkV0WTI5dWRHVnVkQzAyTURObVpUZGxOeTB3TURBd0xUSXlNamN0WW1ZM05TMW1OR1kxWlRnd1pESTVOVFF1CmMzUnZjbUZuWlM1bmIyOW5iR1ZoY0dsekxtTnZiUzlqWVRNMllURmxPVFl5TkRKaU9XWmpZakUwTmk5allTNWoKY25Rd0hnWURWUjBSQVFIL0JCUXdFb0VRWVhOeVlXRkFaMjl2WjJ4bExtTnZiVEFwQmdvckJnRUVBWU8vTUFFQgpCQnRvZEhSd2N6b3ZMMkZqWTI5MWJuUnpMbWR2YjJkc1pTNWpiMjB3Q2dZSUtvWkl6ajBFQXdNRFp3QXdaQUl3Ck1zNk1yT0xLRWRLWGlkbzFncXRDK21RemZHMUczeEkvU0lUN0dVOGJhbnlqUWZLckZLb2M1Yi9XbHo5L3krZWwKQWpBWlcvY0t5T3V4LzNCSWVlWHVDVGFSeCtLRklzVUY1eWZ5YlBONnByYmJyc2NTakt0OUJPdUl3SXhUYmdQYwppd2c9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K",
			"keyid": "e47b8d2a2b634135d827af23abe80312caf36ddfbee96f5da18839858065a68f",
			"sig": "MEQCICafyPTsxLy2KHlbcc2JD6X/1gqqQ4o9DFYoWMpTSY++AiA9s3zyPlrhurolv+x7dk0Fg9H8bkJ8S+03tB9Eetr9Jw=="
		}
	],
	"signed": {
		"_type": "root",
		"consistent_snapshot": true,
		"expires": "2022-02-04T20:15:10Z",
		"keys": {
			"0eda0dd31d8fe01ae3f53bba953c1695c84897177a68563401766be789293623": {
				"keyid_hash_algorithms": [
					"sha256",
					"sha512"
				],
				"keytype": "sigstore-oidc",
				"keyval": {
					"identity": "jpenumak@redhat.com",
					"issuer": "https://accounts.google.com"
				},
				"scheme": "https://fulcio.sigstore.dev"
			},
			"c1c74a408e5ed201fca76a2a70be4e8073c3e94632b28b5e35963d082e0c7aee": {
				"keyid_hash_algorithms": [
					"sha256",
					"sha512"
				],
				"keytype": "sigstore-oidc",
				"keyval": {
					"identity": "lsturman@redhat.com",
					"issuer": "https://accounts.google.com"
				},
				"scheme": "https://fulcio.sigstore.dev"
			},
			"e47b8d2a2b634135d827af23abe80312caf36ddfbee96f5da18839858065a68f": {
				"keyid_hash_algorithms": [
					"sha256",
					"sha512"
				],
				"keytype": "sigstore-oidc",
				"keyval": {
					"identity": "asraa@google.com",
					"issuer": "https://accounts.google.com"
				},
				"scheme": "https://fulcio.sigstore.dev"
			},
			"eb3630ade0d69ff50375c5e2d67dc2ad30d90183b6ea67538b1c86459a56d897": {
				"keyid_hash_algorithms": [
					"sha256",
					"sha512"
				],
				"keytype": "sigstore-oidc",
				"keyval": {
					"identity": "asra123ali@gmail.com",
					"issuer": "https://accounts.google.com"
				},
				"scheme": "https://fulcio.sigstore.dev"
			}
		},
		"namespace": "ghcr.io/asraa/sigstore-kubecon",
		"roles": {
			"root": {
				"keyids": [
					"c1c74a408e5ed201fca76a2a70be4e8073c3e94632b28b5e35963d082e0c7aee",
					"eb3630ade0d69ff50375c5e2d67dc2ad30d90183b6ea67538b1c86459a56d897",
					"e47b8d2a2b634135d827af23abe80312caf36ddfbee96f5da18839858065a68f",
					"0eda0dd31d8fe01ae3f53bba953c1695c84897177a68563401766be789293623"
				],
				"threshold": 2
			}
		},
		"spec_version": "1.0",
		"version": 1
	}
}
```
