### PR TITLE
Check certificate policy flags with only a certificate

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -144,6 +144,10 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			return err
 		}
 		if c.CertChain == "" {
+			err = cosign.CheckCertificatePolicy(cert, co)
+			if err != nil {
+				return err
+			}
 			pubKey, err = signature.LoadVerifier(cert.PublicKey, crypto.SHA256)
 			if err != nil {
 				return err

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -123,6 +123,10 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			return errors.Wrap(err, "loading certificate from reference")
 		}
 		if c.CertChain == "" {
+			err = cosign.CheckCertificatePolicy(cert, co)
+			if err != nil {
+				return err
+			}
 			co.SigVerifier, err = signature.LoadVerifier(cert.PublicKey, crypto.SHA256)
 			if err != nil {
 				return errors.Wrap(err, "creating certificate verifier")

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -105,7 +105,16 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 		if err != nil {
 			return err
 		}
+		co := &cosign.CheckOpts{
+			CertEmail:      certEmail,
+			CertOidcIssuer: certOidcIssuer,
+			EnforceSCT:     enforceSCT,
+		}
 		if certChain == "" {
+			err = cosign.CheckCertificatePolicy(cert, co)
+			if err != nil {
+				return err
+			}
 			verifier, err = signature.LoadVerifier(cert.PublicKey, crypto.SHA256)
 			if err != nil {
 				return err
@@ -115,11 +124,6 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 			chain, err := loadCertChainFromFileOrURL(certChain)
 			if err != nil {
 				return err
-			}
-			co := &cosign.CheckOpts{
-				CertEmail:      certEmail,
-				CertOidcIssuer: certOidcIssuer,
-				EnforceSCT:     enforceSCT,
 			}
 			verifier, err = cosign.ValidateAndUnpackCertWithChain(cert, chain, co)
 			if err != nil {

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -402,6 +402,10 @@ func TestValidateAndUnpackCertSuccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
+	err = CheckCertificatePolicy(leafCert, co)
+	if err != nil {
+		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
+	}
 }
 
 func TestValidateAndUnpackCertSuccessAllowAllValues(t *testing.T) {
@@ -421,6 +425,10 @@ func TestValidateAndUnpackCertSuccessAllowAllValues(t *testing.T) {
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
+	}
+	err = CheckCertificatePolicy(leafCert, co)
+	if err != nil {
+		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
 }
 
@@ -522,6 +530,8 @@ func TestValidateAndUnpackCertInvalidOidcIssuer(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected oidc issuer not found in certificate")
+	err = CheckCertificatePolicy(leafCert, co)
+	require.Contains(t, err.Error(), "expected oidc issuer not found in certificate")
 }
 
 func TestValidateAndUnpackCertInvalidEmail(t *testing.T) {
@@ -541,6 +551,8 @@ func TestValidateAndUnpackCertInvalidEmail(t *testing.T) {
 	}
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
+	require.Contains(t, err.Error(), "expected email not found in certificate")
+	err = CheckCertificatePolicy(leafCert, co)
 	require.Contains(t, err.Error(), "expected email not found in certificate")
 }
 
@@ -696,6 +708,17 @@ func TestValidateAndUnpackCertWithIdentities(t *testing.T) {
 			Identities: tc.identities,
 		}
 		_, err := ValidateAndUnpackCert(leafCert, co)
+		if err == nil && tc.wantErrSubstring != "" {
+			t.Errorf("Expected error %s got none", tc.wantErrSubstring)
+		} else if err != nil {
+			if tc.wantErrSubstring == "" {
+				t.Errorf("Did not expect an error, got err = %v", err)
+			} else if !strings.Contains(err.Error(), tc.wantErrSubstring) {
+				t.Errorf("Did not get the expected error %s, got err = %v", tc.wantErrSubstring, err)
+			}
+		}
+		// Test CheckCertificatePolicy
+		err = CheckCertificatePolicy(leafCert, co)
 		if err == nil && tc.wantErrSubstring != "" {
 			t.Errorf("Expected error %s got none", tc.wantErrSubstring)
 		} else if err != nil {


### PR DESCRIPTION
Flags such as cert-email and cert-oidc-issuer were only checked when a
certificate and its chain were passed to Cosign, or when the certificate
is fetched from either the OCI annotation or from Rekor (for
verify-blob). This adds support for checking certificate policy flags
when only a certificate is passed to Cosign.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes #1848 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixed checking certificate policy flags when only a certificate is provided
```
