### PR TITLE
update  ghcr.io/gythialy/golang-cross to use go 1.17.4

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -50,11 +50,11 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -w /go/src/sigstore/cosign \
             --entrypoint="" \
-            ghcr.io/gythialy/golang-cross:v1.17.3-1@sha256:f934a6b0411bbe6723a65732baa8ff7e318cc2d8b089afddb41be3d60d0ea1ae \
+            ghcr.io/gythialy/golang-cross:v1.17.4-0@sha256:266b7cf2059a18e0709e090a51dfc48cdd7c89abc7fa11afbd9b18fd9e491dbc \
             make snapshot
 
       - name: check binaries
         run: |
           ./dist/cosign-linux-amd64 version
           ./dist/cosigned-linux-amd64 --help
-          ./dist/sget-linux-amd64 --help
+          ./dist/sget-linux-amd64 version

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -38,10 +38,10 @@ steps:
   - 'verify'
   - '--key'
   - 'https://raw.githubusercontent.com/gythialy/golang-cross/master/cosign.pub'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.3-2@sha256:7129cf015701ce65e6527707b0d2b79ae86729240d4f06646352e0d41dc88f4a'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.4-0@sha256:266b7cf2059a18e0709e090a51dfc48cdd7c89abc7fa11afbd9b18fd9e491dbc'
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.3-2@sha256:7129cf015701ce65e6527707b0d2b79ae86729240d4f06646352e0d41dc88f4a
+- name: ghcr.io/gythialy/golang-cross:v1.17.4-0@sha256:266b7cf2059a18e0709e090a51dfc48cdd7c89abc7fa11afbd9b18fd9e491dbc
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -62,7 +62,7 @@ steps:
     - |
       make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.3-2@sha256:7129cf015701ce65e6527707b0d2b79ae86729240d4f06646352e0d41dc88f4a
+- name: ghcr.io/gythialy/golang-cross:v1.17.4-0@sha256:266b7cf2059a18e0709e090a51dfc48cdd7c89abc7fa11afbd9b18fd9e491dbc
   entrypoint: 'bash'
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION

#### Summary
-  ghcr.io/gythialy/golang-cross v1.17.4-0 is out https://github.com/gythialy/golang-cross/releases/tag/v1.17.4-0
that uses go 1.17.4

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
update  ghcr.io/gythialy/golang-cross to use go 1.17.4
```
