### PR TITLE
Add flag for manually specifying a hash algo when verifying

### DIFF
--- a/cmd/cosign/cli/options/signature_digest.go
+++ b/cmd/cosign/cli/options/signature_digest.go
@@ -1,0 +1,85 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"crypto"
+	"fmt"
+	"sort"
+	"strings"
+
+	_ "crypto/sha256" // for sha224 + sha256
+	_ "crypto/sha512" // for sha384 + sha512
+
+	"github.com/spf13/cobra"
+)
+
+var supportedSignatureAlgorithms = map[string]crypto.Hash{
+	"sha224": crypto.SHA224,
+	"sha256": crypto.SHA256,
+	"sha384": crypto.SHA384,
+	"sha512": crypto.SHA512,
+}
+
+func supportedSignatureAlgorithmNames() []string {
+	names := make([]string, 0, len(supportedSignatureAlgorithms))
+
+	for name := range supportedSignatureAlgorithms {
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// SignatureDigestOptions holds options for specifying which digest algorithm should
+// be used when processing a signature.
+type SignatureDigestOptions struct {
+	AlgorithmName string
+}
+
+var _ Interface = (*SignatureDigestOptions)(nil)
+
+// AddFlags implements Interface
+func (o *SignatureDigestOptions) AddFlags(cmd *cobra.Command) {
+	validSignatureDigestAlgorithms := strings.Join(supportedSignatureAlgorithmNames(), "|")
+
+	cmd.Flags().StringVar(&o.AlgorithmName, "signature-digest-algorithm", "sha256",
+		fmt.Sprintf("digest algorithm to use when processing a signature (%s)", validSignatureDigestAlgorithms))
+}
+
+// HashAlgorithm converts the algorithm's name - provided as a string - into a crypto.Hash algorithm.
+// Returns an error if the algorithm name doesn't match a supported algorithm, and defaults to SHA256
+// in the event that the given algorithm is invalid.
+func (o *SignatureDigestOptions) HashAlgorithm() (crypto.Hash, error) {
+	normalizedAlgo := strings.ToLower(strings.TrimSpace(o.AlgorithmName))
+
+	if normalizedAlgo == "" {
+		return crypto.SHA256, nil
+	}
+
+	algo, exists := supportedSignatureAlgorithms[normalizedAlgo]
+	if !exists {
+		return crypto.SHA256, fmt.Errorf("unknown digest algorithm: %s", o.AlgorithmName)
+	}
+
+	if !algo.Available() {
+		return crypto.SHA256, fmt.Errorf("hash %q is not available on this platform", o.AlgorithmName)
+	}
+
+	return algo, nil
+}

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -30,7 +30,8 @@ type VerifyOptions struct {
 	SecurityKey SecurityKeyOptions
 	Rekor       RekorOptions
 	// TODO: this seems like it should have the Fulcio options.
-	Registry RegistryOptions
+	Registry        RegistryOptions
+	SignatureDigest SignatureDigestOptions
 	AnnotationOptions
 }
 
@@ -41,6 +42,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 	o.SecurityKey.AddFlags(cmd)
 	o.Rekor.AddFlags(cmd)
 	o.Registry.AddFlags(cmd)
+	o.SignatureDigest.AddFlags(cmd)
 	o.AnnotationOptions.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Key, "key", "",

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -46,8 +46,12 @@ against the transparency log.`,
   # (experimental) additionally, verify with the transparency log
   COSIGN_EXPERIMENTAL=1 cosign verify <IMAGE>
 
-  # verify image with public key
+  # verify image with an on-disk public key
   cosign verify --key cosign.pub <IMAGE>
+
+  # verify image with an on-disk public key, manually specifying the
+  # signature digest algorithm
+  cosign verify --key cosign.pub --signature-digest-algorithm sha512 <IMAGE>
 
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
@@ -73,6 +77,12 @@ against the transparency log.`,
 			if err != nil {
 				return err
 			}
+
+			hashAlgorithm, err := o.SignatureDigest.HashAlgorithm()
+			if err != nil {
+				return err
+			}
+
 			v := verify.VerifyCommand{
 				RegistryOptions: o.Registry,
 				CheckClaims:     o.CheckClaims,
@@ -84,7 +94,10 @@ against the transparency log.`,
 				RekorURL:        o.Rekor.URL,
 				Attachment:      o.Attachment,
 				Annotations:     annotations,
+
+				HashAlgorithm: hashAlgorithm,
 			}
+
 			return v.Exec(cmd.Context(), args)
 		},
 	}

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -64,6 +64,7 @@ cosign dockerfile verify [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -58,6 +58,7 @@ cosign manifest verify [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -28,8 +28,12 @@ cosign verify [flags]
   # (experimental) additionally, verify with the transparency log
   COSIGN_EXPERIMENTAL=1 cosign verify <IMAGE>
 
-  # verify image with public key
+  # verify image with an on-disk public key
   cosign verify --key cosign.pub <IMAGE>
+
+  # verify image with an on-disk public key, manually specifying the
+  # signature digest algorithm
+  cosign verify --key cosign.pub --signature-digest-algorithm sha512 <IMAGE>
 
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
@@ -64,6 +68,7 @@ cosign verify [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -21,6 +21,7 @@ package test
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -73,11 +74,12 @@ var passFunc = func(_ bool) ([]byte, error) {
 
 var verify = func(keyRef, imageRef string, checkClaims bool, annotations map[string]interface{}, attachment string) error {
 	cmd := cliverify.VerifyCommand{
-		KeyRef:      keyRef,
-		RekorURL:    rekorURL,
-		CheckClaims: checkClaims,
-		Annotations: sigs.AnnotationsMap{Annotations: annotations},
-		Attachment:  attachment,
+		KeyRef:        keyRef,
+		RekorURL:      rekorURL,
+		CheckClaims:   checkClaims,
+		Annotations:   sigs.AnnotationsMap{Annotations: annotations},
+		Attachment:    attachment,
+		HashAlgorithm: crypto.SHA256,
 	}
 
 	args := []string{imageRef}


### PR DESCRIPTION
#### Summary

While, at the time of writing, it's not possible to manually specify the signature digest algorithm which should be used when signing an image, some KMS providers have key types which force a digest algorithm which isn't sha256; e.g. GCP KMS with RSA4096 / SHA512 keys.

Cosign will happily use these keys for signing and will infer the digest algorithm based on what the KMS provider mandates, leading to a situation where cosign generates signatures which it can't later verify.

This commit adds a new `--signature-digest-algorithm`  flag which allows the user to manually specify one of 4 commonly-used secure hashes when using `cosign verify`.

#### Notes

1. Normally I'd (of course) add an e2e test for this kind of thing, but I can't see an obvious way of generating, say, a SHA512 signature without using a cloud KMS currently, and unless I'm missing something it doesn't look trivial to add that. I think adding an e2e test would require adding `--signature-digest-algorithm` to `cosign sign`, which I think would be desirable but is a much bigger piece of work and maybe needs more discussion.
2. I'm not totally sold on  `--signature-digest-algorithm` as a flag name - it's a bit wordy. Happy to rename if someone has a better suggestion!

#### Testing

I've tested that this works correctly using a test image which I think _should_ be publicly available. Using this commit, I can successfully run:

```console
curl -sSL https://raw.githubusercontent.com/SgtCoDFish/ace/main/PUBKEY > /tmp/PUBKEY
$ ./cosign verify --key "/tmp/PUBKEY" --signature-digest-algorithm SHA512 ghcr.io/sgtcodfish/ace:0.5
```

#### Ticket Link

Related to #946, specifically [this comment](https://github.com/sigstore/cosign/issues/946#issuecomment-966519321). That issue is more broad, though, and there's probably more work to be done in the future for that issue to be completed.

#### Release Note

```release-note
- Added the `--signature-digest-algorithm` flag to `cosign verify`, allowing verification of container image signatures which were generated with a non-SHA256 signature algorithm
```
