### PR TITLE
Prompt user before running `cosign clean`

### DIFF
--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/pkg/cosign"
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 )
 
@@ -46,6 +47,14 @@ func Clean() *cobra.Command {
 }
 
 func CleanCmd(ctx context.Context, regOpts options.RegistryOptions, cleanType, imageRef string) error {
+	ok, err := cosign.ConfirmPrompt("WARNING: this will remove all signatures from the image")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return err

--- a/cmd/cosign/cli/options/clean.go
+++ b/cmd/cosign/cli/options/clean.go
@@ -19,6 +19,7 @@ import "github.com/spf13/cobra"
 type CleanOptions struct {
 	Registry  RegistryOptions
 	CleanType string
+	Force     bool
 }
 
 var _ Interface = (*CleanOptions)(nil)
@@ -26,4 +27,5 @@ var _ Interface = (*CleanOptions)(nil)
 func (c *CleanOptions) AddFlags(cmd *cobra.Command) {
 	c.Registry.AddFlags(cmd)
 	cmd.Flags().StringVarP(&c.CleanType, "type", "", "all", "a type of clean: <signature|attestation|sbom|all> (default: all)")
+	cmd.Flags().BoolVarP(&c.Force, "force", "f", false, "do not prompt for confirmation")
 }

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -17,6 +17,7 @@ cosign clean [flags]
 ```
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+  -f, --force                                                                                    do not prompt for confirmation
   -h, --help                                                                                     help for clean
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --type string                                                                              a type of clean: <signature|attestation|sbom|all> (default: all) (default "all")

--- a/pkg/cosign/common.go
+++ b/pkg/cosign/common.go
@@ -16,8 +16,10 @@
 package cosign
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/term"
@@ -30,6 +32,16 @@ func FileExists(filename string) bool {
 		return false
 	}
 	return !info.IsDir()
+}
+
+func ConfirmPrompt(msg string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "%s\n\nAre you sure you want to continue? [Y/n]: ", msg)
+	reader := bufio.NewReader(os.Stdin)
+	r, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	return strings.Trim(r, "\n") == "Y", nil
 }
 
 func GetPassFromTerm(confirm bool) ([]byte, error) {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -168,7 +168,7 @@ func TestSignVerifyClean(t *testing.T) {
 	must(download.SignatureCmd(ctx, options.RegistryOptions{}, imgName), t)
 
 	// Now clean signature from the given image
-	must(cli.CleanCmd(ctx, options.RegistryOptions{}, "all", imgName), t)
+	must(cli.CleanCmd(ctx, options.RegistryOptions{}, "all", imgName, true), t)
 
 	// It doesn't work
 	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
@@ -197,7 +197,7 @@ func TestImportSignVerifyClean(t *testing.T) {
 	must(download.SignatureCmd(ctx, options.RegistryOptions{}, imgName), t)
 
 	// Now clean signature from the given image
-	must(cli.CleanCmd(ctx, options.RegistryOptions{}, "all", imgName), t)
+	must(cli.CleanCmd(ctx, options.RegistryOptions{}, "all", imgName, true), t)
 
 	// It doesn't work
 	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)


### PR DESCRIPTION
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

fixes https://github.com/sigstore/cosign/issues/1452

```release-note
Prompt user before running `cosign clean`
```
