### PR TITLE
pkg/types: add annotation keys

### DIFF
--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/theupdateframework/go-tuf/encrypted"
 
-	"github.com/sigstore/cosign/pkg/oci/static"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
@@ -45,7 +44,6 @@ const (
 	ECPrivateKeyPemType = "EC PRIVATE KEY"
 	// PEM-encoded PKCS #8 RSA, ECDSA or ED25519 private key
 	PrivateKeyPemType = "PRIVATE KEY"
-	BundleKey         = static.BundleAnnotationKey
 )
 
 // PassFunc is the function to be called to retrieve the signer password. If

--- a/pkg/cosign/remote/remote.go
+++ b/pkg/cosign/remote/remote.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/sigstore/cosign/pkg/oci"
 	"github.com/sigstore/cosign/pkg/oci/mutate"
-	"github.com/sigstore/cosign/pkg/oci/static"
+	ctypes "github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
@@ -77,7 +77,7 @@ LayerLoop:
 
 		// if there are any new annotations, then this isn't a duplicate
 		for a, value := range newAnnotations {
-			if a == static.SignatureAnnotationKey {
+			if a == ctypes.SignatureAnnotationKey {
 				continue // Ignore the signature key, we check it with custom logic below.
 			}
 			if val, ok := existingAnnotations[a]; !ok || val != value {

--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -26,14 +26,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/pkg/oci"
+	ctypes "github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-)
-
-const (
-	sigkey    = "dev.cosignproject.cosign/signature"
-	certkey   = "dev.sigstore.cosign/certificate"
-	chainkey  = "dev.sigstore.cosign/chain"
-	BundleKey = "dev.sigstore.cosign/bundle"
 )
 
 type sigLayer struct {
@@ -71,16 +65,16 @@ func (s *sigLayer) Payload() ([]byte, error) {
 
 // Base64Signature implements oci.Signature
 func (s *sigLayer) Base64Signature() (string, error) {
-	b64sig, ok := s.desc.Annotations[sigkey]
+	b64sig, ok := s.desc.Annotations[ctypes.SignatureAnnotationKey]
 	if !ok {
-		return "", fmt.Errorf("signature layer %s is missing %q annotation", s.desc.Digest, sigkey)
+		return "", fmt.Errorf("signature layer %s is missing %q annotation", s.desc.Digest, ctypes.SignatureAnnotationKey)
 	}
 	return b64sig, nil
 }
 
 // Cert implements oci.Signature
 func (s *sigLayer) Cert() (*x509.Certificate, error) {
-	certPEM := s.desc.Annotations[certkey]
+	certPEM := s.desc.Annotations[ctypes.CertificateAnnotationKey]
 	if certPEM == "" {
 		return nil, nil
 	}
@@ -93,7 +87,7 @@ func (s *sigLayer) Cert() (*x509.Certificate, error) {
 
 // Chain implements oci.Signature
 func (s *sigLayer) Chain() ([]*x509.Certificate, error) {
-	chainPEM := s.desc.Annotations[chainkey]
+	chainPEM := s.desc.Annotations[ctypes.ChainAnnotationKey]
 	if chainPEM == "" {
 		return nil, nil
 	}
@@ -106,7 +100,7 @@ func (s *sigLayer) Chain() ([]*x509.Certificate, error) {
 
 // Bundle implements oci.Signature
 func (s *sigLayer) Bundle() (*bundle.RekorBundle, error) {
-	val := s.desc.Annotations[BundleKey]
+	val := s.desc.Annotations[ctypes.BundleAnnotationKey]
 	if val == "" {
 		return nil, nil
 	}

--- a/pkg/oci/internal/signature/layer_test.go
+++ b/pkg/oci/internal/signature/layer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign/bundle"
+	ctypes "github.com/sigstore/cosign/pkg/types"
 )
 
 func mustDecode(s string) []byte {
@@ -66,7 +67,7 @@ func TestSignature(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey: "blah",
+					ctypes.SignatureAnnotationKey: "blah",
 				},
 			},
 		},
@@ -78,10 +79,10 @@ func TestSignature(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:    "blah",
-					certkey:   "",
-					chainkey:  "",
-					BundleKey: "",
+					ctypes.SignatureAnnotationKey:    "blah",
+					ctypes.CertificateAnnotationKey:   "",
+					ctypes.ChainAnnotationKey:  "",
+					ctypes.BundleAnnotationKey: "",
 				},
 			},
 		},
@@ -94,7 +95,7 @@ func TestSignature(t *testing.T) {
 				Digest: digest,
 			},
 		},
-		wantSigErr: fmt.Errorf("signature layer %s is missing %q annotation", digest, sigkey),
+		wantSigErr: fmt.Errorf("signature layer %s is missing %q annotation", digest, ctypes.SignatureAnnotationKey),
 	}, {
 		name: "min plus bad bundle",
 		l: &sigLayer{
@@ -102,8 +103,8 @@ func TestSignature(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:    "blah",
-					BundleKey: `}`,
+					ctypes.SignatureAnnotationKey:    "blah",
+					ctypes.BundleAnnotationKey: `}`,
 				},
 			},
 		},
@@ -116,8 +117,8 @@ func TestSignature(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:  "blah",
-					certkey: `GARBAGE`,
+					ctypes.SignatureAnnotationKey:  "blah",
+					ctypes.CertificateAnnotationKey: `GARBAGE`,
 				},
 			},
 		},
@@ -130,8 +131,8 @@ func TestSignature(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:   "blah",
-					chainkey: `GARBAGE`,
+					ctypes.SignatureAnnotationKey:   "blah",
+					ctypes.ChainAnnotationKey: `GARBAGE`,
 				},
 			},
 		},
