### PR TITLE
feat: add output cert for keyless

### DIFF
--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -23,15 +23,16 @@ import (
 
 // SignBlobOptions is the top level wrapper for the sign-blob command.
 type SignBlobOptions struct {
-	Key          string
-	Base64Output bool
-	Output       string // TODO: this should be the root output file arg.
-	SecurityKey  SecurityKeyOptions
-	Fulcio       FulcioOptions
-	Rekor        RekorOptions
-	OIDC         OIDCOptions
-	Registry     RegistryOptions
-	Timeout      time.Duration
+	Key             string
+	Base64Output    bool
+	OutputSignature string // TODO: this should be the root output file arg.
+	OutputCert      string // TODO: this should be the root output file arg.
+	SecurityKey     SecurityKeyOptions
+	Fulcio          FulcioOptions
+	Rekor           RekorOptions
+	OIDC            OIDCOptions
+	Registry        RegistryOptions
+	Timeout         time.Duration
 }
 
 var _ Interface = (*SignBlobOptions)(nil)
@@ -50,8 +51,11 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Base64Output, "b64", true,
 		"whether to base64 encode the output")
 
-	cmd.Flags().StringVar(&o.Output, "output", "",
+	cmd.Flags().StringVar(&o.OutputSignature, "output-sig", "",
 		"write the signature to FILE")
+
+	cmd.Flags().StringVar(&o.OutputCert, "output-cert", "",
+		"write the certificate to FILE")
 
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", time.Second*30,
 		"HTTP Timeout defaults to 30 seconds")

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -74,7 +74,7 @@ func SignBlob() *cobra.Command {
 				OIDCClientSecret:         o.OIDC.ClientSecret,
 			}
 			for _, blob := range args {
-				if _, err := sign.SignBlobCmd(cmd.Context(), ko, o.Registry, blob, o.Base64Output, o.Output, o.Timeout); err != nil {
+				if _, err := sign.SignBlobCmd(cmd.Context(), ko, o.Registry, blob, o.Base64Output, o.OutputSignature, o.OutputCert, o.Timeout); err != nil {
 					return errors.Wrapf(err, "signing %s", blob)
 				}
 			}

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -45,7 +45,8 @@ cosign sign-blob [flags]
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
-      --output string                                                                            write the signature to FILE
+      --output-cert string                                                                       write the certificate to FILE
+      --output-sig string                                                                        write the signature to FILE
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,7 +28,7 @@ import (
 // This is the fallback data used when version information from git is not
 // provided via go ldflags (e.g. via Makefile).
 var (
-	// Output of "git describe". The prerequisite is that the branch should be
+	// OutputSignature of "git describe". The prerequisite is that the branch should be
 	// tagged using the correct versioning strategy.
 	GitVersion = "devel"
 	// SHA1 from git, output of $(git rev-parse HEAD)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -409,7 +409,7 @@ func TestSignBlob(t *testing.T) {
 		KeyRef:   privKeyPath1,
 		PassFunc: passFunc,
 	}
-	sig, err := sign.SignBlobCmd(ctx, ko, options.RegistryOptions{}, bp, true, "", time.Duration(30*time.Second))
+	sig, err := sign.SignBlobCmd(ctx, ko, options.RegistryOptions{}, bp, true, "", "", time.Duration(30*time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>
Co-authored-by: Furkan Türkal <furkan.turkal@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Add ability to output certificate for keyless mode

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #936

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
feat: add output cert for keyless
```

![render1636543302281](https://user-images.githubusercontent.com/16693043/141104886-4be2b9c1-32c5-4cd6-b108-c9bdf60a94a4.gif)

