### PR TITLE
fix deprecation warning from setup-gcloud

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,11 +35,14 @@ jobs:
         with:
           go-version: '1.17.x'
       - uses: imjasonh/setup-ko@v0.4
+      - id: auth
+        uses: google-github-actions/auth@v0.4.2
+        with:
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0.3.0
         with:
           project_id: projectsigstore
-          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           export_default_credentials: true
       - name: creds
         run: gcloud auth configure-docker --quiet

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -32,11 +32,14 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: '1.17.x'
+      - id: auth
+        uses: google-github-actions/auth@v0.4.2
+        with:
+          credentials_json: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0.3.0
         with:
           project_id: projectsigstore
-          service_account_key: ${{ secrets.GCP_CI_SERVICE_ACCOUNT }}
           export_default_credentials: true
       - run: |
           go install github.com/google/go-containerregistry/cmd/crane@v0.7.0


### PR DESCRIPTION
Fixes warnings e.g. https://github.com/sigstore/cosign/actions/runs/1555909393

#### Release Note
```release-note
NONE
```
