### PR TITLE
enable sbom generation when releasing

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -50,7 +50,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -w /go/src/sigstore/cosign \
             --entrypoint="" \
-            ghcr.io/gythialy/golang-cross:v1.17.5-1@sha256:f6cc024baf829eaa61972c7fd20d0d62bf9faad31246fd61d9d78fc122cbcd29 \
+            ghcr.io/gythialy/golang-cross:v1.17.5-4@sha256:e1ae043ca969c0b46bb23aa3dd0443a9271c2f665513168091864aa3b751f12a \
             make snapshot
 
       - name: check binaries

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,9 @@ before:
 gomod:
   proxy: true
 
+sboms:
+- artifacts: binary
+
 builds:
 - id: linux
   binary: cosign-linux-{{ .Arch }}
@@ -197,23 +200,32 @@ signs:
   # Keyless
   - id: cosign-keyless
     signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
     artifacts: binary
   - id: cosigned-keyless
     signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
     artifacts: binary
     ids:
       - linux-cosigned
   - id: sget-keyless
     signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
     cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "${artifact}"]
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
     artifacts: binary
     ids:
       - sget
+  - id: checksum-keyless
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    cmd: ./dist/cosign-linux-amd64
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
+    artifacts: checksum
 
 archives:
 - format: binary
@@ -248,4 +260,3 @@ rigs:
     homepage: https://sigstore.dev
     description: Container Signing, Verification and Storage in an OCI registry.
     license: "Apache License 2.0"
-

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -36,14 +36,15 @@ steps:
   dir: "go/src/sigstore/cosign"
   env:
   - COSIGN_EXPERIMENTAL=true
+  - TUF_ROOT=/tmp
   args:
   - 'verify'
   - '--key'
   - 'https://raw.githubusercontent.com/gythialy/golang-cross/main/cosign.pub'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.5-1@sha256:f6cc024baf829eaa61972c7fd20d0d62bf9faad31246fd61d9d78fc122cbcd29'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.5-4@sha256:e1ae043ca969c0b46bb23aa3dd0443a9271c2f665513168091864aa3b751f12a'
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.5-1@sha256:f6cc024baf829eaa61972c7fd20d0d62bf9faad31246fd61d9d78fc122cbcd29
+- name: ghcr.io/gythialy/golang-cross:v1.17.5-4@sha256:e1ae043ca969c0b46bb23aa3dd0443a9271c2f665513168091864aa3b751f12a
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -64,7 +65,7 @@ steps:
     - |
       make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.5-1@sha256:f6cc024baf829eaa61972c7fd20d0d62bf9faad31246fd61d9d78fc122cbcd29
+- name: ghcr.io/gythialy/golang-cross:v1.17.5-4@sha256:e1ae043ca969c0b46bb23aa3dd0443a9271c2f665513168091864aa3b751f12a
   entrypoint: 'bash'
   dir: "go/src/sigstore/cosign"
   env:
@@ -97,7 +98,7 @@ artifacts:
   objects:
     location: 'gs://${_STORAGE_LOCATION}/${_GIT_TAG}'
     paths:
-    - "go/src/sigstore/cosign/dist/cosign*"
+    - "go/src/sigstore/cosign/dist/*"
     - "go/src/sigstore/cosign/release/release-cosign.pub"
 
 options:

--- a/release/release.mk
+++ b/release/release.mk
@@ -7,7 +7,6 @@
 release:
 	LDFLAGS="$(LDFLAGS)" goreleaser release
 
-
 ###########################
 # sign with GCP KMS section
 ###########################


### PR DESCRIPTION
#### Summary
- add the sbom for the binaries as part of the release process
- fix the tuf db when validating the builder image


rehearsal release: https://github.com/cpanato/cosign/releases/tag/v99.99.04

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
enable sbom generation when releasing
```
