### PR TITLE
Bump GGCR to latest.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-piv/piv-go v1.9.0
 	github.com/google/certificate-transparency-go v1.1.2
 	github.com/google/go-cmp v0.5.6
-	github.com/google/go-containerregistry v0.7.1-0.20211118220127-abdc633f8305
+	github.com/google/go-containerregistry v0.7.1-0.20211203164431-c75901cce627
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20211203164431-c75901cce627
 	github.com/google/go-github/v39 v39.2.0
 	github.com/google/trillian v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -965,8 +965,9 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-containerregistry v0.5.2-0.20210609162550-f0ce2270b3b4/go.mod h1:R5WRYyTdQqTchlBhX4q+WICGh8HQIL5wDFoFZv7Jq6Q=
 github.com/google/go-containerregistry v0.6.0/go.mod h1:euCCtNbZ6tKqi1E72vwDj2xZcN5ttKpZLfa/wSo5iLw=
-github.com/google/go-containerregistry v0.7.1-0.20211118220127-abdc633f8305 h1:4upgCb+N0/tewaAT+rPGk8zuKCG1hOoICHvFMxy1CMQ=
 github.com/google/go-containerregistry v0.7.1-0.20211118220127-abdc633f8305/go.mod h1:6cMIl1RfryEiPzBE67OgtZdEiLWz4myqCQIiBMy3CsM=
+github.com/google/go-containerregistry v0.7.1-0.20211203164431-c75901cce627 h1:8DWrZOqxQIcUkMhGUJ2Ou/oiyIT0p66yHs0AoRRIuSs=
+github.com/google/go-containerregistry v0.7.1-0.20211203164431-c75901cce627/go.mod h1:IwJblnDNiCs8sxubbfPNniYsUqr8m+nt7YbPzecsGuE=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20211203164431-c75901cce627 h1:vflk3WrGf1M0n1mG2AqAoVaKlLYFR6PrzTGQAUcklCM=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20211203164431-c75901cce627/go.mod h1:j3IqhBG3Ox1NXmmhbWU4UmiHVAf2dUgB7le1Ch7JZQ0=
 github.com/google/go-github/v27 v27.0.6/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=


### PR DESCRIPTION
This picks up a change that dramatically speeds up the http fallback when pushing to insecure registries (e.g. `.svc.cluster.local`)

I am confirming this fixes the issue I was seeing downstream now with a private image build at HEAD (with this change).

#### Release Note
```release-note
Fixes some context-deadline exceeded errors pushing to insecure registries (e.g. `.svc.cluster.local`)
```
