### PR TITLE
added string literal signing functionality

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -46,3 +46,15 @@ The following checks were performed on each of these signatures:
   - Any certificates were verified against the Fulcio roots.
 {"critical":{"identity":{"docker-reference":"us.gcr.io/dlorenc-vmtest2/demo"},"image":{"docker-manifest-digest":"sha256:124e1fdee94fe5c5f902bc94da2d6e2fea243934c74e76c2368acdc8d3ac7155"},"type":"cosign container image signature"},"optional":null}
 ```
+
+## Sign Strings
+
+```shell
+$ cosign sign-string --key cosign.key "hello world"
+Enter password for private key: MEUCIB2yVuhvuwKLH4AiodNzvxVOvsKVygyYXZpa8R7kUHQiAiEAuuBTC2rJF3DkbT+LH4sZUMkO17LWpvYC/7bhdOG1Hy4=
+```
+
+```shell
+$ cosign verify-string --key cosign.pub --signature MEUCIB2yVuhvuwKLH4AiodNzvxVOvsKVygyYXZpa8R7kUHQiAiEAuuBTC2rJF3DkbT+LH4sZUMkO17LWpvYC/7bhdOG1Hy4= "hello world"
+Verified OK
+```

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ This core set includes:
   * WASM modules
   * (probably anything else, feel free to add things to this list)
 * Text files and other binary blobs, using `cosign sign-blob`
+* String literals, using `cosign sign-string`
 
 ### What ** is not ** production ready?
 

--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -85,10 +85,12 @@ func New() *cobra.Command {
 	cmd.AddCommand(Save())
 	cmd.AddCommand(Sign())
 	cmd.AddCommand(SignBlob())
+	cmd.AddCommand(SignString())
 	cmd.AddCommand(Upload())
 	cmd.AddCommand(Verify())
 	cmd.AddCommand(VerifyAttestation())
 	cmd.AddCommand(VerifyBlob())
+	cmd.AddCommand(VerifyString())
 	cmd.AddCommand(Triangulate())
 	cmd.AddCommand(Version())
 

--- a/cmd/cosign/cli/sign/sign_string.go
+++ b/cmd/cosign/cli/sign/sign_string.go
@@ -1,0 +1,137 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sign
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/signature"
+	rekorClient "github.com/sigstore/rekor/pkg/client"
+	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+// nolint
+func SignStringCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOptions, payloadString string, b64 bool, outputSignature string, outputCertificate string, timeout time.Duration) ([]byte, error) {
+	var payload []byte
+	var err error
+	var rekorBytes []byte
+
+	payload = []byte(payloadString)
+
+	if err != nil {
+		return nil, err
+	}
+	if timeout != 0 {
+		var cancelFn context.CancelFunc
+		ctx, cancelFn = context.WithTimeout(ctx, timeout)
+		defer cancelFn()
+	}
+
+	sv, err := SignerFromKeyOpts(ctx, "", ko)
+	if err != nil {
+		return nil, err
+	}
+	defer sv.Close()
+
+	sig, err := sv.SignMessage(bytes.NewReader(payload), signatureoptions.WithContext(ctx))
+	if err != nil {
+		return nil, errors.Wrap(err, "signing blob")
+	}
+
+	if options.EnableExperimental() {
+		// TODO: Refactor with sign.go
+		if sv.Cert != nil {
+			fmt.Fprintf(os.Stderr, "signing with ephemeral certificate:\n%s\n", string(sv.Cert))
+			rekorBytes = sv.Cert
+		} else {
+			pemBytes, err := signature.PublicKeyPem(sv, signatureoptions.WithContext(ctx))
+			if err != nil {
+				return nil, err
+			}
+			rekorBytes = pemBytes
+		}
+		rekorClient, err := rekorClient.GetRekorClient(ko.RekorURL)
+		if err != nil {
+			return nil, err
+		}
+		entry, err := cosign.TLogUpload(ctx, rekorClient, sig, payload, rekorBytes)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintln(os.Stderr, "tlog entry created with index:", *entry.LogIndex)
+	}
+
+	if outputSignature != "" {
+		f, err := os.Create(outputSignature)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		if b64 {
+			_, err = f.Write([]byte(base64.StdEncoding.EncodeToString(sig)))
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			_, err = f.Write(sig)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		fmt.Printf("Signature wrote in the file %s\n", f.Name())
+	} else {
+		if b64 {
+			sig = []byte(base64.StdEncoding.EncodeToString(sig))
+			fmt.Println(string(sig))
+		} else if _, err := os.Stdout.Write(sig); err != nil {
+			// No newline if using the raw signature
+			return nil, err
+		}
+	}
+
+	if outputCertificate != "" {
+		f, err := os.Create(outputCertificate)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		if b64 {
+			_, err = f.Write([]byte(base64.StdEncoding.EncodeToString(rekorBytes)))
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			_, err = f.Write(rekorBytes)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return sig, nil
+}

--- a/cmd/cosign/cli/signstring.go
+++ b/cmd/cosign/cli/signstring.go
@@ -1,0 +1,96 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func SignString() *cobra.Command {
+	o := &options.SignBlobOptions{}
+	viper.RegisterAlias("output", "output-signature")
+
+	cmd := &cobra.Command{
+		Use:   "sign-string",
+		Short: "Sign the supplied string, outputting the base64-encoded signature to stdout.",
+		Example: `  cosign sign-string --key <key path>|<kms uri> <bytes>
+
+  # sign a string with Google sign-in (experimental)
+  COSIGN_EXPERIMENTAL=1 cosign --timeout 90s sign-string <string>
+
+  # sign a string with a local key pair file
+  cosign sign-string --key cosign.key <string>
+
+  # sign a string with a key pair stored in Azure Key Vault
+  cosign sign-string --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <string>
+
+  # sign a string with a key pair stored in AWS KMS
+  cosign sign-string --key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <string>
+
+  # sign a string with a key pair stored in Google Cloud KMS
+  cosign sign-string --key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <string>
+
+  # sign a string with a key pair stored in Hashicorp Vault
+  cosign sign-string --key hashivault://[KEY] <string>`,
+		Args: cobra.MinimumNArgs(1),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// A key file is required unless we're in experimental mode!
+			if !options.EnableExperimental() {
+				if !options.OneOf(o.Key, o.SecurityKey.Use) {
+					return &options.KeyParseError{}
+				}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ko := sign.KeyOpts{
+				KeyRef:                   o.Key,
+				PassFunc:                 generate.GetPass,
+				Sk:                       o.SecurityKey.Use,
+				Slot:                     o.SecurityKey.Slot,
+				FulcioURL:                o.Fulcio.URL,
+				IDToken:                  o.Fulcio.IdentityToken,
+				InsecureSkipFulcioVerify: o.Fulcio.InsecureSkipFulcioVerify,
+				RekorURL:                 o.Rekor.URL,
+				OIDCIssuer:               o.OIDC.Issuer,
+				OIDCClientID:             o.OIDC.ClientID,
+				OIDCClientSecret:         o.OIDC.ClientSecret,
+			}
+			for _, blob := range args {
+				// TODO: remove when the output flag has been deprecated
+				if o.Output != "" {
+					fmt.Fprintln(os.Stderr, "WARNING: the '--output' flag is deprecated and will be removed in the future. Use '--output-signature'")
+					o.OutputSignature = o.Output
+				}
+				if _, err := sign.SignStringCmd(cmd.Context(), ko, o.Registry, blob, o.Base64Output, o.OutputSignature, o.OutputCertificate, o.Timeout); err != nil {
+					return errors.Wrapf(err, "signing %s", blob)
+				}
+			}
+			return nil
+		},
+	}
+
+	o.AddFlags(cmd)
+	return cmd
+}

