### PR TITLE
Refactor + Minor Fixes in key gen and key import commands

### DIFF
--- a/cmd/cosign/cli/generate/generate_key_pair.go
+++ b/cmd/cosign/cli/generate/generate_key_pair.go
@@ -86,15 +86,12 @@ func GenerateKeyPairCmd(ctx context.Context, kmsVal string, args []string) error
 	}
 
 	if cosign.FileExists("cosign.key") {
-		var overwrite string
-		fmt.Fprint(os.Stderr, "File cosign.key already exists. Overwrite (y/n)? ")
-		fmt.Scanf("%s", &overwrite)
-		switch overwrite {
-		case "y", "Y":
-		case "n", "N":
-			return nil
-		default:
-			fmt.Fprintln(os.Stderr, "Invalid input")
+		if overwrite, err := cosign.ConfirmPrompt(
+			"cosign.key already exists. This will overwrite it.", false,
+		); err != nil || !overwrite {
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
 			return nil
 		}
 	}

--- a/cmd/cosign/cli/importkeypair/import_key_pair.go
+++ b/cmd/cosign/cli/importkeypair/import_key_pair.go
@@ -37,15 +37,12 @@ func ImportKeyPairCmd(ctx context.Context, keyVal string, args []string) error {
 	}
 
 	if cosign.FileExists("import-cosign.key") {
-		var overwrite string
-		fmt.Fprint(os.Stderr, "File import-cosign.key already exists. Overwrite (y/n)? ")
-		fmt.Scanf("%s", &overwrite)
-		switch overwrite {
-		case "y", "Y":
-		case "n", "N":
-			return nil
-		default:
-			fmt.Fprintln(os.Stderr, "Invalid input")
+		if overwrite, err := cosign.ConfirmPrompt(
+			"import-cosign.key already exists. This will overwrite it.", false,
+		); err != nil || !overwrite {
+			if err != nil {
+				fmt.Fprintln(os.Stderr, err)
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
Refactors:

- [X] Use the `ConfirmPrompt` function everywhere instead of rolling prompt  implementation everywhere.
- [ ] Move `pkg/cosign/common.go` to internal package.
- [ ] Maybe have a single function for writing + handling perms for  private & public key.

Fixes:

Address https://github.com/sigstore/cosign/blob/1d224d924197d3fab3f624a5cbe27f25d934e9f2/cmd/cosign/cli/generate/generate_key_pair.go#L101 and 
https://github.com/sigstore/cosign/blob/1d224d924197d3fab3f624a5cbe27f25d934e9f2/cmd/cosign/cli/importkeypair/import_key_pair.go#L52

 