### PR TITLE
Remove newline from `download sbom` output

### DIFF
--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -62,7 +62,7 @@ func SBOMCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef stri
 	}
 
 	sboms = append(sboms, string(sbom))
-	fmt.Fprintln(out, string(sbom))
+	fmt.Fprint(out, string(sbom))
 
 	return sboms, nil
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
I had reason to compare the downloaded SBOM to the original payload I uploaded and noticed that the sha256 sum is different because it prints out an extra newline that isn't in the initial payload:

```
$ syft registry:<image> -o cyclonedx-json > bom.json

$ cosign attach sbom --sbom bom.json --type cyclonedx <image>

$ cosign download sbom <image> > download.json

$ sha256sum bom.json
ad84137b261cdb9eebd2267b598c4853be102bd5cb7d84122e6e365e55b88c96  bom.json

$ sha256sum download.json
da157b15d3aa68305874fc37ba2b7e99637a60037989b15dd7f0edd4ce315543  download.json
```

This PR removes the new line so what you get is exactly what was uploaded.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Removed newline from `download sbom` output
```
