### PR TITLE
push latest tag when building a release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ env:
   - CGO_ENABLED=1
   - DOCKER_CLI_EXPERIMENTAL=enabled
   - COSIGN_EXPERIMENTAL=true
+  - LATEST_TAG="--tags latest"
 
 # Prevents parallel builds from stepping on each others toes downloading modules
 before:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ KO_PREFIX ?= gcr.io/projectsigstore
 export KO_DOCKER_REPO=$(KO_PREFIX)
 GHCR_PREFIX ?= ghcr.io/sigstore/cosign
 COSIGNED_YAML ?= cosign-$(GIT_TAG).yaml
+LATEST_TAG ?=
 
 .PHONY: all lint test clean cosign cross
 all: cosign
@@ -146,20 +147,20 @@ ko:
 	$(create_kocache_path)
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) ko build --base-import-paths \
-		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) $(LATEST_TAG)\
 		$(ARTIFACT_HUB_LABELS) \
 		github.com/sigstore/cosign/cmd/cosign
 
 	# cosigned
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KO_DOCKER_REPO=$(KO_PREFIX)/cosigned ko resolve --bare \
-		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) $(LATEST_TAG) \
 		--filename config/ > $(COSIGNED_YAML)
 
 	# sget
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) ko build --base-import-paths \
-		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) \
+		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH) $(LATEST_TAG)\
 		$(ARTIFACT_HUB_LABELS) \
 		github.com/sigstore/cosign/cmd/sget
 

--- a/release/release.mk
+++ b/release/release.mk
@@ -68,4 +68,3 @@ copy-sget-signed-release-to-ghcr:
 
 .PHONY: copy-signed-release-to-ghcr
 copy-signed-release-to-ghcr: copy-cosign-signed-release-to-ghcr copy-cosigned-signed-release-to-ghcr copy-sget-signed-release-to-ghcr
-	


### PR DESCRIPTION
#### Summary
- push latest tag when building a release

this will be good also to set the `latest` tag in the artifacthub

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
