### PR TITLE
Add support for storing attestations in `oci/layout`

### DIFF
--- a/pkg/oci/layout/write.go
+++ b/pkg/oci/layout/write.go
@@ -39,15 +39,34 @@ func WriteSignedImage(path string, si oci.SignedImage) error {
 	if err != nil {
 		return errors.Wrap(err, "getting signatures")
 	}
-	if err := appendImage(layoutPath, sigs, sigsAnnotation); err != nil {
-		return errors.Wrap(err, "appending signatures")
+	if !isEmpty(sigs) {
+		if err := appendImage(layoutPath, sigs, sigsAnnotation); err != nil {
+			return errors.Wrap(err, "appending signatures")
+		}
 	}
-	// TODO (priyawadhwa@) write attestations and attachments
+
+	// write attestations
+	atts, err := si.Attestations()
+	if err != nil {
+		return errors.Wrap(err, "getting atts")
+	}
+	if !isEmpty(atts) {
+		if err := appendImage(layoutPath, atts, attsAnnotation); err != nil {
+			return errors.Wrap(err, "appending atts")
+		}
+	}
+	// TODO (priyawadhwa@) and attachments
 	return nil
+}
+
+// isEmpty returns true if the signatures or attesations are empty
+func isEmpty(s oci.Signatures) bool {
+	ss, _ := s.Get()
+	return ss == nil
 }
 
 func appendImage(path layout.Path, img v1.Image, annotation string) error {
 	return path.AppendImage(img, layout.WithAnnotations(
-		map[string]string{annotation: "true"},
+		map[string]string{kindAnnotation: annotation},
 	))
 }

--- a/pkg/oci/layout/write_test.go
+++ b/pkg/oci/layout/write_test.go
@@ -48,6 +48,19 @@ func TestReadWrite(t *testing.T) {
 	// compare the image we read with the one we wrote
 	compareDigests(t, si, gotSignedImage)
 
+	// make sure we have 5 attestations
+	attImg, err := imageIndex.Attestations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	atts, err := attImg.Get()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(atts) != 5 {
+		t.Fatal("expected 5 attestations")
+	}
+
 	// make sure signatures are correct
 	sigImage, err := imageIndex.Signatures()
 	if err != nil {
@@ -96,6 +109,19 @@ func randomSignedImage(t *testing.T) oci.SignedImage {
 			t.Fatalf("SignEntity() = %v", err)
 		}
 	}
+
+	want = 5 // Add 5 attestations
+	for i := 0; i < want; i++ {
+		sig, err := static.NewAttestation([]byte(fmt.Sprintf("%d", i)))
+		if err != nil {
+			t.Fatalf("static.NewSignature() = %v", err)
+		}
+		si, err = mutate.AttachAttestationToImage(si, sig)
+		if err != nil {
+			t.Fatalf("SignEntity() = %v", err)
+		}
+	}
+
 	return si
 }
 


### PR DESCRIPTION
This doesn't save empty signatures/attestations to disk, since we can't write them later anyway.

Also rename the annotation used to differentiate images to "kind"

Signed-off-by: Priya Wadhwa <priyawadhwa@google.com>

ref #1015

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Add support for storing attestations in `oci/layout`
```
