### PR TITLE
remove obsolete `--output` flag

### DIFF
--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -60,10 +60,6 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Upload, "upload", true,
 		"whether to upload the signature")
 
-	// TODO: remove when output flag is fully deprecated
-	cmd.Flags().StringVar(&o.Output, "output", "",
-		"write the signature to FILE")
-
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
@@ -29,7 +28,6 @@ import (
 
 func Sign() *cobra.Command {
 	o := &options.SignOptions{}
-	viper.RegisterAlias("output", "output-signature")
 
 	cmd := &cobra.Command{
 		Use:   "sign",

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -64,7 +64,6 @@ cosign sign [flags]
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
-      --output string                                                                            write the signature to FILE
       --output-certificate string                                                                write the certificate to FILE
       --output-signature string                                                                  write the signature to FILE
       --payload string                                                                           path to a payload file to use rather than generating one


### PR DESCRIPTION
This flag was added in https://github.com/sigstore/cosign/pull/1066 and obsoleted in https://github.com/sigstore/cosign/pull/1095, which are both within the 1.4.0 release

```release-note
NONE
```
