### PR TITLE
Add deprecation warning for sget CLI and packages

### DIFF
--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -40,7 +40,7 @@ import (
 
 	"github.com/sigstore/cosign/pkg/cosign"
 	cremote "github.com/sigstore/cosign/pkg/cosign/remote"
-	"github.com/sigstore/cosign/pkg/sget"
+	"github.com/sigstore/cosign/pkg/sget" //nolint:staticcheck
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/sigstore/sigstore/pkg/tuf"

--- a/cmd/sget/cli/commands.go
+++ b/cmd/sget/cli/commands.go
@@ -25,8 +25,8 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/version"
 
-	"github.com/sigstore/cosign/cmd/sget/cli/options"
-	"github.com/sigstore/cosign/pkg/sget"
+	"github.com/sigstore/cosign/cmd/sget/cli/options" //nolint:staticcheck
+	"github.com/sigstore/cosign/pkg/sget"             //nolint:staticcheck
 )
 
 var (

--- a/cmd/sget/cli/commands.go
+++ b/cmd/sget/cli/commands.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: This package is deprecated and will be removed in a future release.
 package cli
 
 import (
@@ -36,6 +37,7 @@ func New() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "sget <image reference>",
 		Short: "sget [--key <key reference>] <image reference>",
+		Long:  `sget is DEPRECATED in the cosign repo -- see https://github.com/sigstore/sget for the new tool.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return errors.New("a single image reference is required")

--- a/cmd/sget/cli/options/root.go
+++ b/cmd/sget/cli/options/root.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: This package is deprecated and will be removed in a future release.
 package options
 
 import (

--- a/cmd/sget/main.go
+++ b/cmd/sget/main.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sigstore/cosign/cmd/sget/cli"
+	"github.com/sigstore/cosign/cmd/sget/cli" //nolint:staticcheck
 
 	// Register the provider-specific plugins
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"

--- a/cmd/sget/main.go
+++ b/cmd/sget/main.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/sigstore/cosign/cmd/sget/cli"
 
@@ -30,7 +31,18 @@ import (
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/hashivault"
 )
 
+const deprecationWarning = `
+-------- NOTICE --------
+The sget tool in the cosign repo is deprecated, and will be removed in a future release.
+
+If you're interested in fetching content from an OCI registry or from an arbitrary URLs, please see: https://github.com/sigstore/sget.
+------------------------
+`
+
 func main() {
+	log.Print(deprecationWarning)
+	time.Sleep(3 * time.Second)
+
 	// Fix up flags to POSIX standard flags.
 	for i, arg := range os.Args {
 		if (strings.HasPrefix(arg, "-") && len(arg) == 2) || (strings.HasPrefix(arg, "--") && len(arg) >= 4) {

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -13,6 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Deprecated: This package is deprecated and will be removed in a future release.
 package sget
 
 import (


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

@dlorenc @lukehinds 

#### Release Note

```release-note
The sget tool in the cosign repo is deprecated and will be removed in a future release -- see https://github.com/sigstore/sget for the new tool.
```
