### PR TITLE
sign-blob: bundle should work independently and respect `--output-certificate` and `--output-signature`

### DIFF
--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -91,7 +91,10 @@ func SignBlobCmd(ro *options.RootOptions, ko options.KeyOpts, regOpts options.Re
 		if err != nil {
 			return nil, err
 		}
-		return []byte(signedPayload.Base64Signature), os.WriteFile(ko.BundlePath, contents, 0600)
+		if err := os.WriteFile(ko.BundlePath, contents, 0600); err != nil {
+			return nil, fmt.Errorf("create bundle file: %w", err)
+		}
+		fmt.Printf("Bundle wrote in the file %s\n", ko.BundlePath)
 	}
 
 	if outputSignature != "" {


### PR DESCRIPTION
Fixes #1821
Fixes #2005

Signed-off-by: Furkan <furkan.turkal@trendyol.com>

cc @priyawadhwa
<!--
Thanks for opening a pull request!

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
A description of what this pull request does
-->

```
$ COSIGN_EXPERIMENTAL=true ./cosign sign-blob /dev/null --output-certificate foo.pem --output-signature foo.sig --bundle foo.bundle

Bundle wrote in the file foo.bundle
Signature wrote in the file foo.sig
Certificate wrote in the file foo.pem
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/sigstore/YYYYYY/issues/XXXXX

-->
Fixes

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Fixed an issue where --bundle flag does not work independently with `--output-certificate` and `--output-signature` in sign-blob 
```
