### PR TITLE
Implement identities, fix bug in webhook validation.

### DIFF
--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -140,7 +140,7 @@ jobs:
         echo '::group:: test job success'
         # We signed this above, this should work
         if ! kubectl create -n demo-keyless-signing job demo --image=${{ env.demoimage }} ; then
-          echo Failed to create Job in namespace without label!
+          echo Failed to create Job in namespace with matching signature!
           exit 1
         else
           echo Succcessfully created Job with signed image
@@ -156,6 +156,44 @@ jobs:
           echo Successfully blocked Job creation with unsigned image
         fi
         echo '::endgroup::'
+
+    - name: Add ClusterImagePolicy with identities that match issuer and subject
+      run: |
+        kubectl apply -f ./test/testdata/cosigned/e2e/cip-keyless-with-identities.yaml
+        # make sure the reconciler has enough time to update the configmap
+        sleep 5
+
+    - name: Verify the job still works with additional constraints
+        echo '::group:: test job success'
+        # This has correct issuer/subject, so should work
+        if ! kubectl create -n demo-keyless-signing job demo-identities-works --image=${{ env.demoimage }} ; then
+          echo Failed to create Job in namespace without label!
+          exit 1
+        else
+          echo Succcessfully created Job with signed image
+        fi
+        echo '::endgroup:: test job success'
+
+    - name: Add ClusterImagePolicy with identities that do not match issuer and subject
+      run: |
+        kubectl apply -f ./test/testdata/cosigned/e2e/cip-keyless-with-identities-mismatch.yaml
+        # make sure the reconciler has enough time to update the configmap
+        sleep 5
+
+    - name: Verify the job now fails because subject and issuer do not match
+        echo '::group:: test job block'
+        if kubectl create -n demo-keyless-signing job demo-identities-works --image=${{ env.demoimage }} ; then
+          echo Failed to block Job in namespace with non matching issuer and subject!
+          exit 1
+        else
+          echo Succcessfully blocked Job with mismatching issuer and subject
+        fi
+        echo '::endgroup:: test job block'
+
+    - name: Remove the mismatching cip
+      run: |
+        kubectl delete cip image-policy-keyless-with-identities-mismatch
+        sleep 5
 
     - name: Generate New Signing Key
       run: |

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -164,6 +164,7 @@ jobs:
         sleep 5
 
     - name: Verify the job still works with additional constraints
+      run: |
         echo '::group:: test job success'
         # This has correct issuer/subject, so should work
         if ! kubectl create -n demo-keyless-signing job demo-identities-works --image=${{ env.demoimage }} ; then
@@ -181,6 +182,7 @@ jobs:
         sleep 5
 
     - name: Verify the job now fails because subject and issuer do not match
+      run: |
         echo '::group:: test job block'
         if kubectl create -n demo-keyless-signing job demo-identities-works --image=${{ env.demoimage }} ; then
           echo Failed to block Job in namespace with non matching issuer and subject!

--- a/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation.go
@@ -115,12 +115,9 @@ func (keyless *KeylessRef) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingOneOf("url", "identities", "ca-cert"))
 	}
 
