### PR TITLE
adding HashiCorp Vault namespaces examples to KMS doc

### DIFF
--- a/.github/workflows/scorecard_action.yml
+++ b/.github/workflows/scorecard_action.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@c1aec4ac820532bab364f02a81873c555a0ba3a1
+        uses: ossf/scorecard-action@5c8bc69dc88b65c66584e07611df79d3579b0377
         with:
           results_file: results.sarif
           results_format: sarif

--- a/KMS.md
+++ b/KMS.md
@@ -152,6 +152,38 @@ The URI format for Hashicorp Vault KMS is:
 This provider requires that the standard Vault environment variables (VAULT_ADDR, VAULT_TOKEN) are set correctly.
 This provider also requires that the `transit` secret engine is enabled
 
+If you enabled `transit` secret engine at different path with the use of `-path` flag (i.e., `$ vault secrets enable -path="someotherpath" transit`), you can use `TRANSIT_SECRET_ENGINE_PATH` environment variable to specify this path while generating a key pair like the following:
+
+```shell
+$ TRANSIT_SECRET_ENGINE_PATH="someotherpath" cosign generate-key-pair --kms hashivault://testkey
+```
+
+#### Local Setup
+
+For a local setup, you can run Vault yourself or use the `docker-compose` file from [sigstore/sigstore](https://github.com/sigstore/sigstore/blob/main/test/e2e/docker-compose.yml) as an example.
+
+After running it:
+
+```shell
+$ export VAULT_ADDR=http://localhost:8200
+$ export VAULT_TOKEN=testtoken
+$ vault secrets enable transit
+```
+
+If you enabled `transit` secret engine at different path with the use of `-path` flag (i.e., `$ vault secrets enable -path="someotherpath" transit`), you can use `TRANSIT_SECRET_ENGINE_PATH` environment variable to specify this path while generating a key pair like the following:
+
+```shell
+$ TRANSIT_SECRET_ENGINE_PATH="someotherpath" cosign generate-key-pair --kms hashivault://testkey
+```
+
+If you are using Vault Enterprise Namespaces, you can use the `VAULT_NAMESPACE` [environment variable](https://www.vaultproject.io/docs/commands#vault_namespace) to specify the Vault namespace that the `transit` secret engine is enabled in.
+
+```shell
+$ export VAULT_NAMESPACE="mynamespace"
+$ cosign generate-key-pair --kms hashivault://testkey
+Public key written to cosign.pub
+```
+
 ### Kubernetes Secret
 
 Cosign can use keys stored in Kubernetes Secrets to so sign and verify signatures. In
@@ -167,7 +199,7 @@ Public key written to cosign.pub
 ```
 
 After generating the key pair, cosign will store it in a Kubernetes secret using
-your current context. The secret will contain the private and public keys, as 
+your current context. The secret will contain the private and public keys, as
 well as the password to decrypt the private key.
 
 The secret has the following structure:
@@ -188,21 +220,3 @@ data:
 When verifying an image signature using `cosign verify`, the key will be automatically
 decrypted using the password stored in the kubernetes secret under the `cosign.password`
 field.
-
-#### Local Setup
-
-For a local setup, you can run Vault yourself or use the `docker-compose` file from [sigstore/sigstore](https://github.com/sigstore/sigstore/blob/main/test/e2e/docker-compose.yml) as an example.
-
-After running it:
-
-```shell
-$ export VAULT_ADDR=http://localhost:8200
-$ export VAULT_TOKEN=testtoken
-$ vault secrets enable transit
-```
-
-If you enabled `transit` secret engine at different path with the use of `-path` flag (i.e., `$ vault secrets enable -path="someotherpath" transit`), you can use `TRANSIT_SECRET_ENGINE_PATH` environment variable to specify this path while generating a key pair like the following:
-
-```shell
-$ TRANSIT_SECRET_ENGINE_PATH="someotherpath" cosign generate-key-pair --kms hashivault://testkey
-```


### PR DESCRIPTION
Signed-off-by: nicolaka <nicolaka@gmail.com>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Summary
I updated the KMS.md doc with additional details on using Vault Namespaces with cosign.

Ticket Link
Fixes

Release Note
NONE

