### PR TITLE
add job to run some e2e tests to sing a artifact and check the outputs

### DIFF
--- a/.github/workflows/e2e-with-binary.yml
+++ b/.github/workflows/e2e-with-binary.yml
@@ -1,0 +1,62 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: e2e-tests
+
+# Run on every push, and allow it to be run manually.
+on:
+  push:
+    branches: [ 'main' ]
+  workflow_dispatch:
+
+jobs:
+  e2e-tests-with-binary:
+    # Skip if running in a fork that might not have secrets configured.
+    if: ${{ github.repository == 'sigstore/cosign' }}
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      COSIGN_EXPERIMENTAL: "true"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.x'
+      - name: build cosign and check
+        run: |
+          set -e
+          make cosign
+          ./cosign sign-blob --output-certificate key.pem --output-signature README.md.sig README.md
+
+          if [ -s key.pem ]
+          then
+            echo "all good for key.pem"
+          else
+            echo "file does not exist, or is empty"
+            exit 1
+          fi
+
+          if [ -s README.md.sig ]
+          then
+            exit 0
+          else
+            echo "file does not exist, or is empty"
+            exit 1
+          fi


### PR DESCRIPTION

#### Summary
add job to run some e2e tests to sing a artifact and check the outputs


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
add job to run some e2e tests to sing a artifact and check the outputs
```
