### PR TITLE
Fix piping 'cosign verify' using fulcio/rekor

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -213,9 +213,9 @@ func PrintVerification(imgRef string, verified []oci.Signature, output string) {
 	case "text":
 		for _, sig := range verified {
 			if cert, err := sig.Cert(); err == nil && cert != nil {
-				fmt.Println("Certificate subject: ", sigs.CertSubject(cert))
+				fmt.Fprintln(os.Stderr, "Certificate subject: ", sigs.CertSubject(cert))
 				if issuerURL := sigs.CertIssuerExtension(cert); issuerURL != "" {
-					fmt.Println("Certificate issuer URL: ", issuerURL)
+					fmt.Fprintln(os.Stderr, "Certificate issuer URL: ", issuerURL)
 				}
 			}
 


### PR DESCRIPTION
#### Summary

Piping `cosign verify` with experimental mode is broken in `v1.6.0`.

```bash
$ COSIGN_EXPERIMENTAL=1 cosign verify-attestation ghcr.io/marcofranssen/slsa-workflow-examples-docker@sha256:44aeae57e33b680de437fb49a350adf157aeb5d5b5f4dcbb1103053bd9b415df | jq '.payload |= @base64d | .payload | fromjson | select(.predicateType == "https://spdx.dev/Document") | .predicate.Data | fromjson'

Verification for ghcr.io/marcofranssen/slsa-workflow-examples-docker@sha256:44aeae57e33b680de437fb49a350adf157aeb5d5b5f4dcbb1103053bd9b415df --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - Any certificates were verified against the Fulcio roots.
parse error: Invalid numeric literal at line 1, column 12
```

#### Release Note

```release-note
Fixes piping `cosign verify` to other commands in shell when using experimental mode
```
