### PR TITLE
`sign-blob` `--output` -> `--output-signature`

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -178,19 +178,19 @@ signs:
   - id: cosign
     signature: "${artifact}.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
   - id: cosigned
     signature: "${artifact}.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
     ids:
       - linux-cosigned
   - id: sget
     signature: "${artifact}.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
     ids:
       - sget
@@ -198,19 +198,19 @@ signs:
   - id: cosign-keyless
     signature: "${artifact}-keyless.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output", "${artifact}-keyless.sig", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "${artifact}"]
     artifacts: binary
   - id: cosigned-keyless
     signature: "${artifact}-keyless.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output", "${artifact}-keyless.sig", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "${artifact}"]
     artifacts: binary
     ids:
       - linux-cosigned
   - id: sget-keyless
     signature: "${artifact}-keyless.sig"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output", "${artifact}-keyless.sig", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "${artifact}"]
     artifacts: binary
     ids:
       - sget


### PR DESCRIPTION
The flag was changed in https://github.com/sigstore/cosign/pull/1016

```release-note
NONE
```
