### PR TITLE
convert release cosigned to also generate yaml artifact.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ GOLANGCI_LINT_BIN = $(GOLANGCI_LINT_DIR)/golangci-lint
 
 KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)
+COSIGNED_YAML ?= cosign-$(GIT_TAG).yaml
 
 .PHONY: all lint test clean cosign cross
 all: cosign
@@ -135,9 +136,9 @@ ko:
 
 	# cosigned
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	KO_DOCKER_REPO=${KO_PREFIX}/cosigned ko publish --bare \
+	KO_DOCKER_REPO=${KO_PREFIX}/cosigned ko resolve --bare \
 		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
-		github.com/sigstore/cosign/cmd/cosign/webhook
+		--filename config/ > $(COSIGNED_YAML)
 
 	# sget
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -98,6 +98,7 @@ artifacts:
     paths:
     - "go/src/sigstore/cosign/dist/*"
     - "go/src/sigstore/cosign/release/release-cosign.pub"
+    - "go/src/sigstore/cosign/cosign*.yaml
 
 options:
   machineType: E2_HIGHCPU_8


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

After advise from @cpanato , updated the existing cloud build to generate a yaml artifact for the cosigned webhook instead of the standalone github action. This ensure that the image is built the same way as other artifacts.

This makes #1436 obsolete.


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#1414

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```


Signed-off-by: Kenny Leung <kleung@chainguard.dev>

