### PR TITLE
Init entity from ociremote when signing a digest ref

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -45,7 +45,6 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign/pkcs11key"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
 	"github.com/sigstore/cosign/pkg/oci"
-	ociempty "github.com/sigstore/cosign/pkg/oci/empty"
 	"github.com/sigstore/cosign/pkg/oci/mutate"
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 	"github.com/sigstore/cosign/pkg/oci/walk"
@@ -147,7 +146,7 @@ func SignCmd(ro *options.RootOptions, ko KeyOpts, regOpts options.RegistryOption
 		}
 
 		if digest, ok := ref.(name.Digest); ok && !recursive {
-			se, err := ociempty.SignedImage(ref)
+			se, err := ociremote.SignedEntity(ref, opts...)
 			if err != nil {
 				return errors.Wrap(err, "accessing image")
 			}


### PR DESCRIPTION
#### Summary

This PR modifies the object used to seed the SignedEntity used when signing a digest reference to fix a bug where cosign would wipe out all signatures from the manifest (and thus, not garbage-collecting previous signature layers) when signing a digest reference.

Before, the entity was created from a `ociempty.SignedImage`. This caused cosign to create a new manifest on every invocation of `cosign sign image@sha....` , effectively wiping any previous signatures attached to the image.

Now, cosign el init the entity from a `ociremote.SignedEntity` which will append new signatures to any existing ones.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>

#### Ticket Link

#### Release Note
```release-note
Fixed a bug where cosign would always create a new sig manifest when signing a digest reference, preventing it from attaching more than one signature.
```
