### PR TITLE
feat(spec): remove invocate in vuln predicate

### DIFF
--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -47,9 +47,8 @@ type CosignPredicate struct {
 
 // VulnPredicate specifies the format of the Vulnerability Scan Predicate
 type CosignVulnPredicate struct {
-	Invocation Invocation `json:"invocation"`
-	Scanner    Scanner    `json:"scanner"`
-	Metadata   Metadata   `json:"metadata"`
+	Scanner  Scanner  `json:"scanner"`
+	Metadata Metadata `json:"metadata"`
 }
 
 // I think this will be moving to upstream in-toto in the fullness of time
@@ -65,13 +64,6 @@ type CosignVulnStatement struct {
 type CycloneDXStatement struct {
 	in_toto.StatementHeader
 	Predicate interface{} `json:"predicate"`
-}
-
-type Invocation struct {
-	Parameters interface{} `json:"parameters"`
-	URI        string      `json:"uri"`
-	EventID    string      `json:"event_id"`
-	BuilderID  string      `json:"builder.id"`
 }
 
 type DB struct {

--- a/specs/COSIGN_VULN_ATTESTATION_SPEC.md
+++ b/specs/COSIGN_VULN_ATTESTATION_SPEC.md
@@ -23,16 +23,6 @@ And the final format for this is defined as follows:
   // Predicate:
   "predicateType": "cosign.sigstore.dev/attestation/vuln/v1",
   "predicate": {
-    "invocation": {
-      "parameters": [],
-      // [ "--format=json", "--skip-db-update" ]
-      "uri": "",
-      // https://github.com/developer-guy/alpine/actions/runs/1071875574
-      "event_id": "",
-      // 1071875574
-      "builder.id": ""
-      // GitHub Actions
-    },
     "scanner": {
       "uri": "",
       // pkg:github/aquasecurity/trivy@244fd47e07d1004f0aed9
@@ -258,14 +248,6 @@ Here is an example predicate containing a vulnerability scan result above:
 ```json
 {
   "predicate": {
-    "invocation": {
-      "parameters": [
-        "--format=json"
-      ],
-      "uri": "https://github.com/developer-guy/alpine/actions/runs/1071875574",
-      "event_id": "1071875574",
-      "builder.id": "github actions"
-    },
     "scanner": {
       "uri": "pkg:github/aquasecurity/trivy@244fd47e07d1004f0aed9",
       "version": "0.19.2",


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Ref: #1381 

#### Summar

Many vulnerability scanners are unaware of the type of environment in which they are used.  

The consensus in some issues for this spec seemed to be to remove invocation.

* https://github.com/in-toto/attestation/issues/58#issuecomment-896228987
* https://github.com/sigstore/cosign/issues/1381#issuecomment-1059992973

#### Release Note

* Remove invocation in vuln predicate.

#### Documentation

Need to fix the sample YAML.
https://docs.sigstore.dev/policy-controller/overview#configuring-policy-at-the-clusterimagepolicy-level
