### PR TITLE
tests: `/bin/bash` -> `/usr/bin/env bash`

### DIFF
--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Sigstore Authors.
 #

--- a/test/e2e_test_cosigned.sh
+++ b/test/e2e_test_cosigned.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Sigstore Authors.
 #

--- a/test/e2e_test_insecure_registry.sh
+++ b/test/e2e_test_insecure_registry.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Sigstore Authors.
 #

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright 2021 The Sigstore Authors.
 #


### PR DESCRIPTION


#### Summary
This uses `bash` from the user's `$PATH`, which is (usually) preferable to hardcoding a particular `bash` location: https://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my

Selfishly, without this change these scripts don't work on NixOS.

#### Ticket Link

Fixes N/A

#### Release Note

```release-note
NONE
```