@@ -144,10 +145,10 @@ func TestSignature(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey: "blah",
+					ctypes.SignatureAnnotationKey: "blah",
 					// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16.
 					// The Body has been removed for brevity
-					BundleKey: `{"SignedEntryTimestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
+					ctypes.BundleAnnotationKey: `{"SignedEntryTimestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
 				},
 			},
 		},
@@ -168,9 +169,9 @@ func TestSignature(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey: "blah",
+					ctypes.SignatureAnnotationKey: "blah",
 					// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16
-					certkey: `
+					ctypes.CertificateAnnotationKey: `
 -----BEGIN CERTIFICATE-----
 MIICjzCCAhSgAwIBAgITV2heiswW9YldtVEAu98QxDO8TTAKBggqhkjOPQQDAzAq
 MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx
@@ -200,9 +201,9 @@ uThR1Z6JuA21HwxtL3GyJ8UQZcEPOlTBV593HrSAwBhiCoY=
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey: "blah",
+					ctypes.SignatureAnnotationKey: "blah",
 					// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16
-					chainkey: `
+					ctypes.ChainAnnotationKey: `
 -----BEGIN CERTIFICATE-----
 MIIB+DCCAX6gAwIBAgITNVkDZoCiofPDsy7dfm6geLbuhzAKBggqhkjOPQQDAzAq
 MRUwEwYDVQQKEwxzaWdzdG9yZS5kZXYxETAPBgNVBAMTCHNpZ3N0b3JlMB4XDTIx

--- a/pkg/oci/mutate/signature.go
+++ b/pkg/oci/mutate/signature.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/pkg/oci"
-	"github.com/sigstore/cosign/pkg/oci/static"
+	ctypes "github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
@@ -138,8 +138,8 @@ func Signature(original oci.Signature, opts ...SignatureOption) (oci.Signature, 
 	var newAnn map[string]string
 	if so.annotations != nil {
 		newAnn = copyAnnotations(so.annotations)
-		newAnn[static.SignatureAnnotationKey] = oldAnn[static.SignatureAnnotationKey]
-		for _, key := range []string{static.BundleAnnotationKey, static.CertificateAnnotationKey, static.ChainAnnotationKey} {
+		newAnn[ctypes.SignatureAnnotationKey] = oldAnn[ctypes.SignatureAnnotationKey]
+		for _, key := range []string{ctypes.BundleAnnotationKey, ctypes.CertificateAnnotationKey, ctypes.ChainAnnotationKey} {
 			if val, isSet := oldAnn[key]; isSet {
 				newAnn[key] = val
 			} else {
@@ -156,7 +156,7 @@ func Signature(original oci.Signature, opts ...SignatureOption) (oci.Signature, 
 		if err != nil {
 			return nil, err
 		}
-		newAnn[static.BundleAnnotationKey] = string(b)
+		newAnn[ctypes.BundleAnnotationKey] = string(b)
 	}
 
 	if so.cert != nil {
@@ -167,16 +167,16 @@ func Signature(original oci.Signature, opts ...SignatureOption) (oci.Signature, 
 		if err != nil {
 			return nil, err
 		}
-		newAnn[static.CertificateAnnotationKey] = string(so.cert)
+		newAnn[ctypes.CertificateAnnotationKey] = string(so.cert)
 		cert = certs[0]
 
-		delete(newAnn, static.ChainAnnotationKey)
+		delete(newAnn, ctypes.ChainAnnotationKey)
 		if so.chain != nil {
 			chain, err = cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(so.chain))
 			if err != nil {
 				return nil, err
 			}
-			newAnn[static.ChainAnnotationKey] = string(so.chain)
+			newAnn[ctypes.ChainAnnotationKey] = string(so.chain)
 		}
 
 		newSig.cert = cert

--- a/pkg/oci/static/options.go
+++ b/pkg/oci/static/options.go
@@ -47,8 +47,8 @@ func makeOptions(opts ...Option) (*options, error) {
 	}
 
 	if o.Cert != nil {
-		o.Annotations[CertificateAnnotationKey] = string(o.Cert)
-		o.Annotations[ChainAnnotationKey] = string(o.Chain)
+		o.Annotations[ctypes.CertificateAnnotationKey] = string(o.Cert)
+		o.Annotations[ctypes.ChainAnnotationKey] = string(o.Chain)
 	}
 
 	if o.Bundle != nil {
@@ -56,7 +56,7 @@ func makeOptions(opts ...Option) (*options, error) {
 		if err != nil {
 			return nil, err
 		}
-		o.Annotations[BundleAnnotationKey] = string(b)
+		o.Annotations[ctypes.BundleAnnotationKey] = string(b)
 	}
 
 	return o, nil

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -24,14 +24,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/sigstore/cosign/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/pkg/oci"
+	ctypes "github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-)
-
-const (
-	SignatureAnnotationKey   = "dev.cosignproject.cosign/signature"
-	CertificateAnnotationKey = "dev.sigstore.cosign/certificate"
-	ChainAnnotationKey       = "dev.sigstore.cosign/chain"
-	BundleAnnotationKey      = "dev.sigstore.cosign/bundle"
 )
 
 // NewSignature constructs a new oci.Signature from the provided options.
@@ -70,7 +64,7 @@ func (l *staticLayer) Annotations() (map[string]string, error) {
 	for k, v := range l.opts.Annotations {
 		m[k] = v
 	}
-	m[SignatureAnnotationKey] = l.b64sig
+	m[ctypes.SignatureAnnotationKey] = l.b64sig
 	return m, nil
 }
 

--- a/pkg/types/annotations.go
+++ b/pkg/types/annotations.go
@@ -1,0 +1,30 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+const (
+	// The signature is base64-encoded and stored as an annotation on the
+	// layer, in the same descriptor.
+	SignatureAnnotationKey = "dev.cosignproject.cosign/signature"
+	// The certificate is stored as an annotation on the layer, in the same
+	// descriptor.
+	CertificateAnnotationKey = "dev.sigstore.cosign/certificate"
+	// The chain is stored as an annotation on the layer, in the same descriptor.
+	ChainAnnotationKey = "dev.sigstore.cosign/chain"
+	// Contains a JSON formatted bundle type, which can be used for offline
+	// verification.
+	BundleAnnotationKey = "dev.sigstore.cosign/bundle"
+)


### PR DESCRIPTION
Move the annotation keys to pkg/types to allow for referencing them
without pulling in a number of redundant dependencies.  Update all
internal users to use these new consts.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>

#### Release Note
```release-note
Annotation keys of the Cosign spec have been to pkg/types.
```

@dlorenc @imjasonh PTAL