### PR TITLE
clean up references to 'keyless' in `ephemeral.Signer`

### DIFF
--- a/internal/pkg/cosign/ephemeral/signer.go
+++ b/internal/pkg/cosign/ephemeral/signer.go
@@ -29,14 +29,14 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-type keylessSigner struct {
+type ephemeralSigner struct {
 	signer signature.Signer
 }
 
-var _ icosign.Signer = keylessSigner{}
+var _ icosign.Signer = ephemeralSigner{}
 
 // Sign implements `Signer`
-func (ks keylessSigner) Sign(ctx context.Context, payload io.Reader) (oci.Signature, crypto.PublicKey, error) {
+func (ks ephemeralSigner) Sign(ctx context.Context, payload io.Reader) (oci.Signature, crypto.PublicKey, error) {
 	pub, err := ks.signer.PublicKey()
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "retrieving the static public key somehow failed")
@@ -71,7 +71,7 @@ func NewSigner() (icosign.Signer, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating a SignerVerifier from ephemeral key")
 	}
-	return keylessSigner{
+	return ephemeralSigner{
 		signer: s,
 	}, nil
 }

--- a/internal/pkg/cosign/ephemeral/signer_test.go
+++ b/internal/pkg/cosign/ephemeral/signer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
-func TestKeylessSigner(t *testing.T) {
+func TestEphemeralSigner(t *testing.T) {
 	testSigner, err := NewSigner()
 	if err != nil {
 		t.Fatalf("NewSigner() returned error: %v", err)


### PR DESCRIPTION
#### Release Note
```release-note
NONE
```
