### PR TITLE
Begin exploration of an trust path for specified, unsigned images

### DIFF
--- a/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/cosigned/v1alpha1/clusterimagepolicy_types.go
@@ -90,6 +90,8 @@ type Authority struct {
 	// +optional
 	Keyless *KeylessRef `json:"keyless,omitempty"`
 	// +optional
+	Trusted *TrustedRef `json:"trusted,omitempty"`
+	// +optional
 	Sources []Source `json:"source,omitempty"`
 	// +optional
 	CTLog *TLog `json:"ctlog,omitempty"`
@@ -139,6 +141,13 @@ type KeylessRef struct {
 	Identities []Identity `json:"identities,omitempty"`
 	// +optional
 	CACert *KeyRef `json:"ca-cert,omitempty"`
+}
+
+// TrustedRef is reserved for those images that for whatever reason are not or cannot
+// be signed. An optional expiry date may be added.
+type TrustedRef struct {
+	Trust  string `json:"trust,omitempty"`
+	Expiry string `json:"expiry,omitempty"`
 }
 
 // Attestation defines the type of attestation to validate and optionally


### PR DESCRIPTION
Fixes: #1653 

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Intended to address the referenced issue, where a user must allow a public image to be admitted without a signature.

In this use case, a separate ClusterImagePolicy would be created with a minimal match for the public image, and a single "trusted" authority specified:

```yaml
apiVersion: cosigned.sigstore.dev/v1alpha1
kind: ClusterImagePolicy
metadata:
  name: image-policy
spec:
  images:
  - glob: gcr.io/knative-releases/knative.dev/serving/cmd/queue@
  authorities:
  - trusted:
    - trust: implicit
    - expiry: <iso datestring>
```

I'm proposing an optional expiration be added, though this may be a bit much.

@vaikas @hectorj2f @DennyHoang 