### PR TITLE
Add support for "**" in image glob matching

### DIFF
--- a/pkg/apis/config/glob_test.go
+++ b/pkg/apis/config/glob_test.go
@@ -15,67 +15,66 @@
 package config
 
 import (
-	"runtime"
+	"reflect"
 	"testing"
 )
 
 func TestGlobMatch(t *testing.T) {
-	tests := []struct {
-		glob         string
-		input        string
-		match        bool
-		errString    string
-		windowsMatch *struct {
-			match bool
-		}
+	for _, c := range []struct {
+		image, glob  string
+		wantMatch    bool
+		wantWarnings []string
+		wantErr      bool
 	}{
-		{glob: "foo", input: "foo", match: true},     // exact match
-		{glob: "fooo*", input: "foo", match: false},  // prefix too long
-		{glob: "foo*", input: "foobar", match: true}, // works
-		{glob: "foo*", input: "foo", match: true},    // works
-		{glob: "*", input: "foo", match: true},       // matches anything
-		{glob: "*", input: "bar", match: true},       // matches anything
-		{glob: "*foo*", input: "1foo2", match: true}, // matches wildcard around
-		{glob: "*repository/*", input: "repository/image", match: true},
-		{glob: "*.repository/*", input: "other.repository/image", match: true},
-		{glob: "repository/*", input: "repository/image", match: true},
-		{glob: "repository/*", input: "other.repository/image", match: false},
-		{glob: "repository/*", input: "index.docker.io/repository/image", match: true}, // Testing resolved digest
-		{glob: "image", input: "index.docker.io/library/image", match: true},           // Testing resolved digest and official dockerhub public repository
-		{glob: "[", input: "[", match: false, errString: "syntax error in pattern"},    // Invalid glob pattern
-		{glob: "gcr.io/projectsigstore/*", input: "gcr.io/projectsigstore/cosign", match: true},
-		{glob: "gcr.io/projectsigstore/*", input: "us.gcr.io/projectsigstore/cosign", match: false},
-		{glob: "*gcr.io/projectsigstore/*", input: "gcr.io/projectsigstore/cosign", match: true},
-		{glob: "*gcr.io/projectsigstore/*", input: "gcr.io/projectsigstore2/cosign", match: false},
-		{glob: "*gcr.io/*/*", input: "us.gcr.io/projectsigstore/cosign", match: true}, // Does match with multiple '*'
-		{glob: "us.gcr.io/*/*", input: "us.gcr.io/projectsigstore/cosign", match: true},
-		{glob: "us.gcr.io/*/*", input: "gcr.io/projectsigstore/cosign", match: false},
-		{glob: "*.gcr.io/*/*", input: "asia.gcr.io/projectsigstore/cosign", match: true},
-		{glob: "*.gcr.io/*/*", input: "gcr.io/projectsigstore/cosign", match: false},
-		// Does not match since '*' only handles until next non-separator character '/'
-		// On Windows, '/' is not the separator and therefore it passes
-		{glob: "*gcr.io/*", input: "us.gcr.io/projectsigstore/cosign", match: false, windowsMatch: &struct{ match bool }{match: true}},
-	}
-	for _, tc := range tests {
-		got, err := GlobMatch(tc.glob, tc.input)
-
-		if tc.errString != "" {
-			if tc.errString != err.Error() {
-				t.Errorf("expected %s for error: %s", tc.errString, err.Error())
+		{image: "foo", glob: "index.docker.io/library/foo:latest", wantMatch: true},
+		{image: "foo", glob: "index.docker.io/library/foo:*", wantMatch: true},
+		{image: "foo", glob: "index.docker.io/library/*", wantMatch: true},
+		{image: "foo", glob: "index.docker.io/library/*:latest", wantMatch: true},
+		{image: "foo", glob: "index.docker.io/*/*", wantMatch: true},
+		{image: "foo", glob: "index.docker.io/**", wantMatch: true},
+		{image: "foo", glob: "index.docker.**", wantMatch: true},
+		{image: "foo", glob: "inde**", wantMatch: true},
+		{image: "foo", glob: "**", wantMatch: true},
+		{image: "foo", glob: "foo", wantMatch: false}, // must have index.docker.io/library prefix.
+		{image: "myuser/myapp", glob: "index.docker.io/myuser/myapp:latest", wantMatch: true},
+		{image: "myuser/myapp", glob: "index.docker.io/myuser/myapp:*", wantMatch: true},
+		{image: "myuser/myapp", glob: "index.docker.io/myuser/*", wantMatch: true},
+		{image: "myuser/myapp", glob: "index.docker.io/myuser/*:latest", wantMatch: true},
+		{image: "myuser/myapp", glob: "index.docker.io/*/*", wantMatch: true},
+		{image: "myuser/myapp", glob: "index.docker.io/**", wantMatch: true},
+		{image: "myuser/myapp", glob: "index.docker.**", wantMatch: true},
+		{image: "myuser/myapp", glob: "inde**", wantMatch: true},
+		{image: "myuser/myapp", glob: "**", wantMatch: true},
+		{image: "myuser/myapp", glob: "myuser/myapp", wantMatch: false}, // must have index.docker.io prefix.
+		{image: "ghcr.io/foo/bar", glob: "ghcr.io/*/*", wantMatch: true},
+		{image: "ghcr.io/foo/bar", glob: "ghcr.io/**", wantMatch: true},
+		{image: "ghcr.io/foo", glob: "ghcr.io/*/*", wantMatch: false}, // doesn't match second *
+		{image: "ghcr.io/foo", glob: "ghcr.io/**", wantMatch: true},
+		{image: "ghcr.io/foo", glob: "ghc**", wantMatch: true},
+		{image: "ghcr.io/foo", glob: "**", wantMatch: true},
+		{image: "ghcr.io/foo", glob: "*/**", wantMatch: true},
+		{image: "prefix-ghcr.io/foo", glob: "ghcr.io/foo", wantMatch: false},     // glob starts at beginning.
+		{image: "ghcr.io/foo-suffix", glob: "ghcr.io/foo", wantMatch: false},     // glob ends at the end.
+		{image: "ghcrxio/foo", glob: "ghcr.io/**", wantMatch: false},             // dots in glob are replaced with \., not treated as regexp .
+		{image: "invalid&name", glob: "**", wantMatch: false, wantErr: true},     // invalid refs are not matched.
+		{image: "invalid-glob", glob: ".+", wantMatch: false, wantErr: true},     // invalid globs are rejected.
+		{image: "invalid-glob", glob: "[a-z]*", wantMatch: false, wantErr: true}, // invalid globs are rejected.
+		{image: "foo", glob: "*", wantMatch: true,
+			wantWarnings: []string{`The glob match "*" should be "index.docker.io/library/*"`}},
+		{image: "myuser/myapp", glob: "*/*", wantMatch: true,
+			wantWarnings: []string{`The glob match "*/*" should be "index.docker.io/*/*"`}},
+	} {
+		t.Run(c.image+"|"+c.glob, func(t *testing.T) {
+			match, warnings, err := GlobMatch(c.glob, c.image)
+			if match != c.wantMatch {
+				t.Errorf("match: got %t, want %t", match, c.wantMatch)
 			}
-		} else if err != nil {
-			t.Errorf("unexpected error: %v for glob: %q input: %q", err, tc.glob, tc.input)
-		}
-
-		want := tc.match
-
-		// If OS is Windows, check if there is a different expected match value
-		if runtime.GOOS == "windows" && tc.windowsMatch != nil {
-			want = tc.windowsMatch.match
-		}
-
-		if got != want {
-			t.Errorf("expected %v for glob: %q input: %q", want, tc.glob, tc.input)
-		}
+			if !reflect.DeepEqual(warnings, c.wantWarnings) {
+				t.Errorf("warnings: got %v, want %v", warnings, c.wantWarnings)
+			}
+			if gotErr := err != nil; gotErr != c.wantErr {
+				t.Errorf("err: got %v, want %t", err, c.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/apis/config/image_policies.go
+++ b/pkg/apis/config/image_policies.go
@@ -92,7 +92,7 @@ func (p *ImagePolicyConfig) GetMatchingPolicies(image string) (map[string]webhoo
 	for k, v := range p.Policies {
 		for _, pattern := range v.Images {
 			if pattern.Glob != "" {
-				if matched, err := GlobMatch(pattern.Glob, image); err != nil {
+				if matched, _, err := GlobMatch(pattern.Glob, image); err != nil {
 					lastError = err
 				} else if matched {
 					ret[k] = v

--- a/pkg/apis/config/image_policies.go
+++ b/pkg/apis/config/image_policies.go
@@ -92,7 +92,7 @@ func (p *ImagePolicyConfig) GetMatchingPolicies(image string) (map[string]webhoo
 	for k, v := range p.Policies {
 		for _, pattern := range v.Images {
 			if pattern.Glob != "" {
-				if matched, _, err := GlobMatch(pattern.Glob, image); err != nil {
+				if matched, err := GlobMatch(pattern.Glob, image); err != nil {
 					lastError = err
 				} else if matched {
 					ret[k] = v


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

Fixes https://github.com/sigstore/cosign/issues/1903

This is WIP because it currently breaks a number of previous test cases, and I want to make sure this isn't considered a backward-incompatible change. Or if it is, that we're comfortable with this breakage.

```release-note
Image policy globs now support ** to match any character; matching images that are specified like "ubuntu" or "myuser/myapp" should be matched with a glob like "index.docker.io/library/*" or "index.docker.io/*/*" respectively, rather than expecting "*" or "*/*" to match as before.
```

@hectorj2f @jdolitsky 
