### PR TITLE
fix: improve perms, error handling

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -225,14 +225,8 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko KeyO
 	}
 
 	if outputSignature != "" {
-		out, err := os.Create(outputSignature)
-		if err != nil {
+		if err := os.WriteFile(outputSignature, []byte(b64sig), 0600); err != nil {
 			return errors.Wrap(err, "create signature file")
-		}
-		defer out.Close()
-
-		if _, err := out.Write([]byte(b64sig)); err != nil {
-			return errors.Wrap(err, "write signature to file")
 		}
 	}
 
@@ -262,13 +256,14 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko KeyO
 	if outputCertificate != "" {
 		rekorBytes, err := sv.Bytes(ctx)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "create certificate file")
 		}
 
 		if err := os.WriteFile(outputCertificate, rekorBytes, 0600); err != nil {
-			return err
+			return errors.Wrap(err, "create certificate file")
 		}
 		// TODO: maybe accept a --b64 flag as well?
+		fmt.Printf("Certificate wrote in the file %s\n", outputCertificate)
 	}
 
 	return nil

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -99,25 +99,15 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOption
 	}
 
 	if outputSignature != "" {
-		f, err := os.Create(outputSignature)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-
+		var bts = sig
 		if b64 {
-			_, err = f.Write([]byte(base64.StdEncoding.EncodeToString(sig)))
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			_, err = f.Write(sig)
-			if err != nil {
-				return nil, err
-			}
+			bts = []byte(base64.StdEncoding.EncodeToString(sig))
+		}
+		if err := os.WriteFile(outputSignature, bts, 0600); err != nil {
+			return nil, errors.Wrap(err, "create signature file")
 		}
 
-		fmt.Printf("Signature wrote in the file %s\n", f.Name())
+		fmt.Printf("Signature wrote in the file %s\n", outputSignature)
 	} else {
 		if b64 {
 			sig = []byte(base64.StdEncoding.EncodeToString(sig))
@@ -128,24 +118,15 @@ func SignBlobCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOption
 		}
 	}
 
-	if outputCertificate != "" {
-		f, err := os.Create(outputCertificate)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-
+	if outputCertificate != "" && len(rekorBytes) > 0 {
+		bts := rekorBytes
 		if b64 {
-			_, err = f.Write([]byte(base64.StdEncoding.EncodeToString(rekorBytes)))
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			_, err = f.Write(rekorBytes)
-			if err != nil {
-				return nil, err
-			}
+			bts = []byte(base64.StdEncoding.EncodeToString(rekorBytes))
 		}
+		if err := os.WriteFile(outputCertificate, bts, 0600); err != nil {
+			return nil, errors.Wrap(err, "create certificate file")
+		}
+		fmt.Printf("Certificate wrote in the file %s\n", outputCertificate)
 	}
 
 	return sig, nil


### PR DESCRIPTION
#### Summary
- create certificates and signature with less permissions (`0600` vs `0666` - the default of `os.Create`
- improve error handling a bit by wrapping the errors

#### Ticket Link
n/a

#### Release Note
```release-note
--output-signature and --output-certificate now created with 0600 permissions
```
