### PR TITLE
Add support for cert and cert chain flags with PKCS11 tokens

### DIFF
--- a/cmd/cosign/cli/sign/sign_test.go
+++ b/cmd/cosign/cli/sign/sign_test.go
@@ -178,6 +178,11 @@ func Test_signerFromKeyRefFailure(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "unable to validate certificate chain") {
 		t.Fatalf("expected chain verification error, got %v", err)
 	}
+	// Certificate chain specified without certificate
+	_, err = signerFromKeyRef(ctx, "", chainFile2, keyFile, pass("foo"))
+	if err == nil || !strings.Contains(err.Error(), "no leaf certificate found or provided while specifying chain") {
+		t.Fatalf("expected no leaf error, got %v", err)
+	}
 }
 
 func Test_signerFromKeyRefFailureEmptyChainFile(t *testing.T) {


### PR DESCRIPTION
Currently, Cosign attempts to automatically extract the certificate from
the PKCS11 token, and there's no option to provide your own certificate
chain or different certificate. Now, Cosign will respect those flags.

Note that the chain must be valid, and the public key from the token
must match the provided certificate from either the token or flag.

Note that if a cert flag is specified, it will override the certificate
fetched from the PKCS11 token if one is present, and log a warning.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Ref #1554

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added support for cert and cert-chain flags for PKCS11 tokens
```
