### PR TITLE
Improve error message when image is not found in registry

### DIFF
--- a/pkg/oci/remote/index.go
+++ b/pkg/oci/remote/index.go
@@ -16,8 +16,12 @@
 package remote
 
 import (
+	"errors"
+	"net/http"
+
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/sigstore/cosign/pkg/oci"
 )
 
@@ -25,7 +29,10 @@ import (
 func SignedImageIndex(ref name.Reference, options ...Option) (oci.SignedImageIndex, error) {
 	o := makeOptions(ref.Context(), options...)
 	ri, err := remoteIndex(ref, o.ROpt...)
-	if err != nil {
+	var te *transport.Error
+	if errors.As(err, &te) && te.StatusCode == http.StatusNotFound {
+		return nil, errors.New("index not found in registry")
+	} else if err != nil {
 		return nil, err
 	}
 	return &index{


### PR DESCRIPTION
Before:

```
$ cosign sign gcr.io/imjasonh/aslkjdlfkjasdlkfjasf
...
Error: signing [gcr.io/imjasonh/aslkjdlfkjasdlkfjasf]: accessing entity: GET https://gcr.io/v2/imjasonh/aslkjdlfkjasdlkfjasf/manifests/latest: MANIFEST_UNKNOWN: Failed to fetch "latest" from request "/v2/imjasonh/aslkjdlfkjasdlkfjasf/manifests/latest".
main.go:46: error during command execution: signing [gcr.io/imjasonh/aslkjdlfkjasdlkfjasf]: accessing entity: GET https://gcr.io/v2/imjasonh/aslkjdlfkjasdlkfjasf/manifests/latest: MANIFEST_UNKNOWN: Failed to fetch "latest" from request "/v2/imjasonh/aslkjdlfkjasdlkfjasf/manifests/latest".
```

After:

```
$ go run ./cmd/cosign sign gcr.io/imjasonh/akjsldkfjalkjsdflkajsdf
...
Error: signing [gcr.io/imjasonh/akjsldkfjalkjsdflkajsdf]: accessing entity: entity not found in registry
main.go:46: error during command execution: signing [gcr.io/imjasonh/akjsldkfjalkjsdflkajsdf]: accessing entity: entity not found in registry
```

We might also want to fix the duplicate error message...

In any case, this error message should help indicate to users that the image doesn't exist in the registry, and if they're trying to sign an image they've built locally, they might need to push it.

Suggestions welcome about how to improve even further.
