### PR TITLE
Drop `strfmt.Base64` from `pkg/oci`.

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -403,7 +403,7 @@ func VerifyBundle(sig oci.Signature) (bool, error) {
 		return false, errors.Wrap(err, "pem to ecdsa")
 	}
 
-	if err := VerifySET(bundle.Payload, []byte(bundle.SignedEntryTimestamp), rekorPubKey); err != nil {
+	if err := VerifySET(bundle.Payload, bundle.SignedEntryTimestamp, rekorPubKey); err != nil {
 		return false, err
 	}
 

--- a/pkg/oci/signatures.go
+++ b/pkg/oci/signatures.go
@@ -18,7 +18,6 @@ package oci
 import (
 	"crypto/x509"
 
-	"github.com/go-openapi/strfmt"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
@@ -64,7 +63,7 @@ type Signature interface {
 // Bundle holds metadata about recording a Signature's ephemeral key to
 // a Rekor transparency log.
 type Bundle struct {
-	SignedEntryTimestamp strfmt.Base64
+	SignedEntryTimestamp []byte
 	Payload              BundlePayload
 }
 

--- a/pkg/oci/static/options_test.go
+++ b/pkg/oci/static/options_test.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sigstore/cosign/pkg/oci"
 	ctypes "github.com/sigstore/cosign/pkg/types"
@@ -86,7 +87,7 @@ func TestOptions(t *testing.T) {
 			LayerMediaType:  ctypes.SimpleSigningMediaType,
 			ConfigMediaType: types.OCIConfigJSON,
 			Annotations: map[string]string{
-				BundleAnnotationKey: "{\"SignedEntryTimestamp\":\"\",\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"}}",
+				BundleAnnotationKey: "{\"SignedEntryTimestamp\":null,\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"}}",
 			},
 			Bundle: bundle,
 		},
@@ -100,7 +101,7 @@ func TestOptions(t *testing.T) {
 			}
 
 			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("makeOptions() = %#v, wanted %#v", got, test.want)
+				t.Errorf("makeOptions() = %s", cmp.Diff(got, test.want))
 			}
 		})
 	}


### PR DESCRIPTION
I noticed that vendoring `pkg/oci` was pulling in stuff from `mongodb`, and pulling the thread it seems to come from this line.

`Base64` is an alias of `[]byte`, and changing it seems to break nothing, so great!

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Ticket Link

#### Release Note
```release-note
The SignedEntryTimestamp is now typed []byte, to get the previous behavior call strfmt.Base64(SignedEntryTimestamp)
```
