### PR TITLE
oci/signature: expose descriptor reference to interface

### DIFF
--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -50,6 +50,11 @@ func New(l v1.Layer, desc v1.Descriptor) oci.Signature {
 
 var _ oci.Signature = (*sigLayer)(nil)
 
+// Descriptor holds a reference from the manifest to one of its constituent elements.
+func (s *sigLayer) Descriptor() (v1.Descriptor, error) {
+	return s.desc, nil
+}
+
 // Annotations implements oci.Signature
 func (s *sigLayer) Annotations() (map[string]string, error) {
 	return s.desc.Annotations, nil

--- a/pkg/oci/signatures.go
+++ b/pkg/oci/signatures.go
@@ -35,6 +35,9 @@ type Signatures interface {
 type Signature interface {
 	v1.Layer
 
+	// Descriptor holds a reference from the manifest to one of its constituent elements.
+	Descriptor() (v1.Descriptor, error)
+
 	// Annotations returns the annotations associated with this layer.
 	Annotations() (map[string]string, error)
 


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Ability to expose v1.Descriptor reference in sigLayer{}
```
