### PR TITLE
fix: --output-certificate not working properly

### DIFF
--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -83,7 +83,7 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOption
 	}
 
 	if options.EnableExperimental() {
-		rekorBytes, err := sv.Bytes(ctx)
+		rekorBytes, err = sv.Bytes(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
#### Summary

`--output-certificate` was producing empty certificates.
Likely a bad merge from me when working on #1095

#### Ticket Link
Refs #1095

#### Release Note
```release-note
fix sign-blob --output-certificate writing an empty file
```
