### PR TITLE
Log the proper remote repo for the signatures on verify

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -246,7 +246,13 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko KeyO
 		return errors.Wrap(err, "constructing client options")
 	}
 
-	fmt.Fprintln(os.Stderr, "Pushing signature to:", digest.Repository)
+	// Check if we are overriding the signatures repository location
+	repo, _ := ociremote.GetEnvTargetRepository()
+	if repo.RepositoryStr() == "" {
+		fmt.Fprintln(os.Stderr, "Pushing signature to:", digest.Repository)
+	} else {
+		fmt.Fprintln(os.Stderr, "Pushing signature to:", repo.RepositoryStr())
+	}
 
 	// Publish the signatures associated with this entity
 	if err := ociremote.WriteSignatures(digest.Repository, newSE, walkOpts...); err != nil {


### PR DESCRIPTION
#### Summary

Currently we print the image repo being signed as if we were pushing the
signatures to that same repo, which could lead to users being surprised.

Instead try to get the override and print that instead

#### Ticket Link

Resolves: #1242

#### Release Note

```release-note
NONE
```
