### PR TITLE
Fix wording on attach attestation help

### DIFF
--- a/cmd/cosign/cli/options/attach.go
+++ b/cmd/cosign/cli/options/attach.go
@@ -88,5 +88,5 @@ func (o *AttachAttestationOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Attestation, "attestation", "",
-		"path to the predicate")
+		"path to the attestation envelope")
 }

--- a/doc/cosign_attach_attestation.md
+++ b/doc/cosign_attach_attestation.md
@@ -17,7 +17,7 @@ cosign attach attestation [flags]
 ```
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
-      --attestation string                                                                       path to the predicate
+      --attestation string                                                                       path to the attestation envelope
   -h, --help                                                                                     help for attestation
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```


### PR DESCRIPTION
Super small wording correction... In `cosign attach attestation --attestation <path>`, the path should be to a file with the entire attestation envelope, not the predicate.