### PR TITLE
fix: fix #1930 for AWS KMS formats

### DIFF
--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -86,7 +86,7 @@ spec:
                             description: Data contains the inline public key
                             type: string
                           kms:
-                            description: KMS contains the KMS url of the public key
+                            description: KMS contains the KMS url of the public key Supported formats differ based on the KMS system used.
                             type: string
                           secretRef:
                             type: object
@@ -107,7 +107,7 @@ spec:
                                 description: Data contains the inline public key
                                 type: string
                               kms:
-                                description: KMS contains the KMS url of the public key
+                                description: KMS contains the KMS url of the public key Supported formats differ based on the KMS system used.
                                 type: string
                               secretRef:
                                 type: object

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ThalesIgnite/crypto11 v1.2.5
 	github.com/armon/go-metrics v0.4.0
 	github.com/armon/go-radix v1.0.0
+	github.com/aws/aws-sdk-go-v2 v1.14.0
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220228164355-396b2034c795
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
@@ -122,7 +123,6 @@ require (
 	github.com/ReneKroon/ttlcache/v2 v2.11.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.43.45 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.14.0 // indirect
 	github.com/aws/aws-sdk-go-v2/config v1.14.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.9.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.11.0 // indirect

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -104,6 +104,7 @@ type KeyRef struct {
 	// +optional
 	Data string `json:"data,omitempty"`
 	// KMS contains the KMS url of the public key
+	// Supported formats differ based on the KMS system used.
 	// +optional
 	KMS string `json:"kms,omitempty"`
 }

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -133,6 +133,9 @@ func (keyless *KeylessRef) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("identities"))
 	}
 
+	if keyless.CACert != nil {
+		errs = errs.Also(keyless.DeepCopy().CACert.Validate(ctx).ViaField("ca-cert"))
+	}
 	for i, identity := range keyless.Identities {
 		errs = errs.Also(identity.Validate(ctx).ViaFieldIndex("identities", i))
 	}

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -17,12 +17,17 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"regexp"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/sigstore/cosign/pkg/apis/utils"
 	"knative.dev/pkg/apis"
 )
+
+const awsKMSPrefix = "awskms://"
 
 // Validate implements apis.Validatable
 func (c *ClusterImagePolicy) Validate(ctx context.Context) *apis.FieldError {
@@ -54,6 +59,7 @@ func (image *ImagePattern) Validate(ctx context.Context) *apis.FieldError {
 	}
 
 	errs = errs.Also(ValidateGlob(image.Glob).ViaField("glob"))
+
 	return errs
 }
 
@@ -103,6 +109,11 @@ func (key *KeyRef) Validate(ctx context.Context) *apis.FieldError {
 		}
 	} else if key.KMS != "" && key.SecretRef != nil {
 		errs = errs.Also(apis.ErrMultipleOneOf("data", "kms", "secretref"))
+	}
+	if key.KMS != "" {
+		if strings.HasPrefix(key.KMS, awsKMSPrefix) {
+			errs = errs.Also(validateAWSKMS(key.KMS).ViaField("kms"))
+		}
 	}
 	return errs
 }
@@ -207,5 +218,38 @@ func ValidateRegex(regex string) *apis.FieldError {
 		return apis.ErrInvalidValue(regex, apis.CurrentField, fmt.Sprintf("regex is invalid: %v", err))
 	}
 
