### PR TITLE
tuf: improve TUF client concurrency and caching

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
+++ b/cmd/cosign/cli/fulcio/fulcioroots/fulcioroots.go
@@ -116,7 +116,6 @@ func initRoots() (*x509.CertPool, *x509.CertPool, error) {
 		if err != nil {
 			return nil, nil, fmt.Errorf("initializing tuf: %w", err)
 		}
-		defer tufClient.Close()
 		// Retrieve from the embedded or cached TUF root. If expired, a network
 		// call is made to update the root.
 		targets, err := tufClient.GetTargetsByMeta(tuf.Fulcio, []string{fulcioTargetStr, fulcioV1TargetStr})

--- a/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
+++ b/cmd/cosign/cli/fulcio/fulcioverifier/ctl/verify.go
@@ -81,7 +81,6 @@ func VerifySCT(ctx context.Context, certPEM, chainPEM, rawSCT []byte) error {
 		if err != nil {
 			return err
 		}
-		defer tufClient.Close()
 
 		targets, err := tufClient.GetTargetsByMeta(tuf.CTFE, []string{ctPublicKeyStr})
 		if err != nil {

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -109,7 +109,6 @@ func GetRekorPubs(ctx context.Context, rekorClient *client.Rekor) (map[string]Re
 		if err != nil {
 			return nil, err
 		}
-		defer tufClient.Close()
 		targets, err := tufClient.GetTargetsByMeta(tuf.Rekor, []string{rekorTargetStr})
 		if err != nil {
 			return nil, err

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -77,10 +77,15 @@ func getLogID(pub crypto.PublicKey) (string, error) {
 
 // GetRekorPubs retrieves trusted Rekor public keys from the embedded or cached
 // TUF root. If expired, makes a network call to retrieve the updated targets.
-// There is an Env variable that can be used to override this behaviour:
+// A Rekor client may optionally be provided in case using SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY
+// (see below).
+// There are two Env variable that can be used to override this behaviour:
 // SIGSTORE_REKOR_PUBLIC_KEY - If specified, location of the file that contains
 // the Rekor Public Key on local filesystem
-func GetRekorPubs(ctx context.Context) (map[string]RekorPubKey, error) {
+// SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY - If specified, fetches the Rekor public
+// key from the Rekor server using the provided rekorClient.
+// TODO: Rename SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY to be test-only or remove.
+func GetRekorPubs(ctx context.Context, rekorClient *client.Rekor) (map[string]RekorPubKey, error) {
 	publicKeys := make(map[string]RekorPubKey)
 	altRekorPub := os.Getenv(altRekorPublicKey)
 
@@ -121,6 +126,26 @@ func GetRekorPubs(ctx context.Context) (map[string]RekorPubKey, error) {
 			publicKeys[keyID] = RekorPubKey{PubKey: rekorPubKey, Status: t.Status}
 		}
 	}
+
+	// If we have a Rekor client and we've been told to fetch the Public Key from Rekor,
+	// additionally fetch it here.
+	addRekorPublic := os.Getenv(addRekorPublicKeyFromRekor)
+	if addRekorPublic != "" && rekorClient != nil {
+		pubOK, err := rekorClient.Pubkey.GetPublicKey(nil)
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch rekor public key from rekor: %w", err)
+		}
+		pubFromAPI, err := PemToECDSAKey([]byte(pubOK.Payload))
+		if err != nil {
+			return nil, fmt.Errorf("error converting rekor PEM public key from rekor to ECDSAKey: %w", err)
+		}
+		keyID, err := getLogID(pubFromAPI)
+		if err != nil {
+			return nil, fmt.Errorf("error generating log ID: %w", err)
+		}
+		publicKeys[keyID] = RekorPubKey{PubKey: pubFromAPI, Status: tuf.Active}
+	}
+
 	if len(publicKeys) == 0 {
 		return nil, errors.New("none of the Rekor public keys have been found")
 	}
@@ -330,9 +355,7 @@ func FindTLogEntriesByPayload(ctx context.Context, rekorClient *client.Rekor, pa
 	return searchIndex.GetPayload(), nil
 }
 
-// VerityTLogEntry verifies a TLog entry. If the Env variable
-// SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY is specified, fetches the Rekor public
-// key from the Rekor server using the provided rekorClient.
+// VerityTLogEntry verifies a TLog entry.
 func VerifyTLogEntry(ctx context.Context, rekorClient *client.Rekor, e *models.LogEntryAnon) error {
 	if e.Verification == nil || e.Verification.InclusionProof == nil {
 		return errors.New("inclusion proof not provided")
@@ -365,37 +388,11 @@ func VerifyTLogEntry(ctx context.Context, rekorClient *client.Rekor, e *models.L
 		LogID:          *e.LogID,
 	}
 
-	// If we've been told to fetch the Public Key from Rekor, fetch it here
-	// first before using the TUF code below.
-	rekorPubKeys := make(map[string]RekorPubKey)
-	addRekorPublic := os.Getenv(addRekorPublicKeyFromRekor)
-	if addRekorPublic != "" {
-		pubOK, err := rekorClient.Pubkey.GetPublicKey(nil)
-		if err != nil {
-			return fmt.Errorf("unable to fetch rekor public key from rekor: %w", err)
-		}
-		pubFromAPI, err := PemToECDSAKey([]byte(pubOK.Payload))
-		if err != nil {
-			return fmt.Errorf("error converting rekor PEM public key from rekor to ECDSAKey: %w", err)
-		}
-		keyID, err := getLogID(pubFromAPI)
-		if err != nil {
-			return fmt.Errorf("error generating log ID: %w", err)
-		}
-		rekorPubKeys[keyID] = RekorPubKey{PubKey: pubFromAPI, Status: tuf.Active}
-	}
-
-	rekorPubKeysTuf, err := GetRekorPubs(ctx)
+	rekorPubKeys, err := GetRekorPubs(ctx, rekorClient)
 	if err != nil {
-		if len(rekorPubKeys) == 0 {
-			return fmt.Errorf("unable to fetch Rekor public keys from TUF repository, and not trusting the Rekor API for fetching public keys: %w", err)
-		}
-		fmt.Fprintf(os.Stderr, "**Warning** Failed to fetch Rekor public keys from TUF, using the public key from Rekor API because %s was specified", addRekorPublicKeyFromRekor)
+		return fmt.Errorf("unable to fetch Rekor public keys: %w", err)
 	}
 
-	for k, v := range rekorPubKeysTuf {
-		rekorPubKeys[k] = v
-	}
 	pubKey, ok := rekorPubKeys[payload.LogID]
 	if !ok {
 		return errors.New("rekor log public key not found for payload")

--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestGetRekorPubKeys(t *testing.T) {
-	keys, err := GetRekorPubs(context.Background())
+	keys, err := GetRekorPubs(context.Background(), nil)
 	if err != nil {
 		t.Errorf("Unexpected error calling GetRekorPubs, expected nil: %v", err)
 	}

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -216,18 +216,10 @@ func TestCustomRoot(t *testing.T) {
 		return true
 	}
 
-	// Force a panic error that the remote metadata is expired.
-	func() {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("NewFromEnv with expired remote metadata should have panicked!")
-			}
-		}()
-		// This should cause a panic
-		if _, err = NewFromEnv(ctx); err == nil {
-			t.Errorf("expected expired timestamp from the remote")
-		}
-	}()
+	// This should cause an error that remote metadata is expired.
+	if _, err = NewFromEnv(ctx); err == nil {
+		t.Errorf("expected expired timestamp from the remote")
+	}
 
 	// Let internal TUF verification succeed normally now.
 	verify.IsExpired = oldIsExpired

--- a/pkg/cosign/tuf/client_test.go
+++ b/pkg/cosign/tuf/client_test.go
@@ -29,6 +29,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -61,7 +62,7 @@ func TestNewFromEnv(t *testing.T) {
 	}
 
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	// Now try with expired targets
 	forceExpiration(t, true)
@@ -70,7 +71,7 @@ func TestNewFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	if err := Initialize(ctx, DefaultRemoteRoot, nil); err != nil {
 		t.Error()
@@ -85,7 +86,7 @@ func TestNewFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 }
 
 func TestNoCache(t *testing.T) {
@@ -101,7 +102,7 @@ func TestNoCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	// Force expiration so we have some content to download
 	forceExpiration(t, true)
@@ -111,12 +112,13 @@ func TestNoCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 
 	// No filesystem writes when using SIGSTORE_NO_CACHE.
 	if l := dirLen(t, td); l != 0 {
 		t.Errorf("expected no filesystem writes, got %d entries", l)
 	}
+	resetForTests()
 }
 
 func TestCache(t *testing.T) {
@@ -137,7 +139,7 @@ func TestCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 	cachedDirLen := dirLen(t, td)
 	if cachedDirLen == 0 {
 		t.Errorf("expected filesystem writes, got %d entries", cachedDirLen)
@@ -145,11 +147,11 @@ func TestCache(t *testing.T) {
 
 	// Nothing should get downloaded if everything is up to date.
 	forceExpiration(t, false)
-	tuf, err = NewFromEnv(ctx)
+	_, err = NewFromEnv(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	tuf.Close()
+	resetForTests()
 
 	if l := dirLen(t, td); cachedDirLen != l {
 		t.Errorf("expected no filesystem writes, got %d entries", l-cachedDirLen)
@@ -166,7 +168,7 @@ func TestCache(t *testing.T) {
 		t.Errorf("expected filesystem writes, got %d entries", l)
 	}
 	checkTargetsAndMeta(t, tuf)
-	tuf.Close()
+	resetForTests()
 }
 
 func TestCustomRoot(t *testing.T) {
@@ -205,7 +207,7 @@ func TestCustomRoot(t *testing.T) {
 	if b, err := tufObj.GetTarget("foo.txt"); err != nil || !bytes.Equal(b, []byte("foo")) {
 		t.Fatal(err)
 	}
-	tufObj.Close()
+	resetForTests()
 
 	// Force expiration on the first timestamp and internal go-tuf verification.
 	forceExpirationVersion(t, 1)
@@ -231,7 +233,7 @@ func TestCustomRoot(t *testing.T) {
 	if b, err := tufObj.GetTarget("foo.txt"); err != nil || !bytes.Equal(b, []byte("foo1")) {
 		t.Fatal(err)
 	}
-	tufObj.Close()
+	resetForTests()
 }
 
 func TestGetTargetsByMeta(t *testing.T) {
@@ -266,7 +268,7 @@ func TestGetTargetsByMeta(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tufObj.Close()
+	defer resetForTests()
 	// Fetch a target with no custom metadata.
 	targets, err := tufObj.GetTargetsByMeta(UnknownUsage, []string{"fooNoCustom.txt"})
 	if err != nil {
@@ -361,10 +363,6 @@ func TestUpdatedTargetNamesEmbedded(t *testing.T) {
 
 	origEmbedded := GetEmbedded
 	origDefaultRemote := GetRemoteRoot
-	defer func() {
-		GetEmbedded = origEmbedded
-		GetRemoteRoot = origDefaultRemote
-	}()
 
 	// Create an "expired" embedded repository that does not contain newTarget.
 	ctx := context.Background()
@@ -373,13 +371,18 @@ func TestUpdatedTargetNamesEmbedded(t *testing.T) {
 	mapfs := makeMapFS(repository)
 	GetEmbedded = func() fs.FS { return mapfs }
 
-	oldIsExpired := verify.IsExpired
+	oldIsExpired := isExpiredTimestamp
 	isExpiredTimestamp = func(metadata []byte) bool {
 		m, _ := store.GetMeta()
 		timestampExpires, _ := getExpiration(m["timestamp.json"])
 		metadataExpires, _ := getExpiration(metadata)
 		return metadataExpires.Sub(*timestampExpires) <= 0
 	}
+	defer func() {
+		GetEmbedded = origEmbedded
+		GetRemoteRoot = origDefaultRemote
+		isExpiredTimestamp = oldIsExpired
+	}()
 
 	// Assert that the embedded repository does not contain the newTarget.
 	newTarget := "fooNew.txt"
@@ -402,7 +405,7 @@ func TestUpdatedTargetNamesEmbedded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer tufObj.Close()
+	defer resetForTests()
 
 	// Try to retrieve the newly added target.
 	targets, err := tufObj.GetTargetsByMeta(Fulcio, []string{"fooNoCustom.txt"})
@@ -418,7 +421,6 @@ func TestUpdatedTargetNamesEmbedded(t *testing.T) {
 		cmpopts.SortSlices(func(a, b string) bool { return a < b })) {
 		t.Fatalf("target data mismatched, expected: %v, got: %v", expectedTB, targetBytes)
 	}
-	verify.IsExpired = oldIsExpired
 }
 
 func checkTargetsAndMeta(t *testing.T, tuf *TUF) {
@@ -621,4 +623,24 @@ func updateTufRepo(t *testing.T, td string, r *tuf.Repo, targetData string) {
 	if err := r.Commit(); err != nil {
 		t.Error(err)
 	}
+}
+func TestConcurrentAccess(t *testing.T) {
+	var wg sync.WaitGroup
+
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tufObj, err := NewFromEnv(context.Background())
+			if err != nil {
+				t.Errorf("Failed to construct NewFromEnv: %s", err)
+			}
+			if tufObj == nil {
+				t.Error("Got back nil tufObj")
+			}
+			time.Sleep(1 * time.Second)
+		}()
+	}
+	wg.Wait()
+	resetForTests()
 }

--- a/pkg/cosign/tuf/testutils.go
+++ b/pkg/cosign/tuf/testutils.go
@@ -119,8 +119,12 @@ func NewSigstoreTufRepo(t *testing.T, root TestSigstoreRoot) (tuf.LocalStore, *t
 	if !ok {
 		t.Error(err)
 	}
+	resetForTests()
 	if err := Initialize(ctx, s.URL, rootBytes); err != nil {
 		t.Error(err)
 	}
+	t.Cleanup(func() {
+		resetForTests()
+	})
 	return remote, r
 }

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -510,7 +510,7 @@ func VerifyImageSignature(ctx context.Context, sig oci.Signature, h v1.Hash, co 
 		}
 	}
 
-	bundleVerified, err = VerifyBundle(ctx, sig)
+	bundleVerified, err = VerifyBundle(ctx, sig, co.RekorClient)
 	if err != nil && co.RekorClient == nil {
 		return false, fmt.Errorf("unable to verify bundle: %w", err)
 	}
@@ -689,7 +689,7 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 				}
 			}
 
-			verified, err := VerifyBundle(ctx, att)
+			verified, err := VerifyBundle(ctx, att, co.RekorClient)
 			if err != nil && co.RekorClient == nil {
 				return fmt.Errorf("unable to verify bundle: %w", err)
 			}
@@ -737,7 +737,7 @@ func CheckExpiry(cert *x509.Certificate, it time.Time) error {
 	return nil
 }
 
-func VerifyBundle(ctx context.Context, sig oci.Signature) (bool, error) {
+func VerifyBundle(ctx context.Context, sig oci.Signature, rekorClient *client.Rekor) (bool, error) {
 	bundle, err := sig.Bundle()
 	if err != nil {
 		return false, err
@@ -749,7 +749,7 @@ func VerifyBundle(ctx context.Context, sig oci.Signature) (bool, error) {
 		return false, err
 	}
 
-	publicKeys, err := GetRekorPubs(ctx)
+	publicKeys, err := GetRekorPubs(ctx, rekorClient)
 	if err != nil {
 		return false, fmt.Errorf("retrieving rekor public key: %w", err)
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->
* Moves Rekor public key retrieval from API inside `GetRekorPubs`. 
* TUF objects always use in-memory local stores and target store. If caching is enabled, we sync with the on-disk store on (one-time) start and re-sync on any updates. We do **not** keep the local disk cache open, so we don't hog the OS file lock.
* TUF objects are now singletons (see POC from @vaikas https://github.com/sigstore/cosign/pull/1941): this means no re-initialization for each process, we can re-use the TUF object.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Partial fix https://github.com/sigstore/cosign/issues/1935

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note

```
