### PR TITLE
Prune a few dependencies from ./pkg/oci

### DIFF
--- a/pkg/oci/static/options.go
+++ b/pkg/oci/static/options.go
@@ -16,7 +16,8 @@
 package static
 
 import (
-	"github.com/go-openapi/swag"
+	"encoding/json"
+
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sigstore/cosign/pkg/oci"
 	ctypes "github.com/sigstore/cosign/pkg/types"
@@ -51,7 +52,7 @@ func makeOptions(opts ...Option) (*options, error) {
 	}
 
 	if o.Bundle != nil {
-		b, err := swag.WriteJSON(o.Bundle)
+		b, err := json.Marshal(o.Bundle)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sigstore/cosign/pkg/oci"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-	"knative.dev/pkg/kmeta"
 )
 
 const (
@@ -66,9 +65,12 @@ var _ oci.Signature = (*staticLayer)(nil)
 
 // Annotations implements oci.Signature
 func (l *staticLayer) Annotations() (map[string]string, error) {
-	return kmeta.UnionMaps(l.opts.Annotations, map[string]string{
-		SignatureAnnotationKey: l.b64sig,
-	}), nil
+	m := make(map[string]string, len(l.opts.Annotations)+1)
+	for k, v := range l.opts.Annotations {
+		m[k] = v
+	}
+	m[SignatureAnnotationKey] = l.b64sig
+	return m, nil
 }
 
 // Payload implements oci.Signature


### PR DESCRIPTION
I noticed that pulling in `./pkg/oci/static` downstream pulled in a ton of stuff I don't really want or need.

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Ticket Link

Related: https://github.com/google/ko/pull/506

#### Release Note
```release-note
NONE
```
