### PR TITLE
install latest release for ko instead of head of main branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,9 +37,8 @@ jobs:
         with:
           go-version: '1.17.x'
 
+      # will use the latest release available for ko
       - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 #v0.4
-        with:
-          version: tip
 
       - name: Install goimports
         run: go get golang.org/x/tools/cmd/goimports

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,10 @@ jobs:
     name: build
     runs-on: ubuntu-latest
 
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
       - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
 


### PR DESCRIPTION
#### Summary
Error in the post github action when building the images using `ko`

```
LDFLAGS="-X github.com/sigstore/cosign/pkg/version.GitVersion=888b392-dirty -X github.com/sigstore/cosign/pkg/version.gitCommit=888b39200d1ae4319aa7c6d6c3b5102abf8871ed -X github.com/sigstore/cosign/pkg/version.gitTreeState="dirty" -X github.com/sigstore/cosign/pkg/version.buildDate='2022-01-15T22:28:40Z'" GIT_HASH=888b39200d1ae4319aa7c6d6c3b5102abf8871ed GIT_VERSION=888b392-dirty \
ko publish --base-import-paths --bare \
	--platform=all --tags 888b392-dirty --tags 888b39200d1ae4319aa7c6d6c3b5102abf8871ed \
	github.com/sigstore/cosign/cmd/cosign
2022/01/15 22:33:50 Using base gcr.io/distroless/base:debug-nonroot for github.com/sigstore/cosign/cmd/cosign
2022/01/15 22:33:51 Using build config cosign for github.com/sigstore/cosign/cmd/cosign
2022/01/15 22:33:51 Building github.com/sigstore/cosign/cmd/cosign for linux/ppc64le
2022/01/15 22:33:51 Using build config cosign for github.com/sigstore/cosign/cmd/cosign
2022/01/15 22:33:51 Building github.com/sigstore/cosign/cmd/cosign for linux/amd64
2022/01/15 22:33:53 Unexpected error running "go build": exit status 1
Error: ../../../go/pkg/mod/github.com/sigstore/rekor@v0.4.1-0.20220114213500-23f583409af3/pkg/pki/pgp/pgp.go:27:2: missing go.sum entry needed to verify package github.com/go-playground/validator/v10 (imported by github.com/sigstore/rekor/pkg/util) is provided by exactly one module; to add:
	go get github.com/sigstore/rekor/pkg/util@v0.4.1-0.20220114213500-23f583409af3
Error: ../../../go/pkg/mod/k8s.io/apimachinery@v0.23.1/pkg/util/json/json.go:24:2: missing go.sum entry for module providing package sigs.k8s.io/json (imported by k8s.io/apimachinery/pkg/util/json); to add:
	go get k8s.io/apimachinery/pkg/util/json@v0.23.1
2022/01/15 22:33:53 Unexpected error running "go build": signal: killed
2022/01/15 22:33:54 Using build config cosign for github.com/sigstore/cosign/cmd/cosign
2022/01/15 22:33:54 Building github.com/sigstore/cosign/cmd/cosign for linux/arm
2022/01/15 22:33:54 Unexpected error running "go build": context canceled
Error: failed to publish images: error building "ko://github.com/sigstore/cosign/cmd/cosign": exit status 1
2022/01/15 22:33:54 error during command execution:failed to publish images: error building "ko://github.com/sigstore/cosign/cmd/cosign": exit status 1
make: *** [Makefile:129: ko] Error 1
Error: Process completed with exit code 2.
```

installing the latest release of `ko` instead of the head of main fixed, so looks like there are some issues with ko

ran the job in a fork and it is building: https://github.com/cpanato/cosign/runs/4838052902?check_suite_focus=true

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