--- a/cmd/cosign/cli/verify/verify_string.go
+++ b/cmd/cosign/cli/verify/verify_string.go
@@ -1,0 +1,200 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	_ "crypto/sha256" // for `crypto.SHA256`
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
+	"github.com/sigstore/cosign/pkg/blob"
+	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/cosign/pivkey"
+	"github.com/sigstore/cosign/pkg/cosign/pkcs11key"
+	sigs "github.com/sigstore/cosign/pkg/signature"
+	rekorClient "github.com/sigstore/rekor/pkg/client"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	sigstoresigs "github.com/sigstore/sigstore/pkg/signature"
+	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+// nolint
+func VerifyStringCmd(ctx context.Context, ko sign.KeyOpts, certRef, sigRef, bytesRef string) error {
+	var pubKey sigstoresigs.Verifier
+	var err error
+	var cert *x509.Certificate
+
+	if !options.OneOf(ko.KeyRef, ko.Sk, certRef) && !options.EnableExperimental() {
+		return &options.PubKeyParseError{}
+	}
+
+	var b64sig string
+	if sigRef == "" {
+		return fmt.Errorf("missing flag '--signature'")
+	}
+	targetSig, err := blob.LoadFileOrURL(sigRef)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// ignore if file does not exist, it can be a base64 encoded string as well
+			return err
+		}
+		targetSig = []byte(sigRef)
+	}
+
+	if isb64(targetSig) {
+		b64sig = string(targetSig)
+	} else {
+		b64sig = base64.StdEncoding.EncodeToString(targetSig)
+	}
+
+	blobBytes := []byte(bytesRef)
+
+	// Keys are optional!
+	switch {
+	case ko.KeyRef != "":
+		pubKey, err = sigs.PublicKeyFromKeyRef(ctx, ko.KeyRef)
+		if err != nil {
+			return errors.Wrap(err, "loading public key")
+		}
+		pkcs11Key, ok := pubKey.(*pkcs11key.Key)
+		if ok {
+			defer pkcs11Key.Close()
+		}
+	case ko.Sk:
+		sk, err := pivkey.GetKeyWithSlot(ko.Slot)
+		if err != nil {
+			return errors.Wrap(err, "opening piv token")
+		}
+		defer sk.Close()
+		pubKey, err = sk.Verifier()
+		if err != nil {
+			return errors.Wrap(err, "loading public key from token")
+		}
+	case certRef != "":
+		pems, err := os.ReadFile(certRef)
+		if err != nil {
+			return err
+		}
+
+		var out []byte
+		out, err = base64.StdEncoding.DecodeString(string(pems))
+		if err != nil {
+			// not a base64
+			out = pems
+		}
+
+		certs, err := cryptoutils.UnmarshalCertificatesFromPEM(out)
+		if err != nil {
+			return err
+		}
+		if len(certs) == 0 {
+			return errors.New("no certs found in pem file")
+		}
+		cert = certs[0]
+		pubKey, err = sigstoresigs.LoadECDSAVerifier(cert.PublicKey.(*ecdsa.PublicKey), crypto.SHA256)
+		if err != nil {
+			return err
+		}
+	case options.EnableExperimental():
+		rClient, err := rekorClient.GetRekorClient(ko.RekorURL)
+		if err != nil {
+			return err
+		}
+
+		uuids, err := cosign.FindTLogEntriesByPayload(ctx, rClient, blobBytes)
+		if err != nil {
+			return err
+		}
+
+		if len(uuids) == 0 {
+			return errors.New("could not find a tlog entry for provided blob")
+		}
+
+		tlogEntry, err := cosign.GetTlogEntry(ctx, rClient, uuids[0])
+		if err != nil {
+			return err
+		}
+
+		certs, err := extractCerts(tlogEntry)
+		if err != nil {
+			return err
+		}
+		cert = certs[0]
+		pubKey, err = sigstoresigs.LoadECDSAVerifier(cert.PublicKey.(*ecdsa.PublicKey), crypto.SHA256)
+		if err != nil {
+			return err
+		}
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(b64sig)
+	if err != nil {
+		return err
+	}
+	if err := pubKey.VerifySignature(bytes.NewReader(sig), bytes.NewReader(blobBytes)); err != nil {
+		return err
+	}
+
+	if cert != nil { // cert
+		if err := cosign.TrustedCert(cert, fulcio.GetRoots()); err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stderr, "Certificate is trusted by Fulcio Root CA")
+		fmt.Fprintln(os.Stderr, "Email:", cert.EmailAddresses)
+		for _, uri := range cert.URIs {
+			fmt.Fprintf(os.Stderr, "URI: %s://%s%s\n", uri.Scheme, uri.Host, uri.Path)
+		}
+		fmt.Fprintln(os.Stderr, "Issuer: ", sigs.CertIssuerExtension(cert))
+	}
+	fmt.Fprintln(os.Stderr, "Verified OK")
+
+	if options.EnableExperimental() {
+		rekorClient, err := rekorClient.GetRekorClient(ko.RekorURL)
+		if err != nil {
+			return err
+		}
+		var pubBytes []byte
+		if pubKey != nil {
+			pubBytes, err = sigs.PublicKeyPem(pubKey, signatureoptions.WithContext(ctx))
+			if err != nil {
+				return err
+			}
+		}
+		if cert != nil {
+			pubBytes, err = cryptoutils.MarshalCertificateToPEM(cert)
+			if err != nil {
+				return err
+			}
+		}
+		uuid, index, err := cosign.FindTlogEntry(ctx, rekorClient, b64sig, blobBytes, pubBytes)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %q index: %d\n", uuid, index)
+		return nil
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary

Adding support for signing string literals. This is similar to blob signing, except it allows for a string to be passed in instead of being read from a file.

```shell
$ cosign sign-string --key cosign.key "hello world"
Enter password for private key: MEUCIB2yVuhvuwKLH4AiodNzvxVOvsKVygyYXZpa8R7kUHQiAiEAuuBTC2rJF3DkbT+LH4sZUMkO17LWpvYC/7bhdOG1Hy4=
```

```shell
$ cosign verify-string --key cosign.pub --signature MEUCIB2yVuhvuwKLH4AiodNzvxVOvsKVygyYXZpa8R7kUHQiAiEAuuBTC2rJF3DkbT+LH4sZUMkO17LWpvYC/7bhdOG1Hy4= "hello world"
Verified OK
```

<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link

https://github.com/sigstore/cosign/issues/1298

<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Enhancement https://github.com/sigstore/cosign/issues/1298

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
* Add functionality to sign string literals, using `cosign sign-string`
```
