### PR TITLE
fix(doc): add an example for existing option on verify-blob command

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -200,7 +200,11 @@ The blob may be specified as a path to a file or - for stdin.`,
   cosign verify-blob --key gitlab://[OWNER]/[PROJECT_NAME]  --signature $sig <blob>
 
   # Verify a signature against GitLab with project id
-  cosign verify-blob --key gitlab://[PROJECT_ID]  --signature $sig <blob>`,
+  cosign verify-blob --key gitlab://[PROJECT_ID]  --signature $sig <blob>
+
+  # Verify a signature against a certificate
+  cosign verify-blob --cert <cert> --signature $sig <blob>
+`,
 
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -52,6 +52,10 @@ cosign verify-blob [flags]
 
   # Verify a signature against GitLab with project id
   cosign verify-blob --key gitlab://[PROJECT_ID]  --signature $sig <blob>
+
+  # Verify a signature against a certificate
+  cosign verify-blob --cert <cert> --signature $sig <blob>
+
 ```
 
 ### Options


### PR DESCRIPTION
Co-authored-by: Furkan Türkal <furkan.turkal@trendyol.com>
Co-authored-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>
Signed-off-by: Erkan Zileli <erkan.zileli@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

An existing option is documented with an example on the verify-blob command.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
