### PR TITLE
update to use go1.18

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
 
       # will use the latest release available for ko

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
     - name: Set correct version of Golang to use during CodeQL run
       uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.1.5
       with:
-        go-version: '1.17'
+        go-version: '1.18'
         check-latest: true
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/cross.yaml
+++ b/.github/workflows/cross.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
       - name: Checkout code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0

--- a/.github/workflows/e2e-with-binary.yml
+++ b/.github/workflows/e2e-with-binary.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
       - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
       - name: build cosign and check
         shell: bash

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
       - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb # v0.5.1

--- a/.github/workflows/github-oidc.yaml
+++ b/.github/workflows/github-oidc.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
       - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
 
       # Install tools.

--- a/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
+++ b/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@dcd71f646680f2efd8db4afa5ad64fdcba30e748 # v2.4.0
     - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
       with:
-        go-version: '1.17'
+        go-version: '1.18'
         check-latest: true
 
     # will use the latest release available for ko

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
     - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
       with:
-        go-version: '1.17'
+        go-version: '1.18'
         check-latest: true
 
     # will use the latest release available for ko

--- a/.github/workflows/kind-e2e-cosigned.yaml
+++ b/.github/workflows/kind-e2e-cosigned.yaml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
     - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
       with:
-        go-version: '1.17'
+        go-version: '1.18'
         check-latest: true
 
     - uses: imjasonh/setup-ko@2c3450ca27f6e6f2b02e72a40f2163c281a1f675 # v0.4

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
     - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
       with:
-        go-version: '1.17'
+        go-version: '1.18'
         check-latest: true
 
     # will use the latest release available for ko

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
 
       - name: Check out code
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
 
       - name: Check out code

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -39,4 +39,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
 
-      - uses: chainguard-dev/actions/goimports@84c993eaf02da1c325854fb272a4df9184bd80fc # main
+      - uses: chainguard-dev/actions/goimports@d70913012e2f339f2014e6ffb21813f7ca6644e4 # main

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: 1.17
+  GO_VERSION: 1.18
 
 jobs:
   unit-tests:

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -39,7 +39,7 @@ jobs:
       statuses: none
 
     env:
-      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.17.10-0@sha256:62c64ee6c74285839db86ae0814d2411bfe4bc2cdc025b10122e4bb8d27b1418
+      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.18.2-0@sha256:28f77bf112fc14bfc1d3d272e23bfc99652594e5fdc065e2b71f2e232ab941ed
       COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.8.0@sha256:12b4d428529654c95a7550a936cbb5c6fe93a046ea7454676cb6fb0ce566d78c
 
     steps:

--- a/.github/workflows/verify-codegen.yaml
+++ b/.github/workflows/verify-codegen.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2
       with:
-        go-version: '1.17'
+        go-version: '1.18'
         check-latest: true
 
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/verify-docgen.yaml
+++ b/.github/workflows/verify-docgen.yaml
@@ -34,6 +34,6 @@ jobs:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
       - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2 # v2.2.0
         with:
-          go-version: '1.17'
+          go-version: '1.18'
           check-latest: true
       - run: ./cmd/help/verify.sh

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -39,10 +39,10 @@ steps:
   - TUF_ROOT=/tmp
   args:
   - 'verify'
-  - 'ghcr.io/gythialy/golang-cross:v1.17.10-0@sha256:62c64ee6c74285839db86ae0814d2411bfe4bc2cdc025b10122e4bb8d27b1418'
+  - 'ghcr.io/gythialy/golang-cross:v1.18.2-0@sha256:28f77bf112fc14bfc1d3d272e23bfc99652594e5fdc065e2b71f2e232ab941ed'
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.17.10-0@sha256:62c64ee6c74285839db86ae0814d2411bfe4bc2cdc025b10122e4bb8d27b1418
+- name: ghcr.io/gythialy/golang-cross:v1.18.2-0@sha256:28f77bf112fc14bfc1d3d272e23bfc99652594e5fdc065e2b71f2e232ab941ed
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -65,7 +65,7 @@ steps:
       gcloud auth configure-docker \
       && make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.17.10-0@sha256:62c64ee6c74285839db86ae0814d2411bfe4bc2cdc025b10122e4bb8d27b1418
+- name: ghcr.io/gythialy/golang-cross:v1.18.2-0@sha256:28f77bf112fc14bfc1d3d272e23bfc99652594e5fdc065e2b71f2e232ab941ed
   entrypoint: 'bash'
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION
#### Summary
- update to use go1.18

build cosign and friends using go1.18

#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
