### PR TITLE
DNM concurrent NewFromEnv tests

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
@@ -116,7 +116,6 @@ func initRoots() (*x509.CertPool, *x509.CertPool, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("initializing tuf: %w", err)
 		}
-		defer tufClient.Close()
 		// Retrieve from the embedded or cached TUF root. If expired, a network
 		// call is made to update the root.
 		targets, err := tufClient.GetTargetsByMeta(tuf.Fulcio, []string{fulcioTargetStr, fulcioV1TargetStr})

--- a/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
@@ -81,7 +81,6 @@ func VerifySCT(ctx context.Context, certPEM, chainPEM, rawSCT []byte) error {
 		if err != nil {
 			return err
 		}
-		defer tufClient.Close()
 
 		targets, err := tufClient.GetTargetsByMeta(tuf.CTFE, []string{ctPublicKeyStr})
 		if err != nil {

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -104,7 +104,6 @@ func GetRekorPubs(ctx context.Context) (map[string]RekorPubKey, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error creating new TUF obj from env: %w", err)
 		}
-		defer tufClient.Close()
 		targets, err := tufClient.GetTargetsByMeta(tuf.Rekor, []string{rekorTargetStr})
 		if err != nil {
 			return nil, fmt.Errorf("error getting rekor target by metadata: %w", err)

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -102,12 +102,12 @@ func GetRekorPubs(ctx context.Context) (map[string]RekorPubKey, error) {
 	} else {
 		tufClient, err := tuf.NewFromEnv(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error creating new TUF obj from env: %w", err)
 		}
 		defer tufClient.Close()
 		targets, err := tufClient.GetTargetsByMeta(tuf.Rekor, []string{rekorTargetStr})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting rekor target by metadata: %w", err)
 		}
 		for _, t := range targets {
 			rekorPubKey, err := PemToECDSAKey(t.Target)
@@ -387,10 +387,13 @@ func VerifyTLogEntry(ctx context.Context, rekorClient *client.Rekor, e *models.L
 
 	rekorPubKeysTuf, err := GetRekorPubs(ctx)
 	if err != nil {
-		if len(rekorPubKeys) == 0 {
-			return fmt.Errorf("unable to fetch Rekor public keys from TUF repository, and not trusting the Rekor API for fetching public keys: %w", err)
-		}
-		fmt.Fprintf(os.Stderr, "**Warning** Failed to fetch Rekor public keys from TUF, using the public key from Rekor API because %s was specified", addRekorPublicKeyFromRekor)
+		return fmt.Errorf("Failed to fetch Rekor public keys from TUF: %w", err)
+		/*
+			if len(rekorPubKeys) == 0 {
+				return fmt.Errorf("unable to fetch Rekor public keys from TUF repository, and not trusting the Rekor API for fetching public keys: %w", err)
+			}
+			fmt.Fprintf(os.Stderr, "**Warning** Failed to fetch Rekor public keys from TUF, using the public key from Rekor API because %s was specified", addRekorPublicKeyFromRekor)
+		*/
 	}
 
 	for k, v := range rekorPubKeysTuf {

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -387,7 +387,7 @@ func VerifyTLogEntry(ctx context.Context, rekorClient *client.Rekor, e *models.L
 
 	rekorPubKeysTuf, err := GetRekorPubs(ctx)
 	if err != nil {
-		return fmt.Errorf("Failed to fetch Rekor public keys from TUF: %w", err)
+		return fmt.Errorf("failed to fetch Rekor public keys from TUF: %w", err)
 		/*
 			if len(rekorPubKeys) == 0 {
 				return fmt.Errorf("unable to fetch Rekor public keys from TUF repository, and not trusting the Rekor API for fetching public keys: %w", err)

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -220,7 +220,10 @@ func GetRootStatus(ctx context.Context) (*RootStatus, error) {
 // Close closes the local TUF store. Should only be called once per client.
 func (t *TUF) Close() error {
 	fmt.Printf("Closing TUF obj\n")
-	return t.local.Close()
+	if t.local != nil {
+		return t.local.Close()
+	}
+	return nil
 }
 
 // initializeTUF creates a TUF client using the following params:

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -242,7 +242,7 @@ func initializeTUF(ctx context.Context, mirror string, root []byte, embedded fs.
 	var err error
 	t.local, err = newLocalStore()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("creating new local store: %w", err)
 	}
 
 	t.remote, err = remoteFromMirror(ctx, t.mirror)

--- a/pkg/cosign/tuf/client.go
+++ b/pkg/cosign/tuf/client.go
@@ -219,6 +219,7 @@ func GetRootStatus(ctx context.Context) (*RootStatus, error) {
 
 // Close closes the local TUF store. Should only be called once per client.
 func (t *TUF) Close() error {
+	fmt.Printf("Closing TUF obj\n")
 	return t.local.Close()
 }
 
@@ -290,6 +291,7 @@ func initializeTUF(ctx context.Context, mirror string, root []byte, embedded fs.
 }
 
 func NewFromEnv(ctx context.Context) (*TUF, error) {
+	fmt.Printf("Creating new TUF obj\n")
 	// Check for the current remote mirror.
 	mirror := GetRemoteRoot()
 	b, err := os.ReadFile(cachedRemote(rootCacheDir()))

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -62,7 +62,7 @@ func TestNewFromEnv(t *testing.T) {
 	}
 
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	// Now try with expired targets
 	forceExpiration(t, true)
@@ -71,7 +71,7 @@ func TestNewFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	if err := Initialize(ctx, DefaultRemoteRoot, nil); err != nil {
 		t.Error()
@@ -86,7 +86,7 @@ func TestNewFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 }
 
 func TestNoCache(t *testing.T) {
@@ -102,7 +102,7 @@ func TestNoCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	// Force expiration so we have some content to download
 	forceExpiration(t, true)
@@ -112,7 +112,7 @@ func TestNoCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	// No filesystem writes when using SIGSTORE_NO_CACHE.
 	if l := dirLen(t, td); l != 0 {
@@ -138,7 +138,7 @@ func TestCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 	cachedDirLen := dirLen(t, td)
 	if cachedDirLen == 0 {
 		t.Errorf("expected filesystem writes, got %d entries", cachedDirLen)
@@ -150,8 +150,7 @@ func TestCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	tuf.Close()
-
+	resetForTests()
 	if l := dirLen(t, td); cachedDirLen != l {
 		t.Errorf("expected no filesystem writes, got %d entries", l-cachedDirLen)
 	}
@@ -167,7 +166,7 @@ func TestCache(t *testing.T) {
 		t.Errorf("expected filesystem writes, got %d entries", l)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 }
 
 func TestCustomRoot(t *testing.T) {
@@ -206,7 +205,7 @@ func TestCustomRoot(t *testing.T) {
 	if b, err := tufObj.GetTarget("foo.txt"); err != nil || !bytes.Equal(b, []byte("foo")) {
 		t.Fatal(err)
 	}
-	tufObj.Close()
+	resetForTests()
 
 	// Force expiration on the first timestamp and internal go-tuf verification.
 	forceExpirationVersion(t, 1)
@@ -232,7 +231,6 @@ func TestCustomRoot(t *testing.T) {
 	if b, err := tufObj.GetTarget("foo.txt"); err != nil || !bytes.Equal(b, []byte("foo1")) {
 		t.Fatal(err)
 	}
-	tufObj.Close()
 }
 
 func TestGetTargetsByMeta(t *testing.T) {
@@ -267,7 +265,7 @@ func TestGetTargetsByMeta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tufObj.Close()
+
 	// Fetch a target with no custom metadata.
 	targets, err := tufObj.GetTargetsByMeta(UnknownUsage, []string{"fooNoCustom.txt"})
 	if err != nil {
@@ -403,7 +401,6 @@ func TestUpdatedTargetNamesEmbedded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tufObj.Close()
 
 	// Try to retrieve the newly added target.
 	targets, err := tufObj.GetTargetsByMeta(Fulcio, []string{"fooNoCustom.txt"})
@@ -639,7 +636,6 @@ func TestConcurrentAccess(t *testing.T) {
 				t.Error("Got back nil tufObj")
 			}
 			time.Sleep(1 * time.Second)
-			tufObj.Close()
 		}()
 	}
 	wg.Wait()

--- a/test/e2e_test_cluster_image_policy.sh
+++ b/test/e2e_test_cluster_image_policy.sh
@@ -267,12 +267,12 @@ kubectl create namespace demo-key-remote
 kubectl label namespace demo-key-remote policy.sigstore.dev/include=true
 echo '::endgroup::'
 
-echo '::group:: Verify with three CIP, one without correct Source set'
-if kubectl create -n demo-key-remote job demo --image=${demoimage}; then
-  echo Failed to block unsigned Job creation!
-  exit 1
-fi
-echo '::endgroup::'
+# echo '::group:: Verify with three CIP, one without correct Source set'
+# if kubectl create -n demo-key-remote job demo --image=${demoimage}; then
+#   echo Failed to block unsigned Job creation!
+#   exit 1
+# fi
+# echo '::endgroup::'
 
 echo '::group:: Deploy ClusterImagePolicy With Remote Public Key With Source'
 yq '. | .metadata.name = "image-policy-remote-source"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Follow up to @asraa investigation in #1938 

Some comments in #1938 led me to believe that NewFromEnv is not thread safe, so playing around with some tests for it.

Note, the test fails with this currently because it modifies the expiredTimeStamp.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1031e2d58]

goroutine 423 [running]:
github.com/sigstore/cosign/pkg/cosign/tuf.TestUpdatedTargetNamesEmbedded.func3({0x14000636000, 0x2cd, 0x2cd})
	/Users/vaikas/projects/go/src/github.com/sigstore/cosign/pkg/cosign/tuf/client_test.go:382 +0x98
github.com/sigstore/cosign/pkg/cosign/tuf.initializeTUF({0x1034dd938, 0x140001a8008}, {0x14000dce0d8, 0x11}, {0x0, 0x0, 0x0}, {0x1034d8728?, 0x1034e2aa0}, 0x0)
	/Users/vaikas/projects/go/src/github.com/sigstore/cosign/pkg/cosign/tuf/client.go:283 +0x3b0
github.com/sigstore/cosign/pkg/cosign/tuf.NewFromEnv({0x1034dd938, 0x140001a8008})
	/Users/vaikas/projects/go/src/github.com/sigstore/cosign/pkg/cosign/tuf/client.go:309 +0x160
github.com/sigstore/cosign/pkg/cosign/tuf.TestConcurrentAccess.func1()
	/Users/vaikas/projects/go/src/github.com/sigstore/cosign/pkg/cosign/tuf/client_test.go:634 +0x6c
created by github.com/sigstore/cosign/pkg/cosign/tuf.TestConcurrentAccess
	/Users/vaikas/projects/go/src/github.com/sigstore/cosign/pkg/cosign/tuf/client_test.go:632 +0x3c
```

But if you run the tests with the -v so it doesn't run them in parallel, it fails sort of how I was expecting it to fail:

```
go test -v ./pkg/cosign/tuf/...
<snip>
Creating new TUF obj
    client_test.go:636: Failed to construct NewFromEnv: creating new local store: creating cached local store: resource temporarily unavailable
    client_test.go:639: Got back nil tufObj
Creating new TUF obj
    client_test.go:636: Failed to construct NewFromEnv: creating new local store: creating cached local store: resource temporarily unavailable
    client_test.go:639: Got back nil tufObj
Creating new TUF obj
```

<!--
A description of what this pull request does
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
