### PR TITLE
Add a newline after password input

### DIFF
--- a/pkg/cosign/common.go
+++ b/pkg/cosign/common.go
@@ -38,10 +38,10 @@ func GetPassFromTerm(confirm bool) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	fmt.Fprintln(os.Stderr)
 	if !confirm {
 		return pw1, nil
 	}
-	fmt.Fprintln(os.Stderr)
 	fmt.Fprint(os.Stderr, "Enter password for private key again: ")
 	confirmpw, err := term.ReadPassword(0)
 	fmt.Fprintln(os.Stderr)


### PR DESCRIPTION
#### Summary
There is no newline after entering a password and the output is hard to read.

Before:

```
$ cosign sign --key cosign.key knqyf263/cosign-test
an error occurred: no provider found for that key reference, will try to load key from disk...
Enter password for private key: Pushing signature to: index.docker.io/knqyf263/cosign-test
```

After:

```
$ cosign sign --key cosign.key knqyf263/cosign-test
an error occurred: no provider found for that key reference, will try to load key from disk...
Enter password for private key:
Pushing signature to: index.docker.io/knqyf263/cosign-test
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

```release-note
Add a newline after entering password
```
