### PR TITLE
expand CI testing to Windows and OSX, fix issues uncovered

### DIFF
--- a/.github/workflows/e2e-with-binary.yml
+++ b/.github/workflows/e2e-with-binary.yml
@@ -26,7 +26,10 @@ jobs:
     # Skip if running in a fork that might not have secrets configured.
     if: ${{ github.repository == 'sigstore/cosign' }}
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     permissions:
       id-token: write

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,10 @@ permissions: read-all
 jobs:
   unit-tests:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,6 +53,9 @@ jobs:
           go-version: '1.17.x'
       - name: Run Go tests
         run: go test ./...
+      - name: Run Go tests w/ `-race`
+        if: ${{ runner.os == 'Linux' }}
+        run: go test -race ./...
   
   e2e-tests:
     name: Run e2e tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,11 +24,39 @@ permissions: read-all
 
 jobs:
   unit-tests:
-    name: Run tests
+    name: Run unit tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+      - uses: actions/cache@v2
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Linux)
+          # * Build cache (Mac)
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.x'
+      - name: Run Go tests
+        run: go test ./...
+  
+  e2e-tests:
+    name: Run e2e tests
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -57,8 +85,6 @@ jobs:
           # Used to test: cosign generate-key-pair k8s://...
           go install sigs.k8s.io/kind@v0.11.1
           kind create cluster
