### PR TITLE
cleanup: unexport kubernetes.Client method

### DIFF
--- a/pkg/cosign/kubernetes/secret.go
+++ b/pkg/cosign/kubernetes/secret.go
@@ -40,7 +40,7 @@ func GetKeyPairSecret(ctx context.Context, k8sRef string) (*v1.Secret, error) {
 		return nil, err
 	}
 
-	client, err := Client()
+	client, err := client()
 	if err != nil {
 		return nil, fmt.Errorf("new for config: %w", err)
 	}
@@ -65,7 +65,7 @@ func KeyPairSecret(ctx context.Context, k8sRef string, pf cosign.PassFunc) error
 	}
 
 	// create the k8s client
-	client, err := Client()
+	client, err := client()
 	if err != nil {
 		return fmt.Errorf("new for config: %w", err)
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -41,6 +41,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8s "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// Initialize all known client auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli"
 	"github.com/sigstore/cosign/cmd/cosign/cli/attach"
@@ -427,7 +432,13 @@ func TestGenerateKeyPairK8s(t *testing.T) {
 		t.Fatal(err)
 	}
 	// make sure the secret actually exists
-	client, err := kubernetes.Client()
+
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(), nil).ClientConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := k8s.NewForConfig(cfg)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

The method is only used inside the package, and we shouldn't recommend folks depend on it, so let's unexport it.

The method encapsulates trying to create a k8s client from local environment config, and if one can't be found, it falls back to creating an in-cluster k8s client. This is used by both the policy controller, which uses the in-cluster config, and `cosign generate-key-pair k8s://ns/secret-name`, which may use a regular user config, or if run in a K8s cluster, would use the in-cluster config. As the policy controller moves out to its own repo we might want to consider just having it assume the in-cluster config.

This change also collapses three methods into one, for simplicity.

#### Release Note

```release-note
NONE
```
