### PR TITLE
Use cosign @ HEAD for Github OIDC sign blob test

### DIFF
--- a/.github/workflows/github-oidc.yaml
+++ b/.github/workflows/github-oidc.yaml
@@ -53,4 +53,5 @@ jobs:
       - name: Build and sign a blob
         run: |
           set -e
+          make cosign
           make sign-blob-experimental

--- a/test/sign_blob_test.sh
+++ b/test/sign_blob_test.sh
@@ -22,16 +22,18 @@
 set -ex
 
 export COSIGN_EXPERIMENTAL=1
+COSIGN_CLI=./cosign
 
 echo "Creating a unique blob"
 BLOB=verify-experimental-blob
 date > $BLOB
+cat $BLOB
 
 echo "Sign the blob with cosign first and upload to rekor"
-SIG=$(cosign sign-blob $BLOB)
+SIG=$($COSIGN_CLI sign-blob $BLOB)
 
 echo "Verifying ..."
-cosign verify-blob -signature $SIG $BLOB
+$COSIGN_CLI verify-blob -signature $SIG $BLOB
 
 # Now, sign the blob with a self-signed certificate and upload to rekor
 SIG_FILE=verify-experimental-signature
@@ -76,4 +78,4 @@ curl -X POST https://rekor.sigstore.dev/api/v1/log/entries -H 'Content-Type: app
 
 # Verifying should still work
 echo "Verifying ..."
-cosign verify-blob --signature $SIG $BLOB
+$COSIGN_CLI verify-blob --signature $SIG $BLOB


### PR DESCRIPTION
github oidc run is still [failing](https://github.com/sigstore/cosign/actions/runs/2055700698) because it doesn't install cosign @ HEAD, so it doesn't have fix we merged today.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
