### PR TITLE
refactor release cloudbuild job

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           docker run --rm --privileged \
           -e PROJECT_ID=honk-fake-project \
+          -e CI=$CI \
           -e RUNTIME_IMAGE=gcr.io/distroless/static:debug-nonroot \
           -v ${PWD}:/go/src/sigstore/cosign \
           -v /var/run/docker.sock:/var/run/docker.sock \

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,10 @@ before:
   hooks:
   - go mod tidy
   - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+# if running a release we will generate the images in this step
+# if running in the CI the CI env va is set and we dont run the ko steps
+# this is needed because we are generating files that goreleaser was not aware to push to GH project release
+  - /bin/bash -c 'if [ -z "$CI" ]; then make sign-container-release && make sign-keyless-release; fi'
 
 gomod:
   proxy: true
@@ -250,6 +254,7 @@ release:
 
   extra_files:
     - glob: "./release/release-cosign.pub"
+    - glob: "./cosign*.yaml"
 
 rigs:
   - rig:

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -56,36 +56,14 @@ steps:
   - GIT_TAG=${_GIT_TAG}
   - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
   - COSIGN_EXPERIMENTAL=true
+  - KO_PREFIX=gcr.io/${PROJECT_ID}
   secretEnv:
   - GITHUB_TOKEN
   args:
     - '-c'
     - |
-      make release
-
-- name: ghcr.io/gythialy/golang-cross:v1.17.7-0@sha256:949325ffc52c16867d78412ce70f5ce531812c20e7528ae70dc9e718d72223e8
-  entrypoint: 'bash'
-  dir: "go/src/sigstore/cosign"
-  env:
-  - "GOPATH=/workspace/go"
-  - "GOBIN=/workspace/bin"
-  - PROJECT_ID=${PROJECT_ID}
-  - KEY_LOCATION=${_KEY_LOCATION}
-  - KEY_RING=${_KEY_RING}
-  - KEY_NAME=${_KEY_NAME}
-  - KEY_VERSION=${_KEY_VERSION}
-  - GIT_TAG=${_GIT_TAG}
-  - KO_PREFIX=gcr.io/${PROJECT_ID}
-  - COSIGN_EXPERIMENTAL=true
-  - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
-  secretEnv:
-  - GITHUB_TOKEN
-  args:
-  - '-c'
-  - |
-    gcloud auth configure-docker \
-    && make sign-container-release \
-    && make sign-keyless-release
+      gcloud auth configure-docker \
+      && make release
 
 availableSecrets:
   secretManager:
@@ -98,7 +76,7 @@ artifacts:
     paths:
     - "go/src/sigstore/cosign/dist/*"
     - "go/src/sigstore/cosign/release/release-cosign.pub"
-    - "go/src/sigstore/cosign/cosign*.yaml
+    - "go/src/sigstore/cosign/cosign*.yaml"
 
 options:
   machineType: E2_HIGHCPU_8

--- a/release/release.mk
+++ b/release/release.mk
@@ -5,7 +5,7 @@
 # used when releasing together with GCP CloudBuild
 .PHONY: release
 release:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --timeout 60m
+	LDFLAGS="$(LDFLAGS)" goreleaser release --timeout 120m
 
 ###########################
 # sign with GCP KMS section


### PR DESCRIPTION
#### Summary
In the PR https://github.com/sigstore/cosign/pull/1453 we added the YAML for cosigned, but that is not pushed to the GitHub release because it out of scope for Goreleaser and run outside

This PR joins the image generation using `ko` inside the Goreleaser job and runs as before hook and in the end, it pushed the YAML for cosigned to the release.

Rehersal: https://github.com/cpanato/cosign/releases/tag/v99.99.01

