### PR TITLE
refactor release job

### DIFF
--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Install cosigned
       env:
-        GIT_HASH: $GITHUB_SHA
+        GIT_HASH: ${{ env.GITHUB_SHA }}
         GIT_VERSION: ci
         LDFLAGS: ""
         COSIGNED_YAML: cosigned-e2e.yaml

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -75,7 +75,7 @@ jobs:
 
     - name: Install cosigned
       env:
-        GIT_HASH: ${{ env.GITHUB_SHA }}
+        GIT_HASH: ${{ github.sha }}
         GIT_VERSION: ci
         LDFLAGS: ""
         COSIGNED_YAML: cosigned-e2e.yaml

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -56,6 +56,8 @@ jobs:
     # will use the latest release available for ko
     - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
 
+    - uses: imranismail/setup-kustomize@8fa954828ed3cfa7a487a2ba9f7104899bb48b2f # v1.6.1
+
     - name: Install yq
       uses: mikefarah/yq@bc2118736bca883de2e2c345bb7f7ef52c994920 # v4.16.2
 
@@ -76,8 +78,12 @@ jobs:
         GIT_HASH: $GITHUB_SHA
         GIT_VERSION: ci
         LDFLAGS: ""
+        COSIGNED_YAML: cosigned-e2e.yaml
+        KO_PREFIX: registry.local:5000/cosigned
+        COSIGNED_ARCHS: linux/amd64
       run: |
-        ko apply -Bf config/
+        make ko-cosigned
+        kubectl apply -f cosigned-e2e.yaml
 
         # Wait for the webhook to come up and become Ready
         kubectl rollout status --timeout 5m --namespace cosign-system deployments/webhook

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -50,6 +50,8 @@ jobs:
 
     - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4
 
+    - uses: imranismail/setup-kustomize@8fa954828ed3cfa7a487a2ba9f7104899bb48b2f # v1.6.1
+
     - name: Install yq
       uses: mikefarah/yq@bc2118736bca883de2e2c345bb7f7ef52c994920 # v4.16.2
 
@@ -99,8 +101,12 @@ jobs:
         GIT_HASH: $GITHUB_SHA
         GIT_VERSION: ci
         LDFLAGS: ""
+        COSIGNED_YAML: cosigned-e2e.yaml
+        KO_PREFIX: registry.local:5000/cosigned
+        COSIGNED_ARCHS: linux/amd64
       run: |
-        ko apply -Bf config/
+        make ko-cosigned
+        kubectl apply -f cosigned-e2e.yaml
 
         # Wait for the webhook to come up and become Ready
         kubectl rollout status --timeout 5m --namespace cosign-system deployments/webhook

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Install cosigned
       env:
-        GIT_HASH: $GITHUB_SHA
+        GIT_HASH: ${{ env.GITHUB_SHA }}
         GIT_VERSION: ci
         LDFLAGS: ""
         COSIGNED_YAML: cosigned-e2e.yaml

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -98,7 +98,7 @@ jobs:
 
     - name: Install cosigned
       env:
-        GIT_HASH: ${{ env.GITHUB_SHA }}
+        GIT_HASH: ${{ github.sha }}
         GIT_VERSION: ci
         LDFLAGS: ""
         COSIGNED_YAML: cosigned-e2e.yaml

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -70,5 +70,4 @@ jobs:
       - name: check binaries
         run: |
           ./dist/cosign-linux-amd64 version
-          ./dist/cosigned-linux-amd64 --help
           ./dist/sget-linux-amd64 version

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -39,7 +39,7 @@ jobs:
       statuses: none
 
     env:
-      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.17.8-0@sha256:b5b14c6a61099af5a69864f242766a0dca978d2aea97e311d051ee4f4b7d19ba
+      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.17.8-1@sha256:38effe76e69a728f6c2e76b290c0d5e09fdff439926e3bbe7e69978c84c185f3
       COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.6.0@sha256:b667002156c4bf9fedd9273f689b800bb5c341660e710e3bbac981c9795423d9
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,9 @@
 
 bin*
 dist/
+cosignImagerefs
+cosignedImagerefs
+sgetImagerefs
+policyImagerefs
 
 **verify-experimental*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -236,6 +236,7 @@ snapshot:
   name_template: SNAPSHOT-{{ .ShortCommit }}
 
 release:
