### PR TITLE
Remove img field from sigLayer

### DIFF
--- a/pkg/oci/remote/layer.go
+++ b/pkg/oci/remote/layer.go
@@ -30,7 +30,6 @@ import (
 
 type sigLayer struct {
 	v1.Layer
-	img  *sigs
 	desc v1.Descriptor
 }
 
@@ -43,13 +42,8 @@ func (s *sigLayer) Annotations() (map[string]string, error) {
 
 // Payload implements oci.Signature
 func (s *sigLayer) Payload() ([]byte, error) {
-	l, err := s.img.LayerByDigest(s.desc.Digest)
-	if err != nil {
-		return nil, err
-	}
-
 	// Compressed is a misnomer here, we just want the raw bytes from the registry.
-	r, err := l.Compressed()
+	r, err := s.Layer.Compressed()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/remote/layer_test.go
+++ b/pkg/oci/remote/layer_test.go
@@ -22,12 +22,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/oci"
-	ociempty "github.com/sigstore/cosign/pkg/oci/empty"
 )
 
 func TestSignature(t *testing.T) {
@@ -55,9 +53,7 @@ func TestSignature(t *testing.T) {
 	}{{
 		name: "just payload and signature",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
@@ -69,9 +65,7 @@ func TestSignature(t *testing.T) {
 	}, {
 		name: "with empty other keys",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
@@ -84,26 +78,9 @@ func TestSignature(t *testing.T) {
 		},
 		wantSig: "blah",
 	}, {
-		name: "bad digest",
-		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
-			desc: v1.Descriptor{
-				Digest: v1.Hash{Algorithm: "bad", Hex: "f00d"},
-				Annotations: map[string]string{
-					sigkey: "blah",
-				},
-			},
-		},
-		wantPayloadErr: errors.New("unknown blob bad:f00d"),
-		wantSig:        "blah",
-	}, {
 		name: "missing signature",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 			},
@@ -112,9 +89,7 @@ func TestSignature(t *testing.T) {
 	}, {
 		name: "min plus bad bundle",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
@@ -128,9 +103,7 @@ func TestSignature(t *testing.T) {
 	}, {
 		name: "min plus bad cert",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
@@ -144,9 +117,7 @@ func TestSignature(t *testing.T) {
 	}, {
 		name: "min plus bad chain",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
@@ -160,9 +131,7 @@ func TestSignature(t *testing.T) {
 	}, {
 		name: "min plus bundle",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
@@ -186,9 +155,7 @@ func TestSignature(t *testing.T) {
 	}, {
 		name: "min plus good cert",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
@@ -220,9 +187,7 @@ uThR1Z6JuA21HwxtL3GyJ8UQZcEPOlTBV593HrSAwBhiCoY=
 	}, {
 		name: "min plus bad chain",
 		l: &sigLayer{
-			img: &sigs{
-				Image: must(mutate.Append(ociempty.Signatures(), mutate.Addendum{Layer: layer})),
-			},
+			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{

--- a/pkg/oci/remote/remote_test.go
+++ b/pkg/oci/remote/remote_test.go
@@ -25,13 +25,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func must(img v1.Image, err error) v1.Image {
-	if err != nil {
-		panic(err.Error())
-	}
-	return img
-}
-
 func mustDecode(s string) []byte {
 	b, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {

--- a/pkg/oci/remote/signatures.go
+++ b/pkg/oci/remote/signatures.go
@@ -65,7 +65,6 @@ func (s *sigs) Get() ([]oci.Signature, error) {
 		}
 		signatures = append(signatures, &sigLayer{
 			Layer: layer,
-			img:   s,
 			desc:  desc,
 		})
 	}


### PR DESCRIPTION
We can use the already available Layer to get the payload, so we shouldn't need the `img` field. The only thing we lose is that we no longer call `img.LayerByDigest` so if the descriptor digest is invalid or doesn't match then we don't catch that anymore.
