### PR TITLE
return error when rekor pub cannot be retrieved, fix file path construction

### DIFF
--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -43,14 +43,14 @@ import (
 // This is the rekor public key target name
 var rekorTargetStr = `rekor.pub`
 
-func GetRekorPub(ctx context.Context) string {
+// GetRekorPub retrieves the rekor public key from the embedded or cached TUF root. If expired, makes a
+// network call to retrieve the updated target.
+func GetRekorPub(ctx context.Context) ([]byte, error) {
 	buf := tuf.ByteDestination{Buffer: &bytes.Buffer{}}
-	// Retrieves the rekor public key from the embedded or cached TUF root. If expired, makes a
-	// network call to retrieve the updated target.
 	if err := tuf.GetTarget(ctx, rekorTargetStr, &buf); err != nil {
-		panic("error retrieving rekor public key")
+		return nil, err
 	}
-	return buf.String()
+	return buf.Bytes(), nil
 }
 
 // TLogUpload will upload the signature, public key and payload to the transparency log.

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -41,7 +41,6 @@ import (
 const (
 	TufRootEnv        = "TUF_ROOT"
 	SigstoreNoCache   = "SIGSTORE_NO_CACHE"
-	defaultLocalStore = ".sigstore/root/"
 	DefaultRemoteRoot = "sigstore-tuf-root"
 )
 
@@ -68,7 +67,7 @@ func CosignCachedRoot() string {
 		if err != nil {
 			home = ""
 		}
-		return path.Join(home, defaultLocalStore)
+		return path.Join(home, ".sigstore", "root")
 	}
 	return rootDir
 }
@@ -102,7 +101,7 @@ func getLocalTarget(name string) (fs.File, error) {
 		// Return local cached target
 		return os.Open(path.Join(CosignCachedTargets(), name))
 	}
-	return root.Open(path.Join("repository/targets", name))
+	return root.Open(path.Join("repository", "targets", name))
 }
 
 type signedMeta struct {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -446,7 +446,12 @@ func VerifyBundle(ctx context.Context, sig oci.Signature) (bool, error) {
 		return false, nil
 	}
 
-	rekorPubKey, err := PemToECDSAKey([]byte(GetRekorPub(ctx)))
+	pub, err := GetRekorPub(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "retrieving rekor public key")
+	}
+
+	rekorPubKey, err := PemToECDSAKey(pub)
 	if err != nil {
 		return false, errors.Wrap(err, "pem to ecdsa")
 	}


### PR DESCRIPTION
This (probably) doesn't fix the error being seen by @cpanato during verification on windows, but it does surface the error and take care of some potential root causes

```release-note
NONE
```
