### PR TITLE
add definition for artifact hub to verify the ownership

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,21 @@
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repositoryID: 0344601c-282a-4857-a852-d9207291ccfe
+owners:
+  - name: cpanato
+    email: ctadeu@gmail.com
+  - name: dlorenc
+    email: lorenc.d@gmail.com


### PR DESCRIPTION
#### Summary
- add initial artifact hub config to have verified ownership in artifacthub https://artifacthub.io/

We can review and add/remove others later if needed, I already have my user in artifacthub and part of the sigstore org for the other project, so adding myself, for now, to claim the ownership and configure correctly

#### Ticket Link
n/a
#### Release Note

```release-note
NONE
```
