### PR TITLE
Support deletion of ClusterImagePolicy

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -49,9 +49,10 @@ rules:
   #   resourceNames: ["clusterimagepolicies.cosigned.sigstore.dev"]
 
   # Allow reconciliation of the ClusterImagePolic CRDs.
+  # We need patch to update finalizers
   - apiGroups: ["cosigned.sigstore.dev"]
     resources: ["clusterimagepolicies"]
-    verbs: ["get", "list", "update", "watch"]
+    verbs: ["get", "list", "update", "watch", "patch"]
 
   # This is needed by k8schain to support fetching pull secrets attached to pod specs
   # or their service accounts.  If pull secrets aren't used, the "secrets" below can

--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy_test.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy_test.go
@@ -153,7 +153,7 @@ func TestReconcile(t *testing.T) {
 			makeDifferentConfigMap(),
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			makePatch(system.Namespace(), config.ImagePoliciesConfigName, replaceCIPPatch),
+			makePatch(replaceCIPPatch),
 		},
 	}, {
 		Name: "ClusterImagePolicy with glob and KMS key data, added as a patch",
@@ -176,7 +176,7 @@ func TestReconcile(t *testing.T) {
 			makeConfigMap(), // Make the existing configmap
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
-			makePatch(system.Namespace(), config.ImagePoliciesConfigName, addCIP2Patch),
+			makePatch(addCIP2Patch),
 		},
 	}, {
 		Name: "ClusterImagePolicy with glob and inline key data, already exists, deleted",
@@ -201,7 +201,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveFinalizers(system.Namespace(), cipName),
-			makePatch(system.Namespace(), config.ImagePoliciesConfigName, removeDataPatch),
+			makePatch(removeDataPatch),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", `Updated "test-cip" finalizers`),
@@ -229,7 +229,7 @@ func TestReconcile(t *testing.T) {
 		},
 		WantPatches: []clientgotesting.PatchActionImpl{
 			patchRemoveFinalizers(system.Namespace(), cipName2),
-			makePatch(system.Namespace(), config.ImagePoliciesConfigName, removeSingleEntryPatch),
+			makePatch(removeSingleEntryPatch),
 		},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "FinalizerUpdate", `Updated "test-cip-2" finalizers`),
@@ -292,12 +292,12 @@ func makeConfigMapWithTwoEntries() *corev1.ConfigMap {
 	}
 }
 
-func makePatch(namespace, name, patch string) clientgotesting.PatchActionImpl {
+func makePatch(patch string) clientgotesting.PatchActionImpl {
 	return clientgotesting.PatchActionImpl{
 		ActionImpl: clientgotesting.ActionImpl{
-			Namespace: namespace,
+			Namespace: system.Namespace(),
 		},
-		Name:  name,
+		Name:  config.ImagePoliciesConfigName,
 		Patch: []byte(patch),
 	}
 }

--- a/pkg/reconciler/clusterimagepolicy/controller.go
+++ b/pkg/reconciler/clusterimagepolicy/controller.go
@@ -36,6 +36,10 @@ import (
 	clusterimagepolicyreconciler "github.com/sigstore/cosign/pkg/client/injection/reconciler/cosigned/v1alpha1/clusterimagepolicy"
 )
 
+// This is what the default finalizer name is, but make it explicit so we can
+// use it in tests as well.
+const finalizerName = "clusterimagepolicies.cosigned.sigstore.dev"
+
 // NewController creates a Reconciler and returns the result of NewImpl.
 func NewController(
 	ctx context.Context,
@@ -57,7 +61,9 @@ func NewController(
 		configmaplister: nsConfigMapInformer.Lister(),
 		kubeclient:      kubeclient.Get(ctx),
 	}
-	impl := clusterimagepolicyreconciler.NewImpl(ctx, r)
+	impl := clusterimagepolicyreconciler.NewImpl(ctx, r, func(impl *controller.Impl) controller.Options {
+		return controller.Options{FinalizerName: finalizerName}
+	})
 	r.tracker = impl.Tracker
 
 	clusterimagepolicyInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))

--- a/pkg/reconciler/testing/v1alpha1/clusterimagepolicy.go
+++ b/pkg/reconciler/testing/v1alpha1/clusterimagepolicy.go
@@ -22,6 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const finalizerName = "clusterimagepolicies.cosigned.sigstore.dev"
+
 // ClusterImagePolicyOption enables further configuration of a ClusterImagePolicy.
 type ClusterImagePolicyOption func(*v1alpha1.ClusterImagePolicy)
 
@@ -48,4 +50,8 @@ func WithImagePattern(ip v1alpha1.ImagePattern) ClusterImagePolicyOption {
 	return func(cip *v1alpha1.ClusterImagePolicy) {
 		cip.Spec.Images = append(cip.Spec.Images, ip)
 	}
+}
+
+func WithFinalizer(cip *v1alpha1.ClusterImagePolicy) {
+	cip.Finalizers = []string{finalizerName}
 }


### PR DESCRIPTION
By removing them properly from the CM.

Fixes #1572 

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
