### PR TITLE
adding keyless way to sign the images 

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -38,10 +38,10 @@ steps:
   - 'verify'
   - '--key'
   - 'https://raw.githubusercontent.com/gythialy/golang-cross/master/cosign.pub'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.3-2@sha256:7129cf015701ce65e6527707b0d2b79ae86729240d4f06646352e0d41dc88f4a'
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae
+- name: ghcr.io/gythialy/golang-cross:v1.17.3-2@sha256:7129cf015701ce65e6527707b0d2b79ae86729240d4f06646352e0d41dc88f4a
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -53,6 +53,7 @@ steps:
   - KEY_NAME=${_KEY_NAME}
   - KEY_VERSION=${_KEY_VERSION}
   - GIT_TAG=${_GIT_TAG}
+  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   secretEnv:
   - GITHUB_TOKEN
   args:
@@ -61,7 +62,7 @@ steps:
       git tag ${_GIT_TAG}
       make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae
+- name: ghcr.io/gythialy/golang-cross:v1.17.3-2@sha256:7129cf015701ce65e6527707b0d2b79ae86729240d4f06646352e0d41dc88f4a
   entrypoint: 'bash'
   dir: "go/src/sigstore/cosign"
   env:
@@ -74,13 +75,16 @@ steps:
   - KEY_VERSION=${_KEY_VERSION}
   - GIT_TAG=${_GIT_TAG}
   - KO_PREFIX=gcr.io/${PROJECT_ID}
+  - COSIGN_EXPERIMENTAL=true
+  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   secretEnv:
   - GITHUB_TOKEN
   args:
-    - '-c'
-    - |
-      gcloud auth configure-docker \
-      && make sign-container-release
+  - '-c'
+  - |
+    gcloud auth configure-docker \
+    && make sign-container-release \
+    && make sign-keyless-release
 
 availableSecrets:
   secretManager:

--- a/release/release.mk
+++ b/release/release.mk
@@ -7,20 +7,44 @@
 release:
 	LDFLAGS="$(LDFLAGS)" goreleaser release
 
+
+###########################
+# sign with GCP KMS section
+###########################
+
 .PHONY: sign-cosign-release
 sign-cosign-release:
-	cosign sign --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosign:$(GIT_VERSION)
+	cosign sign --force --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosign:$(GIT_VERSION)
 
 .PHONY: sign-cosigned-release
 sign-cosigned-release:
-	cosign sign --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosigned:$(GIT_VERSION)
+	cosign sign --force --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosigned:$(GIT_VERSION)
 
 .PHONY: sign-sget-release
 sign-sget-release:
-	cosign sign --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/sget:$(GIT_VERSION)
+	cosign sign --force --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/sget:$(GIT_VERSION)
 
 .PHONY: sign-container-release
 sign-container-release: ko sign-cosign-release sign-cosigned-release sign-sget-release
+
+######################
+# sign keyless section
+######################
+
+.PHONY: sign-keyless-cosign-release
+sign-keyless-cosign-release:
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosign:$(GIT_VERSION)
+
+.PHONY: sign-keyless-cosigned-release
+sign-keyless-cosigned-release:
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosigned:$(GIT_VERSION)
+
+.PHONY: sign-keyless-sget-release
+sign-keyless-sget-release:
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/sget:$(GIT_VERSION)
+
+.PHONY: sign-keyless-release
+sign-keyless-release: sign-keyless-cosign-release sign-keyless-cosigned-release sign-keyless-sget-release
 
 # used when need to validate the goreleaser
 .PHONY: snapshot


### PR DESCRIPTION
#### Summary
- adding keyless way to sign the images 

signing the images only for now with keyless because we have an issue when uploading the data to Rekor when trying to sign the blobs. As soon as that is fixed we can add keyless as well to the blobs.

rehearsal release can be found here: https://github.com/cpanato/cosign/releases/tag/v99.999.00-keyless

and the verify works now as well

