### PR TITLE
Add skeleton reconciler for cosigned API CRD.

### DIFF
--- a/cmd/cosign/webhook/main.go
+++ b/cmd/cosign/webhook/main.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/release-utils/version"
 
 	cwebhook "github.com/sigstore/cosign/pkg/cosign/kubernetes/webhook"
+	"github.com/sigstore/cosign/pkg/reconciler/clusterimagepolicy"
 )
 
 var secretName = flag.String("secret-name", "", "The name of the secret in the webhook's namespace that holds the public key for verification.")
@@ -66,6 +67,7 @@ func main() {
 		certificates.NewController,
 		NewValidatingAdmissionController,
 		NewMutatingAdmissionController,
+		clusterimagepolicy.NewController,
 	)
 }
 

--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	"knative.dev/hack/schema/commands"
+	"knative.dev/hack/schema/registry"
+
+	v1alpha1 "github.com/sigstore/cosign/pkg/apis/cosigned/v1alpha1"
+)
+
+// schema is a tool to dump the schema for Eventing resources.
+func main() {
+	registry.Register(&v1alpha1.ClusterImagePolicy{})
+
+	if err := commands.New("github.com/sigstore/cosign").Execute(); err != nil {
+		log.Fatal("Error during command execution: ", err)
+	}
+}

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -37,6 +37,22 @@ rules:
     # which requires we can Get the system namespace.
     resourceNames: ["cosign-system"]
 
+  # TODO: We will need this once we have conversion webhooks.
+  # # Allow the reconciliation of exactly our CRDs.
+  # # This is needed for us to patch in conversion webhook information.
+  # - apiGroups: ["apiextensions.k8s.io"]
+  #   resources: ["customresourcedefinitions"]
+  #   verbs: ["list", "watch"]
+  # - apiGroups: ["apiextensions.k8s.io"]
+  #   resources: ["customresourcedefinitions"]
+  #   verbs: ["get", "update"]
+  #   resourceNames: ["clusterimagepolicies.cosigned.sigstore.dev"]
+
+  # Allow reconciliation of the ClusterImagePolic CRDs.
+  - apiGroups: ["cosigned.sigstore.dev"]
+    resources: ["clusterimagepolicies"]
+    verbs: ["get", "list", "update", "watch"]
+
   # This is needed by k8schain to support fetching pull secrets attached to pod specs
   # or their service accounts.  If pull secrets aren't used, the "secrets" below can
   # be safely dropped, but the logic will fetch the service account to check for pull

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -1,0 +1,43 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterimagepolicies.cosigned.sigstore.dev
+spec:
+  group: cosigned.sigstore.dev
+  names:
+    kind: ClusterImagePolicy
+    plural: clusterimagepolicies
+    singular: clusterimagepolicy
+    categories:
+    - all
+    - sigstore
+    shortNames:
+    - cip
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        # This is the output of:
+        #   go run ./cmd/schema/ dump ClusterImagePolicy
+        type: object
+        properties:
+          spec:
+            description: Spec holds the desired state of the ClusterImagePolicy (from the client).
+            type: object

--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	k8s.io/code-generator v0.22.5
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf
 	knative.dev/hack v0.0.0-20220118141833-9b2ed8471e30
+	knative.dev/hack/schema v0.0.0-20220224013837-e1785985d364
 )
 
 // This is temporary to address conflicting versions of Kubernetes libs in knative and GGCR.

--- a/go.sum
+++ b/go.sum
@@ -3109,6 +3109,8 @@ k8s.io/utils v0.0.0-20220127004650-9b3446523e65 h1:ONWS0Wgdg5wRiQIAui7L/023aC9+I
 k8s.io/utils v0.0.0-20220127004650-9b3446523e65/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/hack v0.0.0-20220118141833-9b2ed8471e30 h1:UkNpCWCMM5C4AeQ8aTrPTuR/6OeARiqk+LEQ6tuMP7c=
 knative.dev/hack v0.0.0-20220118141833-9b2ed8471e30/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
+knative.dev/hack/schema v0.0.0-20220224013837-e1785985d364 h1:iuM9VFi9cjSNuVc3x5gUbPQn4zndXfjWDYCJ1fYpk18=
+knative.dev/hack/schema v0.0.0-20220224013837-e1785985d364/go.mod h1:ffjwmdcrH5vN3mPhO8RrF2KfNnbHeCE2C60A+2cv3U0=
 knative.dev/pkg v0.0.0-20220202132633-df430fa0dd96 h1:JU0DFa06CaUtwSkAY0b3j47ohEJLIYlpPPgNgbPHlAo=
 knative.dev/pkg v0.0.0-20220202132633-df430fa0dd96/go.mod h1:etVT7Tm8pSDf4RKhGk4r7j/hj3dNBpvT7bO6a6wpahs=
 mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=

--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
@@ -1,0 +1,40 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterimagepolicy
+
+import (
+	"context"
+
+	"github.com/sigstore/cosign/pkg/apis/cosigned/v1alpha1"
+	clusterimagepolicyreconciler "github.com/sigstore/cosign/pkg/client/injection/reconciler/cosigned/v1alpha1/clusterimagepolicy"
+	"knative.dev/pkg/reconciler"
+	"knative.dev/pkg/tracker"
+)
+
+// Reconciler implements clusterimagepolicyreconciler.Interface for
+// ClusterImagePolicy resources.
+type Reconciler struct {
+	// Tracker builds an index of what resources are watching other resources
+	// so that we can immediately react to changes tracked resources.
+	Tracker tracker.Interface
+}
+
+// Check that our Reconciler implements Interface
+var _ clusterimagepolicyreconciler.Interface = (*Reconciler)(nil)
+
+// ReconcileKind implements Interface.ReconcileKind.
+func (r *Reconciler) ReconcileKind(ctx context.Context, o *v1alpha1.ClusterImagePolicy) reconciler.Event {
+	return nil
+}

--- a/pkg/reconciler/clusterimagepolicy/controller.go
+++ b/pkg/reconciler/clusterimagepolicy/controller.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusterimagepolicy
+
+import (
+	"context"
+
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+
+	clusterimagepolicyinformer "github.com/sigstore/cosign/pkg/client/injection/informers/cosigned/v1alpha1/clusterimagepolicy"
+	clusterimagepolicyreconciler "github.com/sigstore/cosign/pkg/client/injection/reconciler/cosigned/v1alpha1/clusterimagepolicy"
+)
+
+// NewController creates a Reconciler and returns the result of NewImpl.
+func NewController(
+	ctx context.Context,
+	cmw configmap.Watcher,
+) *controller.Impl {
+	clusterimagepolicyInformer := clusterimagepolicyinformer.Get(ctx)
+
+	r := &Reconciler{}
+	impl := clusterimagepolicyreconciler.NewImpl(ctx, r)
+	r.Tracker = impl.Tracker
+
+	clusterimagepolicyInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
+
+	return impl
+}


### PR DESCRIPTION
This puts together the skeleton of a reconciler for the ClusterImagePolicy CRD, and links it into our controlplane pod.

This adds the CRD definition (and stub to generate the schema), and RBAC to let us reconcile the CRD.

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Ticket Link

Scaffolding for: #1418

#### Release Note

```release-note
Introduce a ClusterImagePolicy CRD, which will be used to configure the cosigned webhook.
```
