### PR TITLE
Fix incorrect error check when verifying SCT

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
@@ -53,7 +53,6 @@ const altCTLogPublicKeyLocation = "SIGSTORE_CT_LOG_PUBLIC_KEY_FILE"
 // some defined time period
 func verifySCT(certPEM, rawSCT []byte) error {
 	var pubKeys []crypto.PublicKey
-	var err error
 	rootEnv := os.Getenv(altCTLogPublicKeyLocation)
 	if rootEnv == "" {
 		ctx := context.TODO()
@@ -96,7 +95,7 @@ func verifySCT(certPEM, rawSCT []byte) error {
 	for _, pubKey := range pubKeys {
 		verifySctErr = ctutil.VerifySCT(pubKey, []*ctx509.Certificate{cert}, &sct, false)
 		// Exit after successful verification of the SCT
-		if err == nil {
+		if verifySctErr == nil {
 			return nil
 		}
 	}


### PR DESCRIPTION
Introduced in #1396, this incorrectly checked err instead
of verifySctErr. This resulted in no error being printed
when SCT validation failed. Verified this is working
correctly now with local testing.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
