### PR TITLE
Support PKCS1 encoded and non-ECDSA CT log public keys

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
@@ -89,7 +89,7 @@ func VerifySCT(ctx context.Context, certPEM, chainPEM, rawSCT []byte) error {
 			return err
 		}
 		for _, t := range targets {
-			pub, err := cryptoutils.UnmarshalPEMToPublicKey(t.Target)
+			pub, err := getPublicKey(t.Target)
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ func VerifySCT(ctx context.Context, certPEM, chainPEM, rawSCT []byte) error {
 		if err != nil {
 			return errors.Wrap(err, "error reading alternate public key file")
 		}
-		pubKey, err := getAlternatePublicKey(raw)
+		pubKey, err := getPublicKey(raw)
 		if err != nil {
 			return errors.Wrap(err, "error parsing alternate public key from the file")
 		}
@@ -206,7 +206,7 @@ func VerifyEmbeddedSCT(ctx context.Context, chain []*x509.Certificate) error {
 // Given a byte array, try to construct a public key from it.
 // Will try first to see if it's PEM formatted, if not, then it will
 // try to parse it as der publics, and failing that
-func getAlternatePublicKey(in []byte) (crypto.PublicKey, error) {
+func getPublicKey(in []byte) (crypto.PublicKey, error) {
 	var pubKey crypto.PublicKey
 	var err error
 	var derBytes []byte
@@ -222,7 +222,7 @@ func getAlternatePublicKey(in []byte) (crypto.PublicKey, error) {
 		// Try using the PKCS1 before giving up.
 		pubKey, err = x509.ParsePKCS1PublicKey(derBytes)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse alternate public key")
+			return nil, errors.Wrap(err, "failed to parse CT log public key")
 		}
 	}
 	return pubKey, nil

--- a/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
@@ -204,8 +204,8 @@ func VerifyEmbeddedSCT(ctx context.Context, chain []*x509.Certificate) error {
 }
 
 // Given a byte array, try to construct a public key from it.
-// Will try first to see if it's PEM formatted, if not, then it will
-// try to parse it as der publics, and failing that
+// Supports PEM encoded public keys, falling back to DER. Supports
+// PKIX and PKCS1 encoded keys.
 func getPublicKey(in []byte) (crypto.PublicKey, error) {
 	var pubKey crypto.PublicKey
 	var err error

--- a/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
@@ -17,7 +17,6 @@ package ctl
 import (
 	"context"
 	"crypto"
-	"crypto/ecdsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/json"
@@ -93,15 +92,11 @@ func VerifySCT(ctx context.Context, certPEM, chainPEM, rawSCT []byte) error {
 			if err != nil {
 				return err
 			}
-			ctPub, ok := pub.(*ecdsa.PublicKey)
-			if !ok {
-				return fmt.Errorf("invalid public key: was %T, require *ecdsa.PublicKey", pub)
-			}
-			keyID, err := ctutil.GetCTLogID(ctPub)
+			keyID, err := ctutil.GetCTLogID(pub)
 			if err != nil {
 				return errors.Wrap(err, "error getting CTFE public key hash")
 			}
-			pubKeys[keyID] = logIDMetadata{ctPub, t.Status}
+			pubKeys[keyID] = logIDMetadata{pub, t.Status}
 		}
 	} else {
 		fmt.Fprintf(os.Stderr, "**Warning** Using a non-standard public key for verifying SCT: %s\n", rootEnv)

--- a/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify_test.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
-func TestGetAlternatePublicKey(t *testing.T) {
+func TestGetPublicKey(t *testing.T) {
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Failed to get cwd: %v", err)
@@ -58,7 +58,7 @@ func TestGetAlternatePublicKey(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to read testfile %s : %v", tc.file, err)
 		}
-		got, err := getAlternatePublicKey(bytes)
+		got, err := getPublicKey(bytes)
 		switch {
 		case err == nil && tc.wantErrSub != "":
 			t.Errorf("Wanted Error for %s but got none", tc.file)


### PR DESCRIPTION
This came up while testing out staging, which uses a PKCS1 encoded
public key. We should be flexible on the supported key format.

This also relaxes the requirement that CT log keys from TUF are ECDSA keys.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Added support for non-ECDSA and PKCS1-encoded CT log public keys from TUF
```
