### PR TITLE
fix: reproducible builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,9 @@ before:
   hooks:
   - go mod tidy
 
+gomod:
+  proxy: true
+
 builds:
 - id: linux
   binary: cosign-linux-{{ .Arch }}
@@ -27,7 +30,7 @@ builds:
     - s390x
     - ppc64le
   goarm:
-    - 7
+    - '7'
   ldflags:
     - "{{ .Env.LDFLAGS }}"
   env:


### PR DESCRIPTION
#### Summary

On #1019 there are some discussion about the builds not being reproducible.

We could also ditch the ldflags and read from `debug.ReadBuildInfo()` only.

What this PR does is:

- enable go mod proxying, so all releases (except snapshots) are built from the gomod proxy version instead of local code

The other bits goreleaser needs for reproducible builds are already there, so this should be working assuming the same inputs are given.

More info:

- https://goreleaser.com/customization/build/#reproducible-builds
- https://goreleaser.com/customization/gomod/
- https://goreleaser.com/cookbooks/build-go-modules/

#### Ticket Link

- refs  #1019

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
