### PR TITLE
Add auth flow option to KeyOpts.

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -138,6 +138,9 @@ func NewSigner(ctx context.Context, ko options.KeyOpts) (*Signer, error) {
 
 	var flow string
 	switch {
+	case ko.FulcioAuthFlow != "":
+		// Caller manually set flow option.
+		flow = ko.FulcioAuthFlow
 	case idToken != "":
 		flow = FlowToken
 	case !term.IsTerminal(0):

--- a/cmd/cosign/cli/options/key.go
+++ b/cmd/cosign/cli/options/key.go
@@ -30,6 +30,10 @@ type KeyOpts struct {
 	OIDCClientSecret string
 	OIDCRedirectURL  string
 	BundlePath       string
+	// FulcioAuthFlow is the auth flow to use when authenticating against
+	// Fulcio. See https://pkg.go.dev/github.com/sigstore/cosign/cmd/cosign/cli/fulcio#pkg-constants
+	// for valid values.
+	FulcioAuthFlow string
 
 	// Modeled after InsecureSkipVerify in tls.Config, this disables
 	// verifying the SCT.


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

This change adds an option for callers to manually select the fulcio
auth flow to go through. This allows callers that don't fit into the
default heuristic to have some control over how cosign is invoked.

For now, this is only added as a KeyOpt and not a flag, since this is
currently only needed by tools calling the cosign libraries, not cosign
itself. Flags can be added on later if needed.

This change should not have any impact on existing cosign behavior.

Because there are no unit tests for `fulcio.NewSigner` at the moment,
this is difficult to test in a way that isn't trivial. This is probably a good
target to improve coverage as part of https://github.com/sigstore/cosign/issues/1385

Signed-off-by: Billy Lynch <billy@chainguard.dev>

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->

Fixes https://github.com/sigstore/cosign/issues/1785

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Users calling cosign via library can set the fulcio interactive flow used with KeyOpts.
```
