### PR TITLE
add parallelism for goreleaser

### DIFF
--- a/release/release.mk
+++ b/release/release.mk
@@ -4,7 +4,7 @@
 # used when releasing together with GCP CloudBuild
 .PHONY: release
 release:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --timeout 120m
+	LDFLAGS="$(LDFLAGS)" goreleaser release --parallelism 1 --timeout 120m
 
 ######################
 # sign section


### PR DESCRIPTION
#### Summary
looks like when signing all the artifacts this is going too fast and there is a lot, and getting some conflicts that i need to debug in a near future, but to unblock the release will set the parallelism to 1 for now

the error

```
getting key from Fulcio: verifying SCT: creating cached local store: resource temporarily unavailable
```

#### Ticket Link
n/a

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
NONE
```
