### PR TITLE
Make the transparency log upload non-fatal.

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -70,11 +70,12 @@ func ShouldUploadToTlog(ctx context.Context, ref name.Reference, force bool, url
 
 	// Check if the image is public (no auth in Get)
 	if _, err := remote.Get(ref, remote.WithContext(ctx)); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: uploading to the transparency log at %s for a private image, please confirm [Y/N]: ", url)
+		fmt.Fprintf(os.Stderr, "%q appears to be a private repository, please confirm uploading to the transparency log at %q [Y/N]: ", ref.Context().String(), url)
 
 		var tlogConfirmResponse string
 		if _, err := fmt.Scanln(&tlogConfirmResponse); err != nil {
-			panic(err)
+			fmt.Fprintf(os.Stderr, "\nWARNING: skipping transparency log upload (use --force to upload from scripts): %v\n", err)
+			return false
 		}
 		if strings.ToUpper(tlogConfirmResponse) != "Y" {
 			fmt.Fprintln(os.Stderr, "not uploading to transparency log")


### PR DESCRIPTION
When keyless signing a private image today we prompt the user about uploading to Rekor, but in automation this prompt fails and on error this code panics (today).

This change rewords the prompt, and makes the error path non-fatal (emits a WARNING, see below):

```
COSIGN_EXPERIMENTAL=true cosign sign ghcr.io/mattmoor/bundles < /dev/null
Generating ephemeral keys...
Retrieving signed certificate...
Non-interactive mode detected, using device flow.
Enter the verification code MVRL-JKVG in your browser at: https://oauth2.sigstore.dev/auth/device?user_code=MVRL-JKVG
Code will be valid for 300 seconds
Token received!
Successfully verified SCT...
"ghcr.io/mattmoor/bundles" appears to be a private repository, please confirm uploading to the transparency log at "https://rekor.sigstore.dev" [Y/N]:
WARNING: skipping transparency log upload (use --force to upload from scripts): EOF
MEYCIQCnyOa+oSLABA07Eb79eJ0/fmN0o0mUKUEXok/j3l7A3AIhAOH/fk7/bG8rO7mid2Iys4KIx8HKwznDbAAsO0sYHRWUmain
```

After this change, it should be possible to use cosign in keyless mode without `--force` on private images!

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Ticket Link
Related: https://github.com/actions/starter-workflows/pull/1255

#### Release Note
```release-note
cosign will no longer fail to sign private images in keyless mode without --force.
```
