### PR TITLE
remove deprecation from goreleaser, go-fish is not supported anymore

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -246,14 +246,3 @@ release:
   extra_files:
     - glob: "./release/release-cosign.pub"
     - glob: "./cosign*.yaml"
-
-rigs:
-  - rig:
-      owner: sigstore
-      name: fish-food
-    commit_author:
-      name: sigstore-bot
-      email: 86837369+sigstore-bot@users.noreply.github.com
-    homepage: https://sigstore.dev
-    description: Container Signing, Verification and Storage in an OCI registry.
-    license: "Apache License 2.0"


### PR DESCRIPTION
#### Summary
- remove deprecation from goreleaser, go-fish is not supported anymore

https://goreleaser.com/deprecations/#rigs



#### Ticket Link
n/a

#### Release Note

```release-note
NONE
```
