### PR TITLE
add ascii art when using the version command

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -66,6 +66,15 @@ func (i *Info) String() string {
 	b := strings.Builder{}
 	w := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
 
+	fmt.Fprint(w, `
+  ______   ______        _______. __    _______ .__   __.
+ /      | /  __  \      /       ||  |  /  _____||  \ |  |
+|  ,----'|  |  |  |    |   (---- |  | |  |  __  |   \|  |
+|  |     |  |  |  |     \   \    |  | |  | |_ | |  .    |
+|  '----.|  '--'  | .----)   |   |  | |  |__| | |  |\   |
+ \______| \______/  |_______/    |__|  \______| |__| \__|
+`)
+	fmt.Fprint(w, "cosign: A tool for Container Signing, Verification and Storage in an OCI registry.\n\n")
 	fmt.Fprintf(w, "GitVersion:\t%s\n", i.GitVersion)
 	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
 	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)


### PR DESCRIPTION
#### Summary
- add ascii art when using the version command

```console
$ ./cosign version

  ______   ______        _______. __    _______ .__   __.
 /      | /  __  \      /       ||  |  /  _____||  \ |  |
|  ,----'|  |  |  |    |   (---- |  | |  |  __  |   \|  |
|  |     |  |  |  |     \   \    |  | |  | |_ | |  .    |
|  '----.|  '--'  | .----)   |   |  | |  |__| | |  |\   |
 \______| \______/  |_______/    |__|  \______| |__| \__|
cosign: A tool for Container Signing, Verification and Storage in an OCI registry.

GitVersion:    v1.4.1-91-g7ca90c8
GitCommit:     7ca90c8cd732897238cc92756eeb69a93af5c29f
GitTreeState:  clean
BuildDate:     '2022-01-22T18:24:37Z'
GoVersion:     go1.17.6
Compiler:      gc
Platform:      darwin/amd64
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
