### PR TITLE
Bump go-containerregistry to pick up ACR keychain fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-piv/piv-go v1.9.0
 	github.com/google/certificate-transparency-go v1.1.2
 	github.com/google/go-cmp v0.5.7
-	github.com/google/go-containerregistry v0.8.1-0.20220110151055-a61fd0a8e2bb
+	github.com/google/go-containerregistry v0.8.1-0.20220125170349-50dfc2733d10
 	github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220120151853-ac864e57b117
 	github.com/google/go-github/v42 v42.0.0
 	github.com/google/trillian v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1021,6 +1021,8 @@ github.com/google/go-containerregistry v0.7.1-0.20211118220127-abdc633f8305/go.m
 github.com/google/go-containerregistry v0.8.0/go.mod h1:wW5v71NHGnQyb4k+gSshjxidrC7lN33MdWEn+Mz9TsI=
 github.com/google/go-containerregistry v0.8.1-0.20220110151055-a61fd0a8e2bb h1:hdevkgIzFpx/Xbz+L2JB+UrmglBf0ZSBZo0tkzzh26s=
 github.com/google/go-containerregistry v0.8.1-0.20220110151055-a61fd0a8e2bb/go.mod h1:wW5v71NHGnQyb4k+gSshjxidrC7lN33MdWEn+Mz9TsI=
+github.com/google/go-containerregistry v0.8.1-0.20220125170349-50dfc2733d10 h1:uChCXSBEfambtWEv8awGO8k1iK/CEyLmTM6gRnNxraU=
+github.com/google/go-containerregistry v0.8.1-0.20220125170349-50dfc2733d10/go.mod h1:wW5v71NHGnQyb4k+gSshjxidrC7lN33MdWEn+Mz9TsI=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220120151853-ac864e57b117 h1:bRrDPmm+4eFXtlwBa63SONIL/21QUdWi//hBcUaLZiE=
 github.com/google/go-containerregistry/pkg/authn/k8schain v0.0.0-20220120151853-ac864e57b117/go.mod h1:BH7pLQnIZhfVpL7cRyWhvvz1bZLY9V45/HvXVh5UMDY=
 github.com/google/go-containerregistry/pkg/authn/kubernetes v0.0.0-20220110151055-a61fd0a8e2bb/go.mod h1:SK4EqntTk6tHEyNngoqHUwjjZaW6mfzLukei4+cbvu8=


### PR DESCRIPTION
Signed-off-by: Jason Hall <jasonhall@redhat.com>

Fixes #1350 

Picks up https://github.com/google/go-containerregistry/pull/1265

#### Release Note

```release-note
Fixes issue with using environment registry credentials for Azure Container Registry
```
