### PR TITLE
refactor release process to use ko to build the images

### DIFF
--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -169,6 +169,10 @@ jobs:
         sudo echo "127.0.0.1 $INSECURE_REGISTRY_NAME" | sudo tee -a /etc/hosts
 
     - name: Install cosigned
+      env:
+        GIT_HASH: $GITHUB_SHA
+        GIT_VERSION: ci
+        LDFLAGS: ""
       run: |
         ko apply -Bf config/
 

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -50,7 +50,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -w /go/src/sigstore/cosign \
             --entrypoint="" \
-            ghcr.io/gythialy/golang-cross:v1.17.2-1@sha256:51f3c71079f6e1d7d0732b33bcc54ebd310f6ea155ac7dbe244a8695334bd50a \
+            ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae \
             make snapshot
 
       - name: check binaries
@@ -58,9 +58,3 @@ jobs:
           ./dist/cosign-linux-amd64 version
           ./dist/cosigned-linux-amd64 --help
           ./dist/sget-linux-amd64 --help
-
-      - name: check images
-        run: |
-          docker run gcr.io/honk-fake-project/cosign:SNAPSHOT-${GITHUB_SHA:0:7}-amd64 version
-          docker run gcr.io/honk-fake-project/cosigned:SNAPSHOT-${GITHUB_SHA:0:7}-amd64 --help
-          docker run gcr.io/honk-fake-project/sget:SNAPSHOT-${GITHUB_SHA:0:7}-amd64 --help

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,7 @@ env:
   - CGO_ENABLED=1
   - DOCKER_CLI_EXPERIMENTAL=enabled
 
-# Prevents parallel builds from stepping on eachothers toes downloading modules
+# Prevents parallel builds from stepping on each others toes downloading modules
 before:
   hooks:
   - go mod tidy
@@ -23,6 +23,11 @@ builds:
   goarch:
     - amd64
     - arm64
+    - arm
+    - s390x
+    - ppc64le
+  goarm:
+    - 7
   ldflags:
     - "{{ .Env.LDFLAGS }}"
   env:
@@ -108,6 +113,7 @@ builds:
     - CC=x86_64-w64-mingw32-gcc
     - CXX=x86_64-w64-mingw32-g++
   main: ./cmd/cosign
+  mod_timestamp: '{{ .CommitTimestamp }}'
   flags:
     - -trimpath
   goos:
@@ -124,6 +130,7 @@ builds:
   binary: cosigned-linux-{{ .Arch }}
   no_unique_dist_dir: true
   main: ./cmd/cosign/webhook
+  mod_timestamp: '{{ .CommitTimestamp }}'
   flags:
     - -trimpath
   goos:
@@ -131,6 +138,11 @@ builds:
   goarch:
     - amd64
     - arm64
+    - arm
+    - s390x
+    - ppc64le
+  goarm:
+    - 7
   ldflags:
     - "{{ .Env.LDFLAGS }}"
   env:
@@ -139,6 +151,7 @@ builds:
 - id: sget
   binary: sget-{{ .Os }}-{{ .Arch }}
   no_unique_dist_dir: true
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./cmd/sget
   flags:
     - -trimpath
@@ -149,9 +162,20 @@ builds:
   goarch:
     - amd64
     - arm64
+    - arm
+    - s390x
+    - ppc64le
+  goarm:
+    - 7
   ignore:
     - goos: windows
       goarch: arm64
+    - goos: windows
+      goarch: arm
+    - goos: windows
+      goarch: s390x
+    - goos: windows
+      goarch: ppc64le
   ldflags:
     - "{{ .Env.LDFLAGS }}"
   env:
@@ -177,92 +201,6 @@ signs:
     artifacts: binary
     ids:
       - sget
-
-dockers:
-  # cosign Image
-  - image_templates:
-      - "gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-amd64"
-    dockerfile: Dockerfile
-    goos: linux
-    goarch: amd64
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      # TODO(dekkagaijin): remove suffix when race condition fixed
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-amd64"
-      - "--build-arg=TARGETARCH=amd64"
-  - image_templates:
-      - "gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-arm64v8"
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      # TODO(dekkagaijin): remove suffix when race condition fixed
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-arm64"
-      - "--build-arg=TARGETARCH=arm64"
-
-  # cosigned Image
-  - image_templates:
-      - "gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-amd64"
-    dockerfile: Dockerfile.cosigned
-    goos: linux
-    goarch: amd64
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      # TODO(dekkagaijin): remove suffix when race condition fixed
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-amd64"
-      - "--build-arg=TARGETARCH=amd64"
-  - image_templates:
-      - "gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-arm64v8"
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile.cosigned
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      # TODO(dekkagaijin): remove suffix when race condition fixed
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-arm64"
-      - "--build-arg=TARGETARCH=arm64"
-
-  # sget Image
-  - image_templates:
-      - "gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-amd64"
-    dockerfile: Dockerfile.sget
-    goos: linux
-    goarch: amd64
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      # TODO(dekkagaijin): remove suffix when race condition fixed
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-amd64"
-      - "--build-arg=TARGETARCH=amd64"
-  - image_templates:
-      - "gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8"
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile.sget
-    build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      # TODO(dekkagaijin): remove suffix when race condition fixed
-      - "--build-arg=RUNTIME_IMAGE={{ .Env.RUNTIME_IMAGE }}-arm64"
-      - "--build-arg=TARGETARCH=arm64"
-
-docker_manifests:
-  - name_template: gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}
-    image_templates:
-      - gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-amd64
-      - gcr.io/{{ .Env.PROJECT_ID }}/cosign:{{ .Version }}-arm64v8
-  - name_template: gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}
-    image_templates:
-      - gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-amd64
-      - gcr.io/{{ .Env.PROJECT_ID }}/cosigned:{{ .Version }}-arm64v8
-  - name_template: gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}
-    image_templates:
-      - gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-amd64
-      - gcr.io/{{ .Env.PROJECT_ID }}/sget:{{ .Version }}-arm64v8
-
-docker_signs:
-  - artifacts: all
-    cmd: ./dist/cosign-linux-amd64
-    args: [ "sign", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}" ]
 
 archives:
 - format: binary

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -15,3 +15,49 @@
 
 # We need a shell for a lot of redirection/piping to work
 defaultBaseImage: gcr.io/distroless/base:debug-nonroot
