### PR TITLE
feat: implement sget blob downloads

### DIFF
--- a/.github/workflows/e2e-with-binary.yml
+++ b/.github/workflows/e2e-with-binary.yml
@@ -22,7 +22,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  e2e-tests-with-binary:
+  e2e-tests-with-cosign:
     # Skip if running in a fork that might not have secrets configured.
     if: ${{ github.repository == 'sigstore/cosign' }}
     name: Run tests
@@ -63,4 +63,36 @@ jobs:
           else
             echo "file does not exist, or is empty"
             exit 1
+          fi
+  e2e-tests-with-sget:
+    # Skip if running in a fork that might not have secrets configured.
+    if: ${{ github.repository == 'sigstore/cosign' }}
+    name: Run tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      COSIGN_EXPERIMENTAL: "true"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.x'
+      - name: build cosign and check
+        shell: bash
+        run: |
+          set -e
+          make sget
+          # this should work
+          ./sget blob --signature https://github.com/sigstore/cosign/releases/download/v1.4.1/sget-darwin-amd64.sig https://github.com/sigstore/cosign/releases/download/v1.4.1/sget-darwin-amd64 --output sget-darwin-amd64
+          # check if the following command fails due to a signature mismatch. Return true if it does
+          if ./sget blob --signature https://github.com/sigstore/cosign/releases/download/v1.4.1/sget-windows-amd64.sig https://github.com/sigstore/cosign/releases/download/v1.4.1/sget-darwin-amd64 --output sget-darwin-amd64
+          then
+            true
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -143,3 +143,4 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: latest
+          args: "--out-${NO_FUTURE}format colored-line-number"

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -220,7 +220,7 @@ func signPolicy() *cobra.Command {
 			}
 
 			result := &bytes.Buffer{}
-			if err := sget.New(imgName+"@"+dgst.String(), "", result).Do(ctx); err != nil {
+			if err := sget.New("", result, "").GetImage(ctx, imgName+"@"+dgst.String()); err != nil {
 				return errors.Wrap(err, "error getting result")
 			}
 			b, err := io.ReadAll(result)

--- a/cmd/sget/cli/image.go
+++ b/cmd/sget/cli/image.go
@@ -1,0 +1,44 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/pkg/errors"
+	"github.com/sigstore/cosign/pkg/sget"
+	"github.com/spf13/cobra"
+)
+
+func Image() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image [--key <key reference>] <image reference>",
+		Short: "download an OCI image and verify its signature",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return errors.New("a single image reference is required")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			wc, err := createSink(ro.OutputFile)
+			if err != nil {
+				return err
+			}
+			defer wc.Close()
+			return sget.New(ro.PublicKey, wc, ro.RekorURL).GetImage(cmd.Context(), args[0])
+		},
+	}
+	return cmd
+}

--- a/cmd/sget/cli/options/blob.go
+++ b/cmd/sget/cli/options/blob.go
@@ -20,23 +20,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// RootOptions define flags and options for the root sget cli.
-type RootOptions struct {
-	OutputFile string
-	PublicKey  string
-	RekorURL   string
+type BlobOptions struct {
+	Signature string
+	Output    bool
 }
 
-var _ options.Interface = (*RootOptions)(nil)
+var _ options.Interface = (*BlobOptions)(nil)
 
 // AddFlags implements options.Interface
-func (o *RootOptions) AddFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVarP(&o.OutputFile, "output", "o", "",
-		"output file")
-
-	cmd.PersistentFlags().StringVar(&o.PublicKey, "key", "",
-		"path to the public key file, URL, or KMS URI")
-
-	cmd.PersistentFlags().StringVar(&o.RekorURL, "rekor-url", "https://rekor.sigstore.dev",
-		"address of rekor STL server")
+func (o *BlobOptions) AddFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVar(&o.Signature, "signature", "",
+		"signature path or remote URL, if empty signature will be <artifact>.sig")
 }

--- a/cmd/sget/cli/root.go
+++ b/cmd/sget/cli/root.go
@@ -1,0 +1,67 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+
+	"github.com/sigstore/cosign/cmd/sget/cli/options"
+	"github.com/spf13/cobra"
+)
+
+var (
+	ro = &options.RootOptions{}
+)
+
+func New() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sget",
+		Short: "sget",
+	}
+	ro.AddFlags(cmd)
+
+	// Add sub-commands.
+	cmd.AddCommand(Version())
+	cmd.AddCommand(Image())
+	cmd.AddCommand(Blob())
+
+	return cmd
+}
+
+func createSink(path string) (io.WriteCloser, error) {
+	if path == "" {
+		// When writing to stdout, buffer so we can check the digest first.
+		return &buffered{w: os.Stdout, buf: &bytes.Buffer{}}, nil
+	}
+
+	return os.Create(path)
+}
+
+type buffered struct {
+	w   io.Writer
+	buf *bytes.Buffer
+}
+
+func (b *buffered) Write(p []byte) (n int, err error) {
+	return b.buf.Write(p)
+}
+
+func (b *buffered) Close() error {
+	_, err := io.Copy(b.w, b.buf)
+	return err
+}

