### PR TITLE
Use ${{github.repository}} placeholder in OIDC GitHub workflow

### DIFF
--- a/.github/workflows/github-oidc.yaml
+++ b/.github/workflows/github-oidc.yaml
@@ -32,7 +32,7 @@ jobs:
       GIT_VERSION: latest
       GITHUB_RUN_ID: ${{ github.run_id }}
       GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
-      KO_PREFIX: ghcr.io/sigstore/cosign
+      KO_PREFIX: ghcr.io/${{ github.repository }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
With sigstore/cosign hard-coded, when someone forks the repo they start
running the workflow every day, which fails because their repo
(hopefully) can't push to ghcr.io/sigstore/cosign.

Using a variable instead means they'll push to their own GHCR namespace.

Signed-off-by: Jason Hall <jasonhall@redhat.com>

#### Release Note

```release-note
NONE
```
