### PR TITLE
TUF: Add search for a delegation in the TUF root

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,8 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/spiffe/go-spiffe/v2 v2.0.0-beta.11
 	github.com/stretchr/testify v1.7.0
-	github.com/theupdateframework/go-tuf v0.0.0-20220124194755-2c5d73bebc1c
 	github.com/xanzy/go-gitlab v0.54.4
+	github.com/theupdateframework/go-tuf v0.0.0-20220127213825-87caa18db2a6
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	google.golang.org/api v0.68.0
@@ -55,7 +55,10 @@ require (
 	github.com/urfave/cli v1.22.5 // indirect
 	go.opentelemetry.io/contrib v1.3.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.12.0 // indirect
+	golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8 // indirect
 	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
+
+replace github.com/theupdateframework/go-tuf => /home/asraa/git/go-tuf

--- a/go.sum
+++ b/go.sum
@@ -1698,7 +1698,6 @@ github.com/sassoftware/relic v0.0.0-20210427151427-dfb082b79b74/go.mod h1:YlB8wF
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
-github.com/secure-systems-lab/go-securesystemslib v0.2.0/go.mod h1:eIjBmIP8LD2MLBL/DkQWayLiz006Q4p+hCu79rvWleY=
 github.com/secure-systems-lab/go-securesystemslib v0.3.0 h1:PH0mUKuUSXVEVDbrKMgGPcrqrnKA8gJii614+EKKi7g=
 github.com/secure-systems-lab/go-securesystemslib v0.3.0/go.mod h1:o8hhjkbNl2gOamKUA/eNW3xUrntHT9L4W89W1nfj43U=
 github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
@@ -1818,9 +1817,6 @@ github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 h1:iGnD/q91
 github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613/go.mod h1:g6AnIpDSYMcphz193otpSIzN+11Rs+AAIIC6rm1enug=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
-github.com/theupdateframework/go-tuf v0.0.0-20211203210025-7ded50136bf9/go.mod h1:n2n6wwC9BEnYS/C/APAtNln0eM5zYAYOkOTx6VEG/mA=
-github.com/theupdateframework/go-tuf v0.0.0-20220124194755-2c5d73bebc1c h1:ACqkD0gnDOlJhT9woBFSTVSyIm0k5jRq3CEM/0N8azw=
-github.com/theupdateframework/go-tuf v0.0.0-20220124194755-2c5d73bebc1c/go.mod h1:I0Gs4Tev4hYQ5wiNqN8VJ7qS0gw7KOZNQuckC624RmE=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
@@ -2075,8 +2071,9 @@ golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20211202192323-5770296d904e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20211209193657-4570a0811e8b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
-golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce h1:Roh6XWxHFKrPgC/EQhVubSAGQ6Ozk6IdxHSzt1mR0EI=
 golang.org/x/crypto v0.0.0-20220112180741-5e0467b6c7ce/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8 h1:kACShD3qhmr/3rLmg1yXyt+N4HcwutKyPRB93s54TIU=
+golang.org/x/crypto v0.0.0-20220126234351-aa10faf2a1f8/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -247,6 +247,38 @@ func (t *TUF) GetTarget(name string) ([]byte, error) {
 	return targetBytes, nil
 }
 
+func (t *TUF) GetTimestamp() ([]byte, error) {
+	trustedMeta, err := t.local.GetMeta()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting trusted meta")
+	}
+	timestamp, ok := trustedMeta["timestamp.json"]
+	if !ok || len(timestamp) == 0 {
+		return nil, errors.New("unable to get TUF timestamp")
+	}
+	return timestamp, nil
+}
+
+func (t *TUF) GetSnapshot() (*data.Snapshot, error) {
+	trustedMeta, err := t.local.GetMeta()
+	if err != nil {
+		return nil, errors.Wrap(err, "getting trusted meta")
+	}
+	snapshotBytes, ok := trustedMeta["snapshot.json"]
+	if !ok || len(snapshotBytes) == 0 {
+		return nil, errors.New("unable to get TUF timestamp")
+	}
+	snapshot := &data.Snapshot{}
+	s := &data.Signed{}
+	if err := json.Unmarshal(snapshotBytes, s); err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(s.Signed, snapshot); err != nil {
+		return nil, err
+	}
+	return snapshot, nil
+}
+
 func localStore(cacheRoot string) (client.LocalStore, error) {
 	local, err := tuf_leveldbstore.FileLocalStore(cacheRoot)
 	if err != nil {

--- a/pkg/cosign/tuf/delegations.go
+++ b/pkg/cosign/tuf/delegations.go
@@ -1,0 +1,65 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuf
+
+import (
+	"github.com/pkg/errors"
+	tuft "github.com/theupdateframework/go-tuf/pkg/targets"
+	"github.com/theupdateframework/go-tuf/verify"
+)
+
+// GetDelegationByPath finds a terminating delegation that matches the target path.
+func (t *TUF) GetDelegationByPath(path string) (tuft.Delegation, error) {
+	// Iterate to find a terminating delegation glob-matching the path.
+	// e.g. If an image name is gcr.io/dlorenc/vm-test, this will return a terminating
+	// delegation role for the path gcr.io/dlorenc/vm-**.
+
+	snapshot, err := t.GetSnapshot()
+	if err != nil {
+		return tuft.Delegation{}, err
+	}
+
+	delegations := tuft.NewDelegationsIterator(path, t.client.DB())
+	for i := 0; i < t.client.MaxDelegations; i++ {
+		d, ok := delegations.Next()
+		if !ok {
+			return tuft.Delegation{}, errors.New("no matching delegation found")
+		}
+
+		// return if this is a terminating delegation matching the path
+		if d.Delegatee.Terminating {
+			return d, nil
+		}
+
+		targets, err := t.client.LoadDelegatedTargets(snapshot, d.Delegatee.Name, d.DB)
+		if err != nil {
+			return tuft.Delegation{}, err
+		}
+
+		if targets.Delegations != nil {
+			delegationsVerifier, err := verify.NewDBFromDelegations(targets.Delegations)
+			if err != nil {
+				return tuft.Delegation{}, err
+			}
+			err = delegations.Add(targets.Delegations.Roles, d.Delegatee.Name, delegationsVerifier)
+			if err != nil {
+				return tuft.Delegation{}, err
+			}
+		}
+	}
+
+	return tuft.Delegation{}, nil
+}

--- a/pkg/cosign/tuf/delegations_test.go
+++ b/pkg/cosign/tuf/delegations_test.go
@@ -1,0 +1,122 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tuf
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/theupdateframework/go-tuf"
+	"github.com/theupdateframework/go-tuf/data"
+	"github.com/theupdateframework/go-tuf/pkg/keys"
+)
+
+func addDelegation(t *testing.T, td string, remote tuf.LocalStore, r *tuf.Repo, delegation, path string, threshold int) {
+	delegatedKey, err := keys.GenerateEd25519Key()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.SaveSigner(delegation, delegatedKey); err != nil {
+		t.Fatal(err)
+	}
+	delegatee := data.DelegatedRole{
+		Name:        delegation,
+		KeyIDs:      delegatedKey.PublicData().IDs(),
+		Paths:       []string{path},
+		Terminating: true,
+		Threshold:   threshold,
+	}
+	publicKeys := []*data.PublicKey{}
+	publicKeys = append(publicKeys, delegatedKey.PublicData())
+
+	if err := r.AddTargetsDelegation("targets", delegatee, publicKeys); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Snapshot(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Timestamp(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Commit(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFetchDelegations(t *testing.T) {
+	ctx := context.Background()
+	// Create a remote repository with delegations.
+	td := t.TempDir()
+	remote, r := newTufRepo(t, td, "foo")
+	delegationThreshold := 1
+	delegateName := "repokitty"
+	delegatedPath := "gcr.io/repokitty/**"
+	addDelegation(t, td, remote, r, delegateName, delegatedPath, delegationThreshold)
+
+	// Serve remote repository.
+	s := httptest.NewServer(http.FileServer(http.Dir(filepath.Join(td, "repository"))))
+	defer s.Close()
+
+	// Initialize with custom root.
+	tufRoot := t.TempDir()
+	t.Setenv("TUF_ROOT", tufRoot)
+	meta, err := remote.GetMeta()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rootBytes, ok := meta["root.json"]
+	if !ok {
+		t.Fatal(err)
+	}
+	if err := Initialize(ctx, s.URL, rootBytes); err != nil {
+		t.Fatal(err)
+	}
+	if l := dirLen(t, tufRoot); l == 0 {
+		t.Errorf("expected filesystem writes, got %d entries", l)
+	}
+
+	// Get delegations by name and path.
+	tufObj, err := NewFromEnv(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := tufObj.GetDelegationByPath("gcr.io/repokitty/cat")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.EqualFold(d.Delegatee.Name, delegateName) {
+		t.Errorf("expected delegatee %s, got %s", delegateName, d.Delegatee.Name)
+	}
+	// check delegation threshold
+	if d.Delegatee.Threshold != delegationThreshold {
+		t.Fatal(err)
+	}
+	// extract key verifiers for this delegation
+	for _, expectedKey := range d.Delegatee.KeyIDs {
+		verifier, err := d.DB.GetVerifier(expectedKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// match this verifier against the added key
+		verifier.Public()
+	}
+
+	tufObj.Close()
+}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->
* Adds the ability to find a delegation matching a particular path.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Part of https://github.com/sigstore/cosign/issues/1437

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```

Blocked on 
https://github.com/theupdateframework/go-tuf/pull/210
https://github.com/theupdateframework/go-tuf/pull/175
(hence the local go-tuf fork...)

@haydentherapper @ethan-lowman-dd