### PR TITLE
Don't lowercase input image refs, just fail

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -133,7 +133,7 @@ func SignCmd(ro *options.RootOptions, ko KeyOpts, regOpts options.RegistryOption
 	}
 
 	for _, inputImg := range imgs {
-		ref, err := name.ParseReference(strings.ToLower(inputImg))
+		ref, err := name.ParseReference(inputImg)
 		if err != nil {
 			return errors.Wrap(err, "parsing reference")
 		}


### PR DESCRIPTION
Reverts https://github.com/sigstore/cosign/pull/1409
Fixes https://github.com/sigstore/cosign/issues/1568

#### Summary

Lowercasing the input was supposed to help when the user's requested repo name included uppercase letters (e.g., ghcr.io/MyUser/CAPS-REPO), which isn't allowed. This unintentionally also lowercased the tag component, which is allowed to contain uppercase letters, and lowercasing them breaks the user's expectation.


#### Release Note

```release-note
Don't lowercase the input image ref, just fail if it includes uppercase characters
```
