### PR TITLE
Fix relative paths in Gitub OIDC blob test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@
 bin*
 dist/
 
-test/verify-experimental*
+**verify-experimental*

--- a/test/ci.mk
+++ b/test/ci.mk
@@ -34,4 +34,4 @@ sign-keyless-container: ko sign-keyless-cosign sign-keyless-cosigned sign-keyles
 
 .PHONY: sign-blob-experimental
 sign-blob-experimental:
-	./sign_blob_test.sh
+	./test/sign_blob_test.sh

--- a/test/sign_blob_test.sh
+++ b/test/sign_blob_test.sh
@@ -35,15 +35,19 @@ cosign verify-blob -signature $SIG $BLOB
 
 # Now, sign the blob with a self-signed certificate and upload to rekor
 SIG_FILE=verify-experimental-signature
-openssl dgst -sha256 -sign testdata/test_blob_private_key -out $SIG_FILE $BLOB
-openssl dgst -sha256 -verify testdata/test_blob_public_key -signature $SIG_FILE $BLOB
+PRIV_KEY=./test/testdata/test_blob_private_key
+PUB_KEY=./test/testdata/test_blob_public_key
+CERT_FILE=./test/testdata/test_blob_cert.pem
+
+openssl dgst -sha256 -sign $PRIV_KEY -out $SIG_FILE $BLOB
+openssl dgst -sha256 -verify $PUB_KEY -signature $SIG_FILE $BLOB
 
 SHA256HASH=$(sha256sum $BLOB |  cut -f1 -d' ')
 
 SIGNATURE=$(cat $SIG_FILE | base64)
 echo "Signature: $SIGNATURE"
 
-CERT=$(cat testdata/test_blob_cert.pem | base64)
+CERT=$(cat $CERT_FILE | base64)
 echo "Cert: $CERT"
 
 JSON_BODY_FILE=verify-experimental-blob-http-body.json


### PR DESCRIPTION
should fix the github oidc action which is [broken](https://github.com/sigstore/cosign/actions/runs/2055532663) due to #1673 

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
