### PR TITLE
Improve log lines to match with implementation

### DIFF
--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -82,7 +82,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 
 	passwordSecretEnvResp, err := client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, passwordSecretEnv)
 	if err != nil {
-		return errors.Wrap(err, "could not create \"COSIGN_PASSWORD\" environment variable")
+		return errors.Wrap(err, "could not create \"COSIGN_PASSWORD\" github actions secret")
 	}
 
 	if passwordSecretEnvResp.StatusCode < 200 && passwordSecretEnvResp.StatusCode >= 300 {
@@ -90,7 +90,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
-	fmt.Fprintln(os.Stderr, "Private key written to COSIGN_PASSWORD environment variable")
+	fmt.Fprintln(os.Stderr, "Password written to COSIGN_PASSWORD github actions secret")
 
 	privateKeySecretEnv := &github.EncryptedSecret{
 		Name:           "COSIGN_PRIVATE_KEY",
@@ -100,7 +100,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 
 	privateKeySecretEnvResp, err := client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, privateKeySecretEnv)
 	if err != nil {
-		return errors.Wrap(err, "could not create \"COSIGN_PRIVATE_KEY\" environment variable")
+		return errors.Wrap(err, "could not create \"COSIGN_PRIVATE_KEY\" github actions secret")
 	}
 
 	if privateKeySecretEnvResp.StatusCode < 200 && privateKeySecretEnvResp.StatusCode >= 300 {
@@ -108,7 +108,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
-	fmt.Fprintln(os.Stderr, "Private key written to COSIGN_PRIVATE_KEY environment variable")
+	fmt.Fprintln(os.Stderr, "Private key written to COSIGN_PRIVATE_KEY github actions secret")
 
 	publicKeySecretEnv := &github.EncryptedSecret{
 		Name:           "COSIGN_PUBLIC_KEY",
@@ -118,7 +118,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 
 	publicKeySecretEnvResp, err := client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, publicKeySecretEnv)
 	if err != nil {
-		return errors.Wrap(err, "could not create \"COSIGN_PUBLIC_KEY\" environment variable")
+		return errors.Wrap(err, "could not create \"COSIGN_PUBLIC_KEY\" github actions secret")
 	}
 
 	if publicKeySecretEnvResp.StatusCode < 200 && publicKeySecretEnvResp.StatusCode >= 300 {
@@ -126,7 +126,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
-	fmt.Fprintln(os.Stderr, "Public key written to COSIGN_PUBLIC_KEY environment variable")
+	fmt.Fprintln(os.Stderr, "Public key written to COSIGN_PUBLIC_KEY github actions secret")
 
 	if err := os.WriteFile("cosign.pub", keys.PublicBytes, 0o600); err != nil {
 		return err


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary

Updates the printed info shown when using `generate-keypair` for Github and Gitlab providers.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes N.A.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Improve generate-keypair info printing
```
