### PR TITLE
Cache the location of the remote repository when running cosign initialize

### DIFF
--- a/cmd/cosign/cli/initialize/init.go
+++ b/cmd/cosign/cli/initialize/init.go
@@ -18,11 +18,9 @@ package initialize
 import (
 	"context"
 	_ "embed" // To enable the `go:embed` directive.
-	"net/url"
 
 	"github.com/sigstore/cosign/pkg/blob"
 	"github.com/sigstore/cosign/pkg/cosign/tuf"
-	"github.com/theupdateframework/go-tuf/client"
 )
 
 func DoInitialize(ctx context.Context, root, mirror string) error {
@@ -36,16 +34,5 @@ func DoInitialize(ctx context.Context, root, mirror string) error {
 		}
 	}
 
-	// Initialize the remote repository.
-	var remote client.RemoteStore
-	if _, parseErr := url.ParseRequestURI(mirror); parseErr != nil {
-		remote, err = tuf.GcsRemoteStore(ctx, mirror, nil, nil)
-	} else {
-		remote, err = client.HTTPRemoteStore(mirror, nil, nil)
-	}
-	if err != nil {
-		return err
-	}
-
-	return tuf.Initialize(remote, rootFileBytes)
+	return tuf.Initialize(ctx, mirror, rootFileBytes)
 }

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -16,6 +16,7 @@
 package options
 
 import (
+	"github.com/sigstore/cosign/pkg/cosign/tuf"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +30,7 @@ var _ Interface = (*InitializeOptions)(nil)
 
 // AddFlags implements Interface
 func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Mirror, "mirror", "sigstore-tuf-root",
+	cmd.Flags().StringVar(&o.Mirror, "mirror", tuf.DefaultRemoteRoot,
 		"GCS bucket to a SigStore TUF repository or HTTP(S) base URL")
 
 	cmd.Flags().StringVar(&o.Root, "root", "",

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -77,16 +77,20 @@ func NewFromEnv(ctx context.Context) (*TUF, error) {
 	// We need to update our tufdb.
 	trustedRoot, err := getRoot(trustedMeta)
 	if err != nil {
+		t.local.Close()
 		return nil, errors.Wrap(err, "getting trusted root")
 	}
 	rootKeys, rootThreshold, err := getRootKeys(trustedRoot)
 	if err != nil {
+		t.local.Close()
 		return nil, errors.Wrap(err, "bad trusted root")
 	}
 	if err := t.client.Init(rootKeys, rootThreshold); err != nil {
+		t.local.Close()
 		return nil, errors.Wrap(err, "unable to initialize client, local cache may be corrupt")
 	}
 	if err := t.updateMetadataAndDownloadTargets(); err != nil {
+		t.local.Close()
 		return nil, errors.Wrap(err, "updating local metadata and targets")
 	}
 

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -442,10 +442,13 @@ func newTuf(ctx context.Context) (*TUF, error) {
 	// default remote root.
 	mirror := DefaultRemoteRoot
 	b, err := os.ReadFile(cachedRemote(rootCacheDir()))
-	remoteInfo := remoteCache{}
-	if err := json.Unmarshal(b, &remoteInfo); err == nil {
-		mirror = remoteInfo.Mirror
+	if err == nil {
+		remoteInfo := remoteCache{}
+		if err := json.Unmarshal(b, &remoteInfo); err == nil {
+			mirror = remoteInfo.Mirror
+		}
 	}
+
 	remote, err := remoteFromMirror(ctx, mirror)
 	if err != nil {
 		return nil, err

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -83,20 +83,20 @@ func NewFromEnv(ctx context.Context) (*TUF, error) {
 	// We need to update our tufdb.
 	trustedRoot, err := getRoot(trustedMeta)
 	if err != nil {
-		t.local.Close()
+		t.Close()
 		return nil, errors.Wrap(err, "getting trusted root")
 	}
 	rootKeys, rootThreshold, err := getRootKeys(trustedRoot)
 	if err != nil {
-		t.local.Close()
+		t.Close()
 		return nil, errors.Wrap(err, "bad trusted root")
 	}
 	if err := t.client.Init(rootKeys, rootThreshold); err != nil {
-		t.local.Close()
+		t.Close()
 		return nil, errors.Wrap(err, "unable to initialize client, local cache may be corrupt")
 	}
 	if err := t.updateMetadataAndDownloadTargets(); err != nil {
-		t.local.Close()
+		t.Close()
 		return nil, errors.Wrap(err, "updating local metadata and targets")
 	}
 

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -51,12 +51,7 @@ func TestNewFromEnv(t *testing.T) {
 	tuf.Close()
 	checkTargetsAndMeta(t, tuf)
 
-	// Now let's explicitly make a root.
-	remote, err := GcsRemoteStore(ctx, DefaultRemoteRoot, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := Initialize(remote, nil); err != nil {
+	if err := Initialize(ctx, DefaultRemoteRoot, nil); err != nil {
 		t.Error()
 	}
 	if l := dirLen(t, td); l == 0 {

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -16,9 +16,20 @@
 package tuf
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/theupdateframework/go-tuf"
+	"github.com/theupdateframework/go-tuf/data"
+	"github.com/theupdateframework/go-tuf/verify"
 )
 
 var targets = []string{
@@ -127,6 +138,68 @@ func TestCache(t *testing.T) {
 	checkTargetsAndMeta(t, tuf)
 }
 
+func TestCustomRoot(t *testing.T) {
+	ctx := context.Background()
+	// Create a remote repository.
+	td := t.TempDir()
+	remote, r := newTufRepo(t, td, "foo")
+
+	// Serve remote repository.
+	s := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(td, "repository"))))
+	defer s.Close()
+
+	// Initialize with custom root.
+	tufRoot := t.TempDir()
+	t.Setenv("TUF_ROOT", tufRoot)
+	meta, err := remote.GetMeta()
+	if err != nil {
+		t.Error(err)
+	}
+	rootBytes, ok := meta["root.json"]
+	if !ok {
+		t.Error(err)
+	}
+	if err := Initialize(ctx, s.URL, rootBytes); err != nil {
+		t.Error(err)
+	}
+	if l := dirLen(t, tufRoot); l == 0 {
+		t.Errorf("expected filesystem writes, got %d entries", l)
+	}
+
+	// Successfully get target.
+	tufObj, err := NewFromEnv(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b, err := tufObj.GetTarget("foo.txt"); err != nil || !bytes.Equal(b, []byte("foo")) {
+		t.Fatal(err)
+	}
+	tufObj.Close()
+
+	// Force expiration on the first timestamp and internal go-tuf verification.
+	expCleanup := forceExpirationVersion(1, true)
+	if _, err = NewFromEnv(ctx); err == nil {
+		t.Errorf("expected expired timestamp from the remote")
+	}
+	expCleanup()
+
+	// Update remote targets, issue a timestamp v2.
+	updateTufRepo(t, td, r, "foo1")
+
+	// Force expiration on the first timestamp.
+	expCleanup = forceExpirationVersion(1, false)
+	// Use newTuf and successfully get updated metadata using the cached remote location.
+	tufObj, err = NewFromEnv(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b, err := tufObj.GetTarget("foo.txt"); err != nil || !bytes.Equal(b, []byte("foo1")) {
+		t.Fatal(err)
+	}
+	expCleanup()
+	tufObj.Close()
+}
+
 func checkTargetsAndMeta(t *testing.T, tuf *TUF) {
 	// Check the targets
 	t.Helper()
@@ -166,4 +239,87 @@ func forceExpiration(t *testing.T, expire bool) {
 	t.Cleanup(func() {
 		isExpiredTimestamp = oldIsExpiredTimestamp
 	})
+}
+
+func forceExpirationVersion(version int, all bool) func() {
+	oldIsExpiredTimestamp := isExpiredTimestamp
+	oldIsExpired := verify.IsExpired
+	isExpiredTimestamp = func(metadata []byte) bool {
+		s := &data.Signed{}
+		if err := json.Unmarshal(metadata, s); err != nil {
+			return true
+		}
+		sm := &data.Timestamp{}
+		if err := json.Unmarshal(s.Signed, sm); err != nil {
+			return true
+		}
+		return sm.Version <= version
+	}
+	if all {
+		verify.IsExpired = func(time time.Time) bool {
+			return true
+		}
+	}
+	return func() {
+		isExpiredTimestamp = oldIsExpiredTimestamp
+		verify.IsExpired = oldIsExpired
+	}
+}
+
+func newTufRepo(t *testing.T, td string, targetData string) (tuf.LocalStore, *tuf.Repo) {
+	remote := tuf.FileSystemStore(td, nil)
+	r, err := tuf.NewRepo(remote)
+	if err != nil {
+		t.Error(err)
+	}
+	if err := r.Init(false); err != nil {
+		t.Error(err)
+	}
+	for _, role := range []string{"root", "targets", "snapshot", "timestamp"} {
+		if _, err := r.GenKey(role); err != nil {
+			t.Error(err)
+		}
+	}
+	targetPath := filepath.Join(td, "staged", "targets", "foo.txt")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		t.Error(err)
+	}
+	if err := ioutil.WriteFile(targetPath, []byte(targetData), 0600); err != nil {
+		t.Error(err)
+	}
+	if err := r.AddTarget("foo.txt", nil); err != nil {
+		t.Error(err)
+	}
+	if err := r.Snapshot(); err != nil {
+		t.Error(err)
+	}
+	if err := r.Timestamp(); err != nil {
+		t.Error(err)
+	}
+	if err := r.Commit(); err != nil {
+		t.Error(err)
+	}
+	return remote, r
+}
+
+func updateTufRepo(t *testing.T, td string, r *tuf.Repo, targetData string) {
+	targetPath := filepath.Join(td, "staged", "targets", "foo.txt")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		t.Error(err)
+	}
+	if err := ioutil.WriteFile(targetPath, []byte(targetData), 0600); err != nil {
+		t.Error(err)
+	}
+	if err := r.AddTarget("foo.txt", nil); err != nil {
+		t.Error(err)
+	}
+	if err := r.Snapshot(); err != nil {
+		t.Error(err)
+	}
+	if err := r.Timestamp(); err != nil {
+		t.Error(err)
+	}
+	if err := r.Commit(); err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
Caches the remote repository location so that updates will pull from the cached remote instead of defaulting to the sigstore GCS bucket. This allows clients to automatically pull updates from their custom root when their root is expired and avoids a local/remote mismatch.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
This fixes https://github.com/sigstore/cosign/issues/1289 per @rgerganov and https://github.com/sigstore/cosign/issues/1293

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
