### PR TITLE
Add --platform flag to cosign sbom download 

### DIFF
--- a/cmd/cosign/cli/download.go
+++ b/cmd/cosign/cli/download.go
@@ -60,6 +60,7 @@ func downloadSignature() *cobra.Command {
 
 func downloadSBOM() *cobra.Command {
 	o := &options.RegistryOptions{}
+	do := &options.SBOMDownloadOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "sbom",
@@ -68,11 +69,12 @@ func downloadSBOM() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(os.Stderr, "WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>' or verify its signature.")
-			_, err := download.SBOMCmd(cmd.Context(), *o, args[0], cmd.OutOrStdout())
+			_, err := download.SBOMCmd(cmd.Context(), *o, *do, args[0], cmd.OutOrStdout())
 			return err
 		},
 	}
 
+	do.AddFlags(cmd)
 	o.AddFlags(cmd)
 
 	return cmd

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -26,7 +26,10 @@ import (
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 )
 
-func SBOMCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef string, out io.Writer) ([]string, error) {
+func SBOMCmd(
+	ctx context.Context, regOpts options.RegistryOptions,
+	dnOpts options.SBOMDownloadOptions, imageRef string, out io.Writer,
+) ([]string, error) {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return nil, err

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -17,6 +17,7 @@ package download
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -47,7 +48,10 @@ func SBOMCmd(
 
 	file, err := se.Attachment("sbom")
 	if err != nil {
-		return nil, err
+		if errors.Is(err, ociremote.ErrImageNotFound) {
+			return nil, errors.New("no sbom attached to reference")
+		}
+		return nil, fmt.Errorf("getting sbom attachment: %+w", err)
 	}
 
 	// "attach sbom" attaches a single static.NewFile

--- a/cmd/cosign/cli/options/download.go
+++ b/cmd/cosign/cli/options/download.go
@@ -1,0 +1,31 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import "github.com/spf13/cobra"
+
+// DownloadOptions is the struct for control
+type SBOMDownloadOptions struct {
+	Platform string // Platform to download sboms
+}
+
+var _ Interface = (*SBOMDownloadOptions)(nil)
+
+// AddFlags implements Interface
+func (o *SBOMDownloadOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.Platform, "platform", "",
+		"download SBOM for a specific platform image")
+}

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -19,6 +19,7 @@ cosign download sbom [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for sbom
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --platform string                                                                          download SBOM for a specific platform image
 ```
 
 ### Options inherited from parent commands

--- a/pkg/oci/remote/image.go
+++ b/pkg/oci/remote/image.go
@@ -25,13 +25,15 @@ import (
 	"github.com/sigstore/cosign/pkg/oci"
 )
 
+var ErrImageNotFound = errors.New("image not found in registry")
+
 // SignedImage provides access to a remote image reference, and its signatures.
 func SignedImage(ref name.Reference, options ...Option) (oci.SignedImage, error) {
 	o := makeOptions(ref.Context(), options...)
 	ri, err := remoteImage(ref, o.ROpt...)
 	var te *transport.Error
 	if errors.As(err, &te) && te.StatusCode == http.StatusNotFound {
-		return nil, errors.New("image not found in registry")
+		return nil, ErrImageNotFound
 	} else if err != nil {
 		return nil, err
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -934,7 +934,12 @@ func TestAttachSBOM(t *testing.T) {
 	defer cleanup()
 
 	out := bytes.Buffer{}
-	_, err := download.SBOMCmd(ctx, options.RegistryOptions{}, img.Name(), &out)
+
+	_, errPl := download.SBOMCmd(ctx, options.RegistryOptions{}, options.SBOMDownloadOptions{Platform: "darwin/amd64"}, img.Name(), &out)
+	if errPl == nil {
+		t.Fatalf("Expected error when passing Platform to single arch image")
+	}
+	_, err := download.SBOMCmd(ctx, options.RegistryOptions{}, options.SBOMDownloadOptions{}, img.Name(), &out)
 	if err == nil {
 		t.Fatal("Expected error")
 	}
@@ -944,7 +949,7 @@ func TestAttachSBOM(t *testing.T) {
 	// Upload it!
 	must(attach.SBOMCmd(ctx, options.RegistryOptions{}, "./testdata/bom-go-mod.spdx", "spdx", imgName), t)
 
-	sboms, err := download.SBOMCmd(ctx, options.RegistryOptions{}, imgName, &out)
+	sboms, err := download.SBOMCmd(ctx, options.RegistryOptions{}, options.SBOMDownloadOptions{}, imgName, &out)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
#### Summary

This PR adds a `--platform` flag to `cosign sbom download `. When downloading an SBOM from a multiarch index, the new flag lets the user specify the SBOM of one of the images listed in the index. 

When trying to download an SBOM from an inbox that does not have one attached, cosign will now present the user with the available architectures:

```
This multiarch image does not have an SBOM attached at the index level.
Try using --platform with one of the following architectures:
 linux/amd64, linux/arm/v5, linux/arm/v7, linux/arm64/v8, linux/386, linux/mips64le, 
 linux/ppc64le, linux/s390x, windows/amd64:10.0.20348.707, windows/amd64:10.0.17763.2928

Error: no SBOM found attached to image index
```

#### Ticket Link

Fixes https://github.com/sigstore/cosign/issues/1086

/cc @jdolitsky @imjasonh  @mattmoor 

#### Release Note

```release-note
- New `--platform` flag  enables downloading a specific sbom from a multi-arch image
- Improved handling of error messages when a multiarch index does not have an sbom attached
```
