### PR TITLE
bump k8s versions used for kind-e2e-cosigned

### DIFF
--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -29,20 +29,25 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.20.7
-        - v1.21.1
+        - v1.21.2
+        - v1.22.4
+        - v1.23.0
 
         include:
           # Map between K8s and KinD versions.
           # This is attempting to make it a bit clearer what's being tested.
           # See: https://github.com/kubernetes-sigs/kind/releases
-        - k8s-version: v1.20.7
-          kind-version: v0.11.1
-          kind-image-sha: sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9
-          cluster-suffix: c${{ github.run_id }}.local
-        - k8s-version: v1.21.1
+        - k8s-version: v1.21.2
           kind-version: v0.11.1
           kind-image-sha: sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
+          cluster-suffix: c${{ github.run_id }}.local
+        - k8s-version: v1.22.4
+          kind-version: v0.11.1
+          kind-image-sha: sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978
+          cluster-suffix: c${{ github.run_id }}.local
+        - k8s-version: v1.23.0
+          kind-version: v0.11.1
+          kind-image-sha: sha256:2f93d3c7b12a3e93e6c1f34f331415e105979961fcddbe69a4e3ab5a93ccbb35
           cluster-suffix: c${{ github.run_id }}.local
 
     env:


### PR DESCRIPTION
```release-note
NONE
```
