### PR TITLE
refactor core password prompting, file exist and terminal checks

### DIFF
--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -27,7 +27,6 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign/git"
 	"github.com/sigstore/cosign/pkg/cosign/git/github"
 	"github.com/sigstore/cosign/pkg/cosign/git/gitlab"
-	"golang.org/x/term"
 
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/kubernetes"
@@ -86,7 +85,7 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error
 		return err
 	}
 
-	if fileExists("cosign.key") {
+	if cosign.FileExists("cosign.key") {
 		var overwrite string
 		fmt.Fprint(os.Stderr, "File cosign.key already exists. Overwrite (y/n)? ")
 		fmt.Scanf("%s", &overwrite)
@@ -124,9 +123,9 @@ func readPasswordFn(confirm bool) func() ([]byte, error) {
 		return func() ([]byte, error) {
 			return []byte(pw), nil
 		}
-	case isTerminal():
+	case cosign.IsTerminal():
 		return func() ([]byte, error) {
-			return getPassFromTerm(confirm)
+			return cosign.GetPassFromTerm(confirm)
 		}
 	// Handle piped in passwords.
 	default:
@@ -134,42 +133,4 @@ func readPasswordFn(confirm bool) func() ([]byte, error) {
 			return io.ReadAll(os.Stdin)
 		}
 	}
-}
-
-func isTerminal() bool {
-	stat, _ := os.Stdin.Stat()
-	return (stat.Mode() & os.ModeCharDevice) != 0
-}
-
-// TODO centralize password prompt logic for code reuse across more use cases -> https://github.com/sigstore/cosign/issues/1078
-func getPassFromTerm(confirm bool) ([]byte, error) {
-	fmt.Fprint(os.Stderr, "Enter password for private key: ")
-	pw1, err := term.ReadPassword(0)
-	fmt.Fprintln(os.Stderr)
-	if err != nil {
-		return nil, err
-	}
-	if !confirm {
-		return pw1, nil
-	}
-	fmt.Fprint(os.Stderr, "Enter password for private key again: ")
-	pw2, err := term.ReadPassword(0)
-	fmt.Fprintln(os.Stderr)
-	if err != nil {
-		return nil, err
-	}
-
-	if string(pw1) != string(pw2) {
-		return nil, errors.New("passwords do not match")
-	}
-	return pw1, nil
-}
-
-// TODO need to centralize this logic
-func fileExists(filename string) bool {
-	info, err := os.Stat(filename)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
 }

--- a/pkg/cosign/common.go
+++ b/pkg/cosign/common.go
@@ -1,0 +1,61 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"golang.org/x/term"
+)
+
+// TODO need to centralize this logic
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func GetPassFromTerm(confirm bool) ([]byte, error) {
+	fmt.Fprint(os.Stderr, "Enter password for private key: ")
+	pw1, err := term.ReadPassword(0)
+	if err != nil {
+		return nil, err
+	}
+	if !confirm {
+		return pw1, nil
+	}
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprint(os.Stderr, "Enter password for private key again: ")
+	confirmpw, err := term.ReadPassword(0)
+	fmt.Fprintln(os.Stderr)
+	if err != nil {
+		return nil, err
+	}
+
+	if string(pw1) != string(confirmpw) {
+		return nil, errors.New("passwords do not match")
+	}
+	return pw1, nil
+}
+
+func IsTerminal() bool {
+	stat, _ := os.Stdin.Stat()
+	return (stat.Mode() & os.ModeCharDevice) != 0
+}


### PR DESCRIPTION
Refactor the common utilities for password prompting, checking for file existence as well as determining terminal status, per #1078 

Signed-off-by: Ivan Wallis ivan.wallis@venafi.com

Summary
Ticket Link
Fixes

Release Note