--- a/pkg/sget/blob.go
+++ b/pkg/sget/blob.go
@@ -1,0 +1,214 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sget
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/go-openapi/runtime"
+	"github.com/pkg/errors"
+	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
+	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
+	"github.com/sigstore/cosign/pkg/blob"
+	"github.com/sigstore/cosign/pkg/cosign"
+	sigs "github.com/sigstore/cosign/pkg/signature"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+	hashedrekord "github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1"
+	rekord "github.com/sigstore/rekor/pkg/types/rekord/v0.0.1"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	sigstoresigs "github.com/sigstore/sigstore/pkg/signature"
+	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+func (sg *SecureGet) GetBlob(ctx context.Context, sigRef, artifactRef string) error {
+	var pubKey sigstoresigs.Verifier
+	var err error
+	var cert *x509.Certificate
+
+	artifact, err := blob.LoadFileOrURL(artifactRef)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		artifact = []byte(artifactRef)
+	}
+
+	if sigRef == "" {
+		sigRef = artifactRef + ".sig"
+	}
+
+	targetSig, err := blob.LoadFileOrURL(sigRef)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// ignore if file does not exist, it can be a base64 encoded string as well
+			return err
+		}
+		targetSig = []byte(sigRef)
+	}
+
+	if isb64(targetSig) {
+		targetSig, err = base64.StdEncoding.DecodeString(string(targetSig))
+		if err != nil {
+			return err
+		}
+	}
+
+	rClient, err := rekor.NewClient(sg.RekorURL)
+	if err != nil {
+		return err
+	}
+
+	uuids, err := cosign.FindTLogEntriesByPayload(ctx, rClient, artifact)
+	if err != nil {
+		return err
+	}
+
+	if len(uuids) == 0 {
+		return errors.New("could not find a tlog entry for provided blob")
+	}
+
+	tlogEntry, err := cosign.GetTlogEntry(ctx, rClient, uuids[0])
+	if err != nil {
+		return err
+	}
+
+	certs, err := extractCerts(tlogEntry)
+	if err != nil {
+		return err
+	}
+	cert = certs[0]
+	pubKey, err = sigstoresigs.LoadECDSAVerifier(cert.PublicKey.(*ecdsa.PublicKey), crypto.SHA256)
+	if err != nil {
+		return err
+	}
+
+	if err := pubKey.VerifySignature(bytes.NewReader(targetSig), bytes.NewReader(artifact)); err != nil {
+		return err
+	}
+
+	if cert != nil { // cert
+		if err := cosign.TrustedCert(cert, fulcio.GetRoots()); err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stderr, "Certificate is trusted by Fulcio Root CA")
+		fmt.Fprintln(os.Stderr, "Email:", cert.EmailAddresses)
+		for _, uri := range cert.URIs {
+			fmt.Fprintf(os.Stderr, "URI: %s://%s%s\n", uri.Scheme, uri.Host, uri.Path)
+		}
+		fmt.Fprintln(os.Stderr, "Issuer: ", sigs.CertIssuerExtension(cert))
+	}
+	fmt.Fprintln(os.Stderr, "Verified OK")
+
+	rekorClient, err := rekor.NewClient(sg.RekorURL)
+	if err != nil {
+		return err
+	}
+	var pubBytes []byte
+
+	pubBytes, err = sigs.PublicKeyPem(pubKey, signatureoptions.WithContext(ctx))
+	if err != nil {
+		return err
+	}
+
+	if cert != nil {
+		pubBytes, err = cryptoutils.MarshalCertificateToPEM(cert)
+		if err != nil {
+			return err
+		}
+	}
+
+	b64sig := base64.StdEncoding.EncodeToString(targetSig)
+	if err != nil {
+		return err
+	}
+
+	uuid, index, err := cosign.FindTlogEntry(ctx, rekorClient, b64sig, artifact, pubBytes)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %q index: %d\n", uuid, index)
+
+	_, err = sg.Out.Write(artifact)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// TODO(shibumi): we might want to export this function or add this to our package?!
+func extractCerts(e *models.LogEntryAnon) ([]*x509.Certificate, error) {
+	b, err := base64.StdEncoding.DecodeString(e.Body.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	pe, err := models.UnmarshalProposedEntry(bytes.NewReader(b), runtime.JSONConsumer())
+	if err != nil {
+		return nil, err
+	}
+
+	eimpl, err := types.NewEntry(pe)
+	if err != nil {
+		return nil, err
+	}
+
+	var publicKeyB64 []byte
+	switch e := eimpl.(type) {
+	case *rekord.V001Entry:
+		publicKeyB64, err = e.RekordObj.Signature.PublicKey.Content.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+	case *hashedrekord.V001Entry:
+		publicKeyB64, err = e.HashedRekordObj.Signature.PublicKey.Content.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("unexpected tlog entry type")
+	}
+
+	publicKey, err := base64.StdEncoding.DecodeString(string(publicKeyB64))
+	if err != nil {
+		return nil, err
+	}
+
+	certs, err := cryptoutils.UnmarshalCertificatesFromPEM(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(certs) == 0 {
+		return nil, errors.New("no certs found in pem tlog")
+	}
+
+	return certs, err
+}
+
+// TODO(shibumi): we might want to export this function or add this to our package?!
+func isb64(data []byte) bool {
+	_, err := base64.StdEncoding.DecodeString(string(data))
+	return err == nil
+}

--- a/pkg/sget/image.go
+++ b/pkg/sget/image.go
@@ -32,22 +32,25 @@ import (
 	sigs "github.com/sigstore/cosign/pkg/signature"
 )
 
-func New(image, key string, out io.Writer) *SecureGet {
+func New(key string, out io.Writer, rekorURL string) *SecureGet {
+	if rekorURL == "" {
+		rekorURL = "https://rekor.sigstore.dev"
+	}
 	return &SecureGet{
-		ImageRef: image,
 		KeyRef:   key,
 		Out:      out,
+		RekorURL: rekorURL,
 	}
 }
 
 type SecureGet struct {
-	ImageRef string
 	KeyRef   string
 	Out      io.Writer
+	RekorURL string
 }
 
-func (sg *SecureGet) Do(ctx context.Context) error {
-	ref, err := name.ParseReference(sg.ImageRef)
+func (sg *SecureGet) GetImage(ctx context.Context, imageRef string) error {
+	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return err
 	}
@@ -89,8 +92,8 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		verify.PrintVerificationHeader(sg.ImageRef, co, bundleVerified)
-		verify.PrintVerification(sg.ImageRef, sp, "text")
+		verify.PrintVerificationHeader(imageRef, co, bundleVerified)
+		verify.PrintVerification(imageRef, sp, "text")
 	}
 
 	// TODO(mattmoor): Depending on what this is, use the higher-level stuff.

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -599,7 +599,7 @@ func TestUploadBlob(t *testing.T) {
 	}
 
 	// Now download it with sget (this should fail by tag)
-	if err := sget.New(imgName, "", os.Stdout).Do(ctx); err == nil {
+	if err := sget.New("", os.Stdout, "").GetImage(ctx, imgName); err == nil {
 		t.Error("expected download to fail")
 	}
 
@@ -615,7 +615,7 @@ func TestUploadBlob(t *testing.T) {
 	result := &bytes.Buffer{}
 
 	// But pass by digest
-	if err := sget.New(imgName+"@"+dgst.String(), "", result).Do(ctx); err != nil {
+	if err := sget.New("", result, "").GetImage(ctx, imgName+"@"+dgst.String()); err != nil {
 		t.Fatal(err)
 	}
 	b, err := io.ReadAll(result)


### PR DESCRIPTION
#### Summary

This commit adds a "blob" subcommand to the sget tool.
The "blob" subcommand provides an easy and convenient way to download
and verify binary large objects (BLOBs).

Breaking Changes: The sget image download command can be now found as subcommand: sget image

Example Output:

```
❯ ./sget blob https://github.com/shibumi/mnemonic/releases/download/v0.3.2/mnemonic_0.3.2_linux_arm64.tar.gz --signature https://github.com/shibumi/mnemonic/releases/download/v0.3.2/mnemonic_0.3.2_linux_arm64.tar.gz.sig > mnemonic_0.3.2_linux_arm64.tar.gz
Certificate is trusted by Fulcio Root CA
Email: []
URI: https://github.com/shibumi/mnemonic/.github/workflows/goreleaser.yml@refs/tags/v0.3.2
Issuer:  https://token.actions.githubusercontent.com
Verified OK
tlog entry verified with uuid: "7afc36d7e17268f0bf3b1f6e415e304aa96795b8c49963588e15a20225c3fa17" index: 932675
```

#### Ticket Link

None

#### Release Note

```release-note
breaking change: sget has obtained two new subcommands: image and blob. Blob allows to download and verify BLOBs..
```