+  disable: true ## not pushing to GitHub release due issues (context https://sigstore.slack.com/archives/C01PZKDL4DP/p1649162659703169?thread_ts=1649089777.081249&cid=C01PZKDL4DP)
   prerelease: allow # remove this when we start publishing non-prerelease or set to auto
   draft: true # allow for manual edits
   github:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ before:
 # if running a release we will generate the images in this step
 # if running in the CI the CI env va is set and we dont run the ko steps
 # this is needed because we are generating files that goreleaser was not aware to push to GH project release
-  - /bin/bash -c 'if [ -z "$CI" ]; then make sign-container-release && make sign-keyless-release; fi'
+  - /bin/bash -c 'if [ -z "$CI" ]; then make sign-release-images; fi'
 
 gomod:
   proxy: true
@@ -128,28 +128,6 @@ builds:
     - pivkey
     - pkcs11key
 
-- id: linux-cosigned
-  binary: cosigned-linux-{{ .Arch }}
-  no_unique_dist_dir: true
-  main: ./cmd/cosign/webhook
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  goos:
-    - linux
-  goarch:
-    - amd64
-    - arm64
-    - arm
-    - s390x
-    - ppc64le
-  goarm:
-    - 7
-  ldflags:
-    - "{{ .Env.LDFLAGS }}"
-  env:
-    - CGO_ENABLED=0
-
 - id: sget
   binary: sget-{{ .Os }}-{{ .Arch }}
   no_unique_dist_dir: true
@@ -189,13 +167,6 @@ signs:
     cmd: ./dist/cosign-linux-amd64
     args: ["sign-blob", "--output-signature", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
     artifacts: binary
-  - id: cosigned
-    signature: "${artifact}.sig"
-    cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output-signature", "${artifact}.sig", "--key", "gcpkms://projects/{{ .Env.PROJECT_ID }}/locations/{{ .Env.KEY_LOCATION }}/keyRings/{{ .Env.KEY_RING }}/cryptoKeys/{{ .Env.KEY_NAME }}/versions/{{ .Env.KEY_VERSION }}", "${artifact}"]
-    artifacts: binary
-    ids:
-      - linux-cosigned
   - id: sget
     signature: "${artifact}.sig"
     cmd: ./dist/cosign-linux-amd64
@@ -210,14 +181,6 @@ signs:
     cmd: ./dist/cosign-linux-amd64
     args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
     artifacts: binary
-  - id: cosigned-keyless
-    signature: "${artifact}-keyless.sig"
-    certificate: "${artifact}-keyless.pem"
-    cmd: ./dist/cosign-linux-amd64
-    args: ["sign-blob", "--output-signature", "${artifact}-keyless.sig", "--output-certificate", "${artifact}-keyless.pem", "${artifact}"]
-    artifacts: binary
-    ids:
-      - linux-cosigned
   - id: sget-keyless
     signature: "${artifact}-keyless.sig"
     certificate: "${artifact}-keyless.pem"

--- a/.ko.yaml
+++ b/.ko.yaml
@@ -47,6 +47,21 @@ builds:
   - -extldflags "-static"
   - "{{ .Env.LDFLAGS }}"
 
+- id: policy_webhook
+  dir: .
+  main: ./cmd/cosign/policy_webhook
+  env:
+  - CGO_ENABLED=0
+  flags:
+  - -trimpath
+  - --tags
+  - "{{ .Env.GIT_HASH }}"
+  - --tags
+  - "{{ .Env.GIT_VERSION }}"
+  ldflags:
+  - -extldflags "-static"
+  - "{{ .Env.LDFLAGS }}"
+
 - id: sget
   dir: .
   main: ./cmd/sget

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ ifeq ($(DIFF), 1)
 endif
 PLATFORMS=darwin linux windows
 ARCHITECTURES=amd64
+COSIGNED_ARCHS?=all
 
 LDFLAGS=-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=$(GIT_VERSION) \
         -X sigs.k8s.io/release-utils/version.gitCommit=$(GIT_HASH) \
@@ -174,14 +175,14 @@ ko-cosigned: kustomize-cosigned ko-policy-webhook
 	# cosigned
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) KO_DOCKER_REPO=$(KO_PREFIX)/cosigned ko resolve --bare \
-		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH)$(LATEST_TAG) \
+		--platform=$(COSIGNED_ARCHS) --tags $(GIT_VERSION) --tags $(GIT_HASH)$(LATEST_TAG) \
 		--image-refs cosignedImagerefs --filename config/webhook.yaml >> $(COSIGNED_YAML)
 
 ko-policy-webhook:
 	# policy_webhook
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) KO_DOCKER_REPO=$(KO_PREFIX)/policy-webhook ko resolve --bare \
-		--platform=all --tags $(GIT_VERSION) --tags $(GIT_HASH)$(LATEST_TAG) \
+		--platform=$(COSIGNED_ARCHS) --tags $(GIT_VERSION) --tags $(GIT_HASH)$(LATEST_TAG) \
 		--image-refs policyImagerefs --filename config/policy-webhook.yaml >> $(COSIGNED_YAML)
 
 .PHONY: ko-local

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - 100-namespace.yaml
+  - 200-serviceaccount.yaml
+  - 200-role.yaml
+  - 200-clusterrole.yaml
+  - 201-rolebinding.yaml
+  - 201-clusterrolebinding.yaml
+  - 300-clusterimagepolicy.yaml
+  - 400-webhook-service.yaml
+  - 500-webhook-configuration.yaml
+  - 501-policy-webhook-configurations.yaml
+  - config-observability.yaml
+  - config-logging.yaml
+  - config-leader-election.yaml
+  - config-image-policies.yaml

