### PR TITLE
update gcp setup for the GH action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,11 +45,13 @@ jobs:
         run: go get golang.org/x/tools/cmd/goimports
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@a45a0825993ace67ae6e11cf3011b3e7d6795f82 #v0.3.0
+        uses: google-github-actions/auth@c6c22902f6af237edb96ede5f25a00e864589b2f #v0.4.4
         with:
           project_id: projectsigstore
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           export_default_credentials: true
+          workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-cosign'
+          service_account: 'github-actions@projectsigstore.iam.gserviceaccount.com'
 
       - name: creds
         run: gcloud auth configure-docker --quiet


### PR DESCRIPTION

#### Summary
- update gcp setup for the GH action
  doing this because the current way is deprecated 

```
Warning: "service_account_key" has been deprecated. Please switch to using google-github-actions/auth which supports both Workload Identity Federation and Service Account Key JSON authentication. For more details, see https://github.com/google-github-actions/setup-gcloud#authorization
```

Not sure if the service_account name is correct 

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
