### PR TITLE
Use bundle log ID to find verification key

### DIFF
--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -27,4 +27,14 @@ func TestGetRekorPubKeys(t *testing.T) {
 	if len(keys) == 0 {
 		t.Errorf("expected 1 or more keys, got 0")
 	}
+	// check that the mapping of key digest to key is correct
+	for logID, key := range keys {
+		expectedLogID, err := getLogID(key.PubKey)
+		if err != nil {
+			t.Fatalf("unexpected error generated log ID: %v", err)
+		}
+		if logID != expectedLogID {
+			t.Fatalf("key digests are not equal")
+		}
+	}
 }


### PR DESCRIPTION
Instead of iterating over all log verification keys, we use the log ID
in the bundle to find the correct key. This avoids iterating over all
trusted keys.

Note that the log ID is not signed. If the offline bundle is manipulated
so that the log ID does not resolve to a valid key, this will not result
in a denial of service attack, because cosign will fall back to fetching
the entry from the online log.

The equivalent change for CT entry verification has been made in another
PR.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
