### PR TITLE
Patch support attestation log search and bundle to payload hash check

### DIFF
--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -144,6 +144,8 @@ func proposedEntry(b64Sig string, payload, pubKey []byte) ([]models.ProposedEntr
 		return nil, errors.Wrap(err, "decoding base64 signature")
 	}
 
+	// The fact that there's no signature (or empty rather), implies
+	// that this is an Attestation that we're verifying.
 	if len(signature) == 0 {
 		te := intotoEntry(payload, pubKey)
 		entry := &models.Intoto{

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -334,9 +334,13 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 
 	payload, err := sig.Payload()
 	if err != nil {
-		return false, errors.Wrap(err, "checking reading payload")
+		return false, errors.Wrap(err, "reading payload")
 	}
-	signature, _ := sig.Base64Signature()
+	signature, err := sig.Base64Signature()
+	if err != nil {
+		return false, errors.Wrap(err, "reading base64signature")
+	}
+
 	alg, bundlehash, err := BundleHash(bundle.Payload.Body.(string), signature, payload)
 	h := sha256.Sum256(payload)
 	payloadHash := hex.EncodeToString(h[:])

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -341,7 +341,7 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 		return false, errors.Wrap(err, "reading base64signature")
 	}
 
-	alg, bundlehash, err := BundleHash(bundle.Payload.Body.(string), signature, payload)
+	alg, bundlehash, err := bundleHash(bundle.Payload.Body.(string), signature, payload)
 	h := sha256.Sum256(payload)
 	payloadHash := hex.EncodeToString(h[:])
 
@@ -351,7 +351,7 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 	return true, nil
 }
 
