### PR TITLE
[Cosigned] Fix publicKey unmarshal

### DIFF
--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -120,9 +120,9 @@ jobs:
         echo Created image $demoimage2
         popd
 
-    - name: Deploy ClusterImagePolicy
+    - name: Deploy ClusterImagePolicy With Keyless Signing
       run: |
-        kubectl apply -f ./test/testdata/cosigned/e2e/cip.yaml
+        kubectl apply -f ./test/testdata/cosigned/e2e/cip-keyless.yaml
 
     - name: Sign demoimage with cosign
       run: |
@@ -134,12 +134,12 @@ jobs:
 
     - name: Deploy jobs and verify signed works, unsigned fails
       run: |
-        kubectl create namespace demo
-        kubectl label namespace demo cosigned.sigstore.dev/include=true
+        kubectl create namespace demo-keyless-signing
+        kubectl label namespace demo-keyless-signing cosigned.sigstore.dev/include=true
 
         echo '::group:: test job success'
         # We signed this above, this should work
-        if ! kubectl create -n demo job demo --image=${{ env.demoimage }} ; then
+        if ! kubectl create -n demo-keyless-signing job demo --image=${{ env.demoimage }} ; then
           echo Failed to create Job in namespace without label!
           exit 1
         else
@@ -149,7 +149,56 @@ jobs:
 
         echo '::group:: test job rejection'
         # We did not sign this, should fail
-        if kubectl create -n demo job demo2 --image=${{ env.demoimage2 }} ; then
+        if kubectl create -n demo-keyless-signing job demo2 --image=${{ env.demoimage2 }} ; then
+          echo Failed to block unsigned Job creation!
+          exit 1
+        else
+          echo Successfully blocked Job creation with unsigned image
+        fi
+        echo '::endgroup::'
+
+    - name: Generate New Signing Key
+      run: |
+        COSIGN_PASSWORD="" ./cosign generate-key-pair
+
+    - name: Deploy ClusterImagePolicy With Key Signing
+      run: |
+        yq '. | .spec.authorities[0].key.data |= load_str("cosign.pub")' ./test/testdata/cosigned/e2e/cip-key.yaml | \
+          kubectl apply -f -
+
+    - name: Verify with two CIP, one not signed with public key
+      run: |
+        if kubectl create -n demo-key-signing job demo --image=${{ env.demoimage }}; then
+          echo Failed to block unsigned Job creation!
+          exit 1
+        fi
+
+    - name: Sign demoimage with cosign key
+      run: |
+        ./cosign sign --key cosign.key --force --allow-insecure-registry ${{ env.demoimage }}
+
+    - name: Verify with cosign
+      run: |
+        ./cosign verify --key cosign.pub --allow-insecure-registry ${{ env.demoimage }}
+
+    - name: Deploy jobs and verify signed works, unsigned fails
+      run: |
+        kubectl create namespace demo-key-signing
+        kubectl label namespace demo-key-signing cosigned.sigstore.dev/include=true
+
+        echo '::group:: test job success'
+        # We signed this above, this should work
+        if ! kubectl create -n demo-key-signing job demo --image=${{ env.demoimage }} ; then
+          echo Failed to create Job in namespace without label!
+          exit 1
+        else
+          echo Succcessfully created Job with signed image
+        fi
+        echo '::endgroup:: test job success'
+
+        echo '::group:: test job rejection'
+        # We did not sign this, should fail
+        if kubectl create -n demo-key-signing job demo2 --image=${{ env.demoimage2 }} ; then
           echo Failed to block unsigned Job creation!
           exit 1
         else

--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
@@ -162,7 +162,6 @@ func (r *Reconciler) convertKeyData(ctx context.Context, cip *internalcip.Cluste
 			}
 			// When publicKeys are successfully converted, clear out Data
 			authority.Key.PublicKeys = keys
-			authority.Key.Data = ""
 		}
 	}
 	return cip, nil

--- a/test/testdata/cosigned/e2e/cip-key.yaml
+++ b/test/testdata/cosigned/e2e/cip-key.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cosigned.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-key
+spec:
+  images:
+  - glob: registry.local:5000/cosigned/demo*
+  authorities:
+  - key:
+      data: |
+        -----BEGIN PUBLIC KEY-----
+        MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZxAfzrQG1EbWyCI8LiSB7YgSFXoI
+        FNGTyQGKHFc6/H8TQumT9VLS78pUwtv3w7EfKoyFZoP32KrO7nzUy2q6Cw==
+        -----END PUBLIC KEY-----
+

--- a/test/testdata/cosigned/e2e/cip-keyless.yaml
+++ b/test/testdata/cosigned/e2e/cip-keyless.yaml
@@ -15,7 +15,7 @@
 apiVersion: cosigned.sigstore.dev/v1alpha1
 kind: ClusterImagePolicy
 metadata:
-  name: image-policy
+  name: image-policy-keyless
 spec:
   images:
   - glob: registry.local:5000/cosigned/demo*


### PR DESCRIPTION
Signed-off-by: Denny Hoang <dhoang@vmware.com>

#### Summary
Unmarshaling PublicKeys causes an error:
```
{"severity":"ERROR","timestamp":"2022-04-06T14:33:44.2084731Z","logger":"cosigned.config-store","caller":"configmap/store.go:148","message":"Error updating image-policies config \"config-image-policies\": \"failed to parse the entry <ENTRY> : math/big: cannot unmarshal \\\"2.7708706494268807e+76\\\" into a *big.Int\"","commit":"9008111","stacktrace":"<STACKTRACE>"}
```

#### Ticket Link
Fixes https://github.com/sigstore/cosign/issues/1717

#### Notes
I am aware I am temporarily duplicating the function for parsing PEMs into the internal clusterimagepolicy_types file.
I have another branch that will address this alongside consolidating a lot of the clusterimagepolicy logic into the types file.

cc: @hectorj2f @vaikas @coyote240 