### PR TITLE
Add `--timeout` support to `sign` command

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -71,7 +71,7 @@ func Attest() *cobra.Command {
 			}
 			for _, img := range args {
 				if err := attest.AttestCmd(cmd.Context(), ko, o.Registry, img, o.Cert, o.NoUpload,
-					o.Predicate.Path, o.Force, o.Predicate.Type, o.Replace, o.Timeout); err != nil {
+					o.Predicate.Path, o.Force, o.Predicate.Type, o.Replace, ro.Timeout); err != nil {
 					return errors.Wrapf(err, "signing %s", img)
 				}
 			}

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -16,8 +16,6 @@
 package options
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +27,6 @@ type AttestOptions struct {
 	Force     bool
 	Recursive bool
 	Replace   bool
-	Timeout   time.Duration
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -67,7 +64,4 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVarP(&o.Replace, "replace", "", false,
 		"")
-
-	cmd.Flags().DurationVar(&o.Timeout, "timeout", time.Second*30,
-		"HTTP Timeout defaults to 30 seconds")
 }

--- a/cmd/cosign/cli/options/policy.go
+++ b/cmd/cosign/cli/options/policy.go
@@ -16,8 +16,6 @@
 package options
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 )
 
@@ -63,7 +61,6 @@ type PolicySignOptions struct {
 	Registry RegistryOptions
 	Fulcio   FulcioOptions
 	Rekor    RekorOptions
-	Timeout  time.Duration
 
 	OIDC OIDCOptions
 }
@@ -77,9 +74,6 @@ func (o *PolicySignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.OutFile, "out", "o",
 		"output policy locally")
-
-	cmd.Flags().DurationVar(&o.Timeout, "timeout", time.Second*30,
-		"HTTP Timeout defaults to 30 seconds")
 
 	o.Registry.AddFlags(cmd)
 	o.Fulcio.AddFlags(cmd)

