### PR TITLE
fix: alias output to output-signature on sign-blob

### DIFF
--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -28,7 +28,7 @@ type SignBlobOptions struct {
 	Base64Output      bool
 	Output            string // deprecated: TODO remove when the output flag is fully deprecated
 	OutputSignature   string // TODO: this should be the root output file arg.
-	OutputCertificate string // TODO: this should be the root output file arg.
+	OutputCertificate string
 	SecurityKey       SecurityKeyOptions
 	Fulcio            FulcioOptions
 	Rekor             RekorOptions

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
@@ -29,7 +28,6 @@ import (
 
 func Sign() *cobra.Command {
 	o := &options.SignOptions{}
-	viper.RegisterAlias("output", "output-signature")
 
 	cmd := &cobra.Command{
 		Use:   "sign",

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -24,10 +24,12 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func SignBlob() *cobra.Command {
 	o := &options.SignBlobOptions{}
+	viper.RegisterAlias("output", "output-signature")
 
 	cmd := &cobra.Command{
 		Use:   "sign-blob",


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
Flag was added to the sign-blob command, but alias was added to sign.

#### Ticket Link
refs #1016 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fix --output-signature alias on sign-blob
```
