### PR TITLE
remove tests with 1.21 k8s cluster because it is deprecated and add v1.23/24

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -32,16 +32,16 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-        - v1.21.x
         - v1.22.x
         # Try without this one now, might have problems with job restartings
         # may require upstream changes.
-        #- v1.23.x
+        - v1.23.x
+        - v1.24.x
 
     env:
-      KNATIVE_VERSION: "1.1.0"
+      KNATIVE_VERSION: "1.5.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.2.2"
+      SCAFFOLDING_RELEASE_VERSION: "v0.3.0"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -40,10 +40,10 @@ jobs:
 
     env:
       CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.17.11-0@sha256:b0c3083b0a420ff649d5a5bfd7e0a96719ab0a7b3f99a049a4950d836a72637a
-      COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.8.0@sha256:12b4d428529654c95a7550a936cbb5c6fe93a046ea7454676cb6fb0ce566d78c
+      COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.9.0@sha256:ef2d14e16dbb7786d8713e4898a8512e69ace4105f5b371a9c115ffcc3e85d84
 
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b #v2.4.0
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v2.4.0
 
       - name: Check Signature
         run: |


### PR DESCRIPTION
#### Summary
- remove tests with 1.21 k8s cluster because it is deprecated and add v1.23/24

#### Release Note

`NONE`

#### Documentation

`NONE`