+	return nil
+}
+
+// validateAWSKMS validates that the KMS conforms to AWS
+// KMS format:
+// awskms://$ENDPOINT/$KEYID
+// Where:
+// $ENDPOINT is optional
+// $KEYID is either the key ARN or an alias ARN
+// Reasoning for only supporting these formats is that other
+// formats require additional configuration via ENV variables.
+func validateAWSKMS(kms string) *apis.FieldError {
+	parts := strings.Split(kms, "/")
+	if len(parts) < 4 {
+		return apis.ErrInvalidValue(kms, apis.CurrentField, "malformed AWS KMS format, should be: 'awskms://$ENDPOINT/$KEYID'")
+	}
+	endpoint := parts[2]
+	// missing endpoint is fine, only validate if not empty
+	if endpoint != "" {
+		_, _, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			return apis.ErrInvalidValue(kms, apis.CurrentField, fmt.Sprintf("malformed endpoint: %s", err))
+		}
+	}
+	keyID := parts[3]
+	arn, err := arn.Parse(keyID)
+	if err != nil {
+		return apis.ErrInvalidValue(kms, apis.CurrentField, fmt.Sprintf("failed to parse either key or alias arn: %s", err))
+	}
+	// Only support key or alias ARN.
+	if arn.Resource != "key" && arn.Resource != "alias" {
+		return apis.ErrInvalidValue(kms, apis.CurrentField, fmt.Sprintf("Got ARN: %+v Resource: %s", arn, arn.Resource))
+	}
 	return nil
 }

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/sigstore/cosign/pkg/apis/utils"
 	"knative.dev/pkg/apis"
 )

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -771,5 +771,4 @@ func TestAWSKMSValidation(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -104,6 +104,7 @@ type KeyRef struct {
 	// +optional
 	Data string `json:"data,omitempty"`
 	// KMS contains the KMS url of the public key
+	// Supported formats differ based on the KMS system used.
 	// +optional
 	KMS string `json:"kms,omitempty"`
 }

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -133,6 +133,9 @@ func (keyless *KeylessRef) Validate(ctx context.Context) *apis.FieldError {
 		errs = errs.Also(apis.ErrMissingField("identities"))
 	}
 
+	if keyless.CACert != nil {
+		errs = errs.Also(keyless.DeepCopy().CACert.Validate(ctx).ViaField("ca-cert"))
+	}
 	for i, identity := range keyless.Identities {
 		errs = errs.Also(identity.Validate(ctx).ViaFieldIndex("identities", i))
 	}
@@ -213,7 +216,6 @@ func ValidateGlob(glob string) *apis.FieldError {
 }
 
 func ValidateRegex(regex string) *apis.FieldError {
-	// It's a regexp, so pull out the regex
 	_, err := regexp.Compile(regex)
 	if err != nil {
 		return apis.ErrInvalidValue(regex, apis.CurrentField, fmt.Sprintf("regex is invalid: %v", err))

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -17,12 +17,17 @@ package v1beta1
 import (
 	"context"
 	"fmt"
+	"net"
 	"path/filepath"
 	"regexp"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/sigstore/cosign/pkg/apis/utils"
 	"knative.dev/pkg/apis"
 )
+
+const awsKMSPrefix = "awskms://"
 
 // Validate implements apis.Validatable
 func (c *ClusterImagePolicy) Validate(ctx context.Context) *apis.FieldError {
@@ -104,6 +109,11 @@ func (key *KeyRef) Validate(ctx context.Context) *apis.FieldError {
 		}
 	} else if key.KMS != "" && key.SecretRef != nil {
 		errs = errs.Also(apis.ErrMultipleOneOf("data", "kms", "secretref"))
+	}
+	if key.KMS != "" {
+		if strings.HasPrefix(key.KMS, awsKMSPrefix) {
+			errs = errs.Also(validateAWSKMS(key.KMS).ViaField("kms"))
+		}
 	}
 	return errs
 }
@@ -209,5 +219,38 @@ func ValidateRegex(regex string) *apis.FieldError {
 		return apis.ErrInvalidValue(regex, apis.CurrentField, fmt.Sprintf("regex is invalid: %v", err))
 	}
 
+	return nil
+}
+
+// validateAWSKMS validates that the KMS conforms to AWS
+// KMS format:
+// awskms://$ENDPOINT/$KEYID
+// Where:
+// $ENDPOINT is optional
+// $KEYID is either the key ARN or an alias ARN
+// Reasoning for only supporting these formats is that other
+// formats require additional configuration via ENV variables.
+func validateAWSKMS(kms string) *apis.FieldError {
+	parts := strings.Split(kms, "/")
+	if len(parts) < 4 {
+		return apis.ErrInvalidValue(kms, apis.CurrentField, "malformed AWS KMS format, should be: 'awskms://$ENDPOINT/$KEYID'")
+	}
+	endpoint := parts[2]
+	// missing endpoint is fine, only validate if not empty
+	if endpoint != "" {
+		_, _, err := net.SplitHostPort(endpoint)
+		if err != nil {
+			return apis.ErrInvalidValue(kms, apis.CurrentField, fmt.Sprintf("malformed endpoint: %s", err))
+		}
+	}
+	keyID := parts[3]
+	arn, err := arn.Parse(keyID)
+	if err != nil {
+		return apis.ErrInvalidValue(kms, apis.CurrentField, fmt.Sprintf("failed to parse either key or alias arn: %s", err))
+	}
+	// Only support key or alias ARN.
+	if arn.Resource != "key" && arn.Resource != "alias" {
+		return apis.ErrInvalidValue(kms, apis.CurrentField, fmt.Sprintf("Got ARN: %+v Resource: %s", arn, arn.Resource))
+	}
 	return nil
 }

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -22,7 +22,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/sigstore/cosign/pkg/apis/utils"
 	"knative.dev/pkg/apis"
 )

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -16,12 +16,15 @@ package v1beta1
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 )
+
+const validPublicKey = "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaEOVJCFtduYr3xqTxeRWSW32CY/s\nTBNZj4oIUPl8JvhVPJ1TKDPlNcuT4YphSt6t3yOmMvkdQbCj8broX6vijw==\n-----END PUBLIC KEY-----"
 
 func TestImagePatternValidation(t *testing.T) {
 	tests := []struct {
@@ -170,6 +173,22 @@ func TestKeyValidation(t *testing.T) {
 			},
 		},
 		{
+			name:        "Should fail with invalid AWS KMS for Keyful",
+			expectErr:   true,
+			errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].key.kms\nfailed to parse either key or alias arn: arn: not enough sections",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Key:     &KeyRef{KMS: "awskms://localhost:8888/arn:butnotvalid"},
+							Sources: []Source{{OCI: "registry.example.com"}},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "Should pass when key has only one property: %v",
 			errorString: "",
 			policy: ClusterImagePolicy{
@@ -248,7 +267,7 @@ func TestKeylessValidation(t *testing.T) {
 									Host: "myhost",
 								},
 								CACert: &KeyRef{
-									Data: "---certificate---",
+									Data: validPublicKey,
 								},
 							},
 						},
