### PR TITLE
disable broken Windows e2e-with-binary

### DIFF
--- a/.github/workflows/e2e-with-binary.yml
+++ b/.github/workflows/e2e-with-binary.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
 
     permissions:
       id-token: write


### PR DESCRIPTION
Didn't catch it earlier because it's only run on push

#### Release Note
```release-note
NONE
```
