### PR TITLE
change file_name_template to PackageName

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -243,7 +243,7 @@ signs:
 nfpms:
   - id: cosign
     package_name: cosign
-    file_name_template: "{{ .ConventionalFileName }}"
+    file_name_template: "{{ .PackageName }}"
     vendor: Sigstore
     homepage: https://sigstore.dev
     maintainer: Sigstore Authors 86837369+sigstore-bot@users.noreply.github.com


### PR DESCRIPTION
Signed-off-by: James Strong <strong.james.e@gmail.com>

#### Summary

Change NFPM artifacts names to match package_name


#### Ticket Link

  Fixes https://github.com/sigstore/cosign/issues/1643


#### Release Note

```release-note
Update Change NFPM artifacts names to match package_name, ie `cosign` and not `cosign-linux-amd64`
```
