### PR TITLE
Bump recommended Go development version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For Linux and macOS binaries see the [GitHub release assets](https://github.com/
 
 ## Developer Installation
 
-If you have Go 1.16+, you can setup a development environment:
+If you have Go 1.17+, you can setup a development environment:
 
     $ git clone https://github.com/sigstore/cosign
     $ cd cosign


### PR DESCRIPTION

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

[#568](https://github.com/sigstore/cosign/pull/568) bumps the Go version for tests to 1.17. Now they break for 1.16:

```sh
$ TMPDIR=$(mktemp -d)
$ cd $TMPDIR
$ git clone https://github.com/sigstore/cosign 2> /dev/null
$ cd cosign
$ for go in go_1_16 go_1_17; do
>   nix-shell \
>     -p ${go} \
>     -p gnumake \
>     --command 'make test' \
>     > /dev/null 2>&1
>   if [ $? -eq 0 ]; then
>     echo ${go} good
>   else
>     echo ${go} bad
>   fi
> done
go_1_16 bad
go_1_17 good
```

[#1252](https://github.com/sigstore/cosign/pull/1252) adds a call to `testing.T.Setenv`, added in [1.17](https://go-review.googlesource.com/c/go/+/326790/3/api/go1.17.txt), which caused this breakage.

(We're still testing *builds* on 1.16, so that's fine.)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