-      - name: Run Go tests
-        run: go test ./...
 
       - name: Run end-to-end tests
         run: ./test/e2e_test.sh

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -55,7 +55,7 @@ var rootClient *client.Client
 var rootClientMu = &sync.Mutex{}
 
 func GetEmbeddedRoot() ([]byte, error) {
-	return root.ReadFile(filepath.Join("repository", "root.json"))
+	return root.ReadFile("repository/root.json")
 }
 
 func CosignCachedRoot() string {
@@ -133,7 +133,7 @@ func RootClient(ctx context.Context, remote client.RemoteStore, altRoot []byte) 
 		if os.IsNotExist(err) && altRoot == nil {
 			// Cache does not exist, check if the embedded metadata is currently valid.
 			// TODO(asraa): Need a better way to check if local metadata is verified at this stage.
-			timestamp, err := root.ReadFile(filepath.Join("repository", "timestamp.json"))
+			timestamp, err := root.ReadFile("repository/timestamp.json")
 			if err != nil {
 				return nil, errors.Wrap(err, "reading local timestamp")
 			}
@@ -142,12 +142,12 @@ func RootClient(ctx context.Context, remote client.RemoteStore, altRoot []byte) 
 				if err := local.SetMeta("timestamp.json", timestamp); err != nil {
 					return nil, errors.Wrap(err, "setting local meta")
 				}
-				for _, metadata := range []string{"root.json", "targets.json", "snapshot.json"} {
-					msg, err := root.ReadFile(filepath.Join("repository", metadata))
+				for _, mdFilename := range []string{"root.json", "targets.json", "snapshot.json"} {
+					msg, err := root.ReadFile("repository/" + mdFilename)
 					if err != nil {
 						return nil, errors.Wrap(err, "reading local root")
 					}
-					if err := local.SetMeta(metadata, msg); err != nil {
+					if err := local.SetMeta(mdFilename, msg); err != nil {
 						return nil, errors.Wrap(err, "setting local meta")
 					}
 				}
@@ -185,7 +185,7 @@ func RootClient(ctx context.Context, remote client.RemoteStore, altRoot []byte) 
 				if altRoot != nil {
 					trustedRoot = altRoot
 				} else {
-					trustedRoot, err = root.ReadFile(filepath.Join("repository", "root.json"))
+					trustedRoot, err = root.ReadFile("repository/root.json")
 					if err != nil {
 						return nil, errors.Wrap(err, "reading embedded trusted root")
 					}

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -131,7 +131,7 @@ func RootClient(ctx context.Context, remote client.RemoteStore, altRoot []byte) 
 		// Instantiate the global TUF client from the local embedded root or the cached root unless altRoot is provided.
 		// In that case, always instantiate from altRoot.
 		path := filepath.Join(CosignCachedRoot(), "tuf.db")
-		_, err := os.Open(path)
+		_, err := os.Stat(path)
 		if os.IsNotExist(err) && altRoot == nil {
 			// Cache does not exist, check if the embedded metadata is currently valid.
 			// TODO(asraa): Need a better way to check if local metadata is verified at this stage.

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"sync"
 	"time"
@@ -67,13 +66,13 @@ func CosignCachedRoot() string {
 		if err != nil {
 			home = ""
 		}
-		return path.Join(home, ".sigstore", "root")
+		return filepath.Join(home, ".sigstore", "root")
 	}
 	return rootDir
 }
 
 func CosignCachedTargets() string {
-	return path.Join(CosignCachedRoot(), "targets")
+	return filepath.Join(CosignCachedRoot(), "targets")
 }
 
 // Target destinations compatible with go-tuf.
@@ -97,11 +96,12 @@ func (b *ByteDestination) Delete() error {
 
 // Retrieves a local target, either from the cached root or the embedded metadata.
 func getLocalTarget(name string) (fs.File, error) {
+
 	if _, err := os.Stat(CosignCachedTargets()); !os.IsNotExist(err) {
 		// Return local cached target
-		return os.Open(path.Join(CosignCachedTargets(), name))
+		return os.Open(filepath.Join(CosignCachedTargets(), name))
 	}
-	return root.Open(path.Join("repository", "targets", name))
+	return root.Open(filepath.Join("repository", "targets", name))
 }
 
 type signedMeta struct {
@@ -283,7 +283,7 @@ func updateMetadataAndDownloadTargets(c *client.Client) error {
 }
 
 func downloadRemoteTarget(name string, c *client.Client, out client.Destination) error {
-	f, err := os.Create(path.Join(CosignCachedTargets(), name))
+	f, err := os.Create(filepath.Join(CosignCachedTargets(), name))
 	if err != nil {
 		return errors.Wrap(err, "creating target file")
 	}

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -264,6 +264,7 @@ func GetTarget(ctx context.Context, name string, out client.Destination) error {
 	}
 
 	// Retrieves the target and writes to out.
+	// We allow for Targets to be retrieved without requiring that the local cache be updated.
 	return getTargetHelper(name, out, c, false /* requiresCoherence */)
 }
 

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -220,6 +220,7 @@ func getTargetHelper(name string, out client.Destination, c *client.Client) erro
 	if err != nil {
 		return errors.Wrap(err, "reading local targets")
 	}
+	defer localTarget.Close()
 
 	tee := io.TeeReader(localTarget, out)
 	localMeta, err := util.GenerateTargetFileMeta(tee)
@@ -233,7 +234,7 @@ func getTargetHelper(name string, out client.Destination, c *client.Client) erro
 		return errors.Wrap(err, "bad local target")
 	}
 
-	return localTarget.Close()
+	return nil
 }
 
 func GetTarget(ctx context.Context, name string, out client.Destination) error {

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -96,10 +96,9 @@ func (b *ByteDestination) Delete() error {
 
 // Retrieves a local target, either from the cached root or the embedded metadata.
 func getLocalTarget(name string) (fs.File, error) {
-
-	if _, err := os.Stat(CosignCachedTargets()); !os.IsNotExist(err) {
+	if f, err := os.Open(filepath.Join(CosignCachedTargets(), name)); err == nil {
 		// Return local cached target
-		return os.Open(filepath.Join(CosignCachedTargets(), name))
+		return f, nil
 	}
 	return root.Open(filepath.Join("repository", "targets", name))
 }

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -132,8 +132,8 @@ func RootClient(ctx context.Context, remote client.RemoteStore, altRoot []byte) 
 
 	// Instantiate the global TUF client from the local embedded root or the cached root unless altRoot is provided.
 	// In that case, always instantiate from altRoot.
-	path := filepath.Join(CosignCachedRoot(), "tuf.db")
-	_, err := os.Stat(path)
+	localCacheDBPath := filepath.Join(CosignCachedRoot(), "tuf.db")
+	_, err := os.Stat(localCacheDBPath)
 	if os.IsNotExist(err) && altRoot == nil {
 		// Cache does not exist, check if the embedded metadata is currently valid.
 		// TODO(asraa): Need a better way to check if local metadata is verified at this stage.
@@ -170,7 +170,7 @@ func RootClient(ctx context.Context, remote client.RemoteStore, altRoot []byte) 
 			return nil, err
 		}
 	}
-	local, err := tuf_leveldbstore.FileLocalStore(path)
+	local, err := tuf_leveldbstore.FileLocalStore(localCacheDBPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating cached local store")
 	}

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -99,7 +99,7 @@ func getLocalTarget(name string) (fs.File, error) {
 		// Return local cached target
 		return f, nil
 	}
-	return root.Open(filepath.Join("repository", "targets", name))
+	return root.Open("repository/targets/" + name)
 }
 
 type signedMeta struct {

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -43,8 +43,7 @@ const (
 	DefaultRemoteRoot = "sigstore-tuf-root"
 )
 
-//go:embed repository/*.json
-//go:embed repository/targets/*.pem repository/targets/*.pub
+//go:embed repository
 var root embed.FS
 
 // Global TUF client.

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -245,8 +245,8 @@ func getTargetHelper(name string, out client.Destination, c *client.Client, requ
 	}
 
 	if requireCoherence {
-		// If local target meta does not match the valid local meta, consider this an error.
-		// We may want to make a network call to update the local metadata and re-download.
+		// If local target meta does not match the valid local meta,
+		// we may want to make a network call to update the local metadata and re-download.
 		if err := util.TargetFileMetaEqual(validMeta, localMeta); err != nil {
 			return errors.Wrap(err, "bad local target")
 		}
@@ -263,9 +263,8 @@ func GetTarget(ctx context.Context, name string, out client.Destination) error {
 		return errors.Wrap(err, "retrieving trusted root; local cache may be corrupt")
 	}
 
-	// Retrieves the target and writes to out. This may make a network call and cache if
-	// the embedded or cached root is invalid (e.g. expired).
-	return getTargetHelper(name, out, c, false)
+	// Retrieves the target and writes to out.
+	return getTargetHelper(name, out, c, false /* requiresCoherence */)
 }
 
 func getRootKeys(rootFileBytes []byte) ([]*data.PublicKey, int, error) {

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/theupdateframework/go-tuf"
 	"github.com/theupdateframework/go-tuf/client"
 	tuf_leveldbstore "github.com/theupdateframework/go-tuf/client/leveldbstore"
@@ -160,5 +161,21 @@ func TestValidMetadata(t *testing.T) {
 	}
 	if !bytes.Equal(buf.Bytes(), targetFiles[target]) {
 		t.Fatalf("error retrieving target, expected %s got %s", buf.String(), targetFiles[target])
+	}
+}
+
+func TestGetEmbeddedRoot(t *testing.T) {
+	got, err := GetEmbeddedRoot()
+	if err != nil {
+		t.Fatalf("GetEmbeddedRoot() returned error: %v", err)
+	}
+
+	want, err := os.ReadFile(filepath.Join("repository", "root.json"))
+	if err != nil {
+		t.Fatalf("failed to read expected root from file: %v", err)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("GetEmbeddedRoot() mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -20,7 +20,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/theupdateframework/go-tuf"
@@ -130,7 +130,7 @@ func TestValidMetadata(t *testing.T) {
 	meta, _ := store.GetMeta()
 	root := meta["root.json"]
 	local.SetMeta("root.json", root)
-	db := path.Join(tmp, "tuf.db")
+	db := filepath.Join(tmp, "tuf.db")
 	if err := os.Setenv(TufRootEnv, db); err != nil {
 		t.Fatalf("error setting env")
 	}

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -128,6 +128,10 @@ func TestValidMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error")
 	}
+	if cl, isCloser := local.(io.Closer); isCloser {
+		// TODO: this is a hack to free the file descriptors, need to patch `tuf_leveldbstore.FileLocalStore` to return a io.Closer
+		defer cl.Close()
+	}
 	meta, _ := store.GetMeta()
 	root := meta["root.json"]
 	local.SetMeta("root.json", root)

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -155,7 +155,7 @@ func TestValidMetadata(t *testing.T) {
 
 	target := "foo.txt"
 	buf := ByteDestination{Buffer: &bytes.Buffer{}}
-	err = getTargetHelper(target, &buf, rootClient)
+	err = getTargetHelper(target, &buf, rootClient, false)
 	if err != nil {
 		t.Fatalf("retrieving target %v", err)
 	}

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -129,7 +129,7 @@ func TestValidMetadata(t *testing.T) {
 		t.Fatalf("unexpected error")
 	}
 	if cl, isCloser := local.(io.Closer); isCloser {
-		// TODO: this is a hack to free the file descriptors, need to patch `tuf_leveldbstore.FileLocalStore` to return a io.Closer
+		// TODO(https://github.com/sigstore/cosign/issues/1160): this is a hack to free the file descriptors, need to patch `tuf_leveldbstore.FileLocalStore` to return a io.Closer
 		defer cl.Close()
 	}
 	meta, _ := store.GetMeta()


### PR DESCRIPTION
I expanded our Windows CI test coverage with the goal of root causing https://github.com/sigstore/cosign/issues/1153. Still haven't done that, yet, but I figure I should get this in

Mitigates https://github.com/sigstore/cosign/issues/1160 -related failures in testing

```release-note
bugfix: `cosign` Windows releases panicking under certain circumstances
```
