### PR TITLE
verify-blob: add URI to verify-blob output

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -174,6 +174,10 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 		}
 		fmt.Fprintln(os.Stderr, "Certificate is trusted by Fulcio Root CA")
 		fmt.Fprintln(os.Stderr, "Email:", cert.EmailAddresses)
+		for _, uri := range cert.URIs {
+			fmt.Fprintf(os.Stderr, "URI: %s://%s%s\n", uri.Scheme, uri.Host, uri.Path)
+		}
+		fmt.Fprintln(os.Stderr, "Issuer: ", sigs.CertIssuerExtension(cert))
 	}
 	fmt.Fprintln(os.Stderr, "Verified OK")
 


### PR DESCRIPTION
#### Summary

Adds an URI field to the verify-blob output.

Before this PR:
```
❯ COSIGN_EXPERIMENTAL=1  cosign verify-blob /tmp/mnemonic-0.3.1.tar.gz --signature /tmp/mnemonic-0.3.1.tar.gz.sig
Certificate is trusted by Fulcio Root CA
Email: []
Verified OK
tlog entry verified with uuid: "228527476f82c59641e27b8fb9b32f5fadbe47cf42c544ea97dc798490c4c14e" index: 853327
```

After this PR:

```
❯ COSIGN_EXPERIMENTAL=1  ./cosign verify-blob /tmp/mnemonic-0.3.1.tar.gz --signature /tmp/mnemonic-0.3.1.tar.gz.sig
Certificate is trusted by Fulcio Root CA
Email: []
URI: https://github.com/shibumi/mnemonic/.github/workflows/goreleaser.yml@refs/tags/v0.3.1
Issuer:  https://token.actions.githubusercontent.com
Verified OK
tlog entry verified with uuid: "228527476f82c59641e27b8fb9b32f5fadbe47cf42c544ea97dc798490c4c14e" index: 853327
```

#### Ticket Link

Fixes #1046 

#### Release Note

```release-note
verify-blob gained functionality for printing the URIs of the certificate if there are any.
```