```console
$ export COSIGN_EXPERIMENTAL=1
$ cosign verify gcr.io/cpanato-general/sget:v99.999.00-keyless

Verification for gcr.io/cpanato-general/sget:v99.999.00-keyless --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - Any certificates were verified against the Fulcio roots.

[{"critical":{"identity":{"docker-reference":"gcr.io/cpanato-general/sget"},"image":{"docker-manifest-digest":"sha256:9a5b6f8686d3b31965290de9ea97dc0b7308925d4a1c58982f1cace4a1791e2a"},"type":"cosign container image signature"},"optional":{"Bundle":{"SignedEntryTimestamp":"MEYCIQDnAdAKGbyGrSAtvNzY7lf+C9Ad88l/NBL4n0gLXwtpUAIhAPaL4dUfDWw+QbVouQZ9kBsx7NF1wTbZCm3o38TteXf2","Payload":{"body":"eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoicmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiIyYjYyZTJmNjk2ZDllOGY5YjcyOGUyYjRmZTBlNjNkYTFjYjhkZDZlMDJmMzE3NTRiZTAyNWZjMmI4OGVhYjY1In19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FVUNJUURDYmVleXJhZStEanRHdUF2bUowZzltUHVlb1M1Nm9PZ09Wa2I0cEoxSjN3SWdPZHdlcmZOMDJSZjlNU3ZMK0lGYzdLTlF0UmdrNVlHSEJXa0Fqay9hNm84PSIsImZvcm1hdCI6Ing1MDkiLCJwdWJsaWNLZXkiOnsiY29udGVudCI6IkxTMHRMUzFDUlVkSlRpQkRSVkpVU1VaSlEwRlVSUzB0TFMwdENrMUpTVU4yYWtORFFXdFhaMEYzU1VKQlowbFZRVXMzUzJKeFlTdGphVFJsTTFONWRIWXljRlZ1WWpWdlpVNDBkME5uV1VsTGIxcEplbW93UlVGM1RYY0tTMnBGVmsxQ1RVZEJNVlZGUTJoTlRXTXliRzVqTTFKMlkyMVZkVnBIVmpKTlVrVjNSSGRaUkZaUlVVUkZkMmg2WVZka2VtUkhPWGxhVkVGbFJuY3dlUXBOVkVWNFRWUm5lRTFxVlhwT1ZFNWhSbmN3ZVUxVVJYaE5WR2Q0VFhwRmVrNVVTbUZOUVVGM1YxUkJWRUpuWTNGb2EycFBVRkZKUWtKblozRm9hMnBQQ2xCUlRVSkNkMDVEUVVGU1JrTm5NM1J5YW1oUmQxaEhNQ3RVVDNod1MxVnROMkZ3WjBZMVFUYzJORWxoWVhaclJHRjRVRU5tYkhWNVdraHNhVXhrTDIwS05WbFhWVEJOYURsQ1UwdDJTVTFUYjBsT2RXeExiVkJrZG5KUVRXRnNiRFp2TkVsQ1kxUkRRMEZYTUhkRVoxbEVWbEl3VUVGUlNDOUNRVkZFUVdkbFFRcE5RazFIUVRGVlpFcFJVVTFOUVc5SFEwTnpSMEZSVlVaQ2QwMUVUVUYzUjBFeFZXUkZkMFZDTDNkUlEwMUJRWGRJVVZsRVZsSXdUMEpDV1VWR1FVNDRDak5yYkRGRGJsVlhLMFZRYlhJM2FVcHhZVEUzZDFJMVZFMUNPRWRCTVZWa1NYZFJXVTFDWVVGR1RXcEdTRkZDUW0xcFVYQk5iRVZyTm5jeWRWTjFNVXNLUW5SUWMwMUpSMDVDWjJkeVFtZEZSa0pSWTBKQlVWTkNaMFJDSzAxSWQwZERRM05IUVZGVlJrSjZRVU5vYmtKdlpFaFNkMDlwT0haalNFcHdaRzFHTUFwYVYwNW9URmRPZG1KdVVteGlibEYwVG1wQmVscHRWVE5hVkdOMFRVUkJkMDFETUhsTmFra3pURmRLYlU1NlZYUmFhbEp0VGxkVk5FMUhVWGxQVkZVd0NreHVUakJpTTBwb1dqSlZkVm95T1haYU1uaHNXVmhDY0dONU5XcGlNakIyV1RKRmVrNXRSWGhhVkdzeVRXcFJlVmxxYkcxWk1rbDRUa1JaZGxreVJYVUtXVE5LTUUxRU1FZEJNVlZrUlZGRlFpOTNVWHBOUkVkQ1RESjBiR1ZYZUd4ak0wNUJXVE5DYUdKdFJqQmllVEZ1V2xjMWJHTnRSbk5NYld4b1lsTTFiZ3BqTWxaNVpHMXNhbHBYUm1wWk1qa3hZbTVSZFZreU9YUk5RMnRIUTJselIwRlJVVUpuTnpoM1FWRkZSVWN5YURCa1NFSjZUMms0ZGxsWFRtcGlNMVoxQ21SSVRYVmFNamwyV2pKNGJFeHRUblppVkVGTFFtZG5jV2hyYWs5UVVWRkVRWGRPYmtGRVFtdEJha0pLWTBjcmFVTnlWWEJrUXpBMU5XNTJlWFppVG0wS09HMUpSbEJYTW5GNFNuWkhWVmRETVd4VGQyeG1Oa1oyWjB0T2FtdHFTbEYwVkdOTU9XMVhMMDB4U1VOTlIzZE9NMU5zZEZKeWRTdHFRblIzZUU1M1JBcDBZWGh1ZWtjdlIydGljVlp2WkU0NWQyRkpRVzR3YjJWbGFIaFRUWEJNVG5wbFFVbEdRMGxxT1ZCR1MwSlJQVDBLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In19fX0=","integratedTime":1637240034,"logIndex":868418,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}},"GIT_HASH":"2e65400dd16eefae299a5e310abd3f6b618c0bdc","GIT_VERSION":"v99.999.00-keyless","Issuer":"https://accounts.google.com","Subject":"keyless@cpanato-general.iam.gserviceaccount.com"}}]
```


#### Ticket Link

Fixes #1055

#### Release Note

```release-note
adding keyless way to sign the images 
```
