### PR TITLE
Consistent parenthesis use in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ ko:
 
 	# cosigned
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
-	KO_DOCKER_REPO=${KO_PREFIX}/cosigned ko resolve --bare \
+	KO_DOCKER_REPO=$(KO_PREFIX)/cosigned ko resolve --bare \
 		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
 		--filename config/ > $(COSIGNED_YAML)
 

--- a/release/release.mk
+++ b/release/release.mk
@@ -13,15 +13,15 @@ release:
 
 .PHONY: sign-cosign-release
 sign-cosign-release:
-	cosign sign --force --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosign:$(GIT_VERSION)
+	cosign sign --force --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosign:$(GIT_VERSION)
 
 .PHONY: sign-cosigned-release
 sign-cosigned-release:
-	cosign sign --force --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosigned:$(GIT_VERSION)
+	cosign sign --force --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosigned:$(GIT_VERSION)
 
 .PHONY: sign-sget-release
 sign-sget-release:
-	cosign sign --force --key "gcpkms://projects/${PROJECT_ID}/locations/${KEY_LOCATION}/keyRings/${KEY_RING}/cryptoKeys/${KEY_NAME}/versions/${KEY_VERSION}" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/sget:$(GIT_VERSION)
+	cosign sign --force --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/sget:$(GIT_VERSION)
 
 .PHONY: sign-container-release
 sign-container-release: ko sign-cosign-release sign-cosigned-release sign-sget-release
@@ -32,15 +32,15 @@ sign-container-release: ko sign-cosign-release sign-cosigned-release sign-sget-r
 
 .PHONY: sign-keyless-cosign-release
 sign-keyless-cosign-release:
-	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosign:$(GIT_VERSION)
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosign:$(GIT_VERSION)
 
 .PHONY: sign-keyless-cosigned-release
 sign-keyless-cosigned-release:
-	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/cosigned:$(GIT_VERSION)
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosigned:$(GIT_VERSION)
 
 .PHONY: sign-keyless-sget-release
 sign-keyless-sget-release:
-	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) ${KO_PREFIX}/sget:$(GIT_VERSION)
+	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/sget:$(GIT_VERSION)
 
 .PHONY: sign-keyless-release
 sign-keyless-release: sign-keyless-cosign-release sign-keyless-cosigned-release sign-keyless-sget-release


### PR DESCRIPTION
Signed-off-by: Kenny Leung <kleung@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

Parenthesis and braces in Makefile are treated the same; https://web.mit.edu/gnu/doc/html/make_6.html#SEC56

We should be consistent and use one or the other, not both.
Since there seems to be more existing use of parenthesis, switching over to that.



#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
None
```
