### PR TITLE
Disable for now due some issues when downloading the knative module

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -232,6 +232,12 @@ signs:
     cmd: ./dist/cosign-linux-amd64
     args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
     artifacts: checksum
+  - id: packages-keyless
+    signature: "${artifact}-keyless.sig"
+    certificate: "${artifact}-keyless.pem"
+    cmd: ./dist/cosign-linux-amd64
+    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
+    artifacts: package
 
 nfpms:
   - id: cosign

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,8 +16,9 @@ before:
 # this is needed because we are generating files that goreleaser was not aware to push to GH project release
   - /bin/bash -c 'if [ -z "$CI" ]; then make sign-container-release && make sign-keyless-release; fi'
 
-gomod:
-  proxy: true
+# Disable for now due some issues when downloading the knative module, maybe due to the replace in the go.mod
+# gomod:
+#   proxy: true
 
 sboms:
 - artifacts: binary


### PR DESCRIPTION
#### Summary
- Disable for now due some issues when downloading the knative module maybe due to the replace in the go.mod
- and sign packages as well

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
