### PR TITLE
verify: remove extra calls to rekor for verify and verify-blob

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -23,6 +23,7 @@ import (
 	_ "crypto/sha256" // for `crypto.SHA256`
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -330,7 +331,7 @@ func verifyRekorEntry(ctx context.Context, ko sign.KeyOpts, e *models.LogEntryAn
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %q index: %d\n", uuid, *e.Verification.InclusionProof.LogIndex)
+	fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %s index: %d\n", hex.EncodeToString(uuid), *e.Verification.InclusionProof.LogIndex)
 	if cert == nil {
 		return nil
 	}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -176,7 +176,7 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, certEmail, cer
 	}
 
 	// verify the rekor entry
-	if err := verifyRekorEntry(ctx, ko, verifier, cert, b64sig, blobBytes); err != nil {
+	if err := verifyRekorEntry(ctx, ko, nil, verifier, cert, b64sig, blobBytes); err != nil {
 		return err
 	}
 
@@ -217,7 +217,7 @@ func verifySigByUUID(ctx context.Context, ko sign.KeyOpts, rClient *client.Rekor
 		}
 
 		// verify the rekor entry
-		if err := verifyRekorEntry(ctx, ko, verifier, cert, b64sig, blobBytes); err != nil {
+		if err := verifyRekorEntry(ctx, ko, tlogEntry, verifier, cert, b64sig, blobBytes); err != nil {
 			continue
 		}
 		validSigExists = true
@@ -284,7 +284,7 @@ func payloadBytes(blobRef string) ([]byte, error) {
 	return blobBytes, nil
 }
 
-func verifyRekorEntry(ctx context.Context, ko sign.KeyOpts, pubKey signature.Verifier, cert *x509.Certificate, b64sig string, blobBytes []byte) error {
+func verifyRekorEntry(ctx context.Context, ko sign.KeyOpts, e *models.LogEntryAnon, pubKey signature.Verifier, cert *x509.Certificate, b64sig string, blobBytes []byte) error {
 	// If we have a bundle with a rekor entry, let's first try to verify offline
 	if ko.BundlePath != "" {
 		if err := verifyRekorBundle(ctx, ko.BundlePath, cert); err == nil {
@@ -300,33 +300,41 @@ func verifyRekorEntry(ctx context.Context, ko sign.KeyOpts, pubKey signature.Ver
 	if err != nil {
 		return err
 	}
-	var pubBytes []byte
-	if pubKey != nil {
-		pubBytes, err = sigs.PublicKeyPem(pubKey, signatureoptions.WithContext(ctx))
+	// Only fetch from rekor tlog if we don't already have the entry.
+	if e == nil {
+		var pubBytes []byte
+		if pubKey != nil {
+			pubBytes, err = sigs.PublicKeyPem(pubKey, signatureoptions.WithContext(ctx))
+			if err != nil {
+				return err
+			}
+		}
+		if cert != nil {
+			pubBytes, err = cryptoutils.MarshalCertificateToPEM(cert)
+			if err != nil {
+				return err
+			}
+		}
+		e, err = cosign.FindTlogEntry(ctx, rekorClient, b64sig, blobBytes, pubBytes)
 		if err != nil {
 			return err
 		}
 	}
-	if cert != nil {
-		pubBytes, err = cryptoutils.MarshalCertificateToPEM(cert)
-		if err != nil {
-			return err
-		}
+
+	if err := cosign.VerifyTLogEntry(ctx, rekorClient, e); err != nil {
+		return nil
 	}
-	uuid, index, err := cosign.FindTlogEntry(ctx, rekorClient, b64sig, blobBytes, pubBytes)
+
+	uuid, err := cosign.ComputeLeafHash(e)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %q index: %d\n", uuid, index)
+
+	fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %q index: %d\n", uuid, *e.Verification.InclusionProof.LogIndex)
 	if cert == nil {
 		return nil
 	}
 	// if we have a cert, we should check expiry
-	// The IntegratedTime verified in VerifyTlog
-	e, err := cosign.GetTlogEntry(ctx, rekorClient, uuid)
-	if err != nil {
-		return err
-	}
 	return cosign.CheckExpiry(cert, time.Unix(*e.IntegratedTime, 0))
 }
 

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -214,7 +214,7 @@ func tlogValidatePublicKey(ctx context.Context, rekorClient *client.Rekor, pub c
 	if err != nil {
 		return err
 	}
-	_, _, err = FindTlogEntry(ctx, rekorClient, b64sig, payload, pemBytes)
+	_, err = FindTlogEntry(ctx, rekorClient, b64sig, payload, pemBytes)
 	return err
 }
 
@@ -235,16 +235,14 @@ func tlogValidateCertificate(ctx context.Context, rekorClient *client.Rekor, sig
 	if err != nil {
 		return err
 	}
-	uuid, _, err := FindTlogEntry(ctx, rekorClient, b64sig, payload, pemBytes)
+	e, err := FindTlogEntry(ctx, rekorClient, b64sig, payload, pemBytes)
 	if err != nil {
+		return err
+	}
+	if err := VerifyTLogEntry(ctx, rekorClient, e); err != nil {
 		return err
 	}
 	// if we have a cert, we should check expiry
-	// The IntegratedTime verified in VerifyTlog
-	e, err := GetTlogEntry(ctx, rekorClient, uuid)
-	if err != nil {
-		return err
-	}
 	return CheckExpiry(cert, time.Unix(*e.IntegratedTime, 0))
 }
 


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
Removes extra calls to Rekor during verification:
1) When verifying a blob, we retrieve the entry UUIDs (by an artifact hash search), and then call `verifyRekorEntry`, which then takes the (cert, pubkey, artifact) and makes a call to rekor to get the entry. Instead, we pass the entry since we already have it.

2) Distangles VerifyTLogEntry from inside of FindTlogEntry. Users can call this directly. This means that we don't need to `FindTlogEntry` to verify it if we already have it, which saves the call from (1).

3) In both `verify` and `verify-blob`, we call `verifyRekorEntry`, which has ANOTHER call to `GetTlogEntry` after `FindTlogEntry` to get the actual entry, we already got it! Refactored `FindTlogEntry` to give you back the... entry.

4) Move the UUID verification into functions that are asking for an entry by UUID (e.g. when you get or find an entry)

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
