### PR TITLE
[cosigned] The webhook name is now configurable via --webhook-name flag

### DIFF
--- a/cmd/cosign/webhook/main.go
+++ b/cmd/cosign/webhook/main.go
@@ -47,7 +47,7 @@ var secretName = flag.String("secret-name", "", "The name of the secret in the w
 // webhookName holds the name of the validating webhook to set up with the
 // types we are watching.  If this changes, you must also change:
 //    ./config/500-webhook-configuration.yaml
-const webhookName = "cosigned.sigstore.dev"
+var webhookName = flag.String("webhook-name", "cosigned.sigstore.dev", "The name of the webhook.")
 
 func main() {
 	opts := webhook.Options{
@@ -92,7 +92,7 @@ func NewValidatingAdmissionController(ctx context.Context, cmw configmap.Watcher
 
 	return validation.NewAdmissionController(ctx,
 		// Name of the resource webhook.
-		webhookName,
+		*webhookName,
 
 		// The path on which to serve the webhook.
 		"/validations",
@@ -123,7 +123,7 @@ func NewMutatingAdmissionController(ctx context.Context, cmw configmap.Watcher) 
 
 	return defaulting.NewAdmissionController(ctx,
 		// Name of the resource webhook.
-		webhookName,
+		*webhookName,
 
 		// The path on which to serve the webhook.
 		"/mutations",

--- a/cmd/cosign/webhook/main.go
+++ b/cmd/cosign/webhook/main.go
@@ -44,10 +44,15 @@ import (
 
 var secretName = flag.String("secret-name", "", "The name of the secret in the webhook's namespace that holds the public key for verification.")
 
-// webhookName holds the name of the validating webhook to set up with the
-// types we are watching.  If this changes, you must also change:
+// webhookName holds the name of the validating and mutating webhook
+// configuration resources dispatching admission requests to cosigned.
+// It is also the name of the webhook which is injected by the controller
+// with the resource types, namespace selectors, CABindle and service path.
+// If this changes, you must also change:
 //    ./config/500-webhook-configuration.yaml
-var webhookName = flag.String("webhook-name", "cosigned.sigstore.dev", "The name of the webhook.")
+//    https://github.com/sigstore/helm-charts/blob/main/charts/cosigned/templates/webhook/webhook_mutating.yaml
+//    https://github.com/sigstore/helm-charts/blob/main/charts/cosigned/templates/webhook/webhook_validating.yaml
+var webhookName = flag.String("webhook-name", "cosigned.sigstore.dev", "The name of the validating and mutating webhook configurations as well as the webhook name that is automatically configured, if exists, with different rules and client settings setting how the admission requests to be dispatched to cosigned.")
 
 func main() {
 	opts := webhook.Options{


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
The webhook name is now configurable via --webhook-name flag for cosigned. This way, cosigned can be deployed multiple times in the same cluster with different webhook configurations, e.g. namespace and/or object selectors. Also, each webhook can be served by different instance of the cosigned using different public keys.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
The name of the cosigned webhook can be now configured via the flag `--webhook-name`, the default value is `cosigned.sigstore.dev`.
```
