### PR TITLE
Separate RegExp matching of issuer/subject from strict

### DIFF
--- a/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
+++ b/.github/workflows/kind-cluster-image-policy-with-attestations.yaml
@@ -90,6 +90,7 @@ jobs:
         kubectl rollout status --timeout 5m --namespace cosign-system deployments/webhook
 
     - name: Run Cluster Image Policy Tests with attestations
+      timeout-minutes: 15
       run: |
         ./test/e2e_test_cluster_image_policy_with_attestations.sh
 

--- a/.github/workflows/kind-cluster-image-policy.yaml
+++ b/.github/workflows/kind-cluster-image-policy.yaml
@@ -41,7 +41,7 @@ jobs:
     env:
       KNATIVE_VERSION: "1.1.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.2.2"
+      SCAFFOLDING_RELEASE_VERSION: "v0.2.8"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko
@@ -90,6 +90,7 @@ jobs:
         kubectl rollout status --timeout 5m --namespace cosign-system deployments/webhook
 
     - name: Run Cluster Image Policy Tests
+      timeout-minutes: 15
       run: |
         ./test/e2e_test_cluster_image_policy.sh
 

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -276,7 +276,11 @@ spec:
                               properties:
                                 issuer:
                                   type: string
+                                issuerRegExp:
+                                  type: string
                                 subject:
+                                  type: string
+                                subjectRegExp:
                                   type: string
                           url:
                             type: string

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -125,7 +125,11 @@ spec:
                               properties:
                                 issuer:
                                   type: string
+                                issuerRE:
+                                  type: string
                                 subject:
+                                  type: string
+                                subjectRE:
                                   type: string
                           url:
                             type: string

--- a/config/300-clusterimagepolicy.yaml
+++ b/config/300-clusterimagepolicy.yaml
@@ -125,11 +125,11 @@ spec:
                               properties:
                                 issuer:
                                   type: string
-                                issuerRE:
+                                issuerRegExp:
                                   type: string
                                 subject:
                                   type: string
-                                subjectRE:
+                                subjectRegExp:
                                   type: string
                           url:
                             type: string

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion.go
@@ -103,7 +103,7 @@ func (authority *Authority) ConvertTo(ctx context.Context, sink *v1beta1.Authori
 			URL: authority.Keyless.URL.DeepCopy(),
 		}
 		for _, id := range authority.Keyless.Identities {
-			sink.Keyless.Identities = append(sink.Keyless.Identities, v1beta1.Identity{Issuer: id.Issuer, Subject: id.Subject})
+			sink.Keyless.Identities = append(sink.Keyless.Identities, v1beta1.Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRegExp: id.IssuerRegExp, SubjectRegExp: id.SubjectRegExp})
 		}
 		if authority.Keyless.CACert != nil {
 			sink.Keyless.CACert = &v1beta1.KeyRef{}
@@ -175,7 +175,7 @@ func (authority *Authority) ConvertFrom(ctx context.Context, source *v1beta1.Aut
 			URL: source.Keyless.URL.DeepCopy(),
 		}
 		for _, id := range source.Keyless.Identities {
-			authority.Keyless.Identities = append(authority.Keyless.Identities, Identity{Issuer: id.Issuer, Subject: id.Subject})
+			authority.Keyless.Identities = append(authority.Keyless.Identities, Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRegExp: id.IssuerRegExp, SubjectRegExp: id.SubjectRegExp})
 		}
 		if source.Keyless.CACert != nil {
 			authority.Keyless.CACert = &KeyRef{}

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_conversion_test.go
@@ -47,6 +47,23 @@ func TestConversionRoundTripV1alpha1(t *testing.T) {
 				},
 			},
 		},
