### PR TITLE
Fix the unit tests with expired TUF metadata.

### DIFF
--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -34,7 +34,6 @@ func TestNewFromEnv(t *testing.T) {
 	ctx := context.Background()
 
 	// Make sure nothing is expired
-	forceExpiration(t, false)
 	tuf, err := NewFromEnv(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +43,6 @@ func TestNewFromEnv(t *testing.T) {
 	tuf.Close()
 
 	// Now try with expired targets
-
 	forceExpiration(t, true)
 	tuf, err = NewFromEnv(ctx)
 	if err != nil {
@@ -136,6 +134,7 @@ func TestCache(t *testing.T) {
 
 func checkTargets(t *testing.T, tuf *TUF) {
 	// Check the targets
+	t.Helper()
 	for _, target := range targets {
 		if _, err := tuf.GetTarget(target); err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
These tests worked by mocking at the "isExpired" level. When the real files
ARE expired, but we mock them to be NOT expired, the code continues down a
path it shouldn't and fails later, trying to use expired metadata.

We should fix this "better" by generating real expired and unexpired metadata,
or changing the system clock somehow.

Signed-off-by: Dan Lorenc <lorenc.d@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
