### PR TITLE
ci: update oidc ci tests

### DIFF
--- a/.github/workflows/github-oidc.yaml
+++ b/.github/workflows/github-oidc.yaml
@@ -29,6 +29,10 @@ jobs:
     env:
       COSIGN_EXPERIMENTAL: "true"
       GIT_HASH: $GITHUB_SHA
+      GIT_VERSION: latest
+      GITHUB_RUN_ID: ${{ github.run_id }}
+      GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+      KO_PREFIX: ghcr.io/sigstore/cosign
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -43,13 +47,5 @@ jobs:
       - name: Build and sign a container image
         run: |
           set -e
-
           # Build and publish an image.
-          image=$(ko publish --preserve-import-paths ./cmd/cosign)
-
-          # Sign the image and annotate relevant information.
-          cosign sign \
-            -a sha=${{ github.sha }} \
-            -a run_id=${{ github.run_id }} \
-            -a run_attempt=${{ github.run_attempt }} \
-            ${image}
+          make sign-keyless-container

--- a/test/ci.mk
+++ b/test/ci.mk
@@ -13,3 +13,21 @@ sign-cosigned:
 .PHONY: sign-sget
 sign-sget:
 	cosign sign --key .github/workflows/cosign-test.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/sget:$(GIT_HASH)
+
+.PHONY: sign-keyless-cosign
+sign-keyless-cosign:
+	cosign sign -a sha=$(GIT_HASH) -a run_id=${GITHUB_RUN_ID} -a run_attempt=${GITHUB_RUN_ATTEMPT} ${KO_PREFIX}/cosign:$(GIT_HASH)
+	cosign sign -a sha=$(GIT_HASH) -a run_id=${GITHUB_RUN_ID} -a run_attempt=${GITHUB_RUN_ATTEMPT} ${KO_PREFIX}/cosign:$(GIT_VERSION)
+
+.PHONY: sign-keyless-cosigned
+sign-keyless-cosigned:
+	cosign sign -a sha=$(GIT_HASH) -a run_id=${GITHUB_RUN_ID} -a run_attempt=${GITHUB_RUN_ATTEMPT} ${KO_PREFIX}/cosigned:$(GIT_HASH)
+	cosign sign -a sha=$(GIT_HASH) -a run_id=${GITHUB_RUN_ID} -a run_attempt=${GITHUB_RUN_ATTEMPT} ${KO_PREFIX}/cosigned:$(GIT_VERSION)
+
+.PHONY: sign-keyless-sget
+sign-keyless-sget:
+	cosign sign -a sha=$(GIT_HASH) -a run_id=${GITHUB_RUN_ID} -a run_attempt=${GITHUB_RUN_ATTEMPT} ${KO_PREFIX}/sget:$(GIT_HASH)
+	cosign sign -a sha=$(GIT_HASH) -a run_id=${GITHUB_RUN_ID} -a run_attempt=${GITHUB_RUN_ATTEMPT} ${KO_PREFIX}/sget:$(GIT_VERSION)
+
+.PHONY: sign-keyless-container
+sign-keyless-container: ko sign-keyless-cosign sign-keyless-cosigned sign-keyless-sget


### PR DESCRIPTION
#### Summary
the oidc tests are broken after we make the changes in how to build the images using `ko` and adding some definitions


#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
ci: update oidc ci tests
```
