### PR TITLE
Fix semantic bugs in attestation verifification.

### DIFF
--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1,0 +1,91 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"context"
+	"crypto"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/pkg/errors"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/sigstore/cosign/pkg/types"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+type mockVerifier struct {
+	shouldErr bool
+}
+
+func (m *mockVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return nil, nil
+}
+
+func (m *mockVerifier) VerifySignature(signature, message io.Reader, opts ...signature.VerifyOption) error {
+	if m.shouldErr {
+		return errors.New("failure")
+	}
+	return nil
+}
+
+var _ signature.Verifier = (*mockVerifier)(nil)
+
+type mockAttestation struct {
+	payload interface{}
+}
+
+var _ payloader = (*mockAttestation)(nil)
+
+func (m *mockAttestation) Annotations() (map[string]string, error) {
+	return nil, nil
+}
+
+func (m *mockAttestation) Payload() ([]byte, error) {
+	return json.Marshal(m.payload)
+}
+func Test_verifyOCIAttestation(t *testing.T) {
+	stmt, err := json.Marshal(in_toto.ProvenanceStatement{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := map[string]interface{}{
+		"payloadType": types.IntotoPayloadType,
+		"payload":     stmt,
+		"signatures":  []dsse.Signature{{Sig: base64.StdEncoding.EncodeToString([]byte("foobar"))}},
+	}
+	// Should Verify
+	if err := verifyOCIAttestation(context.TODO(), &mockVerifier{}, &mockAttestation{payload: valid}); err != nil {
+		t.Errorf("verifyOCIAttestation() error = %v", err)
+	}
+
+	invalid := map[string]interface{}{
+		"payloadType": "not valid type",
+		"payload":     stmt,
+		"signatures":  []dsse.Signature{{Sig: base64.StdEncoding.EncodeToString([]byte("foobar"))}},
+	}
+
+	// Should Not Verify
+	if err := verifyOCIAttestation(context.TODO(), &mockVerifier{}, &mockAttestation{payload: invalid}); err == nil {
+		t.Error("verifyOCIAttestation() expected invalid payload type error, got nil")
+	}
+
+	if err := verifyOCIAttestation(context.TODO(), &mockVerifier{shouldErr: true}, &mockAttestation{payload: valid}); err == nil {
+		t.Error("verifyOCIAttestation() expected invalid payload type error, got nil")
+	}
+}


### PR DESCRIPTION
DSSE requires that the payload types match, but the Attestation
spec requires that the payload type be the specific in-toto one. We
don't actually do anything with the content here other than dump it
in plain text, but semantically we're calling these attestations in the
CLI so we should enforce that part of the specification as well.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
BREAKING: In-Toto Attestations generated in older versions of cosign will not verify in newer versions. 
```
