### PR TITLE
Dont overwrite token set in keyOpts

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -427,8 +427,10 @@ func keylessSigner(ctx context.Context, ko KeyOpts) (*SignerVerifier, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "creating Fulcio client")
 	}
+
 	tok := ko.IDToken
-	if providers.Enabled(ctx) {
+	// If token is not set in the options, get one from the provders
+	if tok == "" && providers.Enabled(ctx) {
 		tok, err = providers.Provide(ctx, "sigstore")
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching ambient OIDC credentials")


### PR DESCRIPTION
#### Summary

This commit fixes a bug where an identity token set via options would get overwritten if one of the providers was able to generate one from the environment. Now, when an identity token is available at the time of signing, the providers will not be queried to generate a new one.

Thanks to Carlos Panato for finding the source of this bug that surfaced in the Kubernetes image promoter.

/cc @cpanato @justaugustus 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>


#### Ticket Link
None

#### Release Note
```release-note
Fixed a bug that overwrote identity tokens set via options when one of the providers was able to get one from the environment. Now, the token in the options, (ie flags) gets precedence.
```