+	}, {name: "key and keyless, regexp",
+		in: &ClusterImagePolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cip",
+			},
+			Spec: ClusterImagePolicySpec{
+				Images: []ImagePattern{{Glob: "*"}},
+				Authorities: []Authority{
+					{Key: &KeyRef{
+						SecretRef: &v1.SecretReference{Name: "mysecret"}}},
+					{Keyless: &KeylessRef{
+						Identities: []Identity{{SubjectRegExp: "subjectregexp", IssuerRegExp: "issuerregexp"}},
+						CACert:     &KeyRef{KMS: "kms", Data: "data", SecretRef: &v1.SecretReference{Name: "secret"}},
+					}},
+				},
+			},
+		},
 	}, {name: "source and attestations",
 		in: &ClusterImagePolicy{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -179,12 +179,17 @@ type ConfigMapReference struct {
 }
 
 // Identity may contain the issuer and/or the subject found in the transparency log.
-// Either field supports a pattern glob.
+// Issuer/Subject uses a strict match, while IssuerRE and SubjectRE apply
+// a regex for matching.
 type Identity struct {
 	// +optional
 	Issuer string `json:"issuer,omitempty"`
 	// +optional
 	Subject string `json:"subject,omitempty"`
+	// +optional
+	IssuerRE string `json:"issuerRE,omitempty"`
+	// +optional
+	SubjectRE string `json:"subjectRE,omitempty"`
 }
 
 // ClusterImagePolicyList is a list of ClusterImagePolicy resources

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_types.go
@@ -178,18 +178,19 @@ type ConfigMapReference struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-// Identity may contain the issuer and/or the subject found in the transparency log.
-// Issuer/Subject uses a strict match, while IssuerRE and SubjectRE apply
-// a regex for matching.
+// Identity may contain the issuer and/or the subject found in the transparency
+// log.
+// Issuer/Subject uses a strict match, while IssuerRegExp and SubjectRegExp
+// apply a regexp for matching.
 type Identity struct {
 	// +optional
 	Issuer string `json:"issuer,omitempty"`
 	// +optional
 	Subject string `json:"subject,omitempty"`
 	// +optional
-	IssuerRE string `json:"issuerRE,omitempty"`
+	IssuerRegExp string `json:"issuerRegExp,omitempty"`
 	// +optional
-	SubjectRE string `json:"subjectRE,omitempty"`
+	SubjectRegExp string `json:"subjectRegExp,omitempty"`
 }
 
 // ClusterImagePolicyList is a list of ClusterImagePolicy resources

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -193,14 +193,14 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 
 func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-	if identity.Issuer == "" && identity.Subject == "" {
-		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject"))
+	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRE == "" && identity.SubjectRE == "" {
+		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRE", "subjectRE"))
 	}
-	if identity.Issuer != "" {
-		errs = errs.Also(ValidateRegex(identity.Issuer).ViaField("issuer"))
+	if identity.IssuerRE != "" {
+		errs = errs.Also(ValidateRegex(identity.IssuerRE).ViaField("issuerRE"))
 	}
-	if identity.Subject != "" {
-		errs = errs.Also(ValidateRegex(identity.Subject).ViaField("subject"))
+	if identity.SubjectRE != "" {
+		errs = errs.Also(ValidateRegex(identity.SubjectRE).ViaField("subjectRE"))
 	}
 	return errs
 }

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -194,7 +194,13 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRegExp == "" && identity.SubjectRegExp == "" {
-		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRegExp", "subjectRegExp"))
+		errs = errs.Also(apis.ErrMissingField("issuer", "subject", "issuerRegExp", "subjectRegExp"))
+	}
+	if identity.Issuer != "" && identity.IssuerRegExp != "" {
+		errs = errs.Also(apis.ErrMultipleOneOf("issuer", "issuerRegExp"))
+	}
+	if identity.Subject != "" && identity.SubjectRegExp != "" {
+		errs = errs.Also(apis.ErrMultipleOneOf("subject", "subjectRegExp"))
 	}
 	if identity.IssuerRegExp != "" {
 		errs = errs.Also(ValidateRegex(identity.IssuerRegExp).ViaField("issuerRegExp"))

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation.go
@@ -193,14 +193,14 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 
 func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRE == "" && identity.SubjectRE == "" {
-		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRE", "subjectRE"))
+	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRegExp == "" && identity.SubjectRegExp == "" {
+		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRegExp", "subjectRegExp"))
 	}
-	if identity.IssuerRE != "" {
-		errs = errs.Also(ValidateRegex(identity.IssuerRE).ViaField("issuerRE"))
+	if identity.IssuerRegExp != "" {
+		errs = errs.Also(ValidateRegex(identity.IssuerRegExp).ViaField("issuerRegExp"))
 	}
-	if identity.SubjectRE != "" {
-		errs = errs.Also(ValidateRegex(identity.SubjectRE).ViaField("subjectRE"))
+	if identity.SubjectRegExp != "" {
+		errs = errs.Also(ValidateRegex(identity.SubjectRegExp).ViaField("subjectRegExp"))
 	}
 	return errs
 }

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -649,7 +649,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when issuer has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRegExp\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -660,7 +660,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{IssuerRE: "****"}},
+								Identities: []Identity{{IssuerRegExp: "****"}},
 							},
 						},
 					},
@@ -670,7 +670,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when subject has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subjectRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subjectRegExp\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -681,7 +681,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{SubjectRE: "****"}},
+								Identities: []Identity{{SubjectRegExp: "****"}},
 							},
 						},
 					},

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -649,7 +649,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when issuer has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuer\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -660,7 +660,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{Issuer: "****"}},
+								Identities: []Identity{{IssuerRE: "****"}},
 							},
 						},
 					},
