### PR TITLE
fix: more informative error

### DIFF
--- a/cmd/cosign/cli/attach/attestation.go
+++ b/cmd/cosign/cli/attach/attestation.go
@@ -42,6 +42,10 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, signed
 		return err
 	}
 
+	if len(payload) == 0 {
+		return fmt.Errorf("%s payload is empty", signedPayload)
+	}
+
 	env := ssldsse.Envelope{}
 	if err := json.Unmarshal(payload, &env); err != nil {
 		return err


### PR DESCRIPTION
Command used: `cosign attach attestation --attestation filename.json image`
When running the attach attestation command with empty file payload the cli returns a hard to understand output:

```
Using payload from: filename.json
Error: unexpected end of JSON input
main.go:46: error during command execution: unexpected end of JSON input
```

By some investigation I found out that attestation file was empty, yes this is a user-error, so I recon it could be more informative as it throws the error while parsing the input making the real error a bit shaded.

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Gives the user a more informative error when providing empty command input.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
