### PR TITLE
Don't fail open in VerifyBundle

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -757,13 +757,14 @@ func VerifyBundle(ctx context.Context, sig oci.Signature) (bool, error) {
 	cert, err := sig.Cert()
 	if err != nil {
 		return false, err
-	} else if cert == nil {
-		return true, nil
 	}
 
-	// verify the cert against the integrated time
-	if err := CheckExpiry(cert, time.Unix(bundle.Payload.IntegratedTime, 0)); err != nil {
-		return false, errors.Wrap(err, "checking expiry on cert")
+	if cert != nil {
+		// Verify the cert against the integrated time.
+		// Note that if the caller requires the certificate to be present, it has to ensure that itself.
+		if err := CheckExpiry(cert, time.Unix(bundle.Payload.IntegratedTime, 0)); err != nil {
+			return false, errors.Wrap(err, "checking expiry on cert")
+		}
 	}
 
 	payload, err := sig.Payload()


### PR DESCRIPTION
#### Summary
Remove a “fail-open” code path in `VerifyBundle`

#### Ticket Link

#### Release Note
NONE

---

This code path succeeding and bypassing all future checks worries me greatly, and I can't find any documentation nor explanation for why that is necessary, so let's close this avenue and see what breaks.

