### PR TITLE
cosign clean: Don't log failure if the registry responds with 404

### DIFF
--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -17,6 +17,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -95,7 +96,8 @@ func CleanCmd(ctx context.Context, regOpts options.RegistryOptions, cleanType, i
 
 	for _, t := range cleanTags {
 		if err := remote.Delete(t, remoteOpts...); err != nil {
-			if terr, ok := err.(*transport.Error); ok && terr.StatusCode == http.StatusNotFound {
+			var te *transport.Error
+			if errors.As(err, &te) && te.StatusCode == http.StatusNotFound {
 				// If the tag doesn't exist, some registries may
 				// respond with a 404, which shouldn't be considered an
 				// error.


### PR DESCRIPTION
`remote.Delete` expects either a `200` or `202`, but if the tag doesn't exist
in the registry, some registries (seemingly ECR, maybe others) respond
with a `404`, which just means there was nothing to delete.

This change also refactors logging to only log if the deletion was
successful, to avoid confusion if we can tell the tag didn't exist
before cleaning.

Signed-off-by: Jason Hall <jasonhall@redhat.com>

Fixes https://github.com/sigstore/cosign/issues/1684

```release-note
cosign clean doesn't log failure to delete a non-existent tag when the registry responds with a 404.
```
