### PR TITLE
Take OIDC client secret into account

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio_test.go
+++ b/cmd/cosign/cli/fulcio/fulcio_test.go
@@ -113,7 +113,7 @@ func TestGetCertForOauthID(t *testing.T) {
 				err: tc.tokenGetterErr,
 			}
 
-			resp, err := getCertForOauthID(testKey, tscp, &tf, "", "")
+			resp, err := getCertForOauthID(testKey, tscp, &tf, "", "", "")
 
 			if err != nil {
 				if !tc.expectErr {

--- a/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
@@ -93,8 +93,8 @@ func verifySCT(certPEM, rawSCT []byte) error {
 	return ctutil.VerifySCT(pubKey, []*ctx509.Certificate{cert}, &sct, false)
 }
 
-func NewSigner(ctx context.Context, idToken, oidcIssuer, oidcClientID string, fClient api.Client) (*fulcio.Signer, error) {
-	fs, err := fulcio.NewSigner(ctx, idToken, oidcIssuer, oidcClientID, fClient)
+func NewSigner(ctx context.Context, idToken, oidcIssuer, oidcClientID, oidcClientSecret string, fClient api.Client) (*fulcio.Signer, error) {
+	fs, err := fulcio.NewSigner(ctx, idToken, oidcIssuer, oidcClientID, oidcClientSecret, fClient)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -401,11 +401,11 @@ func keylessSigner(ctx context.Context, ko KeyOpts) (*SignerVerifier, error) {
 	var k *fulcio.Signer
 
 	if ko.InsecureSkipFulcioVerify {
-		if k, err = fulcio.NewSigner(ctx, tok, ko.OIDCIssuer, ko.OIDCClientID, fClient); err != nil {
+		if k, err = fulcio.NewSigner(ctx, tok, ko.OIDCIssuer, ko.OIDCClientID, ko.OIDCClientSecret, fClient); err != nil {
 			return nil, errors.Wrap(err, "getting key from Fulcio")
 		}
 	} else {
-		if k, err = fulcioverifier.NewSigner(ctx, tok, ko.OIDCIssuer, ko.OIDCClientID, fClient); err != nil {
+		if k, err = fulcioverifier.NewSigner(ctx, tok, ko.OIDCIssuer, ko.OIDCClientID, ko.OIDCClientSecret, fClient); err != nil {
 			return nil, errors.Wrap(err, "getting key from Fulcio")
 		}
 	}


### PR DESCRIPTION
The default value of empty string for OIDC client secret doesn't always
work. Users should be able to specify their own.

Closes #1309

Signed-off-by: Radoslav Gerganov <rgerganov@vmware.com>