### PR TITLE
Fix a bug where an error would send duplicate results.

### DIFF
--- a/pkg/cosign/kubernetes/webhook/validator.go
+++ b/pkg/cosign/kubernetes/webhook/validator.go
@@ -267,9 +267,9 @@ func validatePolicies(ctx context.Context, ref name.Reference, policies map[stri
 					logging.FromContext(ctx).Infof("Validating CIP level policy for %s", cipName)
 					policyJSON, err := json.Marshal(result.policyResult)
 					if err != nil {
-						results <- result
+						result.errors = append(result.errors, err)
 					} else {
-						logging.FromContext(ctx).Infof("Validating CIP level policy against %s", string(policyJSON))
+						logging.FromContext(ctx).Debugf("Validating CIP level policy against %s", string(policyJSON))
 						err = policy.EvaluatePolicyAgainstJSON(ctx, "ClusterImagePolicy", cip.Policy.Type, cip.Policy.Data, policyJSON)
 						if err != nil {
 							result.errors = append(result.errors, err)


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix a bug where a malformed JSON would result in early send to channel, resulting in two events.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
