### PR TITLE
chore(deps): Included dependency review

### DIFF
--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -23,6 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b  # v3
       - name: 'Dependency Review'
-        uses: actions/dependency-review-action@3f943b86c9a289f4e632c632695e2e0898d9d67d
+        uses: actions/dependency-review-action@3f943b86c9a289f4e632c632695e2e0898d9d67d # v1

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -1,0 +1,28 @@
+#
+# Copyright 2021 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@3f943b86c9a289f4e632c632695e2e0898d9d67d

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2021 The Sigstore Authors.
+# Copyright 2022 The Sigstore Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
> Dependency Review GitHub Action in your repository to enforce dependency reviews on your pull requests.
> The action scans for vulnerable versions of dependencies introduced by package version changes in pull requests,
> and warns you about the associated security vulnerabilities.
> This gives you better visibility of what's changing in a pull request,
> and helps prevent vulnerabilities being added to your repository.

https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
