### PR TITLE
cosigned: Test unsupported KMS providers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,6 @@ github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdII
 github.com/OpenPeeDeeP/depguard v1.0.1/go.mod h1:xsIw86fROiiwelg+jB2uM9PiKihMMmUx/1V+TNhjQvM=
 github.com/PaesslerAG/gval v1.0.0 h1:GEKnRwkWDdf9dOmKcNrar9EA1bz1z9DqPIO1+iLzhd8=
 github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
-github.com/PaesslerAG/gval v1.0.0/go.mod h1:y/nm5yEyTeX6av0OfKJNp9rBNj2XrGhAf5+v24IBN1I=
-github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.0/go.mod h1:4BzmtoM/PI8fPO4aQGIusjGxGir2BzcV0grWtFzq1Y8=
 github.com/PaesslerAG/jsonpath v0.1.1 h1:c1/AToHQMVsduPAa4Vh6xp2U0evy4t8SWp8imEsylIk=
 github.com/PaesslerAG/jsonpath v0.1.1/go.mod h1:lVboNxFGal/VwW6d9JzIy56bUsYAP6tH/x80vjnCseY=

--- a/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
+++ b/pkg/reconciler/clusterimagepolicy/clusterimagepolicy.go
@@ -155,16 +155,14 @@ func (r *Reconciler) inlinePublicKeys(ctx context.Context, cip *v1alpha1.Cluster
 				return nil, err
 			}
 		}
-		if authority.Key != nil && authority.Key.KMS != "" {
-			if strings.Contains(authority.Key.KMS, "://") {
-				pubKeyString, err := getKMSPublicKey(ctx, authority.Key.KMS)
-				if err != nil {
-					return nil, err
-				}
-
-				authority.Key.Data = pubKeyString
-				authority.Key.KMS = ""
+		if authority.Key != nil && strings.Contains(authority.Key.KMS, "://") {
+			pubKeyString, err := getKMSPublicKey(ctx, authority.Key.KMS)
+			if err != nil {
+				return nil, err
 			}
+
+			authority.Key.Data = pubKeyString
+			authority.Key.KMS = ""
 		}
 	}
 	return ret, nil


### PR DESCRIPTION
This adds a test case to cover the case where a specified KMS provider
isn't supported; in this case, we fire an event describing the error.

Signed-off-by: Jason Hall <jason@chainguard.dev>

```release-note
NONE
```

cc @mattmoor 
