### PR TITLE
Fix a couple bugs in cert verification for blobs

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -203,7 +203,7 @@ func tlogValidateCertificate(ctx context.Context, rekorClient *client.Rekor, sig
 	if err != nil {
 		return err
 	}
-	return checkExpiry(cert, time.Unix(*e.IntegratedTime, 0))
+	return CheckExpiry(cert, time.Unix(*e.IntegratedTime, 0))
 }
 
 type fakeOCISignatures struct {
@@ -537,7 +537,8 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 	return checkedAttestations, bundleVerified, nil
 }
 
-func checkExpiry(cert *x509.Certificate, it time.Time) error {
+// CheckExpiry confirms the time provided is within the valid period of the cert
+func CheckExpiry(cert *x509.Certificate, it time.Time) error {
 	ft := func(t time.Time) string {
 		return t.Format(time.RFC3339)
 	}
@@ -582,7 +583,7 @@ func VerifyBundle(ctx context.Context, sig oci.Signature) (bool, error) {
 	}
 
 	// verify the cert against the integrated time
-	if err := checkExpiry(cert, time.Unix(bundle.Payload.IntegratedTime, 0)); err != nil {
+	if err := CheckExpiry(cert, time.Unix(bundle.Payload.IntegratedTime, 0)); err != nil {
 		return false, errors.Wrap(err, "checking expiry on cert")
 	}
 


### PR DESCRIPTION
1. We weren't checking the expiry of the cert against the time the entry was added to rekor
2. We weren't verifying the cert passed in by `--cert`

Signed-off-by: Priya Wadhwa <priyawadhwa@google.com>