image:
```
$ cosign verify gcr.io/cpanato-general/cosign:v99.99.01

Verification for gcr.io/cpanato-general/cosign:v99.99.01 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - Any certificates were verified against the Fulcio roots.

[{"critical":{"identity":{"docker-reference":"gcr.io/cpanato-general/cosign"},"image":{"docker-manifest-digest":"sha256:12b564ea5e45881595f8e5a946a3e1bc08f57c2a9f507ed8e5ad1e8ed2a88a5a"},"type":"cosign container image signature"},"optional":{"Bundle":{"SignedEntryTimestamp":"MEUCIHkQ4FxKAozEDPBFZN8I8SAtcT8dNWn+YKdrrat0M2nhAiEAst2VTiuv7q7yOHNlzlodThLa9ba84Zx3jy9ZDWrIW4w=","Payload":{"body":"eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI1ZWM4NGM5YTEwMTJiZjljOTkzZmI3YjhiOWUzNzZlODU1ZDMyZGQzMTBmOTg1OGFiMTk1OTY0M2MzNDQ4NzVjIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FWUNJUURBZXhNWGRaT3c1TUlaQ0NQN3VJZEFIMzg0MDlHUjhCL3NWZEtDR1p0cnFRSWhBT3B5RnNtWHhVL3ZsY1V4NFdBRWVYVkJyZG9IQXBzN0dyOEdkWG9kNjBnSCIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCRFJWSlVTVVpKUTBGVVJTMHRMUzB0Q2sxSlNVTlFSRU5EUVdOUFowRjNTVUpCWjBsVlFVMXlTRkIzYmxkc05sUkVVM1ZQTmpjeFlXWnRMMFk1YjI4NGQwTm5XVWxMYjFwSmVtb3dSVUYzVFhjS1MycEZWazFDVFVkQk1WVkZRMmhOVFdNeWJHNWpNMUoyWTIxVmRWcEhWakpOVWtWM1JIZFpSRlpSVVVSRmQyaDZZVmRrZW1SSE9YbGFWRUZsUm5jd2VRcE5ha0Y1VFZSamVFNUVTVE5OUkVaaFJuY3dlVTFxUVhsTlZHTjRUa1JOTTAxRVFtRk5RazE0UlZSQlVFSm5UbFpDUVc5VVEwaE9jRm96VGpCaU0wcHNDazFHYTNkRmQxbElTMjlhU1hwcU1FTkJVVmxKUzI5YVNYcHFNRVJCVVdORVVXZEJSV0ZqVURsUmFGRmhkM1JwYVZCdWJTOVlSM0ZTUVZjelNISlplSFlLY2toQ1dHMVNaa1J0WTJ0SWFVSndSSGQxZGpKSU4zUkZURk5PVWpZNVJGWk9VVmxOT0VRck5FdEtTazFGZUU5elQyMUlhemcwTVZwdmNVOUNNMVJEUWdveWFrRlBRbWRPVmtoUk9FSkJaamhGUWtGTlEwSTBRWGRGZDFsRVZsSXdiRUpCZDNkRFoxbEpTM2RaUWtKUlZVaEJkMDEzUkVGWlJGWlNNRlJCVVVndkNrSkJTWGRCUkVGa1FtZE9Wa2hSTkVWR1oxRlZUR0ZoVlVkWGJVbHdTbFZOWmxKYWFERm9jbGR0TDBGa01XVTRkMGgzV1VSV1VqQnFRa0puZDBadlFWVUtWMDFCWlZnMVJrWndWMkZ3WlhONVVXOWFUV2t3UTNKR2VHWnZkMDluV1VSV1VqQlNRa1JOZDAxWlJYWmhNbFkxWWtkV2VtTXdRbXBqUjBaMVdWaFNkZ3BNVjJSc1ltMVdlVmxYZDNWaFYwWjBURzFrZWxwWVNqSmhWMDVzV1ZkT2FtSXpWblZrUXpWcVlqSXdkMHRSV1V0TGQxbENRa0ZIUkhaNlFVSkJVVkZpQ21GSVVqQmpTRTAyVEhrNWFGa3lUblprVnpVd1kzazFibUl5T1c1aVIxVjFXVEk1ZEUxQmIwZERRM0ZIVTAwME9VSkJUVVJCTW1OQlRVZFJRMDFJVnpFS1ZIVkhTR3B0Tm1OVVlVNHpXR2c1YkVjNWVrUXZSVEIxSzJWcmNVSm5aWGRhTWs5R01qWjRSRU5UWlVGQ2RrdDNlVWRzZEhreFRWTk5NRmRMTlZGSmR3cFBURVpTWm5CSGMzZDNRa1JRTjJKdmMyOVVWVXRMUm5GM0wxTjFaR041TWs4MlZISkthMmxzTlhBNWVFeFRiWFJXUkU5bVpXRmpWM2xFTm5OWFlVTldDaTB0TFMwdFJVNUVJRU5GVWxSSlJrbERRVlJGTFMwdExTMEsifX19fQ==","integratedTime":1645108024,"logIndex":1431264,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}},"GIT_HASH":"67e94647d83ee2fe44fa1903388d3524c7b70d07","GIT_VERSION":"v99.99.01","Issuer":"https://accounts.google.com","Subject":"keyless@cpanato-general.iam.gserviceaccount.com"}}]
```

/assign @dlorenc @k4leung4 

also if this is running as part of ci validate job it ignore the ko build 

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
