### PR TITLE
GHSA-66x3-6cw3-v5gj: Update go-tuf to v0.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/viper v1.11.0
 	github.com/spiffe/go-spiffe/v2 v2.1.0
 	github.com/stretchr/testify v1.7.1
-	github.com/theupdateframework/go-tuf v0.0.0-20220211205608-f0c3294f63b9
+	github.com/theupdateframework/go-tuf v0.3.0
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399
 	github.com/withfig/autocomplete-tools/packages/cobra v0.0.0-20220122124547-31d3821a6898
 	github.com/xanzy/go-gitlab v0.65.0

--- a/go.sum
+++ b/go.sum
@@ -2162,8 +2162,8 @@ github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gt
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.0.0-20211203210025-7ded50136bf9/go.mod h1:n2n6wwC9BEnYS/C/APAtNln0eM5zYAYOkOTx6VEG/mA=
 github.com/theupdateframework/go-tuf v0.0.0-20220127213825-87caa18db2a6/go.mod h1:I0Gs4Tev4hYQ5wiNqN8VJ7qS0gw7KOZNQuckC624RmE=
-github.com/theupdateframework/go-tuf v0.0.0-20220211205608-f0c3294f63b9 h1:U8bHY5mmNuZHc3+e7l2/LAmfTk7oiMiB3Qn8fsp4z5g=
-github.com/theupdateframework/go-tuf v0.0.0-20220211205608-f0c3294f63b9/go.mod h1:ENa0O55YQfI0U/nn4AAuqPydrbkqQCiq9GDw6YLCyXU=
+github.com/theupdateframework/go-tuf v0.3.0 h1:od2sc5+BSkKZhmUG2o2rmruy0BGSmhrbDhCnpxh87X8=
+github.com/theupdateframework/go-tuf v0.3.0/go.mod h1:E5XP0wXitrFUHe4b8cUcAAdxBW4LbfnqF4WXXGLgWNo=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -425,7 +425,7 @@ func embeddedLocalStore() (client.LocalStore, error) {
 func (t *TUF) updateMetadataAndDownloadTargets() error {
 	// Download updated targets and cache new metadata and targets in ${TUF_ROOT}.
 	targetFiles, err := t.client.Update()
-	if err != nil && !client.IsLatestSnapshot(err) {
+	if err != nil {
 		// Get some extra information for debugging. What was the state of the metadata
 		// on the remote?
 		status := struct {

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -352,7 +352,7 @@ func forceExpiration(t *testing.T, expire bool) {
 	})
 }
 
-func forceExpirationVersion(t *testing.T, version int) {
+func forceExpirationVersion(t *testing.T, version int64) {
 	oldIsExpiredTimestamp := isExpiredTimestamp
 	isExpiredTimestamp = func(metadata []byte) bool {
 		s := &data.Signed{}


### PR DESCRIPTION
Update go-tuf

There is one security update https://github.com/theupdateframework/go-tuf/security/advisories/GHSA-66x3-6cw3-v5gj!

https://github.com/theupdateframework/go-tuf/releases/tag/v0.3.0