-func BundleHash(bundleBody, signature string, payload []byte) (string, string, error) {
+func bundleHash(bundleBody, signature string, payload []byte) (string, string, error) {
 	var toto models.Intoto
 	var rekord models.Rekord
 	var intotoObj models.IntotoV001Schema
@@ -361,6 +361,9 @@ func BundleHash(bundleBody, signature string, payload []byte) (string, string, e
 	if err != nil {
 		return "", "", err
 	}
+
+	// The fact that there's no signature (or empty rather), implies
+	// that this is an Attestation that we're verifying.
 	if len(signature) == 0 {
 		err = json.Unmarshal(bodyDecoded, &toto)
 		if err != nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -343,9 +343,8 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 
 	if alg != "sha256" || bundlehash != payloadHash {
 		return false, errors.Wrap(err, "matching bundle to payload")
-	} else {
-		return true, nil
 	}
+	return true, nil
 }
 
 func BundleHash(bundleBody, signature string, payload []byte) (string, string, error) {
@@ -374,22 +373,22 @@ func BundleHash(bundleBody, signature string, payload []byte) (string, string, e
 		}
 
 		return *intotoObj.Content.Hash.Algorithm, *intotoObj.Content.Hash.Value, nil
-	} else {
-		err = json.Unmarshal(bodyDecoded, &rekord)
-		if err != nil {
-			return "", "", err
-		}
-
-		specMarshal, err := json.Marshal(rekord.Spec)
-		if err != nil {
-			return "", "", err
-		}
-		err = json.Unmarshal(specMarshal, &rekordObj)
-		if err != nil {
-			return "", "", err
-		}
-		return *rekordObj.Data.Hash.Algorithm, *rekordObj.Data.Hash.Value, nil
 	}
+
+	err = json.Unmarshal(bodyDecoded, &rekord)
+	if err != nil {
+		return "", "", err
+	}
+
+	specMarshal, err := json.Marshal(rekord.Spec)
+	if err != nil {
+		return "", "", err
+	}
+	err = json.Unmarshal(specMarshal, &rekordObj)
+	if err != nil {
+		return "", "", err
+	}
+	return *rekordObj.Data.Hash.Algorithm, *rekordObj.Data.Hash.Value, nil
 }
 
 func VerifySET(bundlePayload oci.BundlePayload, signature []byte, pub *ecdsa.PublicKey) error {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -37,6 +38,7 @@ import (
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 	rekor "github.com/sigstore/rekor/pkg/client"
 	"github.com/sigstore/rekor/pkg/generated/client"
+	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
@@ -329,7 +331,65 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 	if err := checkExpiry(cert, time.Unix(bundle.Payload.IntegratedTime, 0)); err != nil {
 		return false, errors.Wrap(err, "checking expiry on cert")
 	}
-	return true, nil
+
+	payload, err := sig.Payload()
+	if err != nil {
+		return false, errors.Wrap(err, "checking reading payload")
+	}
+	signature, _ := sig.Base64Signature()
+	alg, bundlehash, err := BundleHash(bundle.Payload.Body.(string), signature, payload)
+	h := sha256.Sum256(payload)
+	payloadHash := hex.EncodeToString(h[:])
+
+	if alg != "sha256" || bundlehash != payloadHash {
+		return false, errors.Wrap(err, "matching bundle to payload")
+	} else {
+		return true, nil
+	}
+}
+
+func BundleHash(bundleBody, signature string, payload []byte) (string, string, error) {
+	var toto models.Intoto
+	var rekord models.Rekord
+	var intotoObj models.IntotoV001Schema
+	var rekordObj models.RekordV001Schema
+
+	bodyDecoded, err := base64.StdEncoding.DecodeString(bundleBody)
+	if err != nil {
+		return "", "", err
+	}
+	if len(signature) == 0 {
+		err = json.Unmarshal(bodyDecoded, &toto)
+		if err != nil {
+			return "", "", err
+		}
+
+		specMarshal, err := json.Marshal(toto.Spec)
+		if err != nil {
+			return "", "", err
+		}
+		err = json.Unmarshal(specMarshal, &intotoObj)
+		if err != nil {
+			return "", "", err
+		}
+
+		return *intotoObj.Content.Hash.Algorithm, *intotoObj.Content.Hash.Value, nil
+	} else {
+		err = json.Unmarshal(bodyDecoded, &rekord)
+		if err != nil {
+			return "", "", err
+		}
+
+		specMarshal, err := json.Marshal(rekord.Spec)
+		if err != nil {
+			return "", "", err
+		}
+		err = json.Unmarshal(specMarshal, &rekordObj)
+		if err != nil {
+			return "", "", err
+		}
+		return *rekordObj.Data.Hash.Algorithm, *rekordObj.Data.Hash.Value, nil
+	}
 }
 
 func VerifySET(bundlePayload oci.BundlePayload, signature []byte, pub *ecdsa.PublicKey) error {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -341,7 +341,7 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 		return false, errors.Wrap(err, "reading base64signature")
 	}
 
-	alg, bundlehash, err := bundleHash(bundle.Payload.Body.(string), signature, payload)
+	alg, bundlehash, err := bundleHash(bundle.Payload.Body.(string), signature)
 	h := sha256.Sum256(payload)
 	payloadHash := hex.EncodeToString(h[:])
 
@@ -351,7 +351,7 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 	return true, nil
 }
 
-func bundleHash(bundleBody, signature string, payload []byte) (string, string, error) {
+func bundleHash(bundleBody, signature string) (string, string, error) {
 	var toto models.Intoto
 	var rekord models.Rekord
 	var intotoObj models.IntotoV001Schema


### PR DESCRIPTION
Signed-off-by: houdini91 <mdstrauss91@gmail.com>

Hi guys.
My first PR to cosign hope i am not misunderstanding something critical.

## Summary
PR is a patch to the rekor validation flow when using attestation.
1) When bundle is not present searching for intoto rekor entries would fail because of search was using in to the wrong entry type (rekord vs intoto).
2) When verifying the attached rekor Bundle the certificate expire was checked and the validity of the bundle signiture.
I added a  hash test between the bundle content hash and actual payload hash.
I am not sure if the idea is to verify the bundle actual body is the responsibility of the policy.
