### PR TITLE
Refactor fulcio signer to take in KeyOpts.

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/attest"
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 )
 
 func Attest() *cobra.Command {
@@ -63,7 +62,7 @@ func Attest() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ko := sign.KeyOpts{
+			ko := options.KeyOpts{
 				KeyRef:                   o.Key,
 				PassFunc:                 generate.GetPass,
 				Sk:                       o.SecurityKey.Use,

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -74,7 +74,7 @@ func uploadToTlog(ctx context.Context, sv *sign.SignerVerifier, rekorURL string,
 }
 
 //nolint
-func AttestCmd(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOptions, imageRef string, certPath string, certChainPath string,
+func AttestCmd(ctx context.Context, ko options.KeyOpts, regOpts options.RegistryOptions, imageRef string, certPath string, certChainPath string,
 	noUpload bool, predicatePath string, force bool, predicateType string, replace bool, timeout time.Duration) error {
 	// A key file or token is required unless we're in experimental mode!
 	if options.EnableExperimental() {

--- a/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/fulcioverifier.go
@@ -24,11 +24,11 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio/fulcioverifier/ctl"
-	"github.com/sigstore/fulcio/pkg/api"
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 )
 
-func NewSigner(ctx context.Context, idToken, oidcIssuer, oidcClientID, oidcClientSecret, oidcRedirectURL string, fClient api.Client) (*fulcio.Signer, error) {
-	fs, err := fulcio.NewSigner(ctx, idToken, oidcIssuer, oidcClientID, oidcClientSecret, oidcRedirectURL, fClient)
+func NewSigner(ctx context.Context, ko options.KeyOpts) (*fulcio.Signer, error) {
+	fs, err := fulcio.NewSigner(ctx, ko)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cosign/cli/options/key.go
+++ b/cmd/cosign/cli/options/key.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import "github.com/sigstore/cosign/pkg/cosign"
+
+type KeyOpts struct {
+	Sk               bool
+	Slot             string
+	KeyRef           string
+	FulcioURL        string
+	RekorURL         string
+	IDToken          string
+	PassFunc         cosign.PassFunc
+	OIDCIssuer       string
+	OIDCClientID     string
+	OIDCClientSecret string
+	OIDCRedirectURL  string
+	BundlePath       string
+
+	// Modeled after InsecureSkipVerify in tls.Config, this disables
+	// verifying the SCT.
+	InsecureSkipFulcioVerify bool
+}

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -179,7 +179,7 @@ func signPolicy() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			sv, err := sign.SignerFromKeyOpts(ctx, "", "", sign.KeyOpts{
+			sv, err := sign.SignerFromKeyOpts(ctx, "", "", options.KeyOpts{
 				FulcioURL:                o.Fulcio.URL,
 				IDToken:                  o.Fulcio.IdentityToken,
 				InsecureSkipFulcioVerify: o.Fulcio.InsecureSkipFulcioVerify,

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -79,7 +79,7 @@ func Sign() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ko := sign.KeyOpts{
+			ko := options.KeyOpts{
 				KeyRef:                   o.Key,
 				PassFunc:                 generate.GetPass,
 				Sk:                       o.SecurityKey.Use,

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -47,7 +47,6 @@ import (
 	"github.com/sigstore/cosign/pkg/oci/mutate"
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 	"github.com/sigstore/cosign/pkg/oci/walk"
-	providers "github.com/sigstore/cosign/pkg/providers/all"
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -93,7 +92,7 @@ func GetAttachedImageRef(ref name.Reference, attachment string, opts ...ociremot
 }
 
 // nolint
-func SignCmd(ro *options.RootOptions, ko KeyOpts, regOpts options.RegistryOptions, annotations map[string]interface{},
+func SignCmd(ro *options.RootOptions, ko options.KeyOpts, regOpts options.RegistryOptions, annotations map[string]interface{},
 	imgs []string, certPath string, certChainPath string, upload bool, outputSignature, outputCertificate string,
 	payloadPath string, force bool, recursive bool, attachment string) error {
 	if options.EnableExperimental() {
@@ -183,7 +182,7 @@ func SignCmd(ro *options.RootOptions, ko KeyOpts, regOpts options.RegistryOption
 	return nil
 }
 
-func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko KeyOpts,
+func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko options.KeyOpts,
 	regOpts options.RegistryOptions, annotations map[string]interface{}, upload bool, outputSignature, outputCertificate string, force bool, recursive bool,
 	dd mutate.DupeDetector, sv *SignerVerifier, se oci.SignedEntity) error {
 	var err error
@@ -436,29 +435,18 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 	return certSigner, nil
 }
 
-func keylessSigner(ctx context.Context, ko KeyOpts) (*SignerVerifier, error) {
-	fClient, err := fulcio.NewClient(ko.FulcioURL)
-	if err != nil {
-		return nil, errors.Wrap(err, "creating Fulcio client")
-	}
-
-	tok := ko.IDToken
-	// If token is not set in the options, get one from the provders
-	if tok == "" && providers.Enabled(ctx) {
-		tok, err = providers.Provide(ctx, "sigstore")
-		if err != nil {
-			return nil, errors.Wrap(err, "fetching ambient OIDC credentials")
-		}
-	}
-
-	var k *fulcio.Signer
+func keylessSigner(ctx context.Context, ko options.KeyOpts) (*SignerVerifier, error) {
+	var (
+		k   *fulcio.Signer
+		err error
+	)
 
 	if ko.InsecureSkipFulcioVerify {
-		if k, err = fulcio.NewSigner(ctx, tok, ko.OIDCIssuer, ko.OIDCClientID, ko.OIDCClientSecret, ko.OIDCRedirectURL, fClient); err != nil {
+		if k, err = fulcio.NewSigner(ctx, ko); err != nil {
 			return nil, errors.Wrap(err, "getting key from Fulcio")
 		}
 	} else {
-		if k, err = fulcioverifier.NewSigner(ctx, tok, ko.OIDCIssuer, ko.OIDCClientID, ko.OIDCClientSecret, ko.OIDCRedirectURL, fClient); err != nil {
+		if k, err = fulcioverifier.NewSigner(ctx, ko); err != nil {
 			return nil, errors.Wrap(err, "getting key from Fulcio")
 		}
 	}
@@ -470,7 +458,7 @@ func keylessSigner(ctx context.Context, ko KeyOpts) (*SignerVerifier, error) {
 	}, nil
 }
 
-func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko KeyOpts) (*SignerVerifier, error) {
+func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, error) {
 	if ko.Sk {
 		return signerFromSecurityKey(ko.Slot)
 	}

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -34,27 +34,8 @@ import (
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 )
 
-type KeyOpts struct {
-	Sk               bool
-	Slot             string
-	KeyRef           string
-	FulcioURL        string
-	RekorURL         string
-	IDToken          string
-	PassFunc         cosign.PassFunc
-	OIDCIssuer       string
-	OIDCClientID     string
-	OIDCClientSecret string
-	OIDCRedirectURL  string
-	BundlePath       string
-
-	// Modeled after InsecureSkipVerify in tls.Config, this disables
-	// verifying the SCT.
-	InsecureSkipFulcioVerify bool
-}
-
 // nolint
-func SignBlobCmd(ro *options.RootOptions, ko KeyOpts, regOpts options.RegistryOptions, payloadPath string, b64 bool, outputSignature string, outputCertificate string) ([]byte, error) {
+func SignBlobCmd(ro *options.RootOptions, ko options.KeyOpts, regOpts options.RegistryOptions, payloadPath string, b64 bool, outputSignature string, outputCertificate string) ([]byte, error) {
 	var payload []byte
 	var err error
 	var rekorBytes []byte

--- a/cmd/cosign/cli/sign/sign_test.go
+++ b/cmd/cosign/cli/sign/sign_test.go
@@ -110,7 +110,7 @@ func generateCertificateFiles(t *testing.T, tmpDir string, pf cosign.PassFunc) (
 func TestSignCmdLocalKeyAndSk(t *testing.T) {
 	ro := &options.RootOptions{Timeout: options.DefaultTimeout}
 
-	for _, ko := range []KeyOpts{
+	for _, ko := range []options.KeyOpts{
 		// local and sk keys
 		{
 			KeyRef:   "testLocalPath",

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -68,7 +68,7 @@ func SignBlob() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			ko := sign.KeyOpts{
+			ko := options.KeyOpts{
 				KeyRef:                   o.Key,
 				PassFunc:                 generate.GetPass,
 				Sk:                       o.SecurityKey.Use,

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/cmd/cosign/cli/verify"
 )
 
@@ -246,7 +245,7 @@ The blob may be specified as a path to a file or - for stdin.`,
 
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ko := sign.KeyOpts{
+			ko := options.KeyOpts{
 				KeyRef:     o.Key,
 				Sk:         o.SecurityKey.Use,
 				Slot:       o.SecurityKey.Slot,

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -35,7 +35,6 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
-	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/pkg/blob"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/pivkey"
@@ -61,7 +60,7 @@ func isb64(data []byte) bool {
 }
 
 // nolint
-func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, certEmail,
+func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 	certOidcIssuer, certChain, sigRef, blobRef string, enforceSCT bool) error {
 	var verifier signature.Verifier
 	var cert *x509.Certificate
@@ -186,7 +185,7 @@ func VerifyBlobCmd(ctx context.Context, ko sign.KeyOpts, certRef, certEmail,
 	return nil
 }
 
-func verifySigByUUID(ctx context.Context, ko sign.KeyOpts, rClient *client.Rekor, certEmail, certOidcIssuer, sig, b64sig string,
+func verifySigByUUID(ctx context.Context, ko options.KeyOpts, rClient *client.Rekor, certEmail, certOidcIssuer, sig, b64sig string,
 	uuids []string, blobBytes []byte, enforceSCT bool) error {
 	var validSigExists bool
 	for _, u := range uuids {
@@ -289,7 +288,7 @@ func payloadBytes(blobRef string) ([]byte, error) {
 	return blobBytes, nil
 }
 
-func verifyRekorEntry(ctx context.Context, ko sign.KeyOpts, e *models.LogEntryAnon, pubKey signature.Verifier, cert *x509.Certificate, b64sig string, blobBytes []byte) error {
+func verifyRekorEntry(ctx context.Context, ko options.KeyOpts, e *models.LogEntryAnon, pubKey signature.Verifier, cert *x509.Certificate, b64sig string, blobBytes []byte) error {
 	// If we have a bundle with a rekor entry, let's first try to verify offline
 	if ko.BundlePath != "" {
 		if err := verifyRekorBundle(ctx, ko.BundlePath, cert); err == nil {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -125,7 +125,7 @@ func TestSignVerify(t *testing.T) {
 	mustErr(download.SignatureCmd(ctx, options.RegistryOptions{}, imgName), t)
 
 	// Now sign the image
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
@@ -160,7 +160,7 @@ func TestSignVerifyClean(t *testing.T) {
 	ctx := context.Background()
 
 	// Now sign the image
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
@@ -189,7 +189,7 @@ func TestImportSignVerifyClean(t *testing.T) {
 	ctx := context.Background()
 
 	// Now sign the image
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
@@ -232,7 +232,7 @@ func TestAttestVerify(t *testing.T) {
 	}
 
 	// Now attest the image
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(attest.AttestCmd(ctx, ko, options.RegistryOptions{}, imgName, "", "", false, slsaAttestationPath, false,
 		"slsaprovenance", false, 30*time.Second), t)
 
@@ -273,7 +273,7 @@ func TestAttestationReplace(t *testing.T) {
 	defer cleanup()
 
 	_, privKeyPath, _ := keypair(t, td)
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 
 	ctx := context.Background()
 
@@ -327,7 +327,7 @@ func TestRekorBundle(t *testing.T) {
 
 	_, privKeyPath, pubKeyPath := keypair(t, td)
 
-	ko := sign.KeyOpts{
+	ko := options.KeyOpts{
 		KeyRef:   privKeyPath,
 		PassFunc: passFunc,
 		RekorURL: rekorURL,
@@ -363,7 +363,7 @@ func TestDuplicateSign(t *testing.T) {
 	mustErr(download.SignatureCmd(ctx, options.RegistryOptions{}, imgName), t)
 
 	// Now sign the image
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, ""), t)
 
 	// Now verify and download should work!
@@ -460,7 +460,7 @@ func TestMultipleSignatures(t *testing.T) {
 	mustErr(verify(pub2, imgName, true, nil, ""), t)
 
 	// Now sign the image with one key
-	ko := sign.KeyOpts{KeyRef: priv1, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: priv1, PassFunc: passFunc}
 	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, ""), t)
 	// Now verify should work with that one, but not the other
 	must(verify(pub1, imgName, true, nil, ""), t)
@@ -494,10 +494,10 @@ func TestSignBlob(t *testing.T) {
 
 	ctx := context.Background()
 
-	ko1 := sign.KeyOpts{
+	ko1 := options.KeyOpts{
 		KeyRef: pubKeyPath1,
 	}
-	ko2 := sign.KeyOpts{
+	ko2 := options.KeyOpts{
 		KeyRef: pubKeyPath2,
 	}
 	// Verify should fail on a bad input
@@ -505,7 +505,7 @@ func TestSignBlob(t *testing.T) {
 	mustErr(cliverify.VerifyBlobCmd(ctx, ko2, "" /*certRef*/, "" /*certEmail*/, "" /*certOidcIssuer*/, "" /*certChain*/, "badsig", blob, false), t)
 
 	// Now sign the blob with one key
-	ko := sign.KeyOpts{
+	ko := options.KeyOpts{
 		KeyRef:   privKeyPath1,
 		PassFunc: passFunc,
 	}
@@ -535,7 +535,7 @@ func TestSignBlobBundle(t *testing.T) {
 
 	ctx := context.Background()
 
-	ko1 := sign.KeyOpts{
+	ko1 := options.KeyOpts{
 		KeyRef:     pubKeyPath1,
 		BundlePath: bundlePath,
 	}
@@ -543,7 +543,7 @@ func TestSignBlobBundle(t *testing.T) {
 	mustErr(cliverify.VerifyBlobCmd(ctx, ko1, "", "", "", "", "", blob, false), t)
 
 	// Now sign the blob with one key
-	ko := sign.KeyOpts{
+	ko := options.KeyOpts{
 		KeyRef:     privKeyPath1,
 		PassFunc:   passFunc,
 		BundlePath: bundlePath,
@@ -849,7 +849,7 @@ func TestSaveLoad(t *testing.T) {
 
 			ctx := context.Background()
 			// Now sign the image and verify it
-			ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+			ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 			must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, ""), t)
 			must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
@@ -882,7 +882,7 @@ func TestSaveLoadAttestation(t *testing.T) {
 
 	ctx := context.Background()
 	// Now sign the image and verify it
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, ""), t)
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
@@ -894,7 +894,7 @@ func TestSaveLoadAttestation(t *testing.T) {
 	}
 
 	// Now attest the image
-	ko = sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	ko = options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(attest.AttestCmd(ctx, ko, options.RegistryOptions{}, imgName, "", "", false, slsaAttestationPath, false,
 		"custom", false, 30*time.Second), t)
 
@@ -971,7 +971,7 @@ func TestAttachSBOM(t *testing.T) {
 	mustErr(verify(pubKeyPath2, imgName, true, nil, "sbom"), t)
 
 	// Now sign the sbom with one key
-	ko1 := sign.KeyOpts{KeyRef: privKeyPath1, PassFunc: passFunc}
+	ko1 := options.KeyOpts{KeyRef: privKeyPath1, PassFunc: passFunc}
 	must(sign.SignCmd(ro, ko1, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, "sbom"), t)
 
 	// Now verify should work with that one, but not the other
@@ -1004,7 +1004,7 @@ func TestTlog(t *testing.T) {
 	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
 
 	// Now sign the image without the tlog
-	ko := sign.KeyOpts{
+	ko := options.KeyOpts{
 		KeyRef:   privKeyPath,
 		PassFunc: passFunc,
 		RekorURL: rekorURL,
@@ -1182,7 +1182,7 @@ func TestInvalidBundle(t *testing.T) {
 	// (we're just using it for its bundle)
 	defer setenv(t, options.ExperimentalEnv, "1")()
 	remoteOpts := ociremote.WithRemoteOptions(registryClientOpts(ctx)...)
-	ko := sign.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc, RekorURL: rekorURL}
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc, RekorURL: rekorURL}
 	regOpts := options.RegistryOptions{}
 
 	must(sign.SignCmd(ro, ko, regOpts, nil, []string{img1}, "", "", true, "", "", "", true, false, ""), t)


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This commit should not have change in behavior. It changes the fulcio signer
to take in the KeyOpts struct instead of passing individual parameters through,
as well as moves common code dependent on the values to the same place.

The motivation behind this change is to make it easier to add new options without
needing to plumb through another param to the already long list.

To avoid circular dependencies (sign -> fulcio -> sign), KeyOpts was moved to the
options package.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Part of https://github.com/sigstore/cosign/issues/1785 (wanted to make this change first to make adding the option easier)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
