### PR TITLE
chore: add rego function to consume modules and evaluate them

### DIFF
--- a/pkg/cosign/rego/rego.go
+++ b/pkg/cosign/rego/rego.go
@@ -22,12 +22,19 @@ import (
 	"fmt"
 
 	"github.com/open-policy-agent/opa/rego"
+	"knative.dev/pkg/logging"
 )
 
 // The query below should meet the following requirements:
 // * Provides no Bindings. Do not use a query that sets a variable, e.g. x := data.signature.allow
 // * Queries for a single value.
 const QUERY = "data.signature.allow"
+
+// CosignRegoPackageName defines the expected package name of a provided rego module
+const CosignRegoPackageName = "sigstore"
+
+// CosignEvaluationRule defines the expected evaluation role of a provided rego module
+const CosignEvaluationRule = "isCompliant"
 
 func ValidateJSON(jsonBody []byte, entrypoints []string) []error {
 	ctx := context.Background()
@@ -72,4 +79,43 @@ func ValidateJSON(jsonBody []byte, entrypoints []string) []error {
 		errs = append(errs, fmt.Errorf("result is undefined for query '%s'", QUERY))
 	}
 	return errs
+}
+
+// ValidateJSONWithModuleInput takes the body of the results to evaluate and the defined module
+// in a policy to validate against the input data
+func ValidateJSONWithModuleInput(jsonBody []byte, moduleInput string) error {
+	ctx := context.Background()
+	query := fmt.Sprintf("%s = data.%s.%s", CosignEvaluationRule, CosignRegoPackageName, CosignEvaluationRule)
+	module := fmt.Sprintf("%s.rego", CosignRegoPackageName)
+
+	r := rego.New(
+		rego.Query(query),
+		rego.Module(module, moduleInput))
+
+	evalQuery, err := r.PrepareForEval(ctx)
+	if err != nil {
+		return err
+	}
+
+	var input interface{}
+	dec := json.NewDecoder(bytes.NewBuffer(jsonBody))
+	dec.UseNumber()
+	if err := dec.Decode(&input); err != nil {
+		return err
+	}
+
+	rs, err := evalQuery.Eval(ctx, rego.EvalInput(input))
+	if err != nil {
+		return err
+	}
+
+	for _, result := range rs {
+		isCompliant, ok := result.Bindings[CosignEvaluationRule].(bool)
+		if ok && isCompliant {
+			logging.FromContext(ctx).Info("Validated policy is compliant")
+			return nil
+		}
+	}
+
+	return fmt.Errorf("policy is not compliant for query '%s'", query)
 }

--- a/pkg/cosign/rego/rego_test.go
+++ b/pkg/cosign/rego/rego_test.go
@@ -98,3 +98,118 @@ func TestValidationJSON(t *testing.T) {
 		})
 	}
 }
+
+const attestationsJSONBody = `{
+	"authorityMatches": {
+	  "keyatt": {
+		"signatures": null,
+		"attestations": {
+		  "vuln-key": [
+			{
+			  "subject": "PLACEHOLDER",
+			  "issuer": "PLACEHOLDER"
+			}
+		  ]
+		}
+	  },
+	  "keysignature": {
+		"signatures": [
+		  {
+			"subject": "PLACEHOLDER",
+			"issuer": "PLACEHOLDER"
+		  }
+		],
+		"attestations": null
+	  },
+	  "keylessatt": {
+		"signatures": null,
+		"attestations": {
+		  "custom-keyless": [
+			{
+			  "subject": "PLACEHOLDER",
+			  "issuer": "PLACEHOLDER"
+			}
+		  ]
+		}
+	  },
+	  "keylesssignature": {
+		"signatures": [
+		  {
+			"subject": "PLACEHOLDER",
+			"issuer": "PLACEHOLDER"
+		  }
+		],
+		"attestations": null
+	  }
+	}
+  }`
+
+func TestValidateJSONWithModuleInput(t *testing.T) {
+	cases := []struct {
+		name     string
+		jsonBody string
+		policy   string
+		pass     bool
+		errorMsg string
+	}{
+		{
+			name:     "passing policy attestations",
+			jsonBody: attestationsJSONBody,
+			policy: `
+				package sigstore
+				default isCompliant = false
+				isCompliant {
+					attestationsKeylessATT := input.authorityMatches.keylessatt.attestations
+					count(attestationsKeylessATT) == 1
+
+					attestationsKeyATT := input.authorityMatches.keyatt.attestations
+					count(attestationsKeyATT) == 1
+
+					keylessSignature := input.authorityMatches.keylesssignature.signatures
+					count(keylessSignature) == 1
+				
+					keySignature := input.authorityMatches.keysignature.signatures
+					count(keySignature) == 1
+				}
+			`,
+			pass: true,
+		},
+		{
+			name:     "not passing policy attestations",
+			jsonBody: attestationsJSONBody,
+			policy: `
+				package sigstore
+
+				default isCompliant = false
+
+				isCompliant {
+					attestationsKeylessATT := input.authorityMatches.keylessatt.attestations
+					count(attestationsKeylessATT) == 0
+
+					attestationsKeyATT := input.authorityMatches.keyatt.attestations
+					count(attestationsKeyATT) == 1
+
+					keylessSignature := input.authorityMatches.keylesssignature.signatures
+					count(keylessSignature) == 1
+				
+					keySignature := input.authorityMatches.keysignature.signatures
+					count(keySignature) == 1
+				}
+			`,
+			pass:     false,
+			errorMsg: "policy is not compliant for query 'isCompliant = data.sigstore.isCompliant'",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateJSONWithModuleInput([]byte(tt.jsonBody), tt.policy); (err == nil) != tt.pass {
+				t.Fatalf("Unexpected result: %v", err)
+			} else if err != nil {
+				if fmt.Sprintf("%s", err) != tt.errorMsg {
+					t.Errorf("Expected error %q, got %q", tt.errorMsg, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: hectorj2f <hectorf@vmware.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
Add a function that consumes rego policy modules and evaluate them. This would be useful for #1772 work when consuming rego policies and evaluate them.

I also added some unit tests.
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
