### PR TITLE
Add privacy statement for PII storage

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"golang.org/x/term"
 
@@ -41,6 +42,13 @@ const (
 	FlowNormal = "normal"
 	FlowDevice = "device"
 	FlowToken  = "token"
+	// spacing is intentional to have this indented
+	PrivacyStatement = `
+        Note that there may be personally identifiable information associated with this signed artifact.
+        This may include the email address associated with the account with which you authenticate.
+        This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
+        By continuing, you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs.
+`
 )
 
 type oidcConnector interface {
@@ -92,6 +100,9 @@ func GetCert(ctx context.Context, priv *ecdsa.PrivateKey, idToken, flow, oidcIss
 		c.flow = oauthflow.NewDeviceFlowTokenGetter(
 			oidcIssuer, oauthflow.SigstoreDeviceURL, oauthflow.SigstoreTokenURL)
 	case FlowNormal:
+		//nolint:govet // Extra newline intentional
+		fmt.Fprintln(os.Stderr, PrivacyStatement)
+		time.Sleep(4 * time.Second)
 		c.flow = oauthflow.DefaultIDTokenGetter
 	case FlowToken:
 		c.flow = &oauthflow.StaticTokenGetter{RawToken: idToken}


### PR DESCRIPTION
This statement has been added just before the OIDC code/normal flow,
since only in this flow we expect a user to be present. For the device
flow or when a token is provided, it's likely that Cosign is being run
in an automated environment.

Another option is to explicitly require that a user type 'y' or pass a
flag to bypass this check, but this will break existing usage.
Therefore, I simply added a sleep statement to pause to give users a
chance to read the message.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
