### PR TITLE
New flag --oidc-providers-disable to disable OIDC providers

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -119,7 +119,7 @@ func NewSigner(ctx context.Context, ko options.KeyOpts) (*Signer, error) {
 
 	idToken := ko.IDToken
 	// If token is not set in the options, get one from the provders
-	if idToken == "" && providers.Enabled(ctx) {
+	if idToken == "" && providers.Enabled(ctx) && !ko.OIDCDisableProviders {
 		idToken, err = providers.Provide(ctx, "sigstore")
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching ambient OIDC credentials")

--- a/cmd/cosign/cli/options/key.go
+++ b/cmd/cosign/cli/options/key.go
@@ -18,18 +18,19 @@ package options
 import "github.com/sigstore/cosign/pkg/cosign"
 
 type KeyOpts struct {
-	Sk               bool
-	Slot             string
-	KeyRef           string
-	FulcioURL        string
-	RekorURL         string
-	IDToken          string
-	PassFunc         cosign.PassFunc
-	OIDCIssuer       string
-	OIDCClientID     string
-	OIDCClientSecret string
-	OIDCRedirectURL  string
-	BundlePath       string
+	Sk                   bool
+	Slot                 string
+	KeyRef               string
+	FulcioURL            string
+	RekorURL             string
+	IDToken              string
+	PassFunc             cosign.PassFunc
+	OIDCIssuer           string
+	OIDCClientID         string
+	OIDCClientSecret     string
+	OIDCRedirectURL      string
+	OIDCDisableProviders bool // Disable OIDC credential providers in keyless signer
+	BundlePath           string
 	// FulcioAuthFlow is the auth flow to use when authenticating against
 	// Fulcio. See https://pkg.go.dev/github.com/sigstore/cosign/cmd/cosign/cli/fulcio#pkg-constants
 	// for valid values.

--- a/cmd/cosign/cli/options/oidc.go
+++ b/cmd/cosign/cli/options/oidc.go
@@ -29,10 +29,11 @@ const DefaultOIDCIssuerURL = "https://oauth2.sigstore.dev/auth"
 
 // OIDCOptions is the wrapper for OIDC related options.
 type OIDCOptions struct {
-	Issuer           string
-	ClientID         string
-	clientSecretFile string
-	RedirectURL      string
+	Issuer                  string
+	ClientID                string
+	clientSecretFile        string
+	RedirectURL             string
+	DisableAmbientProviders bool
 }
 
 func (o *OIDCOptions) ClientSecret() (string, error) {
@@ -66,4 +67,7 @@ func (o *OIDCOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RedirectURL, "oidc-redirect-url", "",
 		"[EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.")
+
+	cmd.Flags().BoolVar(&o.DisableAmbientProviders, "oidc-disable-ambient-providers", false,
+		"[EXPERIMENTAL] Disable ambient OIDC providers. When true, ambient credentials will not be read")
 }

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -95,6 +95,7 @@ func Sign() *cobra.Command {
 				OIDCClientID:             o.OIDC.ClientID,
 				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
+				OIDCDisableProviders:     o.OIDC.DisableAmbientProviders,
 			}
 			annotationsMap, err := o.AnnotationsMap()
 			if err != nil {

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -81,6 +81,7 @@ func SignBlob() *cobra.Command {
 				OIDCClientID:             o.OIDC.ClientID,
 				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
+				OIDCDisableProviders:     o.OIDC.DisableAmbientProviders,
 				BundlePath:               o.BundlePath,
 			}
 			for _, blob := range args {

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -53,6 +53,7 @@ cosign attest [flags]
       --no-upload                                                                                do not upload the generated attestation
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
+      --oidc-disable-ambient-providers                                                           [EXPERIMENTAL] Disable ambient OIDC providers. When true, ambient credentials will not be read
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --predicate string                                                                         path to the predicate file.

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -25,6 +25,7 @@ cosign policy sign [flags]
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
+      --oidc-disable-ambient-providers                                                           [EXPERIMENTAL] Disable ambient OIDC providers. When true, ambient credentials will not be read
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --out string                                                                               output policy locally (default "o")

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -45,6 +45,7 @@ cosign sign-blob [flags]
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
+      --oidc-disable-ambient-providers                                                           [EXPERIMENTAL] Disable ambient OIDC providers. When true, ambient credentials will not be read
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --output string                                                                            write the signature to FILE

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -70,6 +70,7 @@ cosign sign [flags]
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string                                                                    [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
       --oidc-client-secret-file string                                                           [EXPERIMENTAL] Path to file containing OIDC client secret for application
+      --oidc-disable-ambient-providers                                                           [EXPERIMENTAL] Disable ambient OIDC providers. When true, ambient credentials will not be read
       --oidc-issuer string                                                                       [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --output-certificate string                                                                write the certificate to FILE


### PR DESCRIPTION
#### Summary
This PR adds a new command line flag `--oidc-providers-disable` to `cosign sign` and `cosign sign-blob` to disable the internal OIDC providers. This does not break compatibility with the current cli and skips the providers logic to jump straight to the OIDC flow.

/cc @di @eddiezane 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>

#### Ticket Link

Fixes https://github.com/sigstore/cosign/issues/1819

#### Release Note
```release-note
New command line flag `--oidc-providers-disable` to `cosign sign` and `cosign sign-blob` to disable the internal OIDC providers. This does not break compatibility with the current cli and skips the providers logic to jump straight to the OIDC flow.

```
