### PR TITLE
verify-blob: make the signature flag mandatory

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -62,6 +62,9 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 	}
 
 	var b64sig string
+	if sigRef == "" {
+		return fmt.Errorf("missing flag '--signature'")
+	}
 	targetSig, err := blob.LoadFileOrURL(sigRef)
 	if err != nil {
 		if !os.IsNotExist(err) {


### PR DESCRIPTION
#### Summary

Before this commit, the verify-blob command would fail ungracefully in experimental mode
if no signature has been provided. This commit adds a better fitting error message.

##### Before this change:

```
❯ COSIGN_EXPERIMENTAL=1  cosign verify-blob /tmp/hello-world.txt
Error: verifying blob [/tmp/hello-world.txt]: read .: is a directory
main.go:46: error during command execution: verifying blob [/tmp/hello-world.txt]: read .: is a directory
```

##### After this change:

```
❯ COSIGN_EXPERIMENTAL=1  cosign verify-blob /tmp/hello-world.txt
Error: verifying blob [/tmp/hello-world.txt]: missing flag '--signature'
main.go:46: error during command execution: verifying blob [/tmp/hello-world.txt]: missing flag '--signature'
```

#### Ticket Link

None

#### Release Note

```release-note
Fixed: verify-blob error message for missing signature flag
```
