### PR TITLE
Move the KMS integration imports into the binary entrypoints

### DIFF
--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -21,6 +21,12 @@ import (
 	"strings"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli"
+
+	// Register the provider-specific plugins
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 )
 
 func main() {

--- a/cmd/cosign/policy_webhook/main.go
+++ b/cmd/cosign/policy_webhook/main.go
@@ -40,8 +40,6 @@ import (
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
-	// TODO(mattmoor): Not sure why this is in the final binary...
-	// _ "github.com/sigstore/sigstore/pkg/signature/kms/fake"
 )
 
 func main() {

--- a/cmd/cosign/policy_webhook/main.go
+++ b/cmd/cosign/policy_webhook/main.go
@@ -34,6 +34,14 @@ import (
 
 	"github.com/sigstore/cosign/pkg/apis/cosigned/v1alpha1"
 	"github.com/sigstore/cosign/pkg/reconciler/clusterimagepolicy"
+
+	// Register the provider-specific plugins
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
+	// TODO(mattmoor): Not sure why this is in the final binary...
+	// _ "github.com/sigstore/sigstore/pkg/signature/kms/fake"
 )
 
 func main() {

--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
@@ -44,13 +44,6 @@ import (
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/kms"
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
-
-	// Register the provider-specific plugins
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/fake"
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 )
 
 // Reconciler implements clusterimagepolicyreconciler.Interface for

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -35,12 +35,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 
 	"github.com/sigstore/sigstore/pkg/signature/kms"
-
-	// Register the provider-specific plugins
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
-	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 )
 
 var (


### PR DESCRIPTION
#### Ticket Link
Related: https://github.com/sigstore/sigstore/issues/384
Related: https://github.com/sigstore/sigstore/issues/386

#### Release Note

```release-note
BREAKING: if you use cosign as an SDK and rely on KMS integrations, you will need to start importing the integrations you would like to support.
```
