### PR TITLE
Refactor the tuf client code.

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
@@ -16,13 +16,12 @@
 package fulcioroots
 
 import (
-	"bytes"
 	"context"
 	"crypto/x509"
-	"fmt"
 	"os"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign/tuf"
 )
 
@@ -43,39 +42,47 @@ const (
 
 func Get() *x509.CertPool {
 	rootsOnce.Do(func() {
-		roots = initRoots()
+		var err error
+		roots, err = initRoots()
+		if err != nil {
+			panic(err)
+		}
 	})
 	return roots
 }
 
-func initRoots() *x509.CertPool {
+func initRoots() (*x509.CertPool, error) {
 	cp := x509.NewCertPool()
 	rootEnv := os.Getenv(altRoot)
 	if rootEnv != "" {
 		raw, err := os.ReadFile(rootEnv)
 		if err != nil {
-			panic(fmt.Sprintf("error reading root PEM file: %s", err))
+			return nil, errors.Wrap(err, "error reading root PEM file")
 		}
 		if !cp.AppendCertsFromPEM(raw) {
-			panic("error creating root cert pool")
+			return nil, errors.New("error creating root cert pool")
 		}
 	} else {
+		tuf, err := tuf.NewFromEnv(context.Background())
+		if err != nil {
+			return nil, errors.Wrap(err, "initializing tuf")
+		}
+		defer tuf.Close()
 		// Retrieve from the embedded or cached TUF root. If expired, a network
 		// call is made to update the root.
-		ctx := context.Background() // TODO: pass in context?
 		rootFound := false
 		for _, fulcioTarget := range []string{fulcioTargetStr, fulcioV1TargetStr} {
-			buf := tuf.ByteDestination{Buffer: &bytes.Buffer{}}
-			if err := tuf.GetTarget(ctx, fulcioTarget, &buf); err == nil {
+			b, err := tuf.GetTarget(fulcioTarget)
+			if err == nil {
 				rootFound = true
-				if !cp.AppendCertsFromPEM(buf.Bytes()) {
-					panic("error creating root cert pool")
+				if !cp.AppendCertsFromPEM(b) {
+					return nil, errors.New("error creating root cert pool")
 				}
 			}
 		}
 		if !rootFound {
-			panic("none of the Fulcio roots have been found")
+			return nil, errors.New("none of the Fulcio roots have been found")
 		}
 	}
-	return cp
+	return cp, nil
 }

--- a/cmd/cosign/cli/initialize/init.go
+++ b/cmd/cosign/cli/initialize/init.go
@@ -47,6 +47,5 @@ func DoInitialize(ctx context.Context, root, mirror string) error {
 		return err
 	}
 
-	// Initialize and update the local SigStore root.
-	return tuf.Init(ctx, rootFileBytes, remote)
+	return tuf.Initialize(remote, rootFileBytes)
 }

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -15,7 +15,6 @@
 package cosign
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -46,11 +45,12 @@ var rekorTargetStr = `rekor.pub`
 // GetRekorPub retrieves the rekor public key from the embedded or cached TUF root. If expired, makes a
 // network call to retrieve the updated target.
 func GetRekorPub(ctx context.Context) ([]byte, error) {
-	buf := tuf.ByteDestination{Buffer: &bytes.Buffer{}}
-	if err := tuf.GetTarget(ctx, rekorTargetStr, &buf); err != nil {
+	tuf, err := tuf.NewFromEnv(ctx)
+	if err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	defer tuf.Close()
+	return tuf.GetTarget(rekorTargetStr)
 }
 
 // TLogUpload will upload the signature, public key and payload to the transparency log.


### PR DESCRIPTION
Refactor the tuf client code.

This is my attempt at refactoring the TUF client code to better
support the configuration modes we've recently added.

This also adds support for SIGSTORE_NO_CACHE, and eliminates most
writes to disk from cosign outside of cosign initialize.

I think these tests are about equivalent to what we had before, if not
a bit better. The coverage is at 72% and hits most non-sporadic errors.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
