### PR TITLE
cmd: update triangulate help command

### DIFF
--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -28,9 +28,9 @@ func Triangulate() *cobra.Command {
 	o := &options.TriangulateOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "triangulate",
-		Short: "Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.\ncosign triangulate <image uri>",
-		Long:  "Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.",
+		Use:     "triangulate",
+		Short:   "Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.",
+		Example: "  cosign triangulate <IMAGE>",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return flag.ErrHelp

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -31,7 +31,6 @@
 * [cosign sign](cosign_sign.md)	 - Sign the supplied container image.
 * [cosign sign-blob](cosign_sign-blob.md)	 - Sign the supplied blob, outputting the base64-encoded signature to stdout.
 * [cosign triangulate](cosign_triangulate.md)	 - Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
-cosign triangulate <image uri>
 * [cosign upload](cosign_upload.md)	 - Provides utilities for uploading artifacts to a registry
 * [cosign verify](cosign_verify.md)	 - Verify a signature on the supplied container image
 * [cosign verify-attestation](cosign_verify-attestation.md)	 - Verify an attestation on the supplied container image

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -1,14 +1,15 @@
 ## cosign triangulate
 
 Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
-cosign triangulate <image uri>
-
-### Synopsis
-
-Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
 
 ```
 cosign triangulate [flags]
+```
+
+### Examples
+
+```
+  cosign triangulate <IMAGE>
 ```
 
 ### Options


### PR DESCRIPTION
#### Summary
similar to https://github.com/sigstore/cosign/pull/1058

update the `cosign triangulate` command documentation/help to align with the other commands and to fix some misalignments when using the help.

before
```
$ cosign
...
  sign-blob          Sign the supplied blob, outputting the base64-encoded signature to stdout.
  triangulate        Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
cosign triangulate <image uri>
  upload             Provides utilities for uploading artifacts to a registry
  verify             Verify a signature on the supplied container image
  verify-attestation Verify an attestation on the supplied container image
  verify-blob        Verify a signature on the supplied blob
  version            Prints the cosign version

Flags:
      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
  -h, --help                                     help for cosign
      --output-file string                       log output to a file
  -d, --verbose                                  log debug output

```

after the change

```
$ ./cosign
...
  sign               Sign the supplied container image.
  sign-blob          Sign the supplied blob, outputting the base64-encoded signature to stdout.
  triangulate        Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
  upload             Provides utilities for uploading artifacts to a registry
  verify             Verify a signature on the supplied container image
  verify-attestation Verify an attestation on the supplied container image
  verify-blob        Verify a signature on the supplied blob
  version            Prints the cosign version

Flags:
      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
  -h, --help                                     help for cosign
      --output-file string                       log output to a file
  -d, --verbose                                  log debug output
```

and the clean help

```
$ ./cosign triangulate --help
Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.

Usage:
  cosign triangulate [flags]

Examples:
  cosign triangulate <IMAGE>

Flags:
      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
  -h, --help                                                                                     help for triangulate
      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
      --type string                                                                              related attachment to triangulate (attestation|sbom|signature), default signature (default "signature")

Global Flags:
      --azure-container-registry-config string   Path to the file containing Azure container registry configuration information.
      --output-file string                       log output to a file
  -d, --verbose                                  log debug output
``` 


#### Ticket Link
n/a
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
cmd: update triangulate help command
```
