### PR TITLE
fix: add permissions to patch events

### DIFF
--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -19,7 +19,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["create"]
+    verbs: ["create","patch"]
 
   # Allow the reconciliation of exactly our validating and mutating webhooks.
   - apiGroups: ["admissionregistration.k8s.io"]


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

When looking at the logs from the policy-webhook pod, I found errors while patching events such as:

```
E0407 15:32:56.528437       1 event.go:267] Server rejected event '&v1.Event{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"image-hectorj2f-policy.16e3a4a2d537e800", GenerateName:"", Namespace:"default", SelfLink:"", UID:"", ResourceVersion:"6750", Generation:0, CreationTimestamp:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), DeletionTimestamp:<nil>, DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string(nil), Annotations:map[string]string(nil), OwnerReferences:[]v1.OwnerReference(nil), Finalizers:[]string(nil), ClusterName:"", ManagedFields:[]v1.ManagedFieldsEntry(nil)}, InvolvedObject:v1.ObjectReference{Kind:"ClusterImagePolicy", Namespace:"", Name:"image-hectorj2f-policy", UID:"0e2d2952-e524-44a9-8bfc-3641c559f863", APIVersion:"cosigned.sigstore.dev/v1alpha1", ResourceVersion:"13141", FieldPath:""}, Reason:"FinalizerUpdate", Message:"Updated \"image-hectorj2f-policy\" finalizers", Source:v1.EventSource{Component:"clusterimagepolicy-controller", Host:""}, FirstTimestamp:time.Date(2022, time.April, 7, 14, 48, 27, 0, time.Local), LastTimestamp:time.Date(2022, time.April, 7, 15, 32, 56, 522014000, time.Local), Count:3, Type:"Normal", EventTime:time.Date(1, time.January, 1, 0, 0, 0, 0, time.UTC), Series:(*v1.EventSeries)(nil), Action:"", Related:(*v1.ObjectReference)(nil), ReportingController:"", ReportingInstance:""}': 'events "image-hectorj2f-policy.16e3a4a2d537e800" is forbidden: User "system:serviceaccount:cosign-system:webhook" cannot patch resource "events" in API group "" in the namespace "default"' (will not retry!)
```

I added the permissions to patch events too, so we can see now events:

```
$kubectl get events -A

NAMESPACE      LAST SEEN   TYPE     REASON            OBJECT                                      MESSAGE
default        4m22s       Normal   FinalizerUpdate   clusterimagepolicy/image-hectorj2f-policy   Updated "image-hectorj2f-policy" finalizers
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
