### PR TITLE
Fix comparison in replace option for attestation

### DIFF
--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -137,30 +137,29 @@ func (r *ro) Replace(signatures oci.Signatures, o oci.Signature) (oci.Signatures
 			return nil, fmt.Errorf("unmarshal payload data: %w", err)
 		}
 
-		var decodedPayload []byte
-		if val, ok := signaturePayload["payload"]; ok {
-			decodedPayload, err = base64.StdEncoding.DecodeString(val.(string))
-			if err != nil {
-				return nil, fmt.Errorf("could not decode 'payload': %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("could not find 'payload' in payload data")
+		val, ok := signaturePayload["payload"]
+		if !ok {
+		   return nil, fmt.Errorf("could not find 'payload' in payload data")
+		}
+		decodedPayload, err := base64.StdEncoding.DecodeString(val.(string))
+		if err != nil {
+			return nil, fmt.Errorf("could not decode 'payload': %w", err)
 		}
 
 		var payloadData map[string]interface{}
 		if err := json.Unmarshal(decodedPayload, &payloadData); err != nil {
 			return nil, fmt.Errorf("unmarshal payloadData: %w", err)
 		}
-		if val, ok := payloadData["predicateType"]; ok {
-			if r.predicateURI == val {
-				fmt.Fprintln(os.Stderr, "Replacing attestation predicate:", r.predicateURI)
-				continue
-			} else {
-				fmt.Fprintln(os.Stderr, "Not replacing attestation predicate:", val)
-				sigsCopy = append(sigsCopy, s)
-			}
-		} else {
+		val, ok = payloadData["predicateType"]
+		if !ok {
 			return nil, fmt.Errorf("could not find 'predicateType' in payload data")
+		}
+		if r.predicateURI == val {
+			fmt.Fprintln(os.Stderr, "Replacing attestation predicate:", r.predicateURI)
+			continue
+		} else {
+			fmt.Fprintln(os.Stderr, "Not replacing attestation predicate:", val)
+			sigsCopy = append(sigsCopy, s)
 		}
 	}
 

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -139,7 +139,7 @@ func (r *ro) Replace(signatures oci.Signatures, o oci.Signature) (oci.Signatures
 
 		val, ok := signaturePayload["payload"]
 		if !ok {
-		   return nil, fmt.Errorf("could not find 'payload' in payload data")
+			return nil, fmt.Errorf("could not find 'payload' in payload data")
 		}
 		decodedPayload, err := base64.StdEncoding.DecodeString(val.(string))
 		if err != nil {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -275,8 +275,8 @@ func TestAttestVerify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(attestations) != 2 {
-		t.Fatal(fmt.Errorf("Expected len(attestations) == 2, got %d", len(attestations)))
+	if len(attestations) != 1 {
+		t.Fatal(fmt.Errorf("Expected len(attestations) == 1, got %d", len(attestations)))
 	}
 }
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -275,8 +275,8 @@ func TestAttestVerify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(attestations) != 1 {
-		t.Fatal(fmt.Errorf("Expected len(attestations) == 1, got %d", len(attestations)))
+	if len(attestations) != 2 {
+		t.Fatal(fmt.Errorf("Expected len(attestations) == 2, got %d", len(attestations)))
 	}
 }
 


### PR DESCRIPTION
#### Summary
Currently the replace option compares `r.predicateURI == payloadData["payloadType"]` when evaluating each signature:
https://github.com/sigstore/cosign/blob/21e6b806143652331b77c29c62a131fb33a71ae0/pkg/cosign/remote/remote.go#L142

This appears to be comparing the payload's `predicateType` (e.g a URI `https://example.com/predicate` or `cosign.sigstore.dev/attestation/v1` for custom) to the signature's `payloadType` (which is always(?) `application/vnd.in-toto+json`). This appears to be a bug unless I'm misunderstanding something.

Fix this by making the replace option replace all attestations which match the current predicate type. I think this is the intended behavior?

The command line output has been updated to clarify the actions taken, clearly listing all the attestations retained and deleted:
```
$ cosign attest --type https://example.com/predicate --key "$key" --predicate predicate.json --replace "localhost:5000/$image"
Not replacing attestation predicate: https://example.com/aaaa
Replacing attestation predicate: https://example.com/predicate
Replacing attestation predicate: https://example.com/predicate
```

This feature was initially requested in #923 and implemented in #1039.

#### Ticket Link

No ticket.

#### Release Note

```release-note
* Fixed predicate type comparison in replace option of attestation
```
