### PR TITLE
Add extra label and change the latest tag to unstable for non tagged releases

### DIFF
--- a/.github/workflows/github-oidc.yaml
+++ b/.github/workflows/github-oidc.yaml
@@ -29,7 +29,7 @@ jobs:
     env:
       COSIGN_EXPERIMENTAL: "true"
       GIT_HASH: ${{ github.sha }}
-      GIT_VERSION: latest
+      GIT_VERSION: unstable
       GITHUB_RUN_ID: ${{ github.run_id }}
       GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
       KO_PREFIX: ghcr.io/${{ github.repository }}

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ clean:
 
 
 KOCACHE_PATH=/tmp/ko
-ARTIFACT_HUB_LABELS=--image-label io.artifacthub.package.readme-url=https://raw.githubusercontent.com/sigstore/cosign/main/README.md --image-label io.artifacthub.package.logo-url=https://raw.githubusercontent.com/sigstore/cosign/main/images/logo.svg --image-label io.artifacthub.package.license=Apache-2.0 --image-label io.artifacthub.package.vendor=sigstore --image-label io.artifacthub.package.version=0.1.0 --image-label io.artifacthub.package.name=cosign --image-label org.opencontainers.image.created=$(BUILD_DATE) --image-label org.opencontainers.image.description='Container signing verification and storage in an OCI registry --image-label io.artifacthub.package.alternative-locations="oci://ghcr.io/sigstore/cosign/cosign"'
+ARTIFACT_HUB_LABELS=--image-label io.artifacthub.package.readme-url=https://raw.githubusercontent.com/sigstore/cosign/main/README.md --image-label io.artifacthub.package.logo-url=https://raw.githubusercontent.com/sigstore/cosign/main/images/logo.svg --image-label io.artifacthub.package.license=Apache-2.0 --image-label io.artifacthub.package.vendor=sigstore --image-label io.artifacthub.package.version=0.1.0 --image-label io.artifacthub.package.name=cosign --image-label org.opencontainers.image.created=$(BUILD_DATE) --image-label org.opencontainers.image.description='Container signing verification and storage in an OCI registry' --image-label io.artifacthub.package.alternative-locations="oci://ghcr.io/sigstore/cosign/cosign"
 
 define create_kocache_path
   mkdir -p $(KOCACHE_PATH)

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ clean:
 
 
 KOCACHE_PATH=/tmp/ko
-ARTIFACT_HUB_LABELS=--image-label io.artifacthub.package.readme-url=https://raw.githubusercontent.com/sigstore/cosign/main/README.md --image-label io.artifacthub.package.logo-url=https://raw.githubusercontent.com/sigstore/cosign/main/images/logo.svg --image-label io.artifacthub.package.license=Apache-2.0 --image-label io.artifacthub.package.vendor=sigstore --image-label io.artifacthub.package.version=0.1.0 --image-label io.artifacthub.package.name=cosign --image-label org.opencontainers.image.created=$(BUILD_DATE) --image-label org.opencontainers.image.description='Container signing verification and storage in an OCI registry'
+ARTIFACT_HUB_LABELS=--image-label io.artifacthub.package.readme-url=https://raw.githubusercontent.com/sigstore/cosign/main/README.md --image-label io.artifacthub.package.logo-url=https://raw.githubusercontent.com/sigstore/cosign/main/images/logo.svg --image-label io.artifacthub.package.license=Apache-2.0 --image-label io.artifacthub.package.vendor=sigstore --image-label io.artifacthub.package.version=0.1.0 --image-label io.artifacthub.package.name=cosign --image-label org.opencontainers.image.created=$(BUILD_DATE) --image-label org.opencontainers.image.description='Container signing verification and storage in an OCI registry --image-label io.artifacthub.package.alternative-locations="oci://ghcr.io/sigstore/cosign/cosign"'
 
 define create_kocache_path
   mkdir -p $(KOCACHE_PATH)


### PR DESCRIPTION
#### Summary
- adding extra label to the container to be show in the artifact hub another location that users can consume the image
- also rename the tag that we push in CI to be `unstable` instead of `latest`, we will use the latest tag when releasing a new version (xref: https://github.com/sigstore/cosign/pull/1636)


#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
