### PR TITLE
Add Fulcio intermediate CA certificate to intermediate pool

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
@@ -39,6 +39,23 @@ var fulcioTargetStr = `fulcio.crt.pem`
 // This is the v1 migrated root.
 var fulcioV1TargetStr = `fulcio_v1.crt.pem`
 
+// The untrusted intermediate CA certificate, used for chain building
+// TODO: Remove once this is bundled in TUF metadata.
+var fulcioIntermediateV1 = `-----BEGIN CERTIFICATE-----
+MIICGjCCAaGgAwIBAgIUALnViVfnU0brJasmRkHrn/UnfaQwCgYIKoZIzj0EAwMw
+KjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MREwDwYDVQQDEwhzaWdzdG9yZTAeFw0y
+MjA0MTMyMDA2MTVaFw0zMTEwMDUxMzU2NThaMDcxFTATBgNVBAoTDHNpZ3N0b3Jl
+LmRldjEeMBwGA1UEAxMVc2lnc3RvcmUtaW50ZXJtZWRpYXRlMHYwEAYHKoZIzj0C
+AQYFK4EEACIDYgAE8RVS/ysH+NOvuDZyPIZtilgUF9NlarYpAd9HP1vBBH1U5CV7
+7LSS7s0ZiH4nE7Hv7ptS6LvvR/STk798LVgMzLlJ4HeIfF3tHSaexLcYpSASr1kS
+0N/RgBJz/9jWCiXno3sweTAOBgNVHQ8BAf8EBAMCAQYwEwYDVR0lBAwwCgYIKwYB
+BQUHAwMwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU39Ppz1YkEZb5qNjp
+KFWixi4YZD8wHwYDVR0jBBgwFoAUWMAeX5FFpWapesyQoZMi0CrFxfowCgYIKoZI
+zj0EAwMDZwAwZAIwPCsQK4DYiZYDPIaDi5HFKnfxXx6ASSVmERfsynYBiX2X6SJR
+nZU84/9DZdnFvvxmAjBOt6QpBlc4J/0DxvkTCqpclvziL6BCCPnjdlIB3Pu3BxsP
+mygUY7Ii2zbdCdliiow=
+-----END CERTIFICATE-----`
+
 const (
 	altRoot = "SIGSTORE_ROOT_FILE"
 )
@@ -116,6 +133,7 @@ func initRoots() (*x509.CertPool, *x509.CertPool, error) {
 				}
 			}
 		}
+		intermediatePool.AppendCertsFromPEM([]byte(fulcioIntermediateV1))
 	}
 	return rootPool, intermediatePool, nil
 }

--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots_test.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots_test.go
@@ -40,8 +40,7 @@ func TestGetFulcioRoots(t *testing.T) {
 	if _, err := tmpCertFile.Write(chain); err != nil {
 		t.Fatalf("failed to write cert file: %v", err)
 	}
-	os.Setenv("SIGSTORE_ROOT_FILE", tmpCertFile.Name())
-	defer os.Unsetenv("SIGSTORE_ROOT_FILE")
+	t.Setenv("SIGSTORE_ROOT_FILE", tmpCertFile.Name())
 
 	rootCertPool := Get()
 	// ignore deprecation error because certificates do not contain from SystemCertPool


### PR DESCRIPTION
This certificate will be necessary for chain building from a leaf
certificate to a root once a new version of Fulcio is rolled out. For
OCI, the chain is stored in an annotation. This intermediate is
currently only needed for verify-blob when looking up the certificate
from Rekor.

For the V3 TUF Root, the intermediate will be bundled, so that it is
easily discoverable and revokable. For now, we'll simply bundle it with
Cosign. Note that intermediates are considered untrusted, so it's fine
if the intermediate is not in TUF currently, as the root that issued the
intermediate certificate is in TUF.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
