### PR TITLE
Remove remaining ioutil usage

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier_test.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier_test.go
@@ -17,7 +17,6 @@ package fulcioverifier
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -45,7 +44,7 @@ func TestGetAlternatePublicKey(t *testing.T) {
 	}
 	for _, tc := range tests {
 		filepath := fmt.Sprintf("%s/testdata/%s", wd, tc.file)
-		bytes, err := ioutil.ReadFile(filepath)
+		bytes, err := os.ReadFile(filepath)
 		if err != nil {
 			t.Fatalf("Failed to read testfile %s : %v", tc.file, err)
 		}

--- a/test/pkcs11_test.go
+++ b/test/pkcs11_test.go
@@ -45,7 +45,6 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"strings"
@@ -351,7 +350,7 @@ func importKey(slotID uint) error {
 	keyLabelBytes := []byte(keyLabel)
 
 	r := strings.NewReader(rsaPrivKey)
-	pemBytes, err = ioutil.ReadAll(r)
+	pemBytes, err = os.ReadAll(r)
 	if err != nil {
 		return fmt.Errorf("unable to read pem")
 	}


### PR DESCRIPTION
Remove the remaining ioutil usage from the code

Signed-off-by: Morten Linderud <morten@linderud.pw>

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
