### PR TITLE
cmd: update clean command help

### DIFF
--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -32,10 +32,10 @@ func Clean() *cobra.Command {
 	o := &options.RegistryOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "clean",
-		Short: "Remove all signatures from an image.\ncosign clean <image uri>",
-		Long:  "Remove all signatures from an image.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "clean",
+		Short:   "Remove all signatures from an image.",
+		Example: "  cosign clean <IMAGE>",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return CleanCmd(cmd.Context(), *o, args[0])
 		},

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -16,7 +16,6 @@
 * [cosign attach](cosign_attach.md)	 - Provides utilities for attaching artifacts to other artifacts in a registry
 * [cosign attest](cosign_attest.md)	 - Attest the supplied container image.
 * [cosign clean](cosign_clean.md)	 - Remove all signatures from an image.
-cosign clean <image uri>
 * [cosign completion](cosign_completion.md)	 - Generate completion script
 * [cosign copy](cosign_copy.md)	 - Copy the supplied container image and signatures.
 * [cosign dockerfile](cosign_dockerfile.md)	 - Provides utilities for discovering images in and performing operations on Dockerfiles

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -1,14 +1,15 @@
 ## cosign clean
 
 Remove all signatures from an image.
-cosign clean <image uri>
-
-### Synopsis
-
-Remove all signatures from an image.
 
 ```
 cosign clean [flags]
+```
+
+### Examples
+
+```
+  cosign clean <IMAGE>
 ```
 
 ### Options


### PR DESCRIPTION
#### Summary
update the `cosign clean` command documentation/help to align with the other commands and to fix some misalignments when using the help.

before
```
$ cosign
Usage:
  cosign [command]

Available Commands:
  attach             Provides utilities for attaching artifacts to other artifacts in a registry
  attest             Attest the supplied container image.
  clean              Remove all signatures from an image.
cosign clean <image uri>
  completion         Generate completion script
  copy               Copy the supplied container image and signatures.
  dockerfile         Provides utilities for discovering images in and performing operations on Dockerfiles
  download           Provides utilities for downloading artifacts and attached artifacts in a registry
...
```

after the change

```
$ ./cosign
Usage:
  cosign [command]

Available Commands:
  attach             Provides utilities for attaching artifacts to other artifacts in a registry
  attest             Attest the supplied container image.
  clean              Remove all signatures from an image.
  completion         Generate completion script
  copy               Copy the supplied container image and signatures.
  dockerfile         Provides utilities for discovering images in and performing operations on Dockerfiles
  download           Provides utilities for downloading artifacts and attached artifacts in a registry
  generate           Generates (unsigned) signature payloads from the supplied container image.
  generate-key-pair  Generates a key-pair.
...
```

and the clean help

```
$ ./cosign clean --help
Remove all signatures from an image.

Usage:
  cosign clean [flags]

Examples:
  cosign clean <image uri>

Flags:
...
``` 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
