### PR TITLE
Route deprecated  -version to version subcommand

### DIFF
--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -43,7 +43,17 @@ func main() {
 		} else if strings.HasPrefix(arg, "-") {
 			// Handle -output, convert to --output
 			newArg := fmt.Sprintf("-%s", arg)
-			fmt.Fprintf(os.Stderr, "WARNING: the flag %s is deprecated and will be removed in a future release. Please use the flag %s.\n", arg, newArg)
+			newArgType := "flag"
+			if newArg == "--version" {
+				newArg = "version"
+				newArgType = "subcommand"
+			}
+			fmt.Fprintf(
+				os.Stderr,
+				"WARNING: the %s flag is deprecated and will be removed in a future release. "+
+					"Please use the %s %s instead.\n",
+				arg, newArg, newArgType,
+			)
 			os.Args[i] = newArg
 		}
 	}


### PR DESCRIPTION

#### Summary

This commit fixes the routing of the deprecated -version flag to avoid translating it to --version. Instead, it routes the flag to the `version` subcommand, prefixing it with the deprecation warning.

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>

#### Ticket Link

Fixes https://github.com/sigstore/cosign/issues/1811

#### Release Note
```release-note
The -version flag now works as other deprecated flags, patching it to the expected output and preceding it with a warning
```
