### PR TITLE
PKCS11: Fix certificate check

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -342,7 +342,7 @@ func SignerFromKeyOpts(ctx context.Context, certPath string, ko KeyOpts) (*CertS
 		if ok {
 			certFromPKCS11, err := pkcs11Key.Certificate()
 			var pemBytes []byte
-			if err != nil {
+			if certFromPKCS11 == nil {
 				fmt.Fprintln(os.Stderr, "warning: no x509 certificate retrieved from the PKCS11 token")
 			} else {
 				pemBytes, err = cryptoutils.MarshalCertificateToPEM(certFromPKCS11)

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -340,7 +340,7 @@ func SignerFromKeyOpts(ctx context.Context, certPath string, ko KeyOpts) (*CertS
 		// user.
 		pkcs11Key, ok := k.(*pkcs11key.Key)
 		if ok {
-			certFromPKCS11, err := pkcs11Key.Certificate()
+			certFromPKCS11, _ := pkcs11Key.Certificate()
 			var pemBytes []byte
 			if certFromPKCS11 == nil {
 				fmt.Fprintln(os.Stderr, "warning: no x509 certificate retrieved from the PKCS11 token")


### PR DESCRIPTION
#### Summary
This PR fixes a wrong check for when the PKCS11 certificate does not exist.

#### Ticket Link
Fixes [#1037](https://github.com/sigstore/cosign/issues/1037)

#### Release Note
```release-note

```
