### PR TITLE
add e2e tests for Windows + PowerShell

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,6 +91,31 @@ jobs:
 
       - name: Run end-to-end tests
         run: ./test/e2e_test.sh
+  
+  e2e-windows-powershell-tests:
+    name: Run PowerShell E2E tests
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.x'
+
+      # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
+      - uses: actions/cache@v2
+        with:
+          # In order:
+          # * Module download cache
+          # * Build cache (Windows)
+          path: |
+            ~/go/pkg/mod
+            %LocalAppData%\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run e2e_test.ps1
+        run: ./test/e2e_test.ps1
 
   license-check:
     name: license boilerplate check

--- a/test/e2e_test.ps1
+++ b/test/e2e_test.ps1
@@ -21,7 +21,6 @@ function New-TmpDir {
 make cosign
 $TmpDir = New-TmpDir
 Copy-Item -Path .\cosign -Destination (Join-Path $TmpDir cosign.exe)
-# Copy-Item -Path (Join-Path $pwd sget.exe) -Destination (Join-Path $TmpDir sget.exe)
 
 Push-Location $TmpDir
 
@@ -29,8 +28,7 @@ Push-Location $TmpDir
 .\cosign.exe version
 
 # Generate a random alphanumeric password for the private key
-$pass = -join (((48..57)+(65..90)+(97..122)) * 80 | Get-Random -Count 10 | %{[char]$_})
-# $Env:COSIGN_PASSWORD = $pass
+$pass = Get-Random
 
 Write-Output $pass | .\cosign.exe generate-key-pair
 $signing_key = "cosign.key"

--- a/test/e2e_test.ps1
+++ b/test/e2e_test.ps1
@@ -1,0 +1,45 @@
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function New-TmpDir {
+    $parent = [System.IO.Path]::GetTempPath()
+    $name = [System.IO.Path]::GetRandomFileName()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+make cosign
+$TmpDir = New-TmpDir
+Copy-Item -Path .\cosign -Destination (Join-Path $TmpDir cosign.exe)
+# Copy-Item -Path (Join-Path $pwd sget.exe) -Destination (Join-Path $TmpDir sget.exe)
+
+Push-Location $TmpDir
+
+# See if things blow up immediately
+.\cosign.exe version
+
+# Generate a random alphanumeric password for the private key
+$pass = -join (((48..57)+(65..90)+(97..122)) * 80 | Get-Random -Count 10 | %{[char]$_})
+# $Env:COSIGN_PASSWORD = $pass
+
+Write-Output $pass | .\cosign.exe generate-key-pair
+$signing_key = "cosign.key"
+$verification_key = "cosign.pub"
+
+$test_img = "gcr.io/distroless/static"
+Write-Output $pass | .\cosign.exe sign --key $signing_key --output-signature interactive.sig $test_img
+.\cosign.exe verify --key $verification_key --signature interactive.sig $test_img
+
+Pop-Location
+
+Write-Output "Success"


### PR DESCRIPTION
I haven't been able to provoke the bug in #1153, but at least we have some powershell-based tests now

#### Release Note
```release-note
NONE
```