--- a/config/policy-webhook.yaml
+++ b/config/policy-webhook.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/policy-webhook.yaml
+++ b/config/policy-webhook.yaml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 ---
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/config/webhook.yaml
+++ b/config/webhook.yaml
@@ -109,3 +109,4 @@ metadata:
 # stringData:
 #   cosign.pub: |
 #     <PEM encoded public key>
+---

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -39,10 +39,10 @@ steps:
   - TUF_ROOT=/tmp
   args:
   - 'verify'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.8-0@sha256:b5b14c6a61099af5a69864f242766a0dca978d2aea97e311d051ee4f4b7d19ba'
+  - 'ghcr.io/gythialy/golang-cross:v1.17.8-1@sha256:38effe76e69a728f6c2e76b290c0d5e09fdff439926e3bbe7e69978c84c185f3'
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.8-0@sha256:b5b14c6a61099af5a69864f242766a0dca978d2aea97e311d051ee4f4b7d19ba
+- name: ghcr.io/gythialy/golang-cross:v1.17.8-1@sha256:38effe76e69a728f6c2e76b290c0d5e09fdff439926e3bbe7e69978c84c185f3
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -65,7 +65,7 @@ steps:
       gcloud auth configure-docker \
       && make release
 
-- name: gcr.io/cloud-builders/docker
+- name: ghcr.io/gythialy/golang-cross:v1.17.8-1@sha256:38effe76e69a728f6c2e76b290c0d5e09fdff439926e3bbe7e69978c84c185f3
   entrypoint: 'bash'
   dir: "go/src/sigstore/cosign"
   env:
@@ -103,7 +103,7 @@ artifacts:
     - "go/src/sigstore/cosign/cosign*.yaml"
 
 options:
-  machineType: E2_HIGHCPU_8
+  machineType: E2_HIGHCPU_32
 
 tags:
 - cosign-release

--- a/release/ko-sign-release-images.sh
+++ b/release/ko-sign-release-images.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"";
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${GIT_HASH:?Environment variable empty or not defined.}"
+: "${GIT_VERSION:?Environment variable empty or not defined.}"
+: "${PROJECT_ID:?Environment variable empty or not defined.}"
+: "${KEY_LOCATION:?Environment variable empty or not defined.}"
+: "${KEY_RING:?Environment variable empty or not defined.}"
+: "${KEY_NAME:?Environment variable empty or not defined.}"
+: "${KEY_VERSION:?Environment variable empty or not defined.}"
+
+
+if [[ ! -f cosignImagerefs ]]; then
+    echo "cosignImagerefs not found"
+    exit 1
+fi
+
+if [[ ! -f sgetImagerefs ]]; then
+    echo "sgetImagerefs not found"
+    exit 1
+fi
+
+if [[ ! -f cosignedImagerefs ]]; then
+    echo "cosignedImagerefs not found"
+    exit 1
+fi
+
+if [[ ! -f policyImagerefs ]]; then
+    echo "policyImagerefs not found"
+    exit 1
+fi
+
+echo "Signing cosign images with GCP KMS Key..."
+
+cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat cosignImagerefs)"
+cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat sgetImagerefs)"
+cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat cosignedImagerefs)"
+cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat policyImagerefs)"
+
+echo "Signing images with Keyless..."
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat cosignImagerefs)"
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat sgetImagerefs)"
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat cosignedImagerefs)"
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat policyImagerefs)"

