### PR TITLE
feat: tree command utility

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -70,6 +70,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(Attach())
 	cmd.AddCommand(Attest())
 	cmd.AddCommand(Clean())
+	cmd.AddCommand(Tree())
 	cmd.AddCommand(Completion())
 	cmd.AddCommand(Copy())
 	cmd.AddCommand(Dockerfile())

--- a/cmd/cosign/cli/options/tree.go
+++ b/cmd/cosign/cli/options/tree.go
@@ -1,0 +1,28 @@
+// Copyright 2022 The Sigstore Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import "github.com/spf13/cobra"
+
+type TreeOptions struct {
+	Registry  RegistryOptions
+	CleanType string
+}
+
+var _ Interface = (*TreeOptions)(nil)
+
+func (c *TreeOptions) AddFlags(cmd *cobra.Command) {
+	c.Registry.AddFlags(cmd)
+}

--- a/cmd/cosign/cli/tree.go
+++ b/cmd/cosign/cli/tree.go
@@ -1,0 +1,167 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
+)
+
+func Tree() *cobra.Command {
+	c := &options.TreeOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "tree",
+		Short:   "Display supply chain security related artifacts for an image such as signatures, SBOMs and attestations",
+		Example: "  cosign tree <IMAGE>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return TreeCmd(cmd.Context(), c.Registry, args[0])
+		},
+	}
+
+	c.AddFlags(cmd)
+	return cmd
+}
+
+const (
+	SignatureTagSuffix   = ".sig"
+	SBOMTagSuffix        = ".sbom"
+	AttestationTagSuffix = ".att"
+)
+
+func TreeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef string) error {
+	scsaMap := map[name.Tag][]v1.Layer{}
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return err
+	}
+
+	remoteOpts, err := regOpts.ClientOpts(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(os.Stdout, "📦 Supply Chain Security Related artifacts for an image: %s\n", ref.String())
+
+	simg, err := ociremote.SignedEntity(ref, remoteOpts...)
+	if err != nil {
+		return err
+	}
+
+	registryClientOpts := regOpts.GetRegistryClientOpts(ctx)
+
+	attRef, err := ociremote.AttestationTag(ref, ociremote.WithRemoteOptions(registryClientOpts...))
+	if err != nil {
+		return err
+	}
+
+	atts, err := simg.Attestations()
+	var attLayers []v1.Layer
+	if err == nil {
+		layers, err := atts.Layers()
+		if err != nil {
+			return err
+		}
+		attLayers = append(attLayers, layers...)
+	}
+
+	scsaMap[attRef] = attLayers
+
+	sigRef, err := ociremote.SignatureTag(ref, ociremote.WithRemoteOptions(registryClientOpts...))
+	if err != nil {
+		return err
+	}
+
+	sigs, err := simg.Signatures()
+	var sigLayers []v1.Layer
+	if err == nil {
+		layers, err := sigs.Layers()
+		if err != nil {
+			return err
+		}
+		sigLayers = append(sigLayers, layers...)
+	}
+
+	scsaMap[sigRef] = sigLayers
+
+	sbomRef, err := ociremote.SBOMTag(ref, ociremote.WithRemoteOptions(registryClientOpts...))
+	if err != nil {
+		return err
+	}
+
+	sbombs, err := simg.Attachment("sbom")
+	var sbomLayers []v1.Layer
+	if err == nil {
+		layers, err := sbombs.Layers()
+		if err != nil {
+			return err
+		}
+		sbomLayers = append(sbomLayers, layers...)
+	}
+
+	scsaMap[sbomRef] = sbomLayers
+
+	if len(scsaMap) == 0 {
+		fmt.Fprintf(os.Stdout, "No Supply Chain Security Related Artifacts artifacts found for image %s\n, start creating one with simply running"+
+			"$ COSIGN_EXPERIMENTAL=1 cosign sign <img>", ref.String())
+		return nil
+	}
+
+	for t, k := range scsaMap {
+		switch {
+		case strings.HasSuffix(t.TagStr(), SignatureTagSuffix):
+			fmt.Fprintf(os.Stdout, "└── 🔐 Signatures for an image tag: %s\n", t.String())
+		case strings.HasSuffix(t.TagStr(), SBOMTagSuffix):
+			fmt.Fprintf(os.Stdout, "└── 📦 SBOMs for an image tag: %s\n", t.String())
+		case strings.HasSuffix(t.TagStr(), AttestationTagSuffix):
+			fmt.Fprintf(os.Stdout, "└── 💾 Attestations for an image tag: %s\n", t.String())
+		}
+
+		if err := printLayers(k); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func printLayers(layers []v1.Layer) error {
+	for i, l := range layers {
+		last := i == len(layers)-1
+		var sym string
+		if last {
+			sym = "   └──"
+		} else {
+			sym = "   ├──"
+		}
+		digest, err := l.Digest()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("%s 🍒 %s\n", sym, digest)
+	}
+	return nil
+}

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -34,6 +34,7 @@
 * [cosign save](cosign_save.md)	 - Save the container image and associated signatures to disk at the specified directory.
 * [cosign sign](cosign_sign.md)	 - Sign the supplied container image.
 * [cosign sign-blob](cosign_sign-blob.md)	 - Sign the supplied blob, outputting the base64-encoded signature to stdout.
+* [cosign tree](cosign_tree.md)	 - Display supply chain security related artifacts for an image such as signatures, SBOMs and attestations
 * [cosign triangulate](cosign_triangulate.md)	 - Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
 * [cosign upload](cosign_upload.md)	 - Provides utilities for uploading artifacts to a registry
 * [cosign verify](cosign_verify.md)	 - Verify a signature on the supplied container image

--- a/doc/cosign_tree.md
+++ b/doc/cosign_tree.md
@@ -1,0 +1,35 @@
+## cosign tree
+
+Display supply chain security related artifacts for an image such as signatures, SBOMs and attestations
+
+```
+cosign tree [flags]
+```
+
+### Examples
+
+```
+  cosign tree <IMAGE>
+```
+
+### Options
+
+```
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -h, --help                                                                                     help for tree
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign](cosign.md)	 - 
+

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -56,12 +56,6 @@ type AttestationPayload struct {
 }
 
 const (
-	SignatureTagSuffix   = ".sig"
-	SBOMTagSuffix        = ".sbom"
-	AttestationTagSuffix = ".att"
-)
-
-const (
 	Signature   = "signature"
 	SBOM        = "sbom"
 	Attestation = "attestation"


### PR DESCRIPTION
Fixes #1569

Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

![Screen Shot 2022-03-14 at 12 14 11](https://user-images.githubusercontent.com/16693043/158141251-d15811b8-2f3d-4216-85be-3e77fd79f955.png)

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->

#### Summary
<!--
A description of what this pull request does, as well as QA test steps (if applicable and if not already added to the Jira ticket).
-->

This PR will display the Supply Chain Security related artifacts for an image including Signatures, Attestations and SBOMs

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #1569 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to a Mattermost instance administrator (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
feat: tree command utility
```
