### PR TITLE
Add CertExtensions func to extract all extensions

### DIFF
--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -45,7 +45,7 @@ import (
 
 var (
 	// Fulcio cert-extensions, documented here: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
-	CertExtensionIssuer                   = "1.3.6.1.4.1.57264.1.1"
+	CertExtensionOIDCIssuer               = "1.3.6.1.4.1.57264.1.1"
 	CertExtensionGithubWorkflowTrigger    = "1.3.6.1.4.1.57264.1.2"
 	CertExtensionGithubWorkflowSha        = "1.3.6.1.4.1.57264.1.3"
 	CertExtensionGithubWorkflowName       = "1.3.6.1.4.1.57264.1.4"
@@ -53,7 +53,7 @@ var (
 	CertExtensionGithubWorkflowRef        = "1.3.6.1.4.1.57264.1.6"
 
 	CertExtensionMap = map[string]string{
-		CertExtensionIssuer:                   "issuer",
+		CertExtensionOIDCIssuer:               "oidcIssuer",
 		CertExtensionGithubWorkflowTrigger:    "githubWorkflowTrigger",
 		CertExtensionGithubWorkflowSha:        "githubWorkflowSha",
 		CertExtensionGithubWorkflowName:       "githubWorkflowName",
@@ -262,7 +262,7 @@ func CertSubject(c *x509.Certificate) string {
 
 func CertIssuerExtension(cert *x509.Certificate) string {
 	for _, ext := range cert.Extensions {
-		if ext.Id.String() == CertExtensionIssuer {
+		if ext.Id.String() == CertExtensionOIDCIssuer {
 			return string(ext.Value)
 		}
 	}

--- a/pkg/signature/keys_test.go
+++ b/pkg/signature/keys_test.go
@@ -135,8 +135,8 @@ func TestCertExtensions(t *testing.T) {
 		t.Fatalf("Unexpected extension-count: %v", len(exts))
 	}
 
-	if val, ok := exts["issuer"]; !ok || val != "myIssuer" {
-		t.Fatal("CertExtension does not extract field 'issuer' correctly")
+	if val, ok := exts["oidcIssuer"]; !ok || val != "myIssuer" {
+		t.Fatal("CertExtension does not extract field 'oidcIssuer' correctly")
 	}
 
 	if val, ok := exts["githubWorkflowName"]; !ok || val != "myWorkflowName" {


### PR DESCRIPTION
Signed-off-by: Christian Kotzbauer <git@ckotzbauer.de>

#### Summary
This adds a `CertExtensions` function to the signature package to extract all extensions from a cert and return them as map. The map-key is either a human-readable name or the extensionID (if no name is specified in the mapping).
I did not remove the `CertIssuerExtension` func for backward compatibility.

#### Ticket Link
close #1456

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Add CertExtensions func to extract all extensions
```

/cc @JimBugwadia 