### PR TITLE
tree: only report artifacts that are present

### DIFF
--- a/cmd/cosign/cli/tree.go
+++ b/cmd/cosign/cli/tree.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 
@@ -46,12 +45,6 @@ func Tree() *cobra.Command {
 	c.AddFlags(cmd)
 	return cmd
 }
-
-const (
-	SignatureTagSuffix   = ".sig"
-	SBOMTagSuffix        = ".sbom"
-	AttestationTagSuffix = ".att"
-)
 
 func TreeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef string) error {
 	scsaMap := map[name.Tag][]v1.Layer{}
@@ -110,7 +103,7 @@ func TreeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef stri
 		return err
 	}
 
-	sbombs, err := simg.Attachment("sbom")
+	sbombs, err := simg.Attachment(ociremote.SBOMTagSuffix)
 	if err == nil {
 		layers, err := sbombs.Layers()
 		if err != nil {
@@ -128,12 +121,12 @@ func TreeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef stri
 	}
 
 	for t, k := range scsaMap {
-		switch {
-		case strings.HasSuffix(t.TagStr(), SignatureTagSuffix):
+		switch t {
+		case sigRef:
 			fmt.Fprintf(os.Stdout, "└── 🔐 Signatures for an image tag: %s\n", t.String())
-		case strings.HasSuffix(t.TagStr(), SBOMTagSuffix):
+		case sbomRef:
 			fmt.Fprintf(os.Stdout, "└── 📦 SBOMs for an image tag: %s\n", t.String())
-		case strings.HasSuffix(t.TagStr(), AttestationTagSuffix):
+		case attRef:
 			fmt.Fprintf(os.Stdout, "└── 💾 Attestations for an image tag: %s\n", t.String())
 		}
 

--- a/cmd/cosign/cli/tree.go
+++ b/cmd/cosign/cli/tree.go
@@ -79,16 +79,15 @@ func TreeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef stri
 	}
 
 	atts, err := simg.Attestations()
-	var attLayers []v1.Layer
 	if err == nil {
 		layers, err := atts.Layers()
 		if err != nil {
 			return err
 		}
-		attLayers = append(attLayers, layers...)
+		if len(layers) > 0 {
+			scsaMap[attRef] = layers
+		}
 	}
-
-	scsaMap[attRef] = attLayers
 
 	sigRef, err := ociremote.SignatureTag(ref, ociremote.WithRemoteOptions(registryClientOpts...))
 	if err != nil {
@@ -96,16 +95,15 @@ func TreeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef stri
 	}
 
 	sigs, err := simg.Signatures()
-	var sigLayers []v1.Layer
 	if err == nil {
 		layers, err := sigs.Layers()
 		if err != nil {
 			return err
 		}
-		sigLayers = append(sigLayers, layers...)
+		if len(layers) > 0 {
+			scsaMap[sigRef] = layers
+		}
 	}
-
-	scsaMap[sigRef] = sigLayers
 
 	sbomRef, err := ociremote.SBOMTag(ref, ociremote.WithRemoteOptions(registryClientOpts...))
 	if err != nil {
@@ -113,16 +111,15 @@ func TreeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef stri
 	}
 
 	sbombs, err := simg.Attachment("sbom")
-	var sbomLayers []v1.Layer
 	if err == nil {
 		layers, err := sbombs.Layers()
 		if err != nil {
 			return err
 		}
-		sbomLayers = append(sbomLayers, layers...)
+		if len(layers) > 0 {
+			scsaMap[sbomRef] = layers
+		}
 	}
-
-	scsaMap[sbomRef] = sbomLayers
 
 	if len(scsaMap) == 0 {
 		fmt.Fprintf(os.Stdout, "No Supply Chain Security Related Artifacts artifacts found for image %s\n, start creating one with simply running"+


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
Only returns artifacts in the tree if they actually exist. I think this matches the expectations a user would have when using this command.

Also tweaks how we're using the references:
- Use the actual references we added to the map when checking them during the print phase
- Use the tag suffix from the `ociremote` package rather than redefining it in cli

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
N/A

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Modifies 'cosign tree' to only return artifacts that exist
```