@@ -670,7 +670,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when subject has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subject\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subjectRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -681,7 +681,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{Subject: "****"}},
+								Identities: []Identity{{SubjectRE: "****"}},
 							},
 						},
 					},

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -763,7 +763,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{Subject: ".*subject.*", Issuer: ".*issuer.*"}},
+								Identities: []Identity{{SubjectRegExp: ".*subject.*", IssuerRegExp: ".*issuer.*"}},
 							},
 						},
 					},

--- a/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1alpha1/clusterimagepolicy_validation_test.go
@@ -647,6 +647,69 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 		{
+			name:        "Should fail when identities fields are empty",
+			expectErr:   true,
+			errorString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp, spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "globbityglob",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Keyless: &KeylessRef{
+								Identities: []Identity{{Issuer: ""}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Should fail with both issuer and issuerRegExp",
+			expectErr:   true,
+			errorString: "expected exactly one, got both: spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "globbityglob",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Keyless: &KeylessRef{
+								Identities: []Identity{{Issuer: "issuer", IssuerRegExp: "issuerregexp"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Should fail with both subject and subjectRegExp",
+			expectErr:   true,
+			errorString: "expected exactly one, got both: spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "globbityglob",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Keyless: &KeylessRef{
+								Identities: []Identity{{Subject: "subject", SubjectRegExp: "subjectregexp"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "Should fail when issuer has invalid regex",
 			expectErr:   true,
 			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRegExp\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -179,12 +179,17 @@ type ConfigMapReference struct {
 }
 
 // Identity may contain the issuer and/or the subject found in the transparency log.
-// Either field supports a pattern glob.
+// Issuer/Subject uses a strict match, while IssuerRE and SubjectRE apply
+// a regex for matching.
 type Identity struct {
 	// +optional
 	Issuer string `json:"issuer,omitempty"`
 	// +optional
 	Subject string `json:"subject,omitempty"`
+	// +optional
+	IssuerRE string `json:"issuerRE,omitempty"`
+	// +optional
+	SubjectRE string `json:"subjectRE,omitempty"`
 }
 
 // ClusterImagePolicyList is a list of ClusterImagePolicy resources

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_types.go
@@ -178,18 +178,19 @@ type ConfigMapReference struct {
 	Namespace string `json:"namespace,omitempty"`
 }
 
-// Identity may contain the issuer and/or the subject found in the transparency log.
-// Issuer/Subject uses a strict match, while IssuerRE and SubjectRE apply
-// a regex for matching.
+// Identity may contain the issuer and/or the subject found in the transparency
+// log.
+// Issuer/Subject uses a strict match, while IssuerRegExp and SubjectRegExp
+// apply a regexp for matching.
 type Identity struct {
 	// +optional
 	Issuer string `json:"issuer,omitempty"`
 	// +optional
 	Subject string `json:"subject,omitempty"`
 	// +optional
-	IssuerRE string `json:"issuerRE,omitempty"`
+	IssuerRegExp string `json:"issuerRegExp,omitempty"`
 	// +optional
-	SubjectRE string `json:"subjectRE,omitempty"`
+	SubjectRegExp string `json:"subjectRegExp,omitempty"`
 }
 
 // ClusterImagePolicyList is a list of ClusterImagePolicy resources

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -193,14 +193,14 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 
 func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-	if identity.Issuer == "" && identity.Subject == "" {
-		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject"))
+	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRE == "" && identity.SubjectRE == "" {
+		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRE", "subjectRE"))
 	}
-	if identity.Issuer != "" {
-		errs = errs.Also(ValidateRegex(identity.Issuer).ViaField("issuer"))
+	if identity.IssuerRE != "" {
+		errs = errs.Also(ValidateRegex(identity.IssuerRE).ViaField("issuerRE"))
 	}
-	if identity.Subject != "" {
-		errs = errs.Also(ValidateRegex(identity.Subject).ViaField("subject"))
+	if identity.SubjectRE != "" {
+		errs = errs.Also(ValidateRegex(identity.SubjectRE).ViaField("subjectRE"))
 	}
 	return errs
 }

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -194,7 +194,13 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
 	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRegExp == "" && identity.SubjectRegExp == "" {
-		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRegExp", "subjectRegExp"))
+		errs = errs.Also(apis.ErrMissingField("issuer", "subject", "issuerRegExp", "subjectRegExp"))
+	}
+	if identity.Issuer != "" && identity.IssuerRegExp != "" {
+		errs = errs.Also(apis.ErrMultipleOneOf("issuer", "issuerRegExp"))
+	}
+	if identity.Subject != "" && identity.SubjectRegExp != "" {
+		errs = errs.Also(apis.ErrMultipleOneOf("subject", "subjectRegExp"))
 	}
 	if identity.IssuerRegExp != "" {
 		errs = errs.Also(ValidateRegex(identity.IssuerRegExp).ViaField("issuerRegExp"))

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation.go
@@ -193,14 +193,14 @@ func (p *Policy) Validate(ctx context.Context) *apis.FieldError {
 
 func (identity *Identity) Validate(ctx context.Context) *apis.FieldError {
 	var errs *apis.FieldError
-	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRE == "" && identity.SubjectRE == "" {
-		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRE", "subjectRE"))
+	if identity.Issuer == "" && identity.Subject == "" && identity.IssuerRegExp == "" && identity.SubjectRegExp == "" {
+		errs = errs.Also(apis.ErrMissingOneOf("issuer", "subject", "issuerRegExp", "subjectRegExp"))
 	}
-	if identity.IssuerRE != "" {
-		errs = errs.Also(ValidateRegex(identity.IssuerRE).ViaField("issuerRE"))
+	if identity.IssuerRegExp != "" {
+		errs = errs.Also(ValidateRegex(identity.IssuerRegExp).ViaField("issuerRegExp"))
 	}
-	if identity.SubjectRE != "" {
-		errs = errs.Also(ValidateRegex(identity.SubjectRE).ViaField("subjectRE"))
+	if identity.SubjectRegExp != "" {
+		errs = errs.Also(ValidateRegex(identity.SubjectRegExp).ViaField("subjectRegExp"))
 	}
 	return errs
 }

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -615,7 +615,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when issuer has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuer\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -626,7 +626,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{Issuer: "****"}},
+								Identities: []Identity{{IssuerRE: "****"}},
 							},
 						},
 					},
@@ -636,7 +636,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when subject has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subject\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subjectRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -647,7 +647,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{Subject: "****"}},
+								Identities: []Identity{{SubjectRE: "****"}},
 							},
 						},
 					},
@@ -666,7 +666,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{Subject: ".*subject.*", Issuer: ".*issuer.*"}},
+								Identities: []Identity{{SubjectRE: ".*subject.*", IssuerRE: ".*issuer.*"}},
 							},
 						},
 					},

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -615,7 +615,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when issuer has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRegExp\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -626,7 +626,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{IssuerRE: "****"}},
+								Identities: []Identity{{IssuerRegExp: "****"}},
 							},
 						},
 					},
