### PR TITLE
Load in intermediate cert pool from TUF

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
@@ -83,8 +83,8 @@ func GetIntermediates() *x509.CertPool {
 }
 
 func initRoots() (*x509.CertPool, *x509.CertPool, error) {
-	rootPool := x509.NewCertPool()
-	intermediatePool := x509.NewCertPool()
+	var rootPool *x509.CertPool
+	var intermediatePool *x509.CertPool
 
 	rootEnv := os.Getenv(altRoot)
 	if rootEnv != "" {
@@ -99,8 +99,14 @@ func initRoots() (*x509.CertPool, *x509.CertPool, error) {
 		for _, cert := range certs {
 			// root certificates are self-signed
 			if bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+				if rootPool == nil {
+					rootPool = x509.NewCertPool()
+				}
 				rootPool.AddCert(cert)
 			} else {
+				if intermediatePool == nil {
+					intermediatePool = x509.NewCertPool()
+				}
 				intermediatePool.AddCert(cert)
 			}
 		}
@@ -127,11 +133,20 @@ func initRoots() (*x509.CertPool, *x509.CertPool, error) {
 			for _, cert := range certs {
 				// root certificates are self-signed
 				if bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+					if rootPool == nil {
+						rootPool = x509.NewCertPool()
+					}
 					rootPool.AddCert(cert)
 				} else {
+					if intermediatePool == nil {
+						intermediatePool = x509.NewCertPool()
+					}
 					intermediatePool.AddCert(cert)
 				}
 			}
+		}
+		if intermediatePool == nil {
+			intermediatePool = x509.NewCertPool()
 		}
 		intermediatePool.AppendCertsFromPEM([]byte(fulcioIntermediateV1))
 	}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -111,6 +111,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			co.RekorClient = rekorClient
 		}
 		co.RootCerts = fulcio.GetRoots()
+		co.IntermediateCerts = fulcio.GetIntermediates()
 	}
 	keyRef := c.KeyRef
 	certRef := c.CertRef

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -92,6 +92,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			co.RekorClient = rekorClient
 		}
 		co.RootCerts = fulcio.GetRoots()
+		co.IntermediateCerts = fulcio.GetIntermediates()
 	}
 	keyRef := c.KeyRef
 

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -475,7 +475,8 @@ func VerifyImageSignature(ctx context.Context, sig oci.Signature, h v1.Hash, co 
 		// If the chain annotation is not present or there is only a root
 		if chain == nil || len(chain) <= 1 {
 			co.IntermediateCerts = nil
-		} else {
+		} else if co.IntermediateCerts == nil {
+			// If the intermediate certs have not been loaded in by TUF
 			pool := x509.NewCertPool()
 			for _, cert := range chain[:len(chain)-1] {
 				pool.AddCert(cert)
@@ -653,7 +654,8 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 				// If the chain annotation is not present or there is only a root
 				if chain == nil || len(chain) <= 1 {
 					co.IntermediateCerts = nil
-				} else {
+				} else if co.IntermediateCerts == nil {
+					// If the intermediate certs have not been loaded in by TUF
 					pool := x509.NewCertPool()
 					for _, cert := range chain[:len(chain)-1] {
 						pool.AddCert(cert)

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -91,6 +91,7 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 		fulcioVerified := (co.SigVerifier == nil)
 
 		co.RootCerts = fulcio.GetRoots()
+		co.IntermediateCerts = fulcio.GetIntermediates()
 
 		sp, bundleVerified, err := cosign.VerifyImageSignatures(ctx, ref, co)
 		if err != nil {


### PR DESCRIPTION
With the v3 TUF root, the intermediate CA certificate will be included,
so that if the intermediate signing key was compromised, the
intermediate certificate could be revoked by removing it from the TUF
targets and replacing it with a trusted certificate.

This change loads the intermediate certificate from TUF. However, we
don't want to force all users to follow this structure - They may choose
to use CRLs to detect revoked intermediates. Also, I don't want to
enforce TUF usage in the Verify package. Therefore, for TUF, we lazily create
a certificate pool only if an intermediate certificate is found, and if
it's not found, then VerifyImageSignature will create a pool using the
chain provided in the annotation.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added support for loading intermediate certificates from TUF on verification
```
