### PR TITLE
Fix #1378 create new attestation signature in replace mode if not existent

### DIFF
--- a/pkg/oci/mutate/mutate.go
+++ b/pkg/oci/mutate/mutate.go
@@ -242,7 +242,7 @@ func (si *signedImage) Attestations() (oci.Signatures, error) {
 		if err != nil {
 			return nil, err
 		}
-		return AppendSignatures(replace)
+		return ReplaceSignatures(replace)
 	}
 	return AppendSignatures(base, si.att)
 }


### PR DESCRIPTION
#### Summary
Currently it is not possible to use `cosign attest` with the `--replace` option if either the attestation artifact or the attestation predicate does not exist.  
Adds the ability to `cosign attest` with the `--replace` option to create new attestation artifacts or append new predicates to an existing attestation artifact.

#### Ticket Link
Fixes #1378 

#### Release Note
```release-note
Fixed the ability of `cosign attest` with the `--replace` option to create new attestations
```
