### PR TITLE
[Cosigned] Glob matching improvement

### DIFF
--- a/pkg/apis/config/image_policies.go
+++ b/pkg/apis/config/image_policies.go
@@ -93,7 +93,9 @@ func (p *ImagePolicyConfig) GetMatchingPolicies(image string) (map[string]webhoo
 	for k, v := range p.Policies {
 		for _, pattern := range v.Images {
 			if pattern.Glob != "" {
-				if GlobMatch(image, pattern.Glob) {
+				if matched, err := GlobMatch(pattern.Glob, image); err != nil {
+					lastError = err
+				} else if matched {
 					ret[k] = v
 				}
 			} else if pattern.Regex != "" {

--- a/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation.go
@@ -17,8 +17,8 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"regexp"
-	"strings"
 
 	"github.com/sigstore/cosign/pkg/apis/utils"
 	"knative.dev/pkg/apis"
@@ -202,20 +202,13 @@ func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 	return errs
 }
 
-// ValidateGlob makes sure that if there's "*" specified it's the trailing
-// character.
+// ValidateGlob glob compilation by testing against empty string
 func ValidateGlob(glob string) *apis.FieldError {
-	c := strings.Count(glob, "*")
-	switch c {
-	case 0:
-		return nil
-	case 1:
-		if !strings.HasSuffix(glob, "*") {
-			return apis.ErrInvalidValue(glob, apis.CurrentField, "glob match supports only * as a trailing character")
-		}
-	default:
-		return apis.ErrInvalidValue(glob, apis.CurrentField, "glob match supports only a single * as a trailing character")
+	_, err := filepath.Match(glob, "")
+	if err != nil {
+		return apis.ErrInvalidValue(glob, apis.CurrentField, fmt.Sprintf("glob is invalid: %v", err))
 	}
+
 	return nil
 }
 

--- a/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_validation_test.go
@@ -33,7 +33,7 @@ func TestImagePatternValidation(t *testing.T) {
 		{
 			name:        "Should fail when both regex and glob are present",
 			expectErr:   true,
-			errorString: "expected exactly one, got both: spec.images[0].glob, spec.images[0].regex\ninvalid value: **: spec.images[0].glob\nglob match supports only a single * as a trailing character\nmissing field(s): spec.authorities",
+			errorString: "expected exactly one, got both: spec.images[0].glob, spec.images[0].regex\nmissing field(s): spec.authorities",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -58,28 +58,14 @@ func TestImagePatternValidation(t *testing.T) {
 			},
 		},
 		{
-			name:        "Glob should fail with multiple *",
+			name:        "Glob should fail with invalid glob",
 			expectErr:   true,
-			errorString: "invalid value: **: spec.images[0].glob\nglob match supports only a single * as a trailing character\nmissing field(s): spec.authorities",
+			errorString: "invalid value: [: spec.images[0].glob\nglob is invalid: syntax error in pattern\nmissing field(s): spec.authorities",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
 						{
-							Glob: "**",
-						},
-					},
-				},
-			},
-		},
-		{
-			name:        "Glob should fail with non-trailing *",
-			expectErr:   true,
-			errorString: "invalid value: foo*bar: spec.images[0].glob\nglob match supports only * as a trailing character\nmissing field(s): spec.authorities",
-			policy: ClusterImagePolicy{
-				Spec: ClusterImagePolicySpec{
-					Images: []ImagePattern{
-						{
-							Glob: "foo*bar",
+							Glob: "[",
 						},
 					},
 				},


### PR DESCRIPTION
#### Summary
Instead of doing a prefix check only for glob matching, use the `filepath` implementation of `Match` to match against glob patterns.
This will also remove the restrictions for only supporting trailing wildcard `*`

Alongside this change:
- I also added defaulting to use `index.docker.io/` host if there is no host in the glob pattern and there was not a match prior. 
  This is important since when a user deploys using `myproject/nginx` for example, the image reference gets resolved to `index.docker.io/myproject/nginx`
- I also added defaulting to the `library` repository when a glob is specified without multiple path elements.
  This is important since when a user deploys `busybox` for example, the image reference gets resolved to `index.docker.io/library/busybox` 
  
Now a user should be able to able to create a cluster image policy with glob patterns:
```yaml
- busybox
- myproject/image
```

when previously they needed to prefix those as such:
```yaml
- index.docker.io/library/busybox
- index.docker.io/myproject/image
```
#### Ticket Link

Fixes https://github.com/sigstore/cosign/issues/1840
Related https://github.com/sigstore/cosign/issues/1834

#### Release Note
```release-note
* Updated cosigned glob matching logic to allow for multiple wildcards
* Updated cosigned glob matching to handle dockerhub image references better

```

cc: @coyote240 @elfotografo007 @hectorj2f @vaikas 