### PR TITLE
Document Elastic container registry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Today, `cosign` has been tested and works against the following registries:
 * Sonatype Nexus Container Registry
 * Alibaba Cloud Container Registry
 * Red Hat Quay Container Registry 3.6+ / Red Hat quay.io
+* Elastic Container Registry
 
 We aim for wide registry support. To `sign` images in registries which do not yet fully support [OCI media types](https://github.com/sigstore/cosign/blob/main/SPEC.md#object-types), one may need to use `COSIGN_DOCKER_MEDIA_TYPES` to fall back to legacy equivalents. For example:
 ```shell


### PR DESCRIPTION
#### Summary

`cosign` has been tested and works against the Elastic Container
registry (docker.elastic.co)

```
cosign verify --key https://ela.st/mgreau-public-key docker.elastic.co/experimental/cosign-test
```

This commit updates the README to add the Elastic container registry to
the list of supported registries.

Signed-off-by: mgreau <greaumaxime@gmail.com>

