### PR TITLE
Add env subcommand.

### DIFF
--- a/cmd/cosign/cli/env.go
+++ b/cmd/cosign/cli/env.go
@@ -1,0 +1,58 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func Env() *cobra.Command {
+	return &cobra.Command{
+		Use:   "env",
+		Short: "Prints Cosign environment variables",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, e := range getEnv() {
+				fmt.Println(e)
+			}
+			return nil
+		},
+	}
+}
+
+func getEnv() []string {
+	out := []string{}
+	for _, e := range os.Environ() {
+		// Prefixes to look for. err on the side of showing too much rather
+		// than too little. We'll only output things that have values set.
+		for _, prefix := range []string{
+			"COSIGN_",
+			// Can modify Sigstore/TUF client behavior - https://github.com/sigstore/sigstore/blob/35d6a82c15183f7fe7a07eca45e17e378aa32126/pkg/tuf/client.go#L52
+			"SIGSTORE_",
+			"TUF_",
+		} {
+			if strings.HasPrefix(e, prefix) {
+				out = append(out, e)
+				continue
+			}
+		}
+	}
+	return out
+}

--- a/cmd/cosign/cli/env_test.go
+++ b/cmd/cosign/cli/env_test.go
@@ -1,0 +1,37 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetEnv(t *testing.T) {
+	os.Setenv("COSIGN_EXPERIMENTAL", "foo")
+	os.Setenv("TUF_ROOT", "bar")
+	got := getEnv()
+	want := []string{
+		"COSIGN_EXPERIMENTAL=foo",
+		"TUF_ROOT=bar",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This subcommand prints out cosign/sigstore environment variables. This
is intended for debugging to make it easy to find environment variables
that might be impacting cosign behavior.

This was inspired by https://github.com/sigstore/gitsign/pull/92

Signed-off-by: Billy Lynch <billy@chainguard.dev>

cc @imjasonh 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

```
Added env subcommand to print out cosign environment variables.
```

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Updated CLI docs.