### PR TITLE
Add option to verify local image

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -28,6 +28,7 @@ type VerifyOptions struct {
 	Attachment   string
 	Output       string
 	SignatureRef string
+	LocalImage   bool
 
 	SecurityKey SecurityKeyOptions
 	Rekor       RekorOptions
@@ -67,6 +68,9 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.SignatureRef, "signature", "",
 		"signature content or path or remote URL")
+
+	cmd.Flags().BoolVar(&o.LocalImage, "local-image", false,
+		"whether the path to the image is a local directory")
 }
 
 // VerifyAttestationOptions is the top level wrapper for the `verify attestation` command.

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -53,6 +53,9 @@ against the transparency log.`,
   # signature digest algorithm
   cosign verify --key cosign.pub --signature-digest-algorithm sha512 <IMAGE>
 
+  # verify image with an on-disk signed image from 'cosign save'
+  cosign verify --key cosign.pub --local-image <PATH>
+
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
 
@@ -97,6 +100,7 @@ against the transparency log.`,
 				Annotations:     annotations,
 				HashAlgorithm:   hashAlgorithm,
 				SignatureRef:    o.SignatureRef,
+				LocalImage:      o.LocalImage,
 			}
 
 			return v.Exec(cmd.Context(), args)

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -63,6 +63,7 @@ cosign dockerfile verify [flags]
   -h, --help                                                                                     help for verify
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
+      --local-image                                                                              whether the path to the image is a local directory
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -57,6 +57,7 @@ cosign manifest verify [flags]
   -h, --help                                                                                     help for verify
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
+      --local-image                                                                              whether the path to the image is a local directory
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -35,6 +35,9 @@ cosign verify [flags]
   # signature digest algorithm
   cosign verify --key cosign.pub --signature-digest-algorithm sha512 <IMAGE>
 
+  # verify image with an on-disk signed image from 'cosign save'
+  cosign verify --key cosign.pub --local-image <PATH>
+
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
 
@@ -67,6 +70,7 @@ cosign verify [flags]
   -h, --help                                                                                     help for verify
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
+      --local-image                                                                              whether the path to the image is a local directory
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL


### PR DESCRIPTION
This builds on the previous work to support saving an image and its signature for airgapped environments. This adds a flag, `--local-image`, to verify a signed image from disk.

Example:

```
cosign save us-west1-docker.pkg.dev/project/docker-repo/image:tag1 --dir .
cosign verify --key cosign.pub --local-image . --verbose
```

With `--verbose`, we see no network calls.

Ref #1015

#### Release Note
```release-note
Add `cosign verify --local-image path` for verifying signed images from disk
```
