### PR TITLE
make imageRef lowercase before parsing

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -133,7 +133,7 @@ func SignCmd(ro *options.RootOptions, ko KeyOpts, regOpts options.RegistryOption
 	}
 
 	for _, inputImg := range imgs {
-		ref, err := name.ParseReference(inputImg)
+		ref, err := name.ParseReference(strings.ToLower(inputImg))
 		if err != nil {
 			return errors.Wrap(err, "parsing reference")
 		}


### PR DESCRIPTION
Fixes: #1408

Signed-off-by: Bob Callaway <bob.callaway@gmail.com>