@@ -273,6 +292,21 @@ func TestKeylessValidation(t *testing.T) {
 									Host: "myhost",
 								},
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Should fail with invalid AWS KMS for Keyless",
+			expectErr:   true,
+			errorString: "invalid value: awskms://localhost:8888/arn:butnotvalid: spec.authorities[0].keyless.ca-cert.kms\nfailed to parse either key or alias arn: arn: not enough sections",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{{Glob: "gcr.io/*"}},
+					Authorities: []Authority{
+						{
+							Keyless: &KeylessRef{CACert: &KeyRef{KMS: "awskms://localhost:8888/arn:butnotvalid"}},
 						},
 					},
 				},
@@ -678,6 +712,12 @@ func TestIdentitiesValidation(t *testing.T) {
 }
 
 func TestAWSKMSValidation(t *testing.T) {
+	// Note the error messages betweeen the kms / cacert validation is
+	// identical, with the only difference being `kms` or `ca-cert.kms`. Reason
+	// for the ca-cert.kms is because it's embedded within the ca-cert that
+	// we pass in. So we put a KMSORCACERT into the err string that we then
+	// replace based on the tests so we don't have to write identical tests
+	// for both of them.
 	tests := []struct {
 		name        string
 		expectErr   bool
@@ -687,25 +727,25 @@ func TestAWSKMSValidation(t *testing.T) {
 		{
 			name:        "malformed, only 2 slashes ",
 			expectErr:   true,
-			errorString: "invalid value: awskms://1234abcd-12ab-34cd-56ef-1234567890ab: kms\nmalformed AWS KMS format, should be: 'awskms://$ENDPOINT/$KEYID'",
+			errorString: "invalid value: awskms://1234abcd-12ab-34cd-56ef-1234567890ab: KMSORCACERT\nmalformed AWS KMS format, should be: 'awskms://$ENDPOINT/$KEYID'",
 			kms:         "awskms://1234abcd-12ab-34cd-56ef-1234567890ab",
 		},
 		{
 			name:        "fails with invalid host",
 			expectErr:   true,
-			errorString: "invalid value: awskms://localhost:::4566/alias/exampleAlias: kms\nmalformed endpoint: address localhost:::4566: too many colons in address",
+			errorString: "invalid value: awskms://localhost:::4566/alias/exampleAlias: KMSORCACERT\nmalformed endpoint: address localhost:::4566: too many colons in address",
 			kms:         "awskms://localhost:::4566/alias/exampleAlias",
 		},
 		{
 			name:        "fails with non-arn alias",
 			expectErr:   true,
-			errorString: "invalid value: awskms://localhost:4566/alias/exampleAlias: kms\nfailed to parse either key or alias arn: arn: invalid prefix",
+			errorString: "invalid value: awskms://localhost:4566/alias/exampleAlias: KMSORCACERT\nfailed to parse either key or alias arn: arn: invalid prefix",
 			kms:         "awskms://localhost:4566/alias/exampleAlias",
 		},
 		{
 			name:        "Should fail when arn is invalid",
 			expectErr:   true,
-			errorString: "invalid value: awskms://localhost:4566/arn:sonotvalid: kms\nfailed to parse either key or alias arn: arn: not enough sections",
+			errorString: "invalid value: awskms://localhost:4566/arn:sonotvalid: KMSORCACERT\nfailed to parse either key or alias arn: arn: not enough sections",
 			kms:         "awskms://localhost:4566/arn:sonotvalid",
 		},
 		{
@@ -727,11 +767,23 @@ func TestAWSKMSValidation(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			// First test with KeyRef
 			keyRef := KeyRef{KMS: test.kms}
 			err := keyRef.Validate(context.TODO())
 			if test.expectErr {
 				require.NotNil(t, err)
-				require.EqualError(t, err, test.errorString)
+				kmsErrString := strings.Replace(test.errorString, "KMSORCACERT", "kms", 1)
+				require.EqualError(t, err, kmsErrString)
+			} else {
+				require.Nil(t, err)
+			}
+			// Then with Keyless with CACert as KeyRef
+			keylessRef := KeylessRef{CACert: &keyRef}
+			err = keylessRef.Validate(context.TODO())
+			if test.expectErr {
+				require.NotNil(t, err)
+				caCertErrString := strings.Replace(test.errorString, "KMSORCACERT", "ca-cert.kms", 1)
+				require.EqualError(t, err, caCertErrString)
 			} else {
 				require.Nil(t, err)
 			}

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -676,3 +676,65 @@ func TestIdentitiesValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestAWSKMSValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectErr   bool
+		errorString string
+		kms         string
+	}{
+		{
+			name:        "malformed, only 2 slashes ",
+			expectErr:   true,
+			errorString: "invalid value: awskms://1234abcd-12ab-34cd-56ef-1234567890ab: kms\nmalformed AWS KMS format, should be: 'awskms://$ENDPOINT/$KEYID'",
+			kms:         "awskms://1234abcd-12ab-34cd-56ef-1234567890ab",
+		},
+		{
+			name:        "fails with invalid host",
+			expectErr:   true,
+			errorString: "invalid value: awskms://localhost:::4566/alias/exampleAlias: kms\nmalformed endpoint: address localhost:::4566: too many colons in address",
+			kms:         "awskms://localhost:::4566/alias/exampleAlias",
+		},
+		{
+			name:        "fails with non-arn alias",
+			expectErr:   true,
+			errorString: "invalid value: awskms://localhost:4566/alias/exampleAlias: kms\nfailed to parse either key or alias arn: arn: invalid prefix",
+			kms:         "awskms://localhost:4566/alias/exampleAlias",
+		},
+		{
+			name:        "Should fail when arn is invalid",
+			expectErr:   true,
+			errorString: "invalid value: awskms://localhost:4566/arn:sonotvalid: kms\nfailed to parse either key or alias arn: arn: not enough sections",
+			kms:         "awskms://localhost:4566/arn:sonotvalid",
+		},
+		{
+			name: "works with valid arn key and endpoint",
+			kms:  "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+		},
+		{
+			name: "works with valid arn key and no endpoint",
+			kms:  "awskms:///arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+		},
+		{
+			name: "works with valid arn alias and endpoint",
+			kms:  "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias",
+		},
+		{
+			name: "works with valid arn alias and no endpoint",
+			kms:  "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			keyRef := KeyRef{KMS: test.kms}
+			err := keyRef.Validate(context.TODO())
+			if test.expectErr {
+				require.NotNil(t, err)
+				require.EqualError(t, err, test.errorString)
+			} else {
+				require.Nil(t, err)
+			}
+		})
+	}
+}

--- a/test/testdata/policy-controller/invalid/invalid-keyref-awskms.yaml
+++ b/test/testdata/policy-controller/invalid/invalid-keyref-awskms.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   images:
   - glob: images.*
+  authorities:
   - key:
       # keyid is not supported
       kms: "awskms:///1234abcd-12ab-34cd-56ef-1234567890ab"

--- a/test/testdata/policy-controller/invalid/invalid-keyref-awskms.yaml
+++ b/test/testdata/policy-controller/invalid/invalid-keyref-awskms.yaml
@@ -1,0 +1,33 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy
+spec:
+  images:
+  - glob: images.*
+  - key:
+      # keyid is not supported
+      kms: "awskms:///1234abcd-12ab-34cd-56ef-1234567890ab"
+  - key:
+      # keyid with hostname is still not supported
+      kms: "awskms://localhost:4566/1234abcd-12ab-34cd-56ef-1234567890ab"
+  - key:
+      # alias is not supported
+      kms: "awskms:///alias/ExampleAlias"
+  = key:
+      # alias is not supported, even if you give a hostname
+      kms: "awskms://localhost:4566/alias/ExampleAlias"

--- a/test/testdata/policy-controller/valid/valid-keylessref-awskms.yaml
+++ b/test/testdata/policy-controller/valid/valid-keylessref-awskms.yaml
@@ -1,0 +1,34 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy
+spec:
+  images:
+  - glob: images.*
+  authorities:
+  - keyless:
+      ca-cert:
+        kms: "awskms:///arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+  - keyless:
+      ca-cert:
+        kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+  - keyless:
+       ca-cert:
+         kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
+  - keyless:
+       ca-cert:
+         kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"

--- a/test/testdata/policy-controller/valid/valid-keyref-awskms.yaml
+++ b/test/testdata/policy-controller/valid/valid-keyref-awskms.yaml
@@ -26,5 +26,5 @@ spec:
       kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
   - key:
       kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
-  = key:
+  - key:
       kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"

--- a/test/testdata/policy-controller/valid/valid-keyref-awskms.yaml
+++ b/test/testdata/policy-controller/valid/valid-keyref-awskms.yaml
@@ -19,6 +19,7 @@ metadata:
 spec:
   images:
   - glob: images.*
+  authorities:
   - key:
       kms: "awskms:///arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
   - key:

--- a/test/testdata/policy-controller/valid/valid-keyref-awskms.yaml
+++ b/test/testdata/policy-controller/valid/valid-keyref-awskms.yaml
@@ -1,0 +1,29 @@
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: policy.sigstore.dev/v1alpha1
+kind: ClusterImagePolicy
+metadata:
+  name: image-policy
+spec:
+  images:
+  - glob: images.*
+  - key:
+      kms: "awskms:///arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+  - key:
+      kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+  - key:
+      kms: "awskms:///arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"
+  = key:
+      kms: "awskms://localhost:4566/arn:aws:kms:us-east-2:111122223333:alias/ExampleAlias"


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fix #1930 by adding validation for the AWS KMS formats. Only support either the key ARN or an alias ARN.
Also validate the endpoint if given.

#### Ticket Link
Fixes #1930

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
ClusterImagePolicy for AWS KMS only supports key ARN or alias ARN
```
