### PR TITLE
Fix packages name and binary in the packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -206,7 +206,7 @@ signs:
 nfpms:
   - id: cosign
     package_name: cosign
-    file_name_template: "{{ .PackageName }}"
+    file_name_template: "{{ .ConventionalFileName }}"
     vendor: Sigstore
     homepage: https://sigstore.dev
     maintainer: Sigstore Authors 86837369+sigstore-bot@users.noreply.github.com

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -212,18 +212,16 @@ nfpms:
     maintainer: Sigstore Authors 86837369+sigstore-bot@users.noreply.github.com
     builds:
       - linux
-      - linux-pivkey-pkcs11key-amd64
     description: Container Signing, Verification and Storage in an OCI registry.
-    replacements:
-      amd64: 64-bit
-      386: 32-bit
-      darwin: macOS
-      linux: Tux
     license: "Apache License 2.0"
     formats:
       - apk
       - deb
       - rpm
+    contents:
+      - src: /usr/bin/cosign-linux-{{ .Arch }}
+        dst: /usr/bin/cosign
+        type: "symlink"
 
 archives:
 - format: binary


### PR DESCRIPTION
#### Summary
In the PR https://github.com/sigstore/cosign/pull/1683 we replaced the name to be just `cosign` but that affects the multi-arch packages, so at the end of the process we just have one available and miss others.

Changing that fixes the issue and we will have one for each arch.
The other issue was the binary name which is not `cosign` but instead `cosign-linux-amd64` (in this case for amd64), this is because we build the binary and generate with that name, but in the package when installed should be just `cosign` , adding symlink fixes that

Rehearsal : https://github.com/cpanato/cosign/releases/tag/v99.99.01

The snippet below shows the closing after installing the change from this PR amd64 ubuntu machine

```
root@ubuntu-s-1vcpu-1gb-amd-fra1-01:~# which cosign
/usr/bin/cosign
root@ubuntu-s-1vcpu-1gb-amd-fra1-01:~# cosign version
  ______   ______        _______. __    _______ .__   __.
 /      | /  __  \      /       ||  |  /  _____||  \ |  |
|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
 \______| \______/  |_______/    |__|  \______| |__| \__|
cosign: A tool for Container Signing, Verification and Storage in an OCI registry.

GitVersion:    v99.99.00-dirty
GitCommit:     8def7341d261c2d831a4b06c12cd5ff952a458b5
GitTreeState:  dirty
BuildDate:     2022-04-11T07:45:56Z
GoVersion:     go1.18
Compiler:      gc
Platform:      linux/amd64

root@ubuntu-s-1vcpu-1gb-amd-fra1-01:~# cd /usr/bin/
root@ubuntu-s-1vcpu-1gb-amd-fra1-01:/usr/bin# ls -la co*
....
lrwxrwxrwx 1 root root       27 Apr 11 08:30 cosign -> /usr/bin/cosign-linux-amd64
-rwxr-xr-x 1 root root 91780356 Apr 11 07:45 cosign-linux-amd64
root@ubuntu-s-1vcpu-1gb-amd-fra1-01:/usr/bin#
```



#### Ticket Link

Fixes https://github.com/sigstore/cosign/issues/1733

#### Release Note

```release-note
Fix packages name and binary in the packages
```