@@ -636,7 +636,7 @@ func TestIdentitiesValidation(t *testing.T) {
 		{
 			name:        "Should fail when subject has invalid regex",
 			expectErr:   true,
-			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subjectRE\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
+			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].subjectRegExp\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",
 			policy: ClusterImagePolicy{
 				Spec: ClusterImagePolicySpec{
 					Images: []ImagePattern{
@@ -647,7 +647,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{SubjectRE: "****"}},
+								Identities: []Identity{{SubjectRegExp: "****"}},
 							},
 						},
 					},
@@ -666,7 +666,7 @@ func TestIdentitiesValidation(t *testing.T) {
 					Authorities: []Authority{
 						{
 							Keyless: &KeylessRef{
-								Identities: []Identity{{SubjectRE: ".*subject.*", IssuerRE: ".*issuer.*"}},
+								Identities: []Identity{{SubjectRegExp: ".*subject.*", IssuerRegExp: ".*issuer.*"}},
 							},
 						},
 					},

--- a/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
+++ b/pkg/apis/policy/v1beta1/clusterimagepolicy_validation_test.go
@@ -613,6 +613,70 @@ func TestIdentitiesValidation(t *testing.T) {
 			},
 		},
 		{
+			name:        "Should fail when identities fields are empty",
+			expectErr:   true,
+			errorString: "missing field(s): spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp, spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "globbityglob",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Keyless: &KeylessRef{
+								Identities: []Identity{{Issuer: ""}},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name:        "Should fail with both issuer and issuerRegExp",
+			expectErr:   true,
+			errorString: "expected exactly one, got both: spec.authorities[0].keyless.identities[0].issuer, spec.authorities[0].keyless.identities[0].issuerRegExp",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "globbityglob",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Keyless: &KeylessRef{
+								Identities: []Identity{{Issuer: "issuer", IssuerRegExp: "issuerregexp"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Should fail with both subject and subjectRegExp",
+			expectErr:   true,
+			errorString: "expected exactly one, got both: spec.authorities[0].keyless.identities[0].subject, spec.authorities[0].keyless.identities[0].subjectRegExp",
+			policy: ClusterImagePolicy{
+				Spec: ClusterImagePolicySpec{
+					Images: []ImagePattern{
+						{
+							Glob: "globbityglob",
+						},
+					},
+					Authorities: []Authority{
+						{
+							Keyless: &KeylessRef{
+								Identities: []Identity{{Subject: "subject", SubjectRegExp: "subjectregexp"}},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:        "Should fail when issuer has invalid regex",
 			expectErr:   true,
 			errorString: "invalid value: ****: spec.authorities[0].keyless.identities[0].issuerRegExp\nregex is invalid: error parsing regexp: missing argument to repetition operator: `*`",

--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -91,7 +91,7 @@ func validSignatures(ctx context.Context, ref name.Reference, verifier signature
 func validSignaturesWithFulcio(ctx context.Context, ref name.Reference, fulcioRoots *x509.CertPool, rekorClient *client.Rekor, identities []v1alpha1.Identity, opts ...ociremote.Option) ([]oci.Signature, error) {
 	ids := make([]cosign.Identity, len(identities))
 	for i, id := range identities {
-		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject}
+		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRE: id.IssuerRE, SubjectRE: id.SubjectRE}
 	}
 	sigs, _, err := cosignVerifySignatures(ctx, ref, &cosign.CheckOpts{
 		RegistryClientOpts: opts,
@@ -118,7 +118,7 @@ func validAttestations(ctx context.Context, ref name.Reference, verifier signatu
 func validAttestationsWithFulcio(ctx context.Context, ref name.Reference, fulcioRoots *x509.CertPool, rekorClient *client.Rekor, identities []v1alpha1.Identity, opts ...ociremote.Option) ([]oci.Signature, error) {
 	ids := make([]cosign.Identity, len(identities))
 	for i, id := range identities {
-		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject}
+		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRE: id.IssuerRE, SubjectRE: id.SubjectRE}
 	}
 
 	attestations, _, err := cosignVerifyAttestations(ctx, ref, &cosign.CheckOpts{

--- a/pkg/cosign/kubernetes/webhook/validation.go
+++ b/pkg/cosign/kubernetes/webhook/validation.go
@@ -91,7 +91,7 @@ func validSignatures(ctx context.Context, ref name.Reference, verifier signature
 func validSignaturesWithFulcio(ctx context.Context, ref name.Reference, fulcioRoots *x509.CertPool, rekorClient *client.Rekor, identities []v1alpha1.Identity, opts ...ociremote.Option) ([]oci.Signature, error) {
 	ids := make([]cosign.Identity, len(identities))
 	for i, id := range identities {
-		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRE: id.IssuerRE, SubjectRE: id.SubjectRE}
+		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRegExp: id.IssuerRegExp, SubjectRegExp: id.SubjectRegExp}
 	}
 	sigs, _, err := cosignVerifySignatures(ctx, ref, &cosign.CheckOpts{
 		RegistryClientOpts: opts,
@@ -118,7 +118,7 @@ func validAttestations(ctx context.Context, ref name.Reference, verifier signatu
 func validAttestationsWithFulcio(ctx context.Context, ref name.Reference, fulcioRoots *x509.CertPool, rekorClient *client.Rekor, identities []v1alpha1.Identity, opts ...ociremote.Option) ([]oci.Signature, error) {
 	ids := make([]cosign.Identity, len(identities))
 	for i, id := range identities {
-		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRE: id.IssuerRE, SubjectRE: id.SubjectRE}
+		ids[i] = cosign.Identity{Issuer: id.Issuer, Subject: id.Subject, IssuerRegExp: id.IssuerRegExp, SubjectRegExp: id.SubjectRegExp}
 	}
 
 	attestations, _, err := cosignVerifyAttestations(ctx, ref, &cosign.CheckOpts{

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -669,26 +669,26 @@ func TestValidateAndUnpackCertWithIdentities(t *testing.T) {
 			{Subject: emailSubject, Issuer: oidcIssuer}},
 			emailAddresses: []string{emailSubject}},
 		{identities: []Identity{ // illegal regex for subject
-			{SubjectRE: "****", Issuer: oidcIssuer}},
+			{SubjectRegExp: "****", Issuer: oidcIssuer}},
 			emailAddresses:   []string{emailSubject},
 			wantErrSubstring: "malformed subject in identity"},
 		{identities: []Identity{ // illegal regex for issuer
-			{Subject: emailSubject, IssuerRE: "****"}},
+			{Subject: emailSubject, IssuerRegExp: "****"}},
 			wantErrSubstring: "malformed issuer in identity"},
 		{identities: []Identity{ // regex matches
-			{SubjectRE: ".*example.com", IssuerRE: ".*accounts.google.*"}},
+			{SubjectRegExp: ".*example.com", IssuerRegExp: ".*accounts.google.*"}},
 			emailAddresses:   []string{emailSubject},
 			wantErrSubstring: ""},
 		{identities: []Identity{ // regex matches dnsNames
-			{SubjectRE: ".*ubject.example.com", IssuerRE: ".*accounts.google.*"}},
+			{SubjectRegExp: ".*ubject.example.com", IssuerRegExp: ".*accounts.google.*"}},
 			dnsNames:         dnsSubjects,
 			wantErrSubstring: ""},
 		{identities: []Identity{ // regex matches ip
-			{SubjectRE: "1.2.3.*", IssuerRE: ".*accounts.google.*"}},
+			{SubjectRegExp: "1.2.3.*", IssuerRegExp: ".*accounts.google.*"}},
 			ipAddresses:      ipSubjects,
 			wantErrSubstring: ""},
 		{identities: []Identity{ // regex matches urls
-			{SubjectRE: ".*url.examp.*", IssuerRE: ".*accounts.google.*"}},
+			{SubjectRegExp: ".*url.examp.*", IssuerRegExp: ".*accounts.google.*"}},
 			uris:             uriSubjects,
 			wantErrSubstring: ""},
 	}

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -652,16 +652,13 @@ func TestValidateAndUnpackCertWithIdentities(t *testing.T) {
 		{identities: nil /* No matches required, checks out */},
 		{identities: []Identity{ // Strict match on both
 			{Subject: emailSubject, Issuer: oidcIssuer}},
-			emailAddresses:   []string{emailSubject},
-			wantErrSubstring: ""},
+			emailAddresses: []string{emailSubject}},
 		{identities: []Identity{ // just issuer
 			{Issuer: oidcIssuer}},
-			emailAddresses:   []string{emailSubject},
-			wantErrSubstring: ""},
+			emailAddresses: []string{emailSubject}},
 		{identities: []Identity{ // just subject
 			{Subject: emailSubject}},
-			emailAddresses:   []string{emailSubject},
-			wantErrSubstring: ""},
+			emailAddresses: []string{emailSubject}},
 		{identities: []Identity{ // mis-match
 			{Subject: "wrongsubject", Issuer: oidcIssuer},
 			{Subject: emailSubject, Issuer: "wrongissuer"}},
@@ -670,29 +667,28 @@ func TestValidateAndUnpackCertWithIdentities(t *testing.T) {
 		{identities: []Identity{ // one good identity, other does not match
 			{Subject: "wrongsubject", Issuer: "wrongissuer"},
 			{Subject: emailSubject, Issuer: oidcIssuer}},
-			emailAddresses:   []string{emailSubject},
-			wantErrSubstring: ""},
+			emailAddresses: []string{emailSubject}},
 		{identities: []Identity{ // illegal regex for subject
-			{Subject: "****", Issuer: oidcIssuer}},
+			{SubjectRE: "****", Issuer: oidcIssuer}},
 			emailAddresses:   []string{emailSubject},
 			wantErrSubstring: "malformed subject in identity"},
 		{identities: []Identity{ // illegal regex for issuer
-			{Subject: emailSubject, Issuer: "****"}},
+			{Subject: emailSubject, IssuerRE: "****"}},
 			wantErrSubstring: "malformed issuer in identity"},
 		{identities: []Identity{ // regex matches
-			{Subject: ".*example.com", Issuer: ".*accounts.google.*"}},
+			{SubjectRE: ".*example.com", IssuerRE: ".*accounts.google.*"}},
 			emailAddresses:   []string{emailSubject},
 			wantErrSubstring: ""},
 		{identities: []Identity{ // regex matches dnsNames
-			{Subject: ".*ubject.example.com", Issuer: ".*accounts.google.*"}},
+			{SubjectRE: ".*ubject.example.com", IssuerRE: ".*accounts.google.*"}},
 			dnsNames:         dnsSubjects,
 			wantErrSubstring: ""},
 		{identities: []Identity{ // regex matches ip
-			{Subject: "1.2.3.*", Issuer: ".*accounts.google.*"}},
+			{SubjectRE: "1.2.3.*", IssuerRE: ".*accounts.google.*"}},
 			ipAddresses:      ipSubjects,
 			wantErrSubstring: ""},
 		{identities: []Identity{ // regex matches urls
-			{Subject: ".*url.examp.*", Issuer: ".*accounts.google.*"}},
+			{SubjectRE: ".*url.examp.*", IssuerRE: ".*accounts.google.*"}},
 			uris:             uriSubjects,
 			wantErrSubstring: ""},
 	}

--- a/test/e2e_test_cluster_image_policy.sh
+++ b/test/e2e_test_cluster_image_policy.sh
@@ -179,6 +179,7 @@ echo '::endgroup::'
 
 echo '::group:: Remove mismatching cip, start fresh for key'
 kubectl delete cip --all
+echo 'done deleting cips'
 sleep 5
 echo '::endgroup::'
 

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-identities-mismatch.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-identities-mismatch.yaml
@@ -23,7 +23,7 @@ spec:
   - keyless:
       url: http://fulcio.fulcio-system.svc
       identities:
-      - issuer: .*kubernetes.securenamespace.*
-        subject: .*kubernetes.io/namespaces/securenamespace/serviceaccounts/default
+      - issuerRE: .*kubernetes.securenamespace.*
+        subjectRE: .*kubernetes.io/namespaces/securenamespace/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-identities-mismatch.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-identities-mismatch.yaml
@@ -23,7 +23,7 @@ spec:
   - keyless:
       url: http://fulcio.fulcio-system.svc
       identities:
-      - issuerRE: .*kubernetes.securenamespace.*
-        subjectRE: .*kubernetes.io/namespaces/securenamespace/serviceaccounts/default
+      - issuerRegExp: .*kubernetes.securenamespace.*
+        subjectRegExp: .*kubernetes.io/namespaces/securenamespace/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-identities.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-identities.yaml
@@ -23,7 +23,7 @@ spec:
   - keyless:
       url: http://fulcio.fulcio-system.svc
       identities:
-      - issuer: .*kubernetes.default.*
-        subject: .*kubernetes.io/namespaces/default/serviceaccounts/default
+      - issuerRE: .*kubernetes.default.*
+        subjectRE: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc

--- a/test/testdata/policy-controller/e2e/cip-keyless-with-identities.yaml
+++ b/test/testdata/policy-controller/e2e/cip-keyless-with-identities.yaml
@@ -23,7 +23,7 @@ spec:
   - keyless:
       url: http://fulcio.fulcio-system.svc
       identities:
-      - issuerRE: .*kubernetes.default.*
-        subjectRE: .*kubernetes.io/namespaces/default/serviceaccounts/default
+      - issuerRegExp: .*kubernetes.default.*
+        subjectRegExp: .*kubernetes.io/namespaces/default/serviceaccounts/default
     ctlog:
       url: http://rekor.rekor-system.svc


### PR DESCRIPTION
Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

#### Summary
Add two new fields issuerRegExp and subjectRegExp so that if the user wants RE matching of issuer/subject, it's crystal clear
that RE is being used. issuer / subject are now strict matches only.

#### Ticket Link
Fixes #1871 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
CIP issuer/subject are now strict matches. Add two new fields issuerRegExp and subjectRegExp that will then use RE for matching.
```
