### PR TITLE
Remove the "upload" flag for "cosign initialize"

### DIFF
--- a/cmd/cosign/cli/initialize.go
+++ b/cmd/cosign/cli/initialize.go
@@ -31,9 +31,8 @@ func Initialize() *cobra.Command {
 		Long: `Initializes SigStore root to retrieve trusted certificate and key targets for verification.
 
 The following options are used by default:
-	- The current trusted Sigstore TUF root is embedded inside cosign at the time of release.
-	- SigStore remote TUF repository is pulled from the GCS mirror at sigstore-tuf-root.
-	- A default threshold of 3 root signatures is used.
+ - The current trusted Sigstore TUF root is embedded inside cosign at the time of release.
+ - SigStore remote TUF repository is pulled from the GCS mirror at sigstore-tuf-root.
 
 To provide an out-of-band trusted initial root.json, use the -root flag with a file or URL reference.
 This will enable you to point cosign to a separate TUF root.
@@ -53,7 +52,7 @@ cosign initialize -root <url>
 # initialize with an out-of-band root key file and custom repository mirror.
 cosign initialize -mirror <url> -root <url>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return initialize.DoInitialize(cmd.Context(), o.Root, o.Mirror, o.Threshold)
+			return initialize.DoInitialize(cmd.Context(), o.Root, o.Mirror)
 		},
 	}
 

--- a/cmd/cosign/cli/initialize/init.go
+++ b/cmd/cosign/cli/initialize/init.go
@@ -25,7 +25,7 @@ import (
 	"github.com/theupdateframework/go-tuf/client"
 )
 
-func DoInitialize(ctx context.Context, root, mirror string, threshold int) error {
+func DoInitialize(ctx context.Context, root, mirror string) error {
 	// Get the initial trusted root contents.
 	var rootFileBytes []byte
 	var err error
@@ -48,5 +48,5 @@ func DoInitialize(ctx context.Context, root, mirror string, threshold int) error
 	}
 
 	// Initialize and update the local SigStore root.
-	return tuf.Init(ctx, rootFileBytes, remote, threshold)
+	return tuf.Init(ctx, rootFileBytes, remote)
 }

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -21,9 +21,8 @@ import (
 
 // InitializeOptions is the top level wrapper for the initialize command.
 type InitializeOptions struct {
-	Mirror    string
-	Root      string
-	Threshold int
+	Mirror string
+	Root   string
 }
 
 var _ Interface = (*InitializeOptions)(nil)
@@ -35,7 +34,4 @@ func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Root, "root", "",
 		"path to trusted initial root. defaults to embedded root")
-
-	cmd.Flags().IntVar(&o.Threshold, "upload", 3,
-		"threshold of root key signers")
 }

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -7,9 +7,8 @@ Initializes SigStore root to retrieve trusted certificate and key targets for ve
 Initializes SigStore root to retrieve trusted certificate and key targets for verification.
 
 The following options are used by default:
-	- The current trusted Sigstore TUF root is embedded inside cosign at the time of release.
-	- SigStore remote TUF repository is pulled from the GCS mirror at sigstore-tuf-root.
-	- A default threshold of 3 root signatures is used.
+ - The current trusted Sigstore TUF root is embedded inside cosign at the time of release.
+ - SigStore remote TUF repository is pulled from the GCS mirror at sigstore-tuf-root.
 
 To provide an out-of-band trusted initial root.json, use the -root flag with a file or URL reference.
 This will enable you to point cosign to a separate TUF root.
@@ -44,7 +43,6 @@ cosign initialize -mirror <url> -root <url>
   -h, --help            help for initialize
       --mirror string   GCS bucket to a SigStore TUF repository or HTTP(S) base URL (default "sigstore-tuf-root")
       --root string     path to trusted initial root. defaults to embedded root
-      --upload int      threshold of root key signers (default 3)
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -325,7 +325,7 @@ func downloadRemoteTarget(name string, c *client.Client, out client.Destination)
 
 // Instantiates the global TUF client. Uses the embedded (by default trusted) root in cosign
 // unless a custom root is provided. This will always perform a remote call to update.
-func Init(ctx context.Context, altRootBytes []byte, remote client.RemoteStore, threshold int) error {
+func Init(ctx context.Context, altRootBytes []byte, remote client.RemoteStore) error {
 	rootClient, err := RootClient(ctx, remote, altRootBytes)
 	if err != nil {
 		return errors.Wrap(err, "initializing root client")


### PR DESCRIPTION
The "upload" flag is not used anywhere and it is not really needed. When
we update from the remote TUF repo, we expect the same number of root
signatures (or more) which is a sensible default.

Closes: #1195

Signed-off-by: Radoslav Gerganov <rgerganov@vmware.com>

