### PR TITLE
Allow `PassFunc` to be `nil`

### DIFF
--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -70,9 +70,12 @@ func loadKey(keyPath string, pf cosign.PassFunc) (signature.SignerVerifier, erro
 	if err != nil {
 		return nil, err
 	}
-	pass, err := pf(false)
-	if err != nil {
-		return nil, err
+	pass := []byte{}
+	if pf != nil {
+		pass, err = pf(false)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return cosign.LoadPrivateKey(kb, pass)
 }


### PR DESCRIPTION

#### Summary
This allows API consumers to omit providing a password.



#### Ticket Link
None


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Allow `PassFunc` to be `nil`, which translates to having no password at all.
```
