### PR TITLE
Allow fetching TUF root from HTTP

### DIFF
--- a/cmd/cosign/cli/initialize/init.go
+++ b/cmd/cosign/cli/initialize/init.go
@@ -18,9 +18,11 @@ package initialize
 import (
 	"context"
 	_ "embed" // To enable the `go:embed` directive.
+	"net/url"
 
 	"github.com/sigstore/cosign/pkg/blob"
 	"github.com/sigstore/cosign/pkg/cosign/tuf"
+	"github.com/theupdateframework/go-tuf/client"
 )
 
 func DoInitialize(ctx context.Context, root, mirror string, threshold int) error {
@@ -35,7 +37,12 @@ func DoInitialize(ctx context.Context, root, mirror string, threshold int) error
 	}
 
 	// Initialize the remote repository.
-	remote, err := tuf.GcsRemoteStore(ctx, mirror, nil, nil)
+	var remote client.RemoteStore
+	if _, parseErr := url.ParseRequestURI(mirror); parseErr != nil {
+		remote, err = tuf.GcsRemoteStore(ctx, mirror, nil, nil)
+	} else {
+		remote, err = client.HTTPRemoteStore(mirror, nil, nil)
+	}
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -31,7 +31,7 @@ var _ Interface = (*InitializeOptions)(nil)
 // AddFlags implements Interface
 func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Mirror, "mirror", "sigstore-tuf-root",
-		"GCS bucket to a SigStore TUF repository.")
+		"GCS bucket to a SigStore TUF repository or HTTP(S) base URL")
 
 	cmd.Flags().StringVar(&o.Root, "root", "",
 		"path to trusted initial root. defaults to embedded root")

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -42,7 +42,7 @@ cosign initialize -mirror <url> -root <url>
 
 ```
   -h, --help            help for initialize
-      --mirror string   GCS bucket to a SigStore TUF repository. (default "sigstore-tuf-root")
+      --mirror string   GCS bucket to a SigStore TUF repository or HTTP(S) base URL (default "sigstore-tuf-root")
       --root string     path to trusted initial root. defaults to embedded root
       --upload int      threshold of root key signers (default 3)
 ```


### PR DESCRIPTION
This patch allows fetching TUF root from HTTP in addition to GCS. If the
specified mirror is an HTTP link, then HTTPRemoteStore will be used.
Otherwise it defaults to GCS.