### PR TITLE
chore(ci): add artifact hub support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ clean:
 
 
 KOCACHE_PATH=/tmp/ko
+ARTIFACT_HUB_LABELS=--image-label io.artifacthub.package.readme-url=https://raw.githubusercontent.com/sigstore/cosign/main/README.md --image-label io.artifacthub.package.logo-url=https://raw.githubusercontent.com/sigstore/cosign/main/images/logo.svg --image-label io.artifacthub.package.license=Apache-2.0 --image-label io.artifacthub.package.vendor=sigstore --image-label io.artifacthub.package.version=0.1.0 --image-label io.artifacthub.package.name=cosign --image-label org.opencontainers.image.created=$(BUILD_DATE) --image-label org.opencontainers.image.description='Container signing verification and storage in an OCI registry'
 
 define create_kocache_path
   mkdir -p $(KOCACHE_PATH)
@@ -141,6 +142,7 @@ ko:
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) ko build --base-import-paths --bare \
 		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		$(ARTIFACT_HUB_LABELS) \
 		github.com/sigstore/cosign/cmd/cosign
 
 	# cosigned
@@ -153,6 +155,7 @@ ko:
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) ko build --base-import-paths --bare \
 		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		$(ARTIFACT_HUB_LABELS) \
 		github.com/sigstore/cosign/cmd/sget
 
 .PHONY: ko-local
@@ -161,6 +164,7 @@ ko-local:
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) ko build --base-import-paths --bare \
 		--tags $(GIT_VERSION) --tags $(GIT_HASH) --local \
+		$(ARTIFACT_HUB_LABELS) \
 		github.com/sigstore/cosign/cmd/cosign
 
 ##################


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>
Co-authored-by: Batuhan <batuhan.apaydin@trendyol.com>

[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/furkanturkal)](https://artifacthub.io/packages/search?repo=furkanturkal)

![Screen Shot 2022-02-28 at 16 33 46](https://user-images.githubusercontent.com/16493751/155991995-481f556f-9d97-4537-9d22-7300d47a7eaa.png)

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #1521

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Add Artifact Hub support
```
