### PR TITLE
expose dafaults fulcio, rekor, oidc issuer urls

### DIFF
--- a/cmd/cosign/cli/options/fulcio.go
+++ b/cmd/cosign/cli/options/fulcio.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const DefaultFulcioURL = "https://v1.fulcio.sigstore.dev"
+
 // FulcioOptions is the wrapper for Fulcio related options.
 type FulcioOptions struct {
 	URL                      string
@@ -31,7 +33,7 @@ var _ Interface = (*FulcioOptions)(nil)
 // AddFlags implements Interface
 func (o *FulcioOptions) AddFlags(cmd *cobra.Command) {
 	// TODO: change this back to api.SigstorePublicServerURL after the v1 migration is complete.
-	cmd.Flags().StringVar(&o.URL, "fulcio-url", "https://v1.fulcio.sigstore.dev",
+	cmd.Flags().StringVar(&o.URL, "fulcio-url", DefaultFulcioURL,
 		"[EXPERIMENTAL] address of sigstore PKI server")
 
 	cmd.Flags().StringVar(&o.IdentityToken, "identity-token", "",

--- a/cmd/cosign/cli/options/oidc.go
+++ b/cmd/cosign/cli/options/oidc.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const DefaultOIDCIssuerURL = "https://oauth2.sigstore.dev/auth"
+
 // OIDCOptions is the wrapper for OIDC related options.
 type OIDCOptions struct {
 	Issuer       string
@@ -30,7 +32,7 @@ var _ Interface = (*OIDCOptions)(nil)
 
 // AddFlags implements Interface
 func (o *OIDCOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Issuer, "oidc-issuer", "https://oauth2.sigstore.dev/auth",
+	cmd.Flags().StringVar(&o.Issuer, "oidc-issuer", DefaultOIDCIssuerURL,
 		"[EXPERIMENTAL] OIDC provider to be used to issue ID token")
 
 	cmd.Flags().StringVar(&o.ClientID, "oidc-client-id", "sigstore",

--- a/cmd/cosign/cli/options/rekor.go
+++ b/cmd/cosign/cli/options/rekor.go
@@ -19,6 +19,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const DefaultRekorURL = "https://rekor.sigstore.dev"
+
 // RekorOptions is the wrapper for Rekor related options.
 type RekorOptions struct {
 	URL string
@@ -28,6 +30,6 @@ var _ Interface = (*RekorOptions)(nil)
 
 // AddFlags implements Interface
 func (o *RekorOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.URL, "rekor-url", "https://rekor.sigstore.dev",
+	cmd.Flags().StringVar(&o.URL, "rekor-url", DefaultRekorURL,
 		"[EXPERIMENTAL] address of rekor STL server")
 }


### PR DESCRIPTION

#### Summary
- expose the Fulcio, Rekor, and OIDC Issuer default URLs and make those available if any service that wants to implement can use the default URLs and not change the code when this get an update


example of usage will be here https://github.com/kubernetes-sigs/release-sdk/pull/25

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
expose dafaults fulcio, rekor, oidc issuer urls
```
