### PR TITLE
cosigned: add version to cosigned

### DIFF
--- a/cmd/cosign/webhook/main.go
+++ b/cmd/cosign/webhook/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"flag"
+	"log"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -36,6 +37,7 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
 
 	cwebhook "github.com/sigstore/cosign/pkg/cosign/kubernetes/webhook"
+	"github.com/sigstore/cosign/pkg/version"
 )
 
 var secretName = flag.String("secret-name", "", "The name of the secret in the webhook's namespace that holds the public key for verification.")
@@ -56,6 +58,9 @@ func main() {
 	// Allow folks to configure the port the webhook serves on.
 	flag.IntVar(&opts.Port, "secure-port", opts.Port, "The port on which to serve HTTPS.")
 
+	v := version.GetVersionInfo()
+	vJSON, _ := v.JSONString()
+	log.Printf("%v", vJSON)
 	// This calls flag.Parse()
 	sharedmain.MainWithContext(ctx, "cosigned",
 		certificates.NewController,


### PR DESCRIPTION
#### Summary
cosigned was the last tool to expose the version/gitstate/buid time information

adding this when cosigned start, if there is another better way to expose this info please let me know

```
$ ./cosigned
2021/12/05 16:58:46 {
  "GitVersion": "v99.999.00-keyless-37-ge233ce8-dirty",
  "GitCommit": "e233ce828a70491d5fec699477fb2b679efce8dc",
  "GitTreeState": "dirty",
  "BuildDate": "'2021-12-04T13:38:20Z'",
  "GoVersion": "go1.17.4",
  "Compiler": "gc",
  "Platform": "darwin/amd64"
}
2021/12/05 16:58:46 Registering 2 clients
2021/12/05 16:58:46 Registering 2 informer factories
2021/12/05 16:58:46 Registering 3 informers
2021/12/05 16:58:46 Registering 3 controllers
{"severity":"INFO","timestamp":"2021-12-05T16:58:46.706712+01:00","caller":"logging/config.go:116","message":"Successfully created the logger."}
{"severity":"INFO","timestamp":"2021-12-05T16:58:46.706775+01:00","caller":"logging/config.go:117","message":"Logging level set to: info"}
{"severity":"INFO","timestamp":"2021-12-05T16:58:46.706791+01:00","caller":"logging/config.go:79","message":"Fetch GitHub commit ID from kodata failed","error":"\"KO_DATA_PATH\" does not exist or is empty"}
{"severity":"INFO","timestamp":"2021-12-05T16:58:46.706818+01:00","logger":"cosigned","caller":"profiling/server.go:64","message":"Profiling enabled: false"}
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
