### PR TITLE
Cosigned validate against remote sig src

### DIFF
--- a/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation.go
@@ -83,6 +83,12 @@ func (authority *Authority) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(authority.Keyless.Validate(ctx).ViaField("keyless"))
 	}
 
+	if len(authority.Sources) > 0 {
+		for _, source := range authority.Sources {
+			errs = errs.Also(source.Validate(ctx).ViaField("source"))
+		}
+	}
+
 	return errs
 }
 
@@ -126,6 +132,14 @@ func (keyless *KeylessRef) Validate(ctx context.Context) *apis.FieldError {
 
 	for i, identity := range keyless.Identities {
 		errs = errs.Also(identity.Validate(ctx).ViaFieldIndex("identities", i))
+	}
+	return errs
+}
+
+func (source *Source) Validate(ctx context.Context) *apis.FieldError {
+	var errs *apis.FieldError
+	if source.OCI == "" {
+		errs = errs.Also(apis.ErrMissingField("oci"))
 	}
 	return errs
 }

--- a/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation_test.go
@@ -397,7 +397,57 @@ func TestAuthoritiesValidation(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "Should pass when source oci is present",
+			expectErr: false,
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Regex: ".*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: "registry.example.com"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Should fail when source oci is empty",
+			expectErr:   true,
+			errorString: "missing field(s): spec.authorities[0].source.oci",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Regex: ".*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{{OCI: ""}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "Should pass with multiple source oci is present",
+			expectErr: false,
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Regex: ".*"}},
+					Authorities: []Authority{
+						{
+							Key: &KeyRef{KMS: "kms://key/path"},
+							Sources: []Source{
+								{OCI: "registry1"},
+								{OCI: "registry2"},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := test.policy.Validate(context.TODO())


### PR DESCRIPTION
Signed-off-by: Denny Hoang <dhoang@vmware.com>

#### Summary
- Implementing Authority.Sources to allow verification against signatures in different registry locations
- Also noticed a bug where we are not creating remoteOptions with the keychain and therefore could not verify against private repositories
- RemoteOpts follow the same unmarshalJSON override as publicKeys. This is due to the remoteOption type not being supported by json [un]marshal
- RemoteOpts are parsed and stored as a part of the CIP config to reduce parsing within the validation loop

#### Ticket Link
Fixes https://github.com/sigstore/cosign/issues/1651

#### Release Note
```release-note
* Specifying remote source for signatures in cosigned
```

cc: @coyote240 @hectorj2f @vaikas 