### PR TITLE
WIP: Avoid uploading to tlog when upload is false

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -168,7 +168,7 @@ func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOpt
 	}
 
 	// Check whether we should be uploading to the transparency log
-	if sign.ShouldUploadToTlog(ctx, digest, force, ko.RekorURL) {
+	if sign.ShouldUploadToTlog(ctx, digest, force, !noUpload, ko.RekorURL) {
 		bundle, err := uploadToTlog(ctx, sv, ko.RekorURL, func(r *client.Rekor, b []byte) (*models.LogEntryAnon, error) {
 			return cosign.TLogUploadInTotoAttestation(ctx, r, signedPayload, b)
 		})

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -57,9 +57,9 @@ import (
 	sigPayload "github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
-func ShouldUploadToTlog(ctx context.Context, ref name.Reference, force bool, url string) bool {
-	// Check whether experimental is on!
-	if !options.EnableExperimental() {
+func ShouldUploadToTlog(ctx context.Context, ref name.Reference, force bool, upload bool, url string) bool {
+	// Check whether experimental is on along with uploading!
+	if !options.EnableExperimental() || !upload {
 		return false
 	}
 	// We are forcing publishing to the Tlog.
@@ -208,7 +208,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko KeyO
 	if sv.Cert != nil {
 		s = ifulcio.NewSigner(s, sv.Cert, sv.Chain)
 	}
-	if ShouldUploadToTlog(ctx, digest, force, ko.RekorURL) {
+	if ShouldUploadToTlog(ctx, digest, force, upload, ko.RekorURL) {
 		rClient, err := rekor.NewClient(ko.RekorURL)
 		if err != nil {
 			return err


### PR DESCRIPTION
Goal is to be able to successfully sign and verify container images without having to communicate with tlog when `--upload=false`

Status: 
- [ ] - Disable uploading to tlog
- [x] - Supporting verification of tlog bundle

Related to #1373 