### PR TITLE
Makefile: fix directory not found error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,13 +91,14 @@ cosign: $(SRCS)
 cosign-pivkey-pkcs11key: $(SRCS)
 	CGO_ENABLED=1 go build -trimpath -tags=pivkey,pkcs11key -ldflags "$(LDFLAGS)" -o cosign ./cmd/cosign
 
+## Build cosigned binary
 .PHONY: cosigned
-cosigned: ## Build cosigned binary
+cosigned: policy-webhook
 	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/cosign/webhook
 
 .PHONY: policy-webhook
 policy-webhook: ## Build the policy webhook binary
-	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/cosign/policy-webhook
+	CGO_ENABLED=0 go build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/cosign/policy_webhook
 
 .PHONY: sget
 sget: ## Build sget binary


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

`make policy-webhook` was compiling a wrong directory. I also added the compilation of the policy-webhook binary to the cosigned target.

```
CGO_ENABLED=0 go build -trimpath -ldflags "-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=v1.7.1-4-g9008111-dirty -X sigs.k8s.io/release-utils/version.gitCommit=9008111af46dda51d5336b1570d8bf5fe896a524 -X sigs.k8s.io/release-utils/version.gitTreeState="dirty" -X sigs.k8s.io/release-utils/version.buildDate=2022-04-05T18:38:00Z" -o policy-webhook ./cmd/cosign/policy-webhook
stat /Users/hectorj2f/sigstore/cosign/cmd/cosign/policy-webhook: directory not found
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
