### PR TITLE
Fall back to in-memory cache when local TUF root cannot be instantiated

### DIFF
--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -171,12 +171,10 @@ func initGlobalRootClient(ctx context.Context, remote client.RemoteStore, altRoo
 		}
 	}
 
-	local, err := tuf_leveldbstore.FileLocalStore(localCacheDBPath)
-	if err != nil {
-		if !errors.Is(err, fs.ErrPermission) {
-			return nil, errors.Wrap(err, "creating cached local store")
-		}
-		local = client.MemoryLocalStore()
+	local := client.MemoryLocalStore()
+	if localDB, err := tuf_leveldbstore.FileLocalStore(localCacheDBPath); err == nil {
+		// TODO: log errors
+		local = localDB
 	}
 
 	// We may need to download latest metadata and targets if the cache is un-initialized or expired.

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -173,7 +173,10 @@ func initGlobalRootClient(ctx context.Context, remote client.RemoteStore, altRoo
 
 	local, err := tuf_leveldbstore.FileLocalStore(localCacheDBPath)
 	if err != nil {
-		return nil, errors.Wrap(err, "creating cached local store")
+		if !errors.Is(err, fs.ErrPermission) {
+			return nil, errors.Wrap(err, "creating cached local store")
+		}
+		local = client.MemoryLocalStore()
 	}
 
 	// We may need to download latest metadata and targets if the cache is un-initialized or expired.


### PR DESCRIPTION
#### Ticket Link
Fixes https://github.com/sigstore/cosign/issues/1207

#### Release Note
```release-note
fixed: panics like `panic ... creating root cert pool: retrieving trusted root; local cache may be corrupt: creating cached local store: mkdir $HOME/.sigstore: read-only file system`
```
