### PR TITLE
Make CLI flag for OIDC client secret take a path

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -59,6 +59,10 @@ func Attest() *cobra.Command {
 
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			oidcClientSecret, err := o.OIDC.ClientSecret()
+			if err != nil {
+				return err
+			}
 			ko := sign.KeyOpts{
 				KeyRef:                   o.Key,
 				PassFunc:                 generate.GetPass,
@@ -70,7 +74,7 @@ func Attest() *cobra.Command {
 				RekorURL:                 o.Rekor.URL,
 				OIDCIssuer:               o.OIDC.Issuer,
 				OIDCClientID:             o.OIDC.ClientID,
-				OIDCClientSecret:         o.OIDC.ClientSecret,
+				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 			}
 			for _, img := range args {

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -175,6 +175,10 @@ func signPolicy() *cobra.Command {
 			}
 
 			// Get Fulcio signer
+			oidcClientSecret, err := o.OIDC.ClientSecret()
+			if err != nil {
+				return err
+			}
 			sv, err := sign.SignerFromKeyOpts(ctx, "", "", sign.KeyOpts{
 				FulcioURL:                o.Fulcio.URL,
 				IDToken:                  o.Fulcio.IdentityToken,
@@ -182,7 +186,7 @@ func signPolicy() *cobra.Command {
 				RekorURL:                 o.Rekor.URL,
 				OIDCIssuer:               o.OIDC.Issuer,
 				OIDCClientID:             o.OIDC.ClientID,
-				OIDCClientSecret:         o.OIDC.ClientSecret,
+				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 			})
 			if err != nil {

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -75,6 +75,10 @@ func Sign() *cobra.Command {
 			default:
 				return flag.ErrHelp
 			}
+			oidcClientSecret, err := o.OIDC.ClientSecret()
+			if err != nil {
+				return err
+			}
 			ko := sign.KeyOpts{
 				KeyRef:                   o.Key,
 				PassFunc:                 generate.GetPass,
@@ -86,7 +90,7 @@ func Sign() *cobra.Command {
 				RekorURL:                 o.Rekor.URL,
 				OIDCIssuer:               o.OIDC.Issuer,
 				OIDCClientID:             o.OIDC.ClientID,
-				OIDCClientSecret:         o.OIDC.ClientSecret,
+				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 			}
 			annotationsMap, err := o.AnnotationsMap()

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -64,6 +64,10 @@ func SignBlob() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			oidcClientSecret, err := o.OIDC.ClientSecret()
+			if err != nil {
+				return err
+			}
 			ko := sign.KeyOpts{
 				KeyRef:                   o.Key,
 				PassFunc:                 generate.GetPass,
@@ -75,7 +79,7 @@ func SignBlob() *cobra.Command {
 				RekorURL:                 o.Rekor.URL,
 				OIDCIssuer:               o.OIDC.Issuer,
 				OIDCClientID:             o.OIDC.ClientID,
-				OIDCClientSecret:         o.OIDC.ClientSecret,
+				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 				BundlePath:               o.BundlePath,
 			}

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -52,7 +52,7 @@ cosign attest [flags]
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --no-upload                                                                                do not upload the generated attestation
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --predicate string                                                                         path to the predicate file.

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -24,7 +24,7 @@ cosign policy sign [flags]
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --out string                                                                               output policy locally (default "o")

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -44,7 +44,7 @@ cosign sign-blob [flags]
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --output string                                                                            write the signature to FILE

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -66,7 +66,7 @@ cosign sign [flags]
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret string                                                                [EXPERIMENTAL] OIDC client secret for application
+      --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --output-certificate string                                                                write the certificate to FILE


### PR DESCRIPTION
Before, `--oidc-client-secret` secret was specified on the command line.
This runs the risk of leaking the secret to any other processes on the
same machine.

Now, the new flag `--oidc-client-secret-file` takes a path to a file
containing the OIDC secret.

This is a breaking change, but the flag is behind `COSIGN_EXPERIMENTAL=1`.

Signed-off-by: Zachary Newman <z@znewman.net>


#### Summary
Change `--oidc-client-secret` flag to `--oidc-client-secret-file` to prevent leaking secrets on the command line.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Changed `--oidc-client-secret` flag to `--oidc-client-secret-file` to prevent leaking secrets on the command line.
```
