### PR TITLE
Fetch verification targets by TUF custom metadata

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots_test.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots_test.go
@@ -1,0 +1,24 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fulcioroots
+
+import "testing"
+
+func TestGetFulcioRoots(t *testing.T) {
+	certPool := Get()
+	if len(certPool.Subjects()) == 0 {
+		t.Errorf("expected 1 or more certificates, got 0")
+	}
+}

--- a/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
@@ -51,7 +51,7 @@ const altCTLogPublicKeyLocation = "SIGSTORE_CT_LOG_PUBLIC_KEY_FILE"
 // The SCT is a `Signed Certificate Timestamp`, which promises that
 // the certificate issued by Fulcio was also added to the public CT log within
 // some defined time period
-func verifySCT(certPEM, rawSCT []byte, ctx context.Context) error {
+func verifySCT(ctx context.Context, certPEM, rawSCT []byte) error {
 	var pubKeys []crypto.PublicKey
 	rootEnv := os.Getenv(altCTLogPublicKeyLocation)
 	if rootEnv == "" {
@@ -114,7 +114,7 @@ func NewSigner(ctx context.Context, idToken, oidcIssuer, oidcClientID, oidcClien
 	}
 
 	// verify the sct
-	if err := verifySCT(fs.Cert, fs.SCT, ctx); err != nil {
+	if err := verifySCT(ctx, fs.Cert, fs.SCT); err != nil {
 		return nil, errors.Wrap(err, "verifying SCT")
 	}
 	fmt.Fprintln(os.Stderr, "Successfully verified SCT...")

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -55,7 +55,7 @@ func GetRekorPubs(ctx context.Context) ([]*ecdsa.PublicKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	var publicKeys []*ecdsa.PublicKey
+	publicKeys := make([]*ecdsa.PublicKey, 0, len(targets))
 	for _, t := range targets {
 		rekorPubKey, err := PemToECDSAKey(t.Target)
 		if err != nil {

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -277,7 +277,8 @@ func (t *TUF) GetTargetsByMeta(usage UsageKind, fallbacks []string) ([]TargetFil
 		var scm sigstoreCustomMetadata
 		err := json.Unmarshal(*targetMeta.Custom, &scm)
 		if err != nil {
-			return nil, errors.Wrap(err, "error unmarshaling custom metadata")
+			fmt.Fprintf(os.Stderr, "**Warning** Custom metadata not configured properly for target %s, skipping target\n", name)
+			continue
 		}
 		if scm.Sigstore.Usage == usage {
 			target, err := t.GetTarget(name)

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -61,6 +61,20 @@ type RootStatus struct {
 	Targets    []string          `json:"targets"`
 }
 
+type TargetFile struct {
+	Target []byte
+	Status StatusKind
+}
+
+type customMetadata struct {
+	Usage  UsageKind  `json:"usage"`
+	Status StatusKind `json:"status"`
+}
+
+type sigstoreCustomMetadata struct {
+	Sigstore customMetadata `json:"sigstore"`
+}
+
 // RemoteCache contains information to cache on the location of the remote
 // repository.
 type remoteCache struct {
@@ -245,6 +259,44 @@ func (t *TUF) GetTarget(name string) ([]byte, error) {
 	}
 
 	return targetBytes, nil
+}
+
+// Get target files by a custom usage metadata tag. If there are no files found,
+// use the fallback target names to fetch the targets by name.
+func (t *TUF) GetTargetsByMeta(usage UsageKind, fallbacks []string) ([]TargetFile, error) {
+	targets, err := t.client.Targets()
+	if err != nil {
+		return nil, errors.Wrap(err, "error getting targets")
+	}
+	var matchedTargets []TargetFile
+	for name, targetMeta := range targets {
+		// Skip any targets that do not include custom metadata.
+		if targetMeta.Custom == nil {
+			continue
+		}
+		var scm sigstoreCustomMetadata
+		err := json.Unmarshal(*targetMeta.Custom, &scm)
+		if err != nil {
+			return nil, errors.Wrap(err, "error unmarshaling custom metadata")
+		}
+		if scm.Sigstore.Usage == usage {
+			target, err := t.GetTarget(name)
+			if err != nil {
+				return nil, errors.Wrap(err, "error getting target")
+			}
+			matchedTargets = append(matchedTargets, TargetFile{Target: target, Status: scm.Sigstore.Status})
+		}
+	}
+	if len(matchedTargets) == 0 {
+		for _, fallback := range fallbacks {
+			target, err := t.GetTarget(fallback)
+			if err != nil {
+				return nil, errors.Wrap(err, "error getting target")
+			}
+			matchedTargets = append(matchedTargets, TargetFile{Target: target, Status: Active})
+		}
+	}
+	return matchedTargets, nil
 }
 
 func localStore(cacheRoot string) (client.LocalStore, error) {

--- a/pkg/cosign/tuf/status_type.go
+++ b/pkg/cosign/tuf/status_type.go
@@ -17,8 +17,6 @@ package tuf
 import (
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type StatusKind int
@@ -42,7 +40,7 @@ func (s StatusKind) String() string {
 func (s StatusKind) MarshalText() ([]byte, error) {
 	str := s.String()
 	if len(str) == 0 {
-		return nil, errors.New(fmt.Sprintf("error while marshalling, int(StatusKind)=%d not valid", int(s)))
+		return nil, fmt.Errorf("error while marshalling, int(StatusKind)=%d not valid", int(s))
 	}
 	return []byte(s.String()), nil
 }
@@ -56,7 +54,7 @@ func (s *StatusKind) UnmarshalText(text []byte) error {
 	case "expired":
 		*s = Expired
 	default:
-		return errors.New(fmt.Sprintf("error while unmarshalling, StatusKind=%v not valid", string(text)))
+		return fmt.Errorf("error while unmarshalling, StatusKind=%v not valid", string(text))
 	}
 	return nil
 }

--- a/pkg/cosign/tuf/status_type.go
+++ b/pkg/cosign/tuf/status_type.go
@@ -1,0 +1,62 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuf
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type StatusKind int
+
+const (
+	UnknownStatus StatusKind = iota
+	Active
+	Expired
+)
+
+var toStatusString = map[StatusKind]string{
+	UnknownStatus: "Unknown",
+	Active:        "Active",
+	Expired:       "Expired",
+}
+
+func (s StatusKind) String() string {
+	return toStatusString[s]
+}
+
+func (s StatusKind) MarshalText() ([]byte, error) {
+	str := s.String()
+	if len(str) == 0 {
+		return nil, errors.New(fmt.Sprintf("error while marshalling, int(StatusKind)=%d not valid", int(s)))
+	}
+	return []byte(s.String()), nil
+}
+
+func (s *StatusKind) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case "unknown":
+		*s = UnknownStatus
+	case "active":
+		*s = Active
+	case "expired":
+		*s = Expired
+	default:
+		return errors.New(fmt.Sprintf("error while unmarshalling, StatusKind=%v not valid", string(text)))
+	}
+	return nil
+}

--- a/pkg/cosign/tuf/status_type_test.go
+++ b/pkg/cosign/tuf/status_type_test.go
@@ -1,0 +1,84 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuf
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMarshalStatusType(t *testing.T) {
+	statuses := []StatusKind{UnknownStatus, Active, Expired}
+	bytes, err := json.Marshal(statuses)
+	if err != nil {
+		t.Fatalf("expected no error marshalling struct, got: %v", err)
+	}
+	expected := `["Unknown","Active","Expired"]`
+	if string(bytes) != expected {
+		t.Fatalf("error while marshalling, expected: %s, got: %s", expected, bytes)
+	}
+}
+
+func TestMarshalInvalidStatusType(t *testing.T) {
+	invalidStatus := 42
+	statuses := []StatusKind{StatusKind(invalidStatus)}
+	bytes, err := json.Marshal(statuses)
+	if bytes != nil {
+		t.Fatalf("expected error marshalling struct, got: %v", bytes)
+	}
+	expectedErr := fmt.Sprintf("error while marshalling, int(StatusKind)=%d not valid", invalidStatus)
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Fatalf("expected error marshalling struct, expected: %v, got: %v", expectedErr, err)
+	}
+}
+
+func TestUnmarshalStatusType(t *testing.T) {
+	var statuses []StatusKind
+	j := json.RawMessage(`["expired", "active", "unknown"]`)
+	err := json.Unmarshal(j, &statuses)
+	if err != nil {
+		t.Fatalf("expected no error unmarshalling struct, got: %v", err)
+	}
+	if !reflect.DeepEqual(statuses, []StatusKind{Expired, Active, UnknownStatus}) {
+		t.Fatalf("expected [Expired, Active, Unknown], got: %v", statuses)
+	}
+}
+
+func TestUnmarshalStatusTypeCapitalization(t *testing.T) {
+	// Any capitalization is allowed.
+	var statuses []StatusKind
+	j := json.RawMessage(`["eXpIrEd", "aCtIvE", "uNkNoWn"]`)
+	err := json.Unmarshal(j, &statuses)
+	if err != nil {
+		t.Fatalf("expected no error unmarshalling struct, got: %v", err)
+	}
+	if !reflect.DeepEqual(statuses, []StatusKind{Expired, Active, UnknownStatus}) {
+		t.Fatalf("expected [Expired, Active, Unknown], got: %v", statuses)
+	}
+}
+
+func TestUnmarshalInvalidStatusType(t *testing.T) {
+	var statuses []StatusKind
+	invalidStatus := "invalid"
+	j := json.RawMessage(fmt.Sprintf(`["%s"]`, invalidStatus))
+	err := json.Unmarshal(j, &statuses)
+	expectedErr := fmt.Sprintf("error while unmarshalling, StatusKind=%s not valid", invalidStatus)
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Fatalf("expected error unmarshalling struct, expected: %v, got: %v", expectedErr, err)
+	}
+}

--- a/pkg/cosign/tuf/usage_type.go
+++ b/pkg/cosign/tuf/usage_type.go
@@ -1,0 +1,66 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuf
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type UsageKind int
+
+const (
+	UnknownUsage UsageKind = iota
+	Fulcio
+	Rekor
+	CTFE
+)
+
+var toUsageString = map[UsageKind]string{
+	UnknownUsage: "Unknown",
+	Fulcio:       "Fulcio",
+	Rekor:        "Rekor",
+	CTFE:         "CTFE",
+}
+
+func (u UsageKind) String() string {
+	return toUsageString[u]
+}
+
+func (u UsageKind) MarshalText() ([]byte, error) {
+	str := u.String()
+	if len(str) == 0 {
+		return nil, errors.New(fmt.Sprintf("error while marshalling, int(UsageKind)=%d not valid", int(u)))
+	}
+	return []byte(u.String()), nil
+}
+
+func (u *UsageKind) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case "unknown":
+		*u = UnknownUsage
+	case "fulcio":
+		*u = Fulcio
+	case "rekor":
+		*u = Rekor
+	case "ctfe":
+		*u = CTFE
+	default:
+		return errors.New(fmt.Sprintf("error while unmarshalling, UsageKind=%v not valid", string(text)))
+	}
+	return nil
+}

--- a/pkg/cosign/tuf/usage_type.go
+++ b/pkg/cosign/tuf/usage_type.go
@@ -17,8 +17,6 @@ package tuf
 import (
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type UsageKind int
@@ -44,7 +42,7 @@ func (u UsageKind) String() string {
 func (u UsageKind) MarshalText() ([]byte, error) {
 	str := u.String()
 	if len(str) == 0 {
-		return nil, errors.New(fmt.Sprintf("error while marshalling, int(UsageKind)=%d not valid", int(u)))
+		return nil, fmt.Errorf("error while marshalling, int(UsageKind)=%d not valid", int(u))
 	}
 	return []byte(u.String()), nil
 }
@@ -60,7 +58,7 @@ func (u *UsageKind) UnmarshalText(text []byte) error {
 	case "ctfe":
 		*u = CTFE
 	default:
-		return errors.New(fmt.Sprintf("error while unmarshalling, UsageKind=%v not valid", string(text)))
+		return fmt.Errorf("error while unmarshalling, UsageKind=%v not valid", string(text))
 	}
 	return nil
 }

--- a/pkg/cosign/tuf/usage_type_test.go
+++ b/pkg/cosign/tuf/usage_type_test.go
@@ -1,0 +1,84 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuf
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestMarshalUsageType(t *testing.T) {
+	usages := []UsageKind{UnknownUsage, Fulcio, Rekor, CTFE}
+	bytes, err := json.Marshal(usages)
+	if err != nil {
+		t.Fatalf("expected no error marshalling struct, got: %v", err)
+	}
+	expected := `["Unknown","Fulcio","Rekor","CTFE"]`
+	if string(bytes) != expected {
+		t.Fatalf("error while marshalling, expected: %s, got: %s", expected, bytes)
+	}
+}
+
+func TestMarshalInvalidUsageType(t *testing.T) {
+	invalidUsage := 42
+	usages := []UsageKind{UsageKind(invalidUsage)}
+	bytes, err := json.Marshal(usages)
+	if bytes != nil {
+		t.Fatalf("expected error marshalling struct, got: %v", bytes)
+	}
+	expectedErr := fmt.Sprintf("error while marshalling, int(UsageKind)=%d not valid", invalidUsage)
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Fatalf("expected error marshalling struct, expected: %v, got: %v", expectedErr, err)
+	}
+}
+
+func TestUnmarshalUsageType(t *testing.T) {
+	var usages []UsageKind
+	j := json.RawMessage(`["fulcio", "rekor", "ctfe", "unknown"]`)
+	err := json.Unmarshal(j, &usages)
+	if err != nil {
+		t.Fatalf("expected no error unmarshalling struct, got: %v", err)
+	}
+	if !reflect.DeepEqual(usages, []UsageKind{Fulcio, Rekor, CTFE, UnknownUsage}) {
+		t.Fatalf("expected [Fulcio, Rekor, CTFE, UnknownUsage], got: %v", usages)
+	}
+}
+
+func TestUnmarshalUsageTypeCapitalization(t *testing.T) {
+	// Any capitalization is allowed.
+	var usages []UsageKind
+	j := json.RawMessage(`["fUlCiO", "rEkOr", "cTfE", "uNkNoWn"]`)
+	err := json.Unmarshal(j, &usages)
+	if err != nil {
+		t.Fatalf("expected no error unmarshalling struct, got: %v", err)
+	}
+	if !reflect.DeepEqual(usages, []UsageKind{Fulcio, Rekor, CTFE, UnknownUsage}) {
+		t.Fatalf("expected [Fulcio, Rekor, CTFE, UnknownUsage], got: %v", usages)
+	}
+}
+
+func TestUnmarshalInvalidUsageType(t *testing.T) {
+	var usages []UsageKind
+	invalidUsage := "invalid"
+	j := json.RawMessage(fmt.Sprintf(`["%s"]`, invalidUsage))
+	err := json.Unmarshal(j, &usages)
+	expectedErr := fmt.Sprintf("error while unmarshalling, UsageKind=%s not valid", invalidUsage)
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Fatalf("expected error unmarshalling struct, expected: %v, got: %v", expectedErr, err)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Continuing #1273, this adds support for fetching a list of TUF targets by custom metadata. This will be used for verification using expired/rotated targets. All targets will be persisted in the TUF target metadata. Only one will be marked as `active` while the others are marked as `expired`.

The custom metadata on a target looks like looks like:
```
      "fulcio.crt.pem": {
        "custom": {
          "sigstore": {
            "status": "Active",
            "usage": "Fulcio"
          }
        },
        "hashes": {
          "sha512": "f2e33a6dc208cee1f51d33bbea675ab0f0ced269617497985f9a0680689ee7073e4b6f8fef64c91bda590d30c129b3070dddce824c05bc165ac9802f0705cab6"
        },
        "length": 740
      },
```

Possible statuses are `active` or `expired`, and possible usages are `fulcio`, `rekor`, and `ctfe`. `unknown` is also supported for each as a default value.

To test this, I:
* Used the current TUF targets to sign and verify. These TUF targets do not contain custom metadata, so this tested the fallback.
* Initialized a TUF repository with custom metadata for each target (based on [the script](https://gist.github.com/asraa/947f1a38afd03af57c7b71d893c36af0) from the BYO TUF blog post). I changed the filenames too so no fallback would happen. Initialized Cosign with the custom TUF metadata. Successfully signed and verified. 

Next steps:
* Use the `Status` of the custom metadata to inform users when verifying with an expired target
* Remove the OCI timestamp code
* After TUF Root v3 is published and bundled with Cosign, we can remove the code that falls back to targets by filename.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #1342

Ref #1273

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
TUF targets can now be referenced by custom metadata instead of filename

Multiple verification keys can be used to verify Fulcio certificates, Rekor entries, or Fulcio CT log SCTs
```
