### PR TITLE
feat: resolve --cert from URL

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
+	"github.com/sigstore/cosign/pkg/blob"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/pivkey"
 	"github.com/sigstore/cosign/pkg/cosign/pkcs11key"
@@ -131,7 +132,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			return errors.Wrap(err, "initializing piv token verifier")
 		}
 	case certRef != "":
-		pubKey, err = loadCertFromFile(c.CertRef)
+		pubKey, err = loadCertFromFileOrURL(c.CertRef)
 		if err != nil {
 			return err
 		}
@@ -254,8 +255,8 @@ func PrintVerification(imgRef string, verified []oci.Signature, output string) {
 	}
 }
 
-func loadCertFromFile(path string) (*signature.ECDSAVerifier, error) {
-	pems, err := os.ReadFile(path)
+func loadCertFromFileOrURL(path string) (*signature.ECDSAVerifier, error) {
+	pems, err := blob.LoadFileOrURL(path)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -113,7 +113,7 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, blobRe
 			return errors.Wrap(err, "loading public key from token")
 		}
 	case certRef != "":
-		pubKey, err = loadCertFromFile(certRef)
+		pubKey, err = loadCertFromFileOrURL(certRef)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### Summary

`verify` and `verify-blob`'s `--cert` param should accept an URL as well, so we can verify without previously downloading files, e.g.:

```sh
cosign verify-blob \
  --cert https://github.com/goreleaser/supply-chain-example/releases/download/v1.0.0/checksums.txt.pem \
  --signature https://github.com/goreleaser/supply-chain-example/releases/download/v1.0.0/checksums.txt.sig \
  https://github.com/goreleaser/supply-chain-example/releases/download/v1.0.0/checksums.txt
```

#### Ticket Link

https://github.com/gythialy/golang-cross/pull/67/files#r774120479

#### Release Note

```release-note
verify and verify-blob resolve --cert from URL
```
