### PR TITLE
Fix minor typo (a missing verb) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ If you're aware of another system that does meet these, please let me know!
 ### Registry API Changes
 
 The naming convention and read-modify-write update patterns we use to store things in
-a registry a bit, well, "hacky".
+a registry are a bit, well, "hacky".
 I think they're the best (only) real option available today, but if the registry API
 changes we can improve these.
 


### PR DESCRIPTION
Signed-off-by: John Speed Meyers <jsmeyers@chainguard.dev>

#### Summary

Fixes minor typo in main README documentation