+
+builds:
+- id: cosign
+  dir: .
+  main: ./cmd/cosign
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - -tags
+  - "{{ .Env.GIT_HASH }}"
+  - -tags
+  - "{{ .Env.GIT_VERSION }}"
+  ldflags:
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
+
+- id: cosigned
+  dir: .
+  main: ./cmd/cosign/webhook
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - --tags
+  - "{{ .Env.GIT_HASH }}"
+  - --tags
+  - "{{ .Env.GIT_VERSION }}"
+  ldflags:
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
+
+- id: sget
+  dir: .
+  main: ./cmd/sget
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - --tags
+  - "{{ .Env.GIT_HASH }}"
+  - --tags
+  - "{{ .Env.GIT_VERSION }}"
+  ldflags:
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -74,10 +74,10 @@ steps:
   - 'verify'
   - '--key'
   - 'https://raw.githubusercontent.com/gythialy/golang-cross/master/cosign.pub'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.2-1@sha256:51f3c71079f6e1d7d0732b33bcc54ebd310f6ea155ac7dbe244a8695334bd50a'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae'
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.2-1@sha256:51f3c71079f6e1d7d0732b33bcc54ebd310f6ea155ac7dbe244a8695334bd50a
+- name: ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -97,6 +97,27 @@ steps:
     - |
       git tag ${_GIT_TAG}
       make release
+
+- name: ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae
+  entrypoint: 'bash'
+  dir: "go/src/sigstore/cosign"
+  env:
+  - "GOPATH=/workspace/go"
+  - "GOBIN=/workspace/bin"
+  - PROJECT_ID=${PROJECT_ID}
+  - KEY_LOCATION=${_KEY_LOCATION}
+  - KEY_RING=${_KEY_RING}
+  - KEY_NAME=${_KEY_NAME}
+  - KEY_VERSION=${_KEY_VERSION}
+  - GIT_TAG=${_GIT_TAG}
+  - KO_PREFIX=gcr.io/${PROJECT_ID}
+  secretEnv:
+  - GITHUB_TOKEN
+  args:
+    - '-c'
+    - |
+      gcloud auth configure-docker \
+      && make sign-container-release
 
 availableSecrets:
   secretManager:

--- a/release/release.mk
+++ b/release/release.mk
@@ -1,0 +1,28 @@
+##################
+# release section
+##################
+
+# used when releasing together with GCP CloudBuild
+.PHONY: release
+release:
+	LDFLAGS="$(LDFLAGS)" goreleaser release
+
+.PHONY: sign-cosign-release
+sign-cosign-release:
+	cosign sign --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosign:$(GIT_VERSION)
+
+.PHONY: sign-cosigned-release
+sign-cosigned-release:
+	cosign sign --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosigned:$(GIT_VERSION)
+
+.PHONY: sign-sget-release
+sign-sget-release:
+	cosign sign --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/sget:$(GIT_VERSION)
+
+.PHONY: sign-container-release
+sign-container-release: ko sign-cosign-release sign-cosigned-release sign-sget-release
+
+# used when need to validate the goreleaser
+.PHONY: snapshot
+snapshot:
+	LDFLAGS="$(LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --rm-dist

--- a/test/ci.mk
+++ b/test/ci.mk
@@ -1,0 +1,15 @@
+############
+# signing ci
+############
+
+.PHONY: sign-container
+sign-container: ko
+	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosign:$(GIT_HASH)
+
+.PHONY: sign-cosigned
+sign-cosigned:
+	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosigned:$(GIT_HASH)
+
+.PHONY: sign-sget
+sign-sget:
+	cosign sign --key .github/workflows/cosign.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/sget:$(GIT_HASH)

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -64,7 +64,7 @@ if (./cosign manifest verify --key ${DISTROLESS_PUB_KEY} ./test/testdata/unsigne
 
 # Run the built container to make sure it doesn't crash
 make ko-local
-img="ko.local:$(git rev-parse HEAD)"
+img="ko.local/cosign:$(git rev-parse HEAD)"
 docker run $img version
 
 echo "cleanup"


### PR DESCRIPTION

#### Summary
- add more platforms when building the binaries
- use ko to build/push the container images

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
 refactor release process to use ko to build the images
```
