### PR TITLE
Support in-toto payloadType in verify-attestation

### DIFF
--- a/cmd/cosign/cli/options/predicate.go
+++ b/cmd/cosign/cli/options/predicate.go
@@ -33,6 +33,7 @@ const (
 	PredicateSPDX   = "spdx"
 	PredicateLink   = "link"
 	PredicateVuln   = "vuln"
+	PredicateInToto = "intoto"
 )
 
 // PredicateTypeMap is the mapping between the predicate `type` option to predicate URI.
@@ -42,6 +43,7 @@ var PredicateTypeMap = map[string]string{
 	PredicateSPDX:   in_toto.PredicateSPDX,
 	PredicateLink:   in_toto.PredicateLinkV1,
 	PredicateVuln:   attestation.CosignVulnProvenanceV01,
+	PredicateInToto: in_toto.PayloadType,
 }
 
 // PredicateOptions is the wrapper for predicate related options.

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -259,6 +259,15 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 				if err != nil {
 					return fmt.Errorf("error when generating SPDXStatement: %w", err)
 				}
+			case options.PredicateInToto:
+				var statement in_toto.Statement
+				if err := json.Unmarshal(decodedPayload, &statement); err != nil {
+					return fmt.Errorf("unmarshal in_toto.Statement: %w", err)
+				}
+				payload, err = json.Marshal(statement)
+				if err != nil {
+					return fmt.Errorf("error when generating in_toto.Statement: %w", err)
+				}
 			}
 
 			if len(cuePolicies) > 0 {


### PR DESCRIPTION
#### Summary
Adds support for the in-toto (`application/vnd.in-toto+json`) DSSE payload type in verify-attestation subcommand.

For example, verifying that against a CUE policy:

```sh
$ cosign verify-attestation docker.io/zregvart/blank:latest \
  --key cosign.pub \
  --policy policy-test.cue \
  --type intoto
```

where `policy-test.cue` is:

```cue
predicate: passed: true
```

Signed-off-by: Zoran Regvart <zoran@regvart.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->


<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #1679

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Support for `--policy intoto` in `cosign verify-attestation`
```
