### PR TITLE
If SBOM ref has .json suffix, assume JSON mediatype

### DIFF
--- a/cmd/cosign/cli/options/attach.go
+++ b/cmd/cosign/cli/options/attach.go
@@ -17,6 +17,7 @@ package options
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/spf13/cobra"
@@ -69,12 +70,16 @@ func (o *AttachSBOMOptions) AddFlags(cmd *cobra.Command) {
 }
 
 func (o *AttachSBOMOptions) MediaType() (types.MediaType, error) {
+	var looksLikeJSON bool
+	if strings.HasSuffix(o.SBOM, ".json") {
+		looksLikeJSON = true
+	}
 	switch o.SBOMType {
 	case "cyclonedx":
 		if o.SBOMInputFormat != "" && o.SBOMInputFormat != ctypes.XMLInputFormat && o.SBOMInputFormat != ctypes.JSONInputFormat {
 			return "invalid", fmt.Errorf("invalid SBOM input format: %q, expected (json|xml)", o.SBOMInputFormat)
 		}
-		if o.SBOMInputFormat == ctypes.JSONInputFormat {
+		if o.SBOMInputFormat == ctypes.JSONInputFormat || looksLikeJSON {
 			return ctypes.CycloneDXJSONMediaType, nil
 		}
 		return ctypes.CycloneDXXMLMediaType, nil
@@ -83,7 +88,7 @@ func (o *AttachSBOMOptions) MediaType() (types.MediaType, error) {
 		if o.SBOMInputFormat != "" && o.SBOMInputFormat != ctypes.TextInputFormat && o.SBOMInputFormat != ctypes.JSONInputFormat {
 			return "invalid", fmt.Errorf("invalid SBOM input format: %q, expected (json|text)", o.SBOMInputFormat)
 		}
-		if o.SBOMInputFormat == ctypes.JSONInputFormat {
+		if o.SBOMInputFormat == ctypes.JSONInputFormat || looksLikeJSON {
 			return ctypes.SPDXJSONMediaType, nil
 		}
 		return ctypes.SPDXMediaType, nil


### PR DESCRIPTION
When attaching a CycloneDX SBOM:

```
$ cosign attach sbom --type=cyclonedx --sbom=./sbom.json example.com/testing123:v0.1.0
WARNING: Attaching SBOMs this way does not sign them. If you want to sign them, use 'cosign attest -predicate ./myclone.json -key <key path>' or 'cosign sign -key <key path> <sbom image>'.
Uploading SBOM file for [example.com/testing123:v0.1.0] to [example.com/testing123:v0.1.0:sha256-*****.sbom] with mediaType [application/vnd.cyclonedx+xml].
```

The mediatype defaults to `application/vnd.cyclonedx+xml`, even though the incoming SBOM path has a `.json` extension.

This PR tries to help make a more educated guess as to the proper mediatype to use.