### PR TITLE
Remove go.mod exclude line

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -315,5 +315,3 @@ require (
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
-
-exclude github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b


### PR DESCRIPTION
This line got added in PR #1731 (commit
920dcfadc29a3b0a04ee3f4dc503fb08ab96437a), and breaks go install
github.com/sigstore/cosign/cmd/cosign.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>