### PR TITLE
Fix incorrect unmarshalling of SCT response

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
@@ -91,13 +91,17 @@ func verifySCT(ctx context.Context, certPEM, rawSCT []byte) error {
 	if err != nil {
 		return err
 	}
-	var sct ct.SignedCertificateTimestamp
-	if err := json.Unmarshal(rawSCT, &sct); err != nil {
+	var addChainResp ct.AddChainResponse
+	if err := json.Unmarshal(rawSCT, &addChainResp); err != nil {
 		return errors.Wrap(err, "unmarshal")
+	}
+	sct, err := addChainResp.ToSignedCertificateTimestamp()
+	if err != nil {
+		return err
 	}
 	var verifySctErr error
 	for pubKey, status := range pubKeys {
-		verifySctErr = ctutil.VerifySCT(pubKey, []*ctx509.Certificate{cert}, &sct, false)
+		verifySctErr = ctutil.VerifySCT(pubKey, []*ctx509.Certificate{cert}, sct, false)
 		// Exit after successful verification of the SCT
 		if verifySctErr == nil {
 			if status != tuf.Active {


### PR DESCRIPTION
Unmarshalling directly to the SCT struct results in an invalid log ID.
Instead we should unmarshal to the AddChainResponse struct and then
convert that to an SCT struct. Note that the AddChainResponse struct
matches the custom CertChainResponse struct in Fulcio.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
