### PR TITLE
TUF: Add error message when local cache's TUF metadata is expired

### DIFF
--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -119,6 +119,9 @@ func New(ctx context.Context, remote client.RemoteStore, cacheRoot string) (*TUF
 	}
 
 	// We need to update our tufdb.
+	// Warning: If a local cache already exists, you may get a local/remote mismatch
+	// since the default remote may not match the remote repository configured during
+	// a cosign initialize.
 	trustedRoot, err := getRoot(trustedMeta)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting trusted root")
@@ -128,7 +131,7 @@ func New(ctx context.Context, remote client.RemoteStore, cacheRoot string) (*TUF
 		return nil, errors.Wrap(err, "bad trusted root")
 	}
 	if err := t.client.Init(rootKeys, rootThreshold); err != nil {
-		return nil, errors.Wrap(err, "unable to initialize client")
+		return nil, errors.Wrap(err, "unable to initialize client, local cache may be corrupt")
 	}
 	if err := t.updateMetadataAndDownloadTargets(); err != nil {
 		return nil, errors.Wrap(err, "updating local metadata and targets")


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Adds a better error handling and comment for https://github.com/sigstore/cosign/issues/1293

I don't think there's a way yet to store state of your remote repository's location (in go-tuf client there isn't), so the best you can do is detect that youre trying to use a different repo than the default remote repo and to warn to check your cache

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
