### PR TITLE
Add option to verify attestations from local image

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -70,7 +70,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 		"signature content or path or remote URL")
 
 	cmd.Flags().BoolVar(&o.LocalImage, "local-image", false,
-		"whether the path to the image is a local directory")
+		"whether the specified image is a path to an image saved locally via 'cosign save'")
 }
 
 // VerifyAttestationOptions is the top level wrapper for the `verify attestation` command.
@@ -85,6 +85,7 @@ type VerifyAttestationOptions struct {
 	Registry    RegistryOptions
 	Predicate   PredicateRemoteOptions
 	Policies    []string
+	LocalImage  bool
 }
 
 var _ Interface = (*VerifyAttestationOptions)(nil)
@@ -108,6 +109,9 @@ func (o *VerifyAttestationOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "json",
 		"output format for the signing image information (json|text)")
+
+	cmd.Flags().BoolVar(&o.LocalImage, "local-image", false,
+		"whether the specified image is a path to an image saved locally via 'cosign save'")
 }
 
 // VerifyBlobOptions is the top level wrapper for the `verify blob` command.

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -136,6 +136,9 @@ against the transparency log.`,
   # verify image with public key
   cosign verify-attestation --key cosign.pub <IMAGE>
 
+  # verify image attestations with an on-disk signed image from 'cosign save'
+  cosign verify-attestation --key cosign.pub --local-image <PATH>
+
   # verify image with public key provided by URL
   cosign verify-attestation --key https://host.for/<FILE> <IMAGE>
 
@@ -164,6 +167,7 @@ against the transparency log.`,
 				FulcioURL:       o.Fulcio.URL,
 				PredicateType:   o.Predicate.Type,
 				Policies:        o.Policies,
+				LocalImage:      o.LocalImage,
 			}
 			return v.Exec(cmd.Context(), args)
 		},

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -63,7 +63,7 @@ cosign dockerfile verify [flags]
   -h, --help                                                                                     help for verify
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
-      --local-image                                                                              whether the path to the image is a local directory
+      --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -57,7 +57,7 @@ cosign manifest verify [flags]
   -h, --help                                                                                     help for verify
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
-      --local-image                                                                              whether the path to the image is a local directory
+      --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -31,6 +31,9 @@ cosign verify-attestation [flags]
   # verify image with public key
   cosign verify-attestation --key cosign.pub <IMAGE>
 
+  # verify image attestations with an on-disk signed image from 'cosign save'
+  cosign verify-attestation --key cosign.pub --local-image <PATH>
+
   # verify image with public key provided by URL
   cosign verify-attestation --key https://host.for/<FILE> <IMAGE>
 
@@ -59,6 +62,7 @@ cosign verify-attestation [flags]
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
+      --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --policy strings                                                                           specify CUE or Rego files will be using for validation
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -70,7 +70,7 @@ cosign verify [flags]
   -h, --help                                                                                     help for verify
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
-      --local-image                                                                              whether the path to the image is a local directory
+      --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -720,12 +720,15 @@ func TestSaveLoadAttestation(t *testing.T) {
 	}
 	verifyAttestation.PredicateType = "slsaprovenance"
 	verifyAttestation.Policies = []string{policyPath}
-	// Success case
+	// Success case (remote)
 	cuePolicy := `builder: id: "2"`
 	if err := os.WriteFile(policyPath, []byte(cuePolicy), 0600); err != nil {
 		t.Fatal(err)
 	}
 	must(verifyAttestation.Exec(ctx, []string{imgName2}), t)
+	// Success case (local)
+	verifyAttestation.LocalImage = true
+	must(verifyAttestation.Exec(ctx, []string{imageDir}), t)
 }
 
 func TestAttachSBOM(t *testing.T) {


### PR DESCRIPTION
This is very similar to a previous PR (#1159) that added support for verifying signatures from a local image.

Ref #1015 

Example:

```
...generate attestation...
cosign save us-west1-docker.pkg.dev/project/docker-repo/image:tag1 --dir .
cosign verify-attestation --key cosign.pub --local-image . --verbose
```

With `--verbose`, we see no network calls.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

#### Release Note

```release-note
Add `cosign verify-attestation --local-image path` for verifying signed images with attestations from disk
```
