### PR TITLE
add correct layer media type to cosign attach attestation

### DIFF
--- a/cmd/cosign/cli/attach/attestation.go
+++ b/cmd/cosign/cli/attach/attestation.go
@@ -68,7 +68,8 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, signed
 	// each access.
 	ref = digest // nolint
 
-	att, err := static.NewAttestation(payload)
+	opts := []static.Option{static.WithLayerMediaType(types.DssePayloadType)}
+	att, err := static.NewAttestation(payload, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Christopher Phillips <christopher.phillips@anchore.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
Closes #1494. 

Updates `cosign attach attestation` command to use the media layer type described in the attestation specification.

#### Ticket Link

Fixes https://github.com/sigstore/cosign/issues/1494

#### Release Note
<!--
Add a release note for each of the following conditions:

* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
update cosign attach attestation to use application/vnd.dsse.envelope.v1+json
```
