### PR TITLE
Update sign output to note when signatures are pushed

### DIFF
--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -144,13 +144,13 @@ func isTerminal() bool {
 func getPassFromTerm(confirm bool) ([]byte, error) {
 	fmt.Fprint(os.Stderr, "Enter password for private key: ")
 	pw1, err := term.ReadPassword(0)
+	fmt.Fprintln(os.Stderr)
 	if err != nil {
 		return nil, err
 	}
 	if !confirm {
 		return pw1, nil
 	}
-	fmt.Fprintln(os.Stderr)
 	fmt.Fprint(os.Stderr, "Enter password for private key again: ")
 	pw2, err := term.ReadPassword(0)
 	fmt.Fprintln(os.Stderr)


### PR DESCRIPTION
This updates the output for `cosign sign` to match what's in the documentation. A few other output cleanups:

* Changed when the newline is written for fetching a password
* Removed writing the signature to stdout, only writing the signature to a file when requested

New output:

```
$ ~/go/bin/cosign sign --key cosign.key us-west1-docker.pkg.dev/project/docker-repo/image:tag1
Enter password for private key:
Pushing signature to: us-west1-docker.pkg.dev/project/docker-repo/image
```

Previous output:

```
$ ~/go/bin/cosign sign --key cosign.key us-west1-docker.pkg.dev/project/docker-repo/image:tag1
Enter password for private key: MEYCI....
```

#### Release Note

```release-note
NONE
```
