### PR TITLE
sget: Enable KMS providers for sget

### DIFF
--- a/cmd/sget/main.go
+++ b/cmd/sget/main.go
@@ -22,6 +22,12 @@ import (
 	"strings"
 
 	"github.com/sigstore/cosign/cmd/sget/cli"
+
+	// Register the provider-specific plugins
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/azure"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/gcp"
+	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 )
 
 func main() {


### PR DESCRIPTION
After https://github.com/sigstore/sigstore/pull/276 `cosign/sget` wasn't set up to initialize all the supported KMS providers. 

#### Release Note

```release-note
Enable supported KMS providers for sget
```
