### PR TITLE
Add ability to override the Spiffe socket via environmental variable:

### DIFF
--- a/pkg/providers/spiffe/spiffe_test.go
+++ b/pkg/providers/spiffe/spiffe_test.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package spiffe
+
+import (
+	"os"
+
+	"testing"
+)
+
+const nonDefault = "/run/sockets/spire"
+
+func TestGetSocketPath(t *testing.T) {
+	if got := getSocketPath(); got != defaultSocketPath {
+		t.Errorf("Expected %s got %s", defaultSocketPath, got)
+	}
+	os.Setenv(socketEnv, nonDefault)
+	if got := getSocketPath(); got != nonDefault {
+		t.Errorf("Expected %s got %s", nonDefault, got)
+	}
+}


### PR DESCRIPTION
SPIFFE_ENDPOINT_SOCKET

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
Allow overriding the Spiffe socket when using Spiffe provider with `SPIFFE_ENDPOINT_SOCKET` environmental variable.

Fixes #1420

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #1420

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Allow overriding the Spiffe socket when using Spiffe provider with `SPIFFE_ENDPOINT_SOCKET` environmental variable.
```
