### PR TITLE
Attempt to clean up pkg/cosign

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -77,6 +77,7 @@ func Attest() *cobra.Command {
 				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 				OIDCProvider:             o.OIDC.Provider,
+				SkipConfirmation:         o.SkipConfirmation,
 			}
 			for _, img := range args {
 				if err := attest.AttestCmd(cmd.Context(), ko, o.Registry, img, o.Cert, o.CertChain, o.NoUpload,

--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -16,11 +16,13 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -28,7 +30,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/pkg/cosign"
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 )
 
@@ -49,9 +50,21 @@ func Clean() *cobra.Command {
 	return cmd
 }
 
+// confirmPromptDestructive prompts the user for confirmation for an action. Ignores
+// skipConfirmation.
+func confirmPromptDestructive(msg string) (bool, error) {
+	fmt.Fprintf(os.Stderr, "%s\n\nAre you sure you want to continue? (y/[N]): ", msg)
+	reader := bufio.NewReader(os.Stdin)
+	r, err := reader.ReadString('\n')
+	if err != nil {
+		return false, err
+	}
+	return strings.Trim(r, "\n") == "Y" || strings.Trim(r, "\n") == "y", nil
+}
+
 func CleanCmd(ctx context.Context, regOpts options.RegistryOptions, cleanType, imageRef string, force bool) error {
 	if !force {
-		ok, err := cosign.ConfirmPromptDestructive(prompt(cleanType))
+		ok, err := confirmPromptDestructive(prompt(cleanType))
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -26,7 +26,6 @@ import (
 
 	cranecmd "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/pkg/cosign"
 )
 
 var (
@@ -73,10 +72,6 @@ func New() *cobra.Command {
 
 			if ro.Verbose {
 				logs.Debug.SetOutput(os.Stderr)
-			}
-
-			if ro.SkipConfirmation {
-				cosign.SetSkipConfirmation(ro.SkipConfirmation)
 			}
 
 			return nil

--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -164,7 +164,7 @@ func NewSigner(ctx context.Context, ko options.KeyOpts) (*Signer, error) {
 		fmt.Fprintln(os.Stderr, "Non-interactive mode detected, using device flow.")
 		flow = FlowDevice
 	default:
-		ok, err := cosign.ConfirmPrompt(PrivacyStatementConfirmation)
+		ok, err := cosign.ConfirmPrompt(PrivacyStatementConfirmation, ko.SkipConfirmation)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/cosign/cli/importkeypair/import_key_pair.go
+++ b/cmd/cosign/cli/importkeypair/import_key_pair.go
@@ -31,7 +31,6 @@ var (
 
 // nolint
 func ImportKeyPairCmd(ctx context.Context, keyVal string, args []string) error {
-
 	keys, err := cosign.ImportKeyPair(keyVal, GetPass)
 	if err != nil {
 		return err

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -21,13 +21,14 @@ import (
 
 // AttestOptions is the top level wrapper for the attest command.
 type AttestOptions struct {
-	Key       string
-	Cert      string
-	CertChain string
-	NoUpload  bool
-	Force     bool
-	Recursive bool
-	Replace   bool
+	Key              string
+	Cert             string
+	CertChain        string
+	NoUpload         bool
+	Force            bool
+	Recursive        bool
+	Replace          bool
+	SkipConfirmation bool
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -71,4 +72,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVarP(&o.Replace, "replace", "", false,
 		"")
+
+	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
+		"skip confirmation prompts for non-destructive operations")
 }

--- a/cmd/cosign/cli/options/key.go
+++ b/cmd/cosign/cli/options/key.go
@@ -32,6 +32,8 @@ type KeyOpts struct {
 	OIDCDisableProviders bool   // Disable OIDC credential providers in keyless signer
 	OIDCProvider         string // Specify which OIDC credential provider to use for keyless signer
 	BundlePath           string
+	SkipConfirmation     bool
+
 	// FulcioAuthFlow is the auth flow to use when authenticating against
 	// Fulcio. See https://pkg.go.dev/github.com/sigstore/cosign/cmd/cosign/cli/fulcio#pkg-constants
 	// for valid values.

--- a/cmd/cosign/cli/options/policy.go
+++ b/cmd/cosign/cli/options/policy.go
@@ -56,11 +56,12 @@ func (o *PolicyInitOptions) AddFlags(cmd *cobra.Command) {
 }
 
 type PolicySignOptions struct {
-	ImageRef string
-	OutFile  string
-	Registry RegistryOptions
-	Fulcio   FulcioOptions
-	Rekor    RekorOptions
+	ImageRef         string
+	OutFile          string
+	Registry         RegistryOptions
+	Fulcio           FulcioOptions
+	Rekor            RekorOptions
+	SkipConfirmation bool
 
 	OIDC OIDCOptions
 }
@@ -74,6 +75,9 @@ func (o *PolicySignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.OutFile, "out", "o",
 		"output policy locally")
+
+	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
+		"skip confirmation prompts for non-destructive operations")
 
 	o.Registry.AddFlags(cmd)
 	o.Fulcio.AddFlags(cmd)

--- a/cmd/cosign/cli/options/root.go
+++ b/cmd/cosign/cli/options/root.go
@@ -23,10 +23,9 @@ import (
 
 // RootOptions define flags and options for the root cosign cli.
 type RootOptions struct {
-	OutputFile       string
-	Verbose          bool
-	Timeout          time.Duration
-	SkipConfirmation bool
+	OutputFile string
+	Verbose    bool
+	Timeout    time.Duration
 }
 
 // DefaultTimeout specifies the default timeout for commands.
@@ -44,7 +43,4 @@ func (o *RootOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().DurationVarP(&o.Timeout, "timeout", "t", DefaultTimeout,
 		"timeout for commands")
-
-	cmd.PersistentFlags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
-		"skip confirmation prompts for non-destructive operations")
 }

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -32,6 +32,7 @@ type SignOptions struct {
 	Force             bool
 	Recursive         bool
 	Attachment        string
+	SkipConfirmation  bool
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -84,4 +85,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Attachment, "attachment", "",
 		"related image attachment to sign (sbom), default none")
+
+	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
+		"skip confirmation prompts for non-destructive operations")
 }

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -33,6 +33,7 @@ type SignBlobOptions struct {
 	OIDC              OIDCOptions
 	Registry          RegistryOptions
 	BundlePath        string
+	SkipConfirmation  bool
 }
 
 var _ Interface = (*SignBlobOptions)(nil)
@@ -62,4 +63,7 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")
+
+	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
+		"skip confirmation prompts for non-destructive operations")
 }

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -189,6 +189,7 @@ func signPolicy() *cobra.Command {
 				OIDCClientSecret:         oidcClientSecret,
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 				OIDCProvider:             o.OIDC.Provider,
+				SkipConfirmation:         o.SkipConfirmation,
 			})
 			if err != nil {
 				return err

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -97,6 +97,7 @@ func Sign() *cobra.Command {
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 				OIDCDisableProviders:     o.OIDC.DisableAmbientProviders,
 				OIDCProvider:             o.OIDC.Provider,
+				SkipConfirmation:         o.SkipConfirmation,
 			}
 			annotationsMap, err := o.AnnotationsMap()
 			if err != nil {

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -82,6 +82,7 @@ func SignBlob() *cobra.Command {
 				OIDCRedirectURL:          o.OIDC.RedirectURL,
 				OIDCDisableProviders:     o.OIDC.DisableAmbientProviders,
 				BundlePath:               o.BundlePath,
+				SkipConfirmation:         o.SkipConfirmation,
 			}
 			for _, blob := range args {
 				// TODO: remove when the output flag has been deprecated

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -9,7 +9,6 @@ A tool for Container Signing, Verification and Storage in an OCI registry.
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach.md
+++ b/doc/cosign_attach.md
@@ -14,7 +14,6 @@ Provides utilities for attaching artifacts to other artifacts in a registry
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach_attestation.md
+++ b/doc/cosign_attach_attestation.md
@@ -28,7 +28,6 @@ cosign attach attestation [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach_sbom.md
+++ b/doc/cosign_attach_sbom.md
@@ -30,7 +30,6 @@ cosign attach sbom [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -29,7 +29,6 @@ cosign attach signature [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -64,6 +64,7 @@ cosign attest [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+  -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```
 
 ### Options inherited from parent commands
@@ -72,7 +73,6 @@ cosign attest [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -29,7 +29,6 @@ cosign clean [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_completion.md
+++ b/doc/cosign_completion.md
@@ -46,7 +46,6 @@ cosign completion [bash|zsh|fish|powershell]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -38,7 +38,6 @@ cosign copy [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_dockerfile.md
+++ b/doc/cosign_dockerfile.md
@@ -14,7 +14,6 @@ Provides utilities for discovering images in and performing operations on Docker
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -81,7 +81,6 @@ cosign dockerfile verify [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download.md
+++ b/doc/cosign_download.md
@@ -14,7 +14,6 @@ Provides utilities for downloading artifacts and attached artifacts in a registr
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download_attestation.md
+++ b/doc/cosign_download_attestation.md
@@ -27,7 +27,6 @@ cosign download attestation [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -28,7 +28,6 @@ cosign download sbom [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_download_signature.md
+++ b/doc/cosign_download_signature.md
@@ -27,7 +27,6 @@ cosign download signature [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_generate-key-pair.md
+++ b/doc/cosign_generate-key-pair.md
@@ -60,7 +60,6 @@ CAVEATS:
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_generate.md
+++ b/doc/cosign_generate.md
@@ -43,7 +43,6 @@ cosign generate [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_import-key-pair.md
+++ b/doc/cosign_import-key-pair.md
@@ -36,7 +36,6 @@ CAVEATS:
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -51,7 +51,6 @@ cosign initialize -mirror <url> -root <url>
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_load.md
+++ b/doc/cosign_load.md
@@ -29,7 +29,6 @@ cosign load [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_login.md
+++ b/doc/cosign_login.md
@@ -28,7 +28,6 @@ cosign login [OPTIONS] [SERVER] [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_manifest.md
+++ b/doc/cosign_manifest.md
@@ -14,7 +14,6 @@ Provides utilities for discovering images in and performing operations on Kubern
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -75,7 +75,6 @@ cosign manifest verify [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool.md
+++ b/doc/cosign_piv-tool.md
@@ -15,7 +15,6 @@ Provides utilities for managing a hardware token
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_attestation.md
+++ b/doc/cosign_piv-tool_attestation.md
@@ -21,7 +21,6 @@ cosign piv-tool attestation [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_generate-key.md
+++ b/doc/cosign_piv-tool_generate-key.md
@@ -24,7 +24,6 @@ cosign piv-tool generate-key [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_reset.md
+++ b/doc/cosign_piv-tool_reset.md
@@ -19,7 +19,6 @@ cosign piv-tool reset [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_set-management-key.md
+++ b/doc/cosign_piv-tool_set-management-key.md
@@ -22,7 +22,6 @@ cosign piv-tool set-management-key [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_set-pin.md
+++ b/doc/cosign_piv-tool_set-pin.md
@@ -21,7 +21,6 @@ cosign piv-tool set-pin [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_set-puk.md
+++ b/doc/cosign_piv-tool_set-puk.md
@@ -21,7 +21,6 @@ cosign piv-tool set-puk [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_piv-tool_unblock.md
+++ b/doc/cosign_piv-tool_unblock.md
@@ -21,7 +21,6 @@ cosign piv-tool unblock [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_pkcs11-tool.md
+++ b/doc/cosign_pkcs11-tool.md
@@ -15,7 +15,6 @@ Provides utilities for retrieving information from a PKCS11 token.
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_pkcs11-tool_list-keys-uris.md
+++ b/doc/cosign_pkcs11-tool_list-keys-uris.md
@@ -22,7 +22,6 @@ cosign pkcs11-tool list-keys-uris [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_pkcs11-tool_list-tokens.md
+++ b/doc/cosign_pkcs11-tool_list-tokens.md
@@ -20,7 +20,6 @@ cosign pkcs11-tool list-tokens [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy.md
+++ b/doc/cosign_policy.md
@@ -24,7 +24,6 @@ cosign policy [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy_init.md
+++ b/doc/cosign_policy_init.md
@@ -41,7 +41,6 @@ cosign policy init [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -31,6 +31,7 @@ cosign policy sign [flags]
       --oidc-redirect-url string                                                                 [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --out string                                                                               output policy locally (default "o")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+  -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```
 
 ### Options inherited from parent commands
@@ -39,7 +40,6 @@ cosign policy sign [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_public-key.md
+++ b/doc/cosign_public-key.md
@@ -56,7 +56,6 @@ cosign public-key [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_save.md
+++ b/doc/cosign_save.md
@@ -29,7 +29,6 @@ cosign save [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -55,6 +55,7 @@ cosign sign-blob [flags]
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
+  -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```
 
 ### Options inherited from parent commands
@@ -63,7 +64,6 @@ cosign sign-blob [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -82,6 +82,7 @@ cosign sign [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --upload                                                                                   whether to upload the signature (default true)
+  -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```
 
 ### Options inherited from parent commands
@@ -90,7 +91,6 @@ cosign sign [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_tree.md
+++ b/doc/cosign_tree.md
@@ -27,7 +27,6 @@ cosign tree [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -28,7 +28,6 @@ cosign triangulate [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload.md
+++ b/doc/cosign_upload.md
@@ -14,7 +14,6 @@ Provides utilities for uploading artifacts to a registry
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload_blob.md
+++ b/doc/cosign_upload_blob.md
@@ -41,7 +41,6 @@ cosign upload blob [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_upload_wasm.md
+++ b/doc/cosign_upload_wasm.md
@@ -28,7 +28,6 @@ cosign upload wasm [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -85,7 +85,6 @@ cosign verify-attestation [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -84,7 +84,6 @@ cosign verify-blob [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -94,7 +94,6 @@ cosign verify [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/doc/cosign_version.md
+++ b/doc/cosign_version.md
@@ -19,7 +19,6 @@ cosign version [flags]
       --output-file string   log output to a file
   -t, --timeout duration     timeout for commands (default 3m0s)
   -d, --verbose              log debug output
-  -y, --yes                  skip confirmation prompts for non-destructive operations
 ```
 
 ### SEE ALSO

--- a/pkg/cosign/common.go
+++ b/pkg/cosign/common.go
@@ -26,15 +26,7 @@ import (
 	"golang.org/x/term"
 )
 
-// skipConfirmation is a global variable to store whether or not the user has provided
-// the --yes flag to skip all confirmation prompts
-var skipConfirmation bool
-
-func SetSkipConfirmation(skip bool) {
-	skipConfirmation = skip
-}
-
-// TODO need to centralize this logic
+// TODO(jason): Move this to an internal package.
 func FileExists(filename string) bool {
 	info, err := os.Stat(filename)
 	if os.IsNotExist(err) {
@@ -44,10 +36,11 @@ func FileExists(filename string) bool {
 }
 
 // ConfirmPrompt prompts the user for confirmation for an action. Supports skipping
-// the confirmation prompt when the global skipConfirmation is set.
-func ConfirmPrompt(msg string) (bool, error) {
+// the confirmation prompt when skipConfirmation is set.
+// TODO(jason): Move this to an internal package.
+func ConfirmPrompt(msg string, skipConfirmation bool) (bool, error) {
 	if skipConfirmation {
-		return skipConfirmation, nil
+		return true, nil
 	}
 
 	fmt.Fprintf(os.Stderr, "%s\n\nAre you sure you want to continue? (y/[N]): ", msg)
@@ -59,18 +52,7 @@ func ConfirmPrompt(msg string) (bool, error) {
 	return strings.Trim(r, "\n") == "Y" || strings.Trim(r, "\n") == "y", nil
 }
 
-// ConfirmPromptDestructive prompts the user for confirmation for an action. Ignores
-// skipConfirmation.
-func ConfirmPromptDestructive(msg string) (bool, error) {
-	fmt.Fprintf(os.Stderr, "%s\n\nAre you sure you want to continue? (y/[N]): ", msg)
-	reader := bufio.NewReader(os.Stdin)
-	r, err := reader.ReadString('\n')
-	if err != nil {
-		return false, err
-	}
-	return strings.Trim(r, "\n") == "Y" || strings.Trim(r, "\n") == "y", nil
-}
-
+// TODO(jason): Move this to an internal package.
 func GetPassFromTerm(confirm bool) ([]byte, error) {
 	fmt.Fprint(os.Stderr, "Enter password for private key: ")
 	// Unnecessary convert of syscall.Stdin on *nix, but Windows is a uintptr
@@ -98,6 +80,7 @@ func GetPassFromTerm(confirm bool) ([]byte, error) {
 	return pw1, nil
 }
 
+// TODO(jason): Move this to an internal package.
 func IsTerminal() bool {
 	stat, _ := os.Stdin.Stat()
 	return (stat.Mode() & os.ModeCharDevice) != 0

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -57,16 +57,23 @@ type Keys struct {
 	public  crypto.PublicKey
 }
 
+// TODO(jason): Move this to an internal package.
 type KeysBytes struct {
 	PrivateBytes []byte
 	PublicBytes  []byte
 	password     []byte
 }
 
+func (k *KeysBytes) Password() []byte {
+	return k.password
+}
+
+// TODO(jason): Move this to an internal package.
 func GeneratePrivateKey() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 }
 
+// TODO(jason): Move this to the only place it's used in cmd/cosign/cli/importkeypair, and unexport it.
 func ImportKeyPair(keyPath string, pf PassFunc) (*KeysBytes, error) {
 	kb, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
@@ -167,6 +174,7 @@ func marshalKeyPair(keypair Keys, pf PassFunc) (key *KeysBytes, err error) {
 	}, nil
 }
 
+// TODO(jason): Move this to an internal package.
 func GenerateKeyPair(pf PassFunc) (*KeysBytes, error) {
 	priv, err := GeneratePrivateKey()
 	if err != nil {
@@ -176,10 +184,7 @@ func GenerateKeyPair(pf PassFunc) (*KeysBytes, error) {
 	return marshalKeyPair(Keys{priv, priv.Public()}, pf)
 }
 
-func (k *KeysBytes) Password() []byte {
-	return k.password
-}
-
+// TODO(jason): Move this to an internal package.
 func PemToECDSAKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
 	pub, err := cryptoutils.UnmarshalPEMToPublicKey(pemBytes)
 	if err != nil {
@@ -192,6 +197,7 @@ func PemToECDSAKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
 	return ecdsaPub, nil
 }
 
+// TODO(jason): Move this to pkg/signature, the only place it's used, and unimport it.
 func LoadPrivateKey(key []byte, pass []byte) (signature.SignerVerifier, error) {
 	// Decrypt first
 	p, _ := pem.Decode(key)

--- a/pkg/cosign/rekor_factory.go
+++ b/pkg/cosign/rekor_factory.go
@@ -21,17 +21,19 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/client"
 )
 
-// Key is used for associating the Rekor client client inside the
+// key is used for associating the Rekor client client inside the
 // context.Context.
-type Key struct{}
+type key struct{}
 
+// TODO(jason): Rename this to something better than pkg/cosign.Set.
 func Set(ctx context.Context, rekorClient *client.Rekor) context.Context {
-	return context.WithValue(ctx, Key{}, rekorClient)
+	return context.WithValue(ctx, key{}, rekorClient)
 }
 
 // Get extracts the Rekor client from the context.
+// TODO(jason): Rename this to something better than pkg/cosign.Get.
 func Get(ctx context.Context) *client.Rekor {
-	untyped := ctx.Value(Key{})
+	untyped := ctx.Value(key{})
 	if untyped == nil {
 		return nil
 	}


### PR DESCRIPTION
#### Summary

`pkg/cosign` is a bit of a kitchen sink at the moment, with [58 total imports](https://pkg.go.dev/github.com/sigstore/cosign/pkg/cosign?tab=imports), and lots of exported methods that only make sense to be used by the CLI and shouldn't be used by external packages. I started doing more and wanted to stop before making this too big. I'll send another PR to move stuff to internal packages.

- remove pkg/cosign.SetSkipConfirmation, move it from a root option to a
  per-method option when it's actually used, remove the global bool.
- add TODOs to move more methods to internal packages, or to the only
  places they're used.
- unexport some stuff that can be unexported easily.

Things like [`pkg/cosign.FindTLogEntry`](https://pkg.go.dev/github.com/sigstore/cosign/pkg/cosign#FindTlogEntry) seem generally useful, and probably belong in sigstore/sigstore, if they're not already.

Signed-off-by: Jason Hall <jason@chainguard.dev>

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```release-note
Some types and methods not likely to be used outside of the cosign CLI in pkg/cosign are removed
```