--- a/cmd/cosign/cli/options/root.go
+++ b/cmd/cosign/cli/options/root.go
@@ -16,6 +16,8 @@
 package options
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +25,11 @@ import (
 type RootOptions struct {
 	OutputFile string
 	Verbose    bool
+	Timeout    time.Duration
 }
+
+// DefaultTimeout specifies the default timeout for commands.
+const DefaultTimeout = 3 * time.Minute
 
 var _ Interface = (*RootOptions)(nil)
 
@@ -34,4 +40,7 @@ func (o *RootOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().BoolVarP(&o.Verbose, "verbose", "d", false,
 		"log debug output")
+
+	cmd.PersistentFlags().DurationVarP(&o.Timeout, "timeout", "t", DefaultTimeout,
+		"timeout for commands")
 }

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -16,8 +16,6 @@
 package options
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +32,6 @@ type SignBlobOptions struct {
 	Rekor             RekorOptions
 	OIDC              OIDCOptions
 	Registry          RegistryOptions
-	Timeout           time.Duration
 	BundlePath        string
 }
 
@@ -62,9 +59,6 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
-
-	cmd.Flags().DurationVar(&o.Timeout, "timeout", time.Second*30,
-		"HTTP Timeout defaults to 30 seconds")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -168,9 +168,9 @@ func signPolicy() *cobra.Command {
 		Long:  "policy is used to manage a root.json policy\nfor keyless signing delegation. This is used to establish a policy for a registry namespace,\na signing threshold and a list of maintainers who can sign over the body section.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
-			if o.Timeout != 0 {
+			if ro.Timeout != 0 {
 				var cancelFn context.CancelFunc
-				ctx, cancelFn = context.WithTimeout(ctx, o.Timeout)
+				ctx, cancelFn = context.WithTimeout(ctx, ro.Timeout)
 				defer cancelFn()
 			}
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -89,7 +89,7 @@ func Sign() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := sign.SignCmd(cmd.Context(), ko, o.Registry, annotationsMap.Annotations, args, o.Cert, o.Upload, o.OutputSignature, o.OutputCertificate, o.PayloadPath, o.Force, o.Recursive, o.Attachment); err != nil {
+			if err := sign.SignCmd(ro, ko, o.Registry, annotationsMap.Annotations, args, o.Cert, o.Upload, o.OutputSignature, o.OutputCertificate, o.PayloadPath, o.Force, o.Recursive, o.Attachment); err != nil {
 				if o.Attachment == "" {
 					return errors.Wrapf(err, "signing %v", args)
 				}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -95,7 +95,7 @@ func GetAttachedImageRef(ref name.Reference, attachment string, opts ...ociremot
 }
 
 // nolint
-func SignCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOptions, annotations map[string]interface{},
+func SignCmd(ro *options.RootOptions, ko KeyOpts, regOpts options.RegistryOptions, annotations map[string]interface{},
 	imgs []string, certPath string, upload bool, outputSignature, outputCertificate string, payloadPath string, force bool, recursive bool, attachment string) error {
 	if options.EnableExperimental() {
 		if options.NOf(ko.KeyRef, ko.Sk) > 1 {
@@ -107,12 +107,8 @@ func SignCmd(ctx context.Context, ko KeyOpts, regOpts options.RegistryOptions, a
 		}
 	}
 
-	// TODO: accept a timeout argument and uncomment the block below
-	// if timeout != 0 {
-	// 	var cancelFn context.CancelFunc
-	// 	ctx, cancelFn = context.WithTimeout(ctx, timeout)
-	// 	defer cancelFn()
-	// }
+	ctx, cancel := context.WithTimeout(context.Background(), ro.Timeout)
+	defer cancel()
 
 	sv, err := SignerFromKeyOpts(ctx, certPath, ko)
 	if err != nil {

--- a/cmd/cosign/cli/sign/sign_test.go
+++ b/cmd/cosign/cli/sign/sign_test.go
@@ -16,7 +16,6 @@
 package sign
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -27,7 +26,7 @@ import (
 // TestSignCmdLocalKeyAndSk verifies the SignCmd returns an error
 // if both a local key path and a sk are specified
 func TestSignCmdLocalKeyAndSk(t *testing.T) {
-	ctx := context.Background()
+	ro := &options.RootOptions{Timeout: options.DefaultTimeout}
 
 	for _, ko := range []KeyOpts{
 		// local and sk keys
@@ -37,7 +36,7 @@ func TestSignCmdLocalKeyAndSk(t *testing.T) {
 			Sk:       true,
 		},
 	} {
-		err := SignCmd(ctx, ko, options.RegistryOptions{}, nil, nil, "", false, "", "", "", false, false, "")
+		err := SignCmd(ro, ko, options.RegistryOptions{}, nil, nil, "", false, "", "", "", false, false, "")
 		if (errors.Is(err, &options.KeyParseError{}) == false) {
 			t.Fatal("expected KeyParseError")
 		}

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -84,7 +84,7 @@ func SignBlob() *cobra.Command {
 					fmt.Fprintln(os.Stderr, "WARNING: the '--output' flag is deprecated and will be removed in the future. Use '--output-signature'")
 					o.OutputSignature = o.Output
 				}
-				if _, err := sign.SignBlobCmd(cmd.Context(), ko, o.Registry, blob, o.Base64Output, o.OutputSignature, o.OutputCertificate, o.Timeout); err != nil {
+				if _, err := sign.SignBlobCmd(cmd.Context(), ko, o.Registry, blob, o.Base64Output, o.OutputSignature, o.OutputCertificate, ro.Timeout); err != nil {
 					return errors.Wrapf(err, "signing %s", blob)
 				}
 			}

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -7,6 +7,7 @@
 ```
   -h, --help                 help for cosign
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_attach.md
+++ b/doc/cosign_attach.md
@@ -12,6 +12,7 @@ Provides utilities for attaching artifacts to other artifacts in a registry
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_attach_attestation.md
+++ b/doc/cosign_attach_attestation.md
@@ -26,6 +26,7 @@ cosign attach attestation [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_attach_sbom.md
+++ b/doc/cosign_attach_sbom.md
@@ -27,6 +27,7 @@ cosign attach sbom [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -27,6 +27,7 @@ cosign attach signature [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -56,7 +56,6 @@ cosign attest [flags]
       --replace                                                                                  
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --timeout duration                                                                         HTTP Timeout defaults to 30 seconds (default 30s)
       --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|vuln|custom) or an URI (default "custom")
 ```
 
@@ -64,6 +63,7 @@ cosign attest [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -25,6 +25,7 @@ cosign clean [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_completion.md
+++ b/doc/cosign_completion.md
@@ -44,6 +44,7 @@ cosign completion [bash|zsh|fish|powershell]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -36,6 +36,7 @@ cosign copy [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_dockerfile.md
+++ b/doc/cosign_dockerfile.md
@@ -12,6 +12,7 @@ Provides utilities for discovering images in and performing operations on Docker
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -77,6 +77,7 @@ cosign dockerfile verify [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_download.md
+++ b/doc/cosign_download.md
@@ -12,6 +12,7 @@ Provides utilities for downloading artifacts and attached artifacts in a registr
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_download_attestation.md
+++ b/doc/cosign_download_attestation.md
@@ -25,6 +25,7 @@ cosign download attestation [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -25,6 +25,7 @@ cosign download sbom [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_download_signature.md
+++ b/doc/cosign_download_signature.md
@@ -25,6 +25,7 @@ cosign download signature [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_generate-key-pair.md
+++ b/doc/cosign_generate-key-pair.md
@@ -58,6 +58,7 @@ CAVEATS:
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_generate.md
+++ b/doc/cosign_generate.md
@@ -41,6 +41,7 @@ cosign generate [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_import-key-pair.md
+++ b/doc/cosign_import-key-pair.md
@@ -34,6 +34,7 @@ CAVEATS:
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -49,6 +49,7 @@ cosign initialize -mirror <url> -root <url>
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_load.md
+++ b/doc/cosign_load.md
@@ -27,6 +27,7 @@ cosign load [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_manifest.md
+++ b/doc/cosign_manifest.md
@@ -12,6 +12,7 @@ Provides utilities for discovering images in and performing operations on Kubern
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -71,6 +71,7 @@ cosign manifest verify [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool.md
+++ b/doc/cosign_piv-tool.md
@@ -13,6 +13,7 @@ Provides utilities for managing a hardware token
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool_attestation.md
+++ b/doc/cosign_piv-tool_attestation.md
@@ -19,6 +19,7 @@ cosign piv-tool attestation [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool_generate-key.md
+++ b/doc/cosign_piv-tool_generate-key.md
@@ -22,6 +22,7 @@ cosign piv-tool generate-key [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool_reset.md
+++ b/doc/cosign_piv-tool_reset.md
@@ -17,6 +17,7 @@ cosign piv-tool reset [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool_set-management-key.md
+++ b/doc/cosign_piv-tool_set-management-key.md
@@ -20,6 +20,7 @@ cosign piv-tool set-management-key [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool_set-pin.md
+++ b/doc/cosign_piv-tool_set-pin.md
@@ -19,6 +19,7 @@ cosign piv-tool set-pin [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool_set-puk.md
+++ b/doc/cosign_piv-tool_set-puk.md
@@ -19,6 +19,7 @@ cosign piv-tool set-puk [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_piv-tool_unblock.md
+++ b/doc/cosign_piv-tool_unblock.md
@@ -19,6 +19,7 @@ cosign piv-tool unblock [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_pkcs11-tool.md
+++ b/doc/cosign_pkcs11-tool.md
@@ -13,6 +13,7 @@ Provides utilities for retrieving information from a PKCS11 token.
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_pkcs11-tool_list-keys-uris.md
+++ b/doc/cosign_pkcs11-tool_list-keys-uris.md
@@ -20,6 +20,7 @@ cosign pkcs11-tool list-keys-uris [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_pkcs11-tool_list-tokens.md
+++ b/doc/cosign_pkcs11-tool_list-tokens.md
@@ -18,6 +18,7 @@ cosign pkcs11-tool list-tokens [flags]
 ```
   -f, --no-input             skip warnings and confirmations
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_policy.md
+++ b/doc/cosign_policy.md
@@ -22,6 +22,7 @@ cosign policy [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_policy_init.md
+++ b/doc/cosign_policy_init.md
@@ -39,6 +39,7 @@ cosign policy init [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -28,13 +28,13 @@ cosign policy sign [flags]
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --out string                                                                               output policy locally (default "o")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --timeout duration                                                                         HTTP Timeout defaults to 30 seconds (default 30s)
 ```
 
 ### Options inherited from parent commands
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_public-key.md
+++ b/doc/cosign_public-key.md
@@ -54,6 +54,7 @@ cosign public-key [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_save.md
+++ b/doc/cosign_save.md
@@ -27,6 +27,7 @@ cosign save [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -52,13 +52,13 @@ cosign sign-blob [flags]
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --timeout duration                                                                         HTTP Timeout defaults to 30 seconds (default 30s)
 ```
 
 ### Options inherited from parent commands
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -78,6 +78,7 @@ cosign sign [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -26,6 +26,7 @@ cosign triangulate [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_upload.md
+++ b/doc/cosign_upload.md
@@ -12,6 +12,7 @@ Provides utilities for uploading artifacts to a registry
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_upload_blob.md
+++ b/doc/cosign_upload_blob.md
@@ -39,6 +39,7 @@ cosign upload blob [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_upload_wasm.md
+++ b/doc/cosign_upload_wasm.md
@@ -26,6 +26,7 @@ cosign upload wasm [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -81,6 +81,7 @@ cosign verify-attestation [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -80,6 +80,7 @@ cosign verify-blob [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -84,6 +84,7 @@ cosign verify [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/doc/cosign_version.md
+++ b/doc/cosign_version.md
@@ -21,6 +21,7 @@ cosign version [flags]
 
 ```
       --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
 ```
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -104,6 +104,8 @@ var verifyLocal = func(keyRef, path string, checkClaims bool, annotations map[st
 	return cmd.Exec(context.Background(), args)
 }
 
+var ro = &options.RootOptions{Timeout: options.DefaultTimeout}
+
 func TestSignVerify(t *testing.T) {
 	repo, stop := reg(t)
 	defer stop()
@@ -124,7 +126,7 @@ func TestSignVerify(t *testing.T) {
 
 	// Now sign the image
 	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
@@ -135,7 +137,7 @@ func TestSignVerify(t *testing.T) {
 
 	// Sign the image with an annotation
 	annotations := map[string]interface{}{"foo": "bar"}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, annotations, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, annotations, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	// It should match this time.
 	must(verify(pubKeyPath, imgName, true, map[string]interface{}{"foo": "bar"}, ""), t)
@@ -159,7 +161,7 @@ func TestSignVerifyClean(t *testing.T) {
 
 	// Now sign the image
 	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
@@ -188,7 +190,7 @@ func TestImportSignVerifyClean(t *testing.T) {
 
 	// Now sign the image
 	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
@@ -271,8 +273,6 @@ func TestRekorBundle(t *testing.T) {
 
 	_, privKeyPath, pubKeyPath := keypair(t, td)
 
-	ctx := context.Background()
-
 	ko := sign.KeyOpts{
 		KeyRef:   privKeyPath,
 		PassFunc: passFunc,
@@ -280,7 +280,7 @@ func TestRekorBundle(t *testing.T) {
 	}
 
 	// Sign the image
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 	// Make sure verify works
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
@@ -310,14 +310,14 @@ func TestDuplicateSign(t *testing.T) {
 
 	// Now sign the image
 	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 	must(download.SignatureCmd(ctx, options.RegistryOptions{}, imgName), t)
 
 	// Signing again should work just fine...
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	se, err := ociremote.SignedEntity(ref, ociremote.WithRemoteOptions(registryClientOpts(ctx)...))
 	must(err, t)
@@ -401,22 +401,20 @@ func TestMultipleSignatures(t *testing.T) {
 	_, priv1, pub1 := keypair(t, td1)
 	_, priv2, pub2 := keypair(t, td2)
 
-	ctx := context.Background()
-
 	// Verify should fail at first for both keys
 	mustErr(verify(pub1, imgName, true, nil, ""), t)
 	mustErr(verify(pub2, imgName, true, nil, ""), t)
 
 	// Now sign the image with one key
 	ko := sign.KeyOpts{KeyRef: priv1, PassFunc: passFunc}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 	// Now verify should work with that one, but not the other
 	must(verify(pub1, imgName, true, nil, ""), t)
 	mustErr(verify(pub2, imgName, true, nil, ""), t)
 
 	// Now sign with the other key too
 	ko.KeyRef = priv2
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	// Now verify should work with both
 	must(verify(pub1, imgName, true, nil, ""), t)
@@ -798,7 +796,7 @@ func TestSaveLoad(t *testing.T) {
 			ctx := context.Background()
 			// Now sign the image and verify it
 			ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-			must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+			must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 			must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
 			// save the image to a temp dir
@@ -831,7 +829,7 @@ func TestSaveLoadAttestation(t *testing.T) {
 	ctx := context.Background()
 	// Now sign the image and verify it
 	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
 	// now, append an attestation to the image
@@ -920,7 +918,7 @@ func TestAttachSBOM(t *testing.T) {
 
 	// Now sign the sbom with one key
 	ko1 := sign.KeyOpts{KeyRef: privKeyPath1, PassFunc: passFunc}
-	must(sign.SignCmd(ctx, ko1, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, "sbom"), t)
+	must(sign.SignCmd(ro, ko1, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, "sbom"), t)
 
 	// Now verify should work with that one, but not the other
 	must(verify(pubKeyPath1, imgName, true, nil, "sbom"), t)
@@ -948,7 +946,6 @@ func TestTlog(t *testing.T) {
 
 	_, privKeyPath, pubKeyPath := keypair(t, td)
 
-	ctx := context.Background()
 	// Verify should fail at first
 	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
 
@@ -958,7 +955,7 @@ func TestTlog(t *testing.T) {
 		PassFunc: passFunc,
 		RekorURL: rekorURL,
 	}
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 
 	// Now verify should work!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
@@ -970,7 +967,7 @@ func TestTlog(t *testing.T) {
 	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
 
 	// Sign again with the tlog env var on
-	must(sign.SignCmd(ctx, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
+	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", true, "", "", "", false, false, ""), t)
 	// And now verify works!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 }


### PR DESCRIPTION
#### Summary
We can now specify a global `-t`/`--timeout` option to specify a timeout for any command. It is implemented for `sign` for now, which resolves a leftover `TODO`.

As a follow-up we can consider adding support to other commands as well.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
None

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
- Added global flag `--timeout`/`-t`, which defaults to 3 minutes. 
  This replaces the existing `--timeout` flags on
  `sign-blob`, `policy sign` and `attest`.
- Added `--timeout` supported to the `sign` command.
```
