### PR TITLE
cjson - Move to go-securesystemslib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
-	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613
 	github.com/theupdateframework/go-tuf v0.0.0-20211203210025-7ded50136bf9
 	github.com/xanzy/go-gitlab v0.52.2
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8

--- a/pkg/cosign/tuf/policy.go
+++ b/pkg/cosign/tuf/policy.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	cjson "github.com/tent/canonical-json-go"
+	cjson "github.com/secure-systems-lab/go-securesystemslib/cjson"
 )
 
 type Signed struct {
@@ -54,7 +54,7 @@ type Key struct {
 
 func (k *Key) ID() string {
 	k.idOnce.Do(func() {
-		data, _ := cjson.Marshal(k)
+		data, _ := cjson.EncodeCanonical(k)
 		digest := sha256.Sum256(data)
 		k.id = hex.EncodeToString(digest[:])
 	})
@@ -127,7 +127,7 @@ func (r *Role) AddKeysWithThreshold(keys []*Key, threshold int) bool {
 
 func (r *Root) Marshal() (*Signed, error) {
 	// Marshals the Root into a Signed type
-	b, err := cjson.Marshal(r)
+	b, err := cjson.EncodeCanonical(r)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (r *Root) ValidKey(key *Key, role string) (string, error) {
 
 func (s *Signed) JSONMarshal(prefix, indent string) ([]byte, error) {
 	// Marshals Signed with prefix and indent.
-	b, err := cjson.Marshal(s)
+	b, err := cjson.EncodeCanonical(s)
 	if err != nil {
 		return []byte{}, err
 	}


### PR DESCRIPTION
The existing cjson hasn't been maintained. The last update was 9 years
ago. This was replaced by the upstream go-securesystemslib
https://github.com/secure-systems-lab/go-securesystemslib/pull/10

cc @asraa

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
