### PR TITLE
[WIP] Implements new policy init iteration

### DIFF
--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -18,7 +18,6 @@ package cli
 import (
 	"bytes"
 	"context"
-	// "encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -42,7 +41,6 @@ import (
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
 	"github.com/sigstore/cosign/pkg/cosign/tuf"
 	"github.com/sigstore/cosign/pkg/sget"
-	// sigs "github.com/sigstore/cosign/pkg/signature"
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/spf13/cobra"
 )

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -114,7 +114,7 @@ func initPolicy() *cobra.Command {
 			role.AddKeysWithThreshold(publicKeys, o.Threshold)
 			root.Roles["root"] = role
 			root.Namespace = o.ImageRef
-			root.PreviousRoot = "null"
+			root.PreviousRoot = ""
 
 			if o.Expires > 0 {
 				root.Expires = time.Now().AddDate(0, 0, o.Expires).UTC().Round(time.Second)

--- a/pkg/cosign/tuf/policy.go
+++ b/pkg/cosign/tuf/policy.go
@@ -65,7 +65,7 @@ type Root struct {
 	Keys         map[string]*Key  `json:"keys"`
 	Roles        map[string]*Role `json:"roles"`
 	Namespace    string           `json:"namespace"`
-	PreviousRoot string           `json:"previous_root"`
+	PreviousRoot string           `json:"previous_root, omitempty"`
 }
 
 func DefaultExpires(role string) time.Time {

--- a/pkg/cosign/tuf/policy.go
+++ b/pkg/cosign/tuf/policy.go
@@ -65,7 +65,7 @@ type Root struct {
 	Keys         map[string]*Key  `json:"keys"`
 	Roles        map[string]*Role `json:"roles"`
 	Namespace    string           `json:"namespace"`
-	PreviousRoot string           `json:"previous_root, omitempty"`
+	PreviousRoot string           `json:"previous_root,omitempty"`
 }
 
 func DefaultExpires(role string) time.Time {

--- a/pkg/cosign/tuf/policy_test.go
+++ b/pkg/cosign/tuf/policy_test.go
@@ -75,7 +75,7 @@ func TestRootRole(t *testing.T) {
 		t.Errorf("Error marshalling root policy")
 	}
 	newRoot := Root{}
-	if err := json.Unmarshal(policy.Signed, &newRoot); err != nil {
+	if err := json.Unmarshal(policy.Policy, &newRoot); err != nil {
 		t.Errorf("Error marshalling root policy")
 	}
 	rootRole, ok := newRoot.Roles["root"]

--- a/pkg/cosign/tuf/signer.go
+++ b/pkg/cosign/tuf/signer.go
@@ -36,10 +36,9 @@ type FulcioKeyVal struct {
 func FulcioVerificationKey(email string, issuer string) *Key {
 	keyValBytes, _ := json.Marshal(FulcioKeyVal{Identity: email, Issuer: issuer})
 	return &Key{
-		Type:       KeyTypeFulcio,
-		Scheme:     KeySchemeFulcio,
-		Algorithms: KeyAlgorithms,
-		Value:      keyValBytes,
+		Type:   KeyTypeFulcio,
+		Scheme: KeySchemeFulcio,
+		Value:  keyValBytes,
 	}
 }
 


### PR DESCRIPTION
Implement a policy init with no signed body and remove unneeded tuf'isms

Users will now instead sign the whole policy and attach the sig
to the cosign signature annotation,rather than the signature body
of the policy

This also introduces a `previous_root` key which will allow
clients that consume policy (such as sget), to walk back a linear
proof of previous signers.

Signed-off-by: Luke Hinds <lhinds@redhat.com>

cc @asraa @imjasonh @jyotsna-penumaka