### PR TITLE
feat: verify-blob --cert base64

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -117,7 +117,14 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 			return err
 		}
 
-		certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(pems))
+		var out []byte
+		out, err = base64.StdEncoding.DecodeString(string(pems))
+		if err != nil {
+			// not a base64
+			out = pems
+		}
+
+		certs, err := cryptoutils.UnmarshalCertificatesFromPEM(out)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary

#1016 added a new `--output-certificate` flag. It writes the certificate as base64 by default (given `--b64` is true by default), but then if you try to use that same file to verify the blob later, it fails, as verify does not decode the string.

This makes `--certificate` works with both a base64'ed file and a regular one.

Not sure if this makes sense and if its the best impl, just throwing the idea around...

#### before

```console
$ COSIGN_EXPERIMENTAL=1 go run ./cmd/cosign/ verify-blob --key key.pem --signature README.md.sig README.md
Error: verifying blob [README.md]: loading public key: pem to public key: PEM decoding failed
main.go:46: error during command execution: verifying blob [README.md]: loading public key: pem to public key: PEM decoding failed
exit status 1
```

#### now

```console
$ ❯ COSIGN_EXPERIMENTAL=1 go run ./cmd/cosign/ verify-blob --cert key.pem --signature README.md.sig README.md
Certificate is trusted by Fulcio Root CA
Email: [carlos@becker.software]
Issuer:  https://github.com/login/oauth
Verified OK
tlog entry verified with uuid: "cca034dcf30323b30d8d131e06458c02187dab25ee1fa481914595777d027177" index: 877676
```

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Allows base64 files as --cert in verify-blob
```
