### PR TITLE
Added: #1076 Custom naming pem and key files

### DIFF
--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2021 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,7 +40,7 @@ var (
 )
 
 // nolint
-func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error {
+func GenerateKeyPairCmd(ctx context.Context, kmsVal string, name string, args []string) error {
 	if kmsVal != "" {
 		k, err := kms.Get(ctx, kmsVal, crypto.SHA256)
 		if err != nil {
@@ -55,10 +54,10 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error
 		if err != nil {
 			return err
 		}
-		if err := os.WriteFile("cosign.pub", pemBytes, 0600); err != nil {
+		if err := os.WriteFile(name+".pub", pemBytes, 0600); err != nil {
 			return err
 		}
-		fmt.Fprintln(os.Stderr, "Public key written to cosign.pub")
+		fmt.Fprintln(os.Stderr, "Public key written to "+name+".pub")
 		return nil
 	}
 
@@ -86,9 +85,9 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error
 		return err
 	}
 
-	if fileExists("cosign.key") {
+	if fileExists(name + ".key") {
 		var overwrite string
-		fmt.Fprint(os.Stderr, "File cosign.key already exists. Overwrite (y/n)? ")
+		fmt.Fprint(os.Stderr, "File "+name+".key already exists. Overwrite (y/n)? ")
 		fmt.Scanf("%s", &overwrite)
 		switch overwrite {
 		case "y", "Y":
@@ -100,15 +99,15 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error
 		}
 	}
 	// TODO: make sure the perms are locked down first.
-	if err := os.WriteFile("cosign.key", keys.PrivateBytes, 0600); err != nil {
+	if err := os.WriteFile(name+".key", keys.PrivateBytes, 0600); err != nil {
 		return err
 	}
-	fmt.Fprintln(os.Stderr, "Private key written to cosign.key")
+	fmt.Fprintln(os.Stderr, "Private key written to "+name+".key")
 
-	if err := os.WriteFile("cosign.pub", keys.PublicBytes, 0644); err != nil {
+	if err := os.WriteFile(name+".pub", keys.PublicBytes, 0644); err != nil {
 		return err
 	} // #nosec G306
-	fmt.Fprintln(os.Stderr, "Public key written to cosign.pub")
+	fmt.Fprintln(os.Stderr, "Public key written to "+name+".pub")
 	return nil
 }
 

--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -61,6 +61,10 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, name string, args []
 		return nil
 	}
 
+	if name == "" {
+		name = "cosign"
+	}
+
 	if len(args) > 0 {
 		split := strings.Split(args[0], "://")
 

--- a/cmd/cosign/cli/generate_key_pair.go
+++ b/cmd/cosign/cli/generate_key_pair.go
@@ -33,6 +33,9 @@ func GenerateKeyPair() *cobra.Command {
 
   # generate key-pair and write to cosign.key and cosign.pub files
   cosign generate-key-pair
+  
+  # generate key-pair and write to a custom .key and .pub files
+  cosign generate-key-pair --name [KEY_NAME]
 
   # generate a key-pair in Azure Key Vault
   cosign generate-key-pair --kms azurekms://[VAULT_NAME][VAULT_URI]/[KEY]
@@ -63,7 +66,7 @@ CAVEATS:
   the COSIGN_PASSWORD environment variable to provide one.`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return generate.GenerateKeyPairCmd(cmd.Context(), o.KMS, args)
+			return generate.GenerateKeyPairCmd(cmd.Context(), o.KMS, o.Name, args)
 		},
 	}
 

--- a/cmd/cosign/cli/options/generate_key_pair.go
+++ b/cmd/cosign/cli/options/generate_key_pair.go
@@ -22,7 +22,8 @@ import (
 // GenerateKeyPairOptions is the top level wrapper for the generate-key-pair command.
 type GenerateKeyPairOptions struct {
 	// KMS Key Management Service
-	KMS string
+	KMS  string
+	Name string
 }
 
 var _ Interface = (*GenerateKeyPairOptions)(nil)
@@ -31,4 +32,6 @@ var _ Interface = (*GenerateKeyPairOptions)(nil)
 func (o *GenerateKeyPairOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.KMS, "kms", "",
 		"create key pair in KMS service to use for signing")
+	cmd.Flags().StringVar(&o.Name, "name", "",
+		"adds a choosen name to your .pub and .key files")
 }


### PR DESCRIPTION
Closes #1076

You as a user can now give the files a custom name, if you are lazy the files still get the name cosign.pub and cosign.key.