### PR TITLE
Verify checksum of downloaded utilities during CI

### DIFF
--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -35,7 +35,7 @@ jobs:
             echo '::group::🐶 Failed to verify checksum, exiting!'
             exit 1
           fi
-          tar zxf "${TEMP_PATH}/reviewdog.tar.gz" reviewdog
+          tar zxf "${TEMP_PATH}/reviewdog.tar.gz" -C ${TEMP_PATH} reviewdog
           echo '::endgroup::'
 
           echo '::group:: Running DO NOT SUBMIT with reviewdog 🐶 ...'

--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -28,7 +28,14 @@ jobs:
           PATH="${TEMP_PATH}:$PATH"
 
           echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
-          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
+          reviewdog_sha='08a5a323939101195af1d420ab6be3a50ec12f58e3419e3fcd07b6871f0b9a7e'
+          curl -s -L https://github.com/reviewdog/reviewdog/releases/download/v0.13.1/reviewdog_0.13.1_Linux_x86_64.tar.gz --output "${TEMP_PATH}/reviewdog.tar.gz"
+          computed_sha=`sha256sum ${TEMP_PATH}/reviewdog.tar.gz|cut -d ' ' -f 1`
+          if [[ $reviewdog_sha != $computed_sha ]]; then
+            echo '::group::🐶 Failed to verify checksum, exiting!'
+            exit 1
+          fi
+          tar zxf "${TEMP_PATH}/reviewdog.tar.gz" reviewdog
           echo '::endgroup::'
 
           echo '::group:: Running DO NOT SUBMIT with reviewdog 🐶 ...'

--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -27,14 +27,16 @@ jobs:
           TEMP_PATH="$(mktemp -d)"
           PATH="${TEMP_PATH}:$PATH"
 
-          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
+          echo '::group::🐶 Installing reviewdog v0.13.1 ... https://github.com/reviewdog/reviewdog'
           reviewdog_sha='08a5a323939101195af1d420ab6be3a50ec12f58e3419e3fcd07b6871f0b9a7e'
           curl -s -L https://github.com/reviewdog/reviewdog/releases/download/v0.13.1/reviewdog_0.13.1_Linux_x86_64.tar.gz --output "${TEMP_PATH}/reviewdog.tar.gz"
+          echo '::group::🐶 Verifying checksum of download'
           computed_sha=`sha256sum ${TEMP_PATH}/reviewdog.tar.gz|cut -d ' ' -f 1`
           if [[ $reviewdog_sha != $computed_sha ]]; then
             echo '::group::🐶 Failed to verify checksum, exiting!'
             exit 1
           fi
+          echo '::group::🐶 Checksum verified successfully, extracting reviewdog'
           tar zxf "${TEMP_PATH}/reviewdog.tar.gz" -C ${TEMP_PATH} reviewdog
           echo '::endgroup::'
 

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -89,9 +89,7 @@ jobs:
         # https://github.com/kubernetes-sigs/kind/issues/845
         sudo mkdir -p /tmp/etcd
         sudo mount -t tmpfs tmpfs /tmp/etcd
-        curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/${{ matrix.kind-version }}/kind-$(uname)-amd64
-        chmod +x ./kind
-        sudo mv kind /usr/local/bin
+        go install sigs.k8s.io/kind@v0.11.1 
 
     - name: Configure KinD Cluster
       run: |

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -89,7 +89,7 @@ jobs:
         # https://github.com/kubernetes-sigs/kind/issues/845
         sudo mkdir -p /tmp/etcd
         sudo mount -t tmpfs tmpfs /tmp/etcd
-        go install sigs.k8s.io/kind@v0.11.1 
+        go install sigs.k8s.io/kind@${{ matrix.kind-version }}
 
     - name: Configure KinD Cluster
       run: |


### PR DESCRIPTION
Switches to `go install` for kind and verifying checksum of `reviewdog` instead of `curl | sh`. 

Fixes #1323 