### PR TITLE
optimize codeql speed by using caching and tracing

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  CODEQL_EXTRACTOR_GO_BUILD_TRACING: true
+
 jobs:
   analyze:
     name: Analyze
@@ -38,27 +41,29 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 #v2.4.0
 
+    - name: Utilize Go Module Cache
+      uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed #v2.1.7
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
+    - name: Set correct version of Golang to use during CodeQL run
+      uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 #v2.1.5
+      with:
+        go-version: '1.17.x'
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@75f07e7ab2ee63cba88752d8c696324e4df67466 #v1.1.2
+      uses: github/codeql-action/init@75f07e7ab2ee63cba88752d8c696324e4df67466 #v1.1.3
       with:
         languages: ${{ matrix.language }}
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@75f07e7ab2ee63cba88752d8c696324e4df67466 #v1.1.2
-
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
-
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Build cosign for CodeQL
+      run: make cosign
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@75f07e7ab2ee63cba88752d8c696324e4df67466 #v1.1.2
+      uses: github/codeql-action/analyze@75f07e7ab2ee63cba88752d8c696324e4df67466 #v1.1.3


### PR DESCRIPTION
This does not run on every commit, but just tries to optimize the time it takes to run this action and give feedback. 

@dlorenc 

Signed-off-by: Bob Callaway <bcallaway@google.com>