--- a/release/release.mk
+++ b/release/release.mk
@@ -1,49 +1,19 @@
 ##################
 # release section
 ##################
-
 # used when releasing together with GCP CloudBuild
 .PHONY: release
 release:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --timeout 120m
-
-###########################
-# sign with GCP KMS section
-###########################
-
-.PHONY: sign-cosign-release
-sign-cosign-release:
-	cosign sign --force --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosign:$(GIT_VERSION)
-
-.PHONY: sign-cosigned-release
-sign-cosigned-release:
-	cosign sign --force --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosigned:$(GIT_VERSION)
-
-.PHONY: sign-sget-release
-sign-sget-release:
-	cosign sign --force --key "gcpkms://projects/$(PROJECT_ID)/locations/$(KEY_LOCATION)/keyRings/$(KEY_RING)/cryptoKeys/$(KEY_NAME)/versions/$(KEY_VERSION)" -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/sget:$(GIT_VERSION)
-
-.PHONY: sign-container-release
-sign-container-release: ko sign-cosign-release sign-cosigned-release sign-sget-release
+	LDFLAGS="$(LDFLAGS)" goreleaser release --debug --timeout 120m
 
 ######################
-# sign keyless section
+# sign section
 ######################
 
-.PHONY: sign-keyless-cosign-release
-sign-keyless-cosign-release:
-	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosign:$(GIT_VERSION)
-
-.PHONY: sign-keyless-cosigned-release
-sign-keyless-cosigned-release:
-	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/cosigned:$(GIT_VERSION)
-
-.PHONY: sign-keyless-sget-release
-sign-keyless-sget-release:
-	cosign sign --force -a GIT_HASH=$(GIT_HASH) -a GIT_VERSION=$(GIT_VERSION) $(KO_PREFIX)/sget:$(GIT_VERSION)
-
-.PHONY: sign-keyless-release
-sign-keyless-release: sign-keyless-cosign-release sign-keyless-cosigned-release sign-keyless-sget-release
+.PHONY: sign-release-images
+sign-release-images: ko
+	GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
+	./release/ko-sign-release-images.sh
 
 # used when need to validate the goreleaser
 .PHONY: snapshot
@@ -62,9 +32,13 @@ copy-cosign-signed-release-to-ghcr:
 copy-cosigned-signed-release-to-ghcr:
 	cosign copy $(KO_PREFIX)/cosigned:$(GIT_VERSION) $(GHCR_PREFIX)/cosigned:$(GIT_VERSION)
 
+.PHONY: copy-policy-webhook-signed-release-to-ghcr
+copy-policy-webhook-signed-release-to-ghcr:
+	cosign copy $(KO_PREFIX)/policy-webhook:$(GIT_VERSION) $(GHCR_PREFIX)/policy-webhook:$(GIT_VERSION)
+
 .PHONY: copy-sget-signed-release-to-ghcr
 copy-sget-signed-release-to-ghcr:
 	cosign copy $(KO_PREFIX)/sget:$(GIT_VERSION) $(GHCR_PREFIX)/sget:$(GIT_VERSION)
 
 .PHONY: copy-signed-release-to-ghcr
-copy-signed-release-to-ghcr: copy-cosign-signed-release-to-ghcr copy-cosigned-signed-release-to-ghcr copy-sget-signed-release-to-ghcr
+copy-signed-release-to-ghcr: copy-cosign-signed-release-to-ghcr copy-cosigned-signed-release-to-ghcr copy-sget-signed-release-to-ghcr copy-policy-webhook-signed-release-to-ghcr


### PR DESCRIPTION
#### Summary
- refactor the release job:
1. remove the cosigned binary which is not needed, the images and manifests is enough
2. add the policy-webhook image that was introduced and sign that
3. use kustomize to help to build the cosigned release manifest
4. general clean up and optizimations 


UPDATE:

disabling the push to github release due some issues with gorelease/github release that is not clear and it is pending investigation, https://sigstore.slack.com/archives/C01PZKDL4DP/p1649162659703169?thread_ts=1649089777.081249&cid=C01PZKDL4DP to no block the release we disable for now


#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