-	if keyless.URL != nil {
-		if keyless.CACert != nil || keyless.Identities != nil {
-			errs = errs.Also(apis.ErrMultipleOneOf("url", "identities", "ca-cert"))
-		}
-	} else if keyless.CACert != nil && keyless.Identities != nil {
-		errs = errs.Also(apis.ErrMultipleOneOf("url", "identities", "ca-cert"))
+	// TODO: Are these really mutually exclusive?
+	if keyless.URL != nil && keyless.CACert != nil {
+		errs = errs.Also(apis.ErrMultipleOneOf("url", "ca-cert"))
 	}
 
 	if keyless.Identities != nil && len(keyless.Identities) == 0 {

--- a/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation_test.go
@@ -295,7 +295,7 @@ func TestKeylessValidation(t *testing.T) {
 		{
 			name:        "Should fail when keyless has multiple properties",
 			expectErr:   true,
-			errorString: "expected exactly one, got both: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.identities, spec.authorities[0].keyless.url",
+			errorString: "expected exactly one, got both: spec.authorities[0].keyless.ca-cert, spec.authorities[0].keyless.url",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{

--- a/pkg/cosign/kubernetes/webhook/validator.go
+++ b/pkg/cosign/kubernetes/webhook/validator.go
@@ -303,7 +303,7 @@ func ValidatePolicy(ctx context.Context, ref name.Reference, kc authn.Keychain, 
 						continue
 					}
 				}
-				sps, err := validSignaturesWithFulcio(ctx, ref, fulcioroot, rekorClient, remoteOpts...)
+				sps, err := validSignaturesWithFulcio(ctx, ref, fulcioroot, rekorClient, authority.Keyless.Identities, remoteOpts...)
 				if err != nil {
 					logging.FromContext(ctx).Errorf("failed validSignatures with fulcio for %s: %v", ref.Name(), err)
 					authorityErrors = append(authorityErrors, errors.Wrap(err, "validate signatures with fulcio"))

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -27,9 +27,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/sigstore/cosign/pkg/apis/cosigned/v1alpha1"
 	cbundle "github.com/sigstore/cosign/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/pkg/cosign/tuf"
 
@@ -84,6 +86,11 @@ type CheckOpts struct {
 
 	// SignatureRef is the reference to the signature file
 	SignatureRef string
+
+	// Identities is an array of Identity (Subject, Issuer) matchers that have
+	// to be met for the signature to ve valid.
+	// Supercedes CertEmail / CertOidcIssuer
+	Identities []v1alpha1.Identity
 }
 
 func getSignedEntity(signedImgRef name.Reference, regClientOpts []ociremote.Option) (oci.SignedEntity, v1.Hash, error) {
@@ -143,7 +150,7 @@ func verifyOCIAttestation(_ context.Context, verifier signature.Verifier, att pa
 }
 
 // ValidateAndUnpackCert creates a Verifier from a certificate. Veries that the certificate
-// chains up to a trusted root. Optionally verifies the subject of the certificate.
+// chains up to a trusted root. Optionally verifies the subject and issuer of the certificate.
 func ValidateAndUnpackCert(cert *x509.Certificate, co *CheckOpts) (signature.Verifier, error) {
 	verifier, err := signature.LoadVerifier(cert.PublicKey, crypto.SHA256)
 	if err != nil {
@@ -167,23 +174,91 @@ func ValidateAndUnpackCert(cert *x509.Certificate, co *CheckOpts) (signature.Ver
 		}
 	}
 	if co.CertOidcIssuer != "" {
-		issuer := ""
-		for _, ext := range cert.Extensions {
-			if ext.Id.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1}) {
-				issuer = string(ext.Value)
-				break
-			}
-		}
-		if issuer != co.CertOidcIssuer {
+		if getIssuer(cert) != co.CertOidcIssuer {
 			return nil, errors.New("expected oidc issuer not found in certificate")
 		}
+	}
+	// If there are identities given, go through them and if one of them
+	// matches, call that good, otherwise, return an error.
+	if len(co.Identities) > 0 {
+		for _, identity := range co.Identities {
+			issuerMatches := false
+			// Check the issuer first
+			fmt.Fprintf(os.Stderr, "Checking identity: %+v", identity)
+			if identity.Issuer != "" {
+				issuer := getIssuer(cert)
+				if regex, err := regexp.Compile(identity.Issuer); err != nil {
+					return nil, fmt.Errorf("malformed issuer in identity: %s : %w", identity.Issuer, err)
+				} else if regex.MatchString(issuer) {
+					issuerMatches = true
+				}
+			} else {
+				// No issuer constraint on this identity, so checks out
+				issuerMatches = true
+			}
+
+			// Then the subject
+			subjectMatches := false
+			if identity.Subject != "" {
+				regex, err := regexp.Compile(identity.Subject)
+				if err != nil {
+					return nil, fmt.Errorf("malformed subject in identity: %s : %w", identity.Subject, err)
+				}
+				for _, san := range getSubjectAlternateNames(cert) {
+					if regex.MatchString(san) {
+						subjectMatches = true
+						break
+					}
+				}
+			} else {
+				// No subject constraint on this identity, so checks out
+				subjectMatches = true
+			}
+			if subjectMatches && issuerMatches {
+				// If both issuer / subject match, return verifier
+				return verifier, nil
+			}
+		}
+		return nil, errors.New("none of the expected identities matched what was in the certificate")
 	}
 	return verifier, nil
 }
 
-// ValidateAndUnpackCertWithChain creates a Verifier from a certificate. Veries that the certificate
+// getSubjectAlternateNames returns all of the following for a Certificate.
+// DNSNames
+// EmailAddresses
+// IPAddresses
+// URIs
+func getSubjectAlternateNames(cert *x509.Certificate) []string {
+	sans := []string{}
+	for _, dnsName := range cert.DNSNames {
+		sans = append(sans, dnsName)
+	}
+	for _, email := range cert.EmailAddresses {
+		sans = append(sans, email)
+	}
+	for _, ip := range cert.IPAddresses {
+		sans = append(sans, ip.String())
+	}
+	for _, uri := range cert.URIs {
+		sans = append(sans, uri.String())
+	}
+	return sans
+}
+
+// getIssuer returns the issuer for a Certificate
+func getIssuer(cert *x509.Certificate) string {
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1}) {
+			return string(ext.Value)
+		}
+	}
+	return ""
+}
+
+// ValidateAndUnpackCertWithChain creates a Verifier from a certificate. Verifies that the certificate
 // chains up to the provided root. Chain should start with the parent of the certificate and end with the root.
-// Optionally verifies the subject of the certificate.
+// Optionally verifies the subject and issuer of the certificate.
 func ValidateAndUnpackCertWithChain(cert *x509.Certificate, chain []*x509.Certificate, co *CheckOpts) (signature.Verifier, error) {
 	if len(chain) == 0 {
 		return nil, errors.New("no chain provided to validate certificate")

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -231,12 +231,8 @@ func ValidateAndUnpackCert(cert *x509.Certificate, co *CheckOpts) (signature.Ver
 // URIs
 func getSubjectAlternateNames(cert *x509.Certificate) []string {
 	sans := []string{}
-	for _, dnsName := range cert.DNSNames {
-		sans = append(sans, dnsName)
-	}
-	for _, email := range cert.EmailAddresses {
-		sans = append(sans, email)
-	}
+	sans = append(sans, cert.DNSNames...)
+	sans = append(sans, cert.EmailAddresses...)
 	for _, ip := range cert.IPAddresses {
 		sans = append(sans, ip.String())
 	}

--- a/test/testdata/cosigned/e2e/cip-keyless-with-identities-mismatch.yaml
+++ b/test/testdata/cosigned/e2e/cip-keyless-with-identities-mismatch.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cosigned.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-keyless-with-identities-mismatch
+spec:
+  images:
+  - glob: registry.local:5000/cosigned/demo*
+  authorities:
+  - keyless:
+      url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuer: .*kubernetes.securenamespace.*
+        subject: .*kubernetes.io/namespaces/securenamespace/serviceaccounts/default
+    ctlog:
+      url: http://rekor.rekor-system.svc

--- a/test/testdata/cosigned/e2e/cip-keyless-with-identities.yaml
+++ b/test/testdata/cosigned/e2e/cip-keyless-with-identities.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cosigned.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy-keyless-with-identities
+spec:
+  images:
+  - glob: registry.local:5000/cosigned/demo*
+  authorities:
+  - keyless:
+      url: http://fulcio.fulcio-system.svc
+      identities:
+      - issuer: .*kubernetes.default.*
+        subject: .*kubernetes.io/namespaces/default/serviceaccounts/default
+    ctlog:
+      url: http://rekor.rekor-system.svc

--- a/test/testdata/cosigned/invalid/keylessref-with-multiple-properties.yaml
+++ b/test/testdata/cosigned/invalid/keylessref-with-multiple-properties.yaml
@@ -25,6 +25,4 @@ spec:
         secretRef:
           name: ca-cert-secret
           namespace: some-namespace
-      identities:
-      - issuer: "issue-details"
-        subject: "subject-details"
+      url: http://example.com


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
* Implement ClusterImagePolicy for Keyless for identities, so you can restrict which issuer/subject needs to be matched.
* Also fixed the webhook validator logic that actually would prevent being able to specify both the URL as well as identities in keyless, even though it's a valid configuration as per the design spec.
* Add e2e tests for them.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Add support for specifying identities (issuer/subject matching) in ClusterImagePolicy
Fix bug that would now allow creation of CIP with identities
```
