### PR TITLE
update builder image to use go1.18.4

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -39,7 +39,7 @@ jobs:
       statuses: none
 
     env:
-      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.18.3-0@sha256:d4614e3a12fd43b1ef29252d1add330c0b496b5313eda37975d4a87815a6ae90
+      CROSS_BUILDER_IMAGE: ghcr.io/gythialy/golang-cross:v1.18.4-0@sha256:eb34062f525b626622ada1b4e7ee782537edef2c0938122fc133ea2ca4fafe9d
       COSIGN_IMAGE: gcr.io/projectsigstore/cosign:v1.9.0@sha256:ef2d14e16dbb7786d8713e4898a8512e69ace4105f5b371a9c115ffcc3e85d84
 
     steps:

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -39,10 +39,10 @@ steps:
   - TUF_ROOT=/tmp
   args:
   - 'verify'
-  - 'ghcr.io/gythialy/golang-cross:v1.18.3-0@sha256:d4614e3a12fd43b1ef29252d1add330c0b496b5313eda37975d4a87815a6ae90
+  - 'ghcr.io/gythialy/golang-cross:v1.18.4-0@sha256:eb34062f525b626622ada1b4e7ee782537edef2c0938122fc133ea2ca4fafe9d
 
 # maybe we can build our own image and use that to be more in a safe side
-- name: ghcr.io/gythialy/golang-cross:v1.18.3-0@sha256:d4614e3a12fd43b1ef29252d1add330c0b496b5313eda37975d4a87815a6ae90
+- name: ghcr.io/gythialy/golang-cross:v1.18.4-0@sha256:eb34062f525b626622ada1b4e7ee782537edef2c0938122fc133ea2ca4fafe9d
   entrypoint: /bin/sh
   dir: "go/src/sigstore/cosign"
   env:
@@ -65,7 +65,7 @@ steps:
       gcloud auth configure-docker \
       && make release
 
-- name: ghcr.io/gythialy/golang-cross:v1.18.3-0@sha256:d4614e3a12fd43b1ef29252d1add330c0b496b5313eda37975d4a87815a6ae90
+- name: ghcr.io/gythialy/golang-cross:v1.18.4-0@sha256:eb34062f525b626622ada1b4e7ee782537edef2c0938122fc133ea2ca4fafe9d
   entrypoint: 'bash'
   dir: "go/src/sigstore/cosign"
   env:


### PR DESCRIPTION
#### Summary
- update builder image to use go1.18.4

#### Release Note

`n/a`


#### Documentation

`n/a`