### PR TITLE
Remove knative/pkg deps

### DIFF
--- a/cmd/cosign/cli/fulcio/depcheck_test.go
+++ b/cmd/cosign/cli/fulcio/depcheck_test.go
@@ -18,7 +18,7 @@ package fulcio_test
 import (
 	"testing"
 
-	"knative.dev/pkg/depcheck"
+	"github.com/depcheck-test/depcheck-test/depcheck"
 )
 
 func TestNoDeps(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/cenkalti/backoff/v3 v3.2.2
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21
 	github.com/cyberphone/json-canonicalization v0.0.0-20210823021906-dc406ceaf94b
+	github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936
 	github.com/go-openapi/runtime v0.24.1
 	github.com/go-openapi/strfmt v0.21.3
 	github.com/go-openapi/swag v0.21.1
@@ -70,6 +71,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d
 	golang.org/x/net v0.0.0-20220708220712-1185a9018129
 	golang.org/x/oauth2 v0.0.0-20220718184931-c8730f7fcb92
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306
@@ -82,7 +84,6 @@ require (
 	k8s.io/apimachinery v0.23.5
 	k8s.io/client-go v0.23.5
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
-	knative.dev/pkg v0.0.0-20220325200448-1f7514acd0c2
 	sigs.k8s.io/release-utils v0.6.0
 )
 
@@ -130,7 +131,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/blendle/zapdriver v1.3.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
@@ -277,7 +277,6 @@ require (
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,6 @@ github.com/blakesmith/ar v0.0.0-20190502131153-809d4375e1fb/go.mod h1:PkYb9DJNAw
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blendle/zapdriver v1.3.1 h1:C3dydBOWYRiOk+B8X9IVZ5IOe+7cl+tGOexN4QqHfpE=
-github.com/blendle/zapdriver v1.3.1/go.mod h1:mdXfREi6u5MArG4j9fewC+FGnXaBR+T4Ox4J2u4eHCc=
 github.com/blizzy78/varnamelen v0.3.0/go.mod h1:hbwRdBvoBqxk34XyQ6HA0UH3G0/1TKuv5AC4eaBT0Ec=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/wsl/v3 v3.3.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
@@ -672,6 +670,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denis-tingajkin/go-header v0.4.2/go.mod h1:eLRHAVXzE5atsKAnNRDB90WHCFFnBUn4RN0nRcs1LJA=
 github.com/denisenkom/go-mssqldb v0.11.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
+github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936 h1:foGzavPWwtoyBvjWyKJYDYsyzy+23iBV7NKTwdk+LRY=
+github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936/go.mod h1:ttKPnOepYt4LLzD+loXQ1rT6EmpyIYHro7TAJuIIlHo=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgraph-io/badger/v3 v3.2103.2 h1:dpyM5eCJAtQCBcMCZcT4UBZchuTJgCywerHHgmxfxM8=
 github.com/dgraph-io/badger/v3 v3.2103.2/go.mod h1:RHo4/GmYcKKh5Lxu63wLEMHJ70Pac2JqZRYGhlyAo2M=
@@ -3303,8 +3303,6 @@ k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20211116205334-6203023598ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/pkg v0.0.0-20220325200448-1f7514acd0c2 h1:dJ1YKQ1IvCfxtYqS1dHm18VT153ntHi5uJsFVv7oxfc=
-knative.dev/pkg v0.0.0-20220325200448-1f7514acd0c2/go.mod h1:5xt0nzCwxvQ2N4w71smY7pYm5nVrQ8qnRsMinSLVpio=
 mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
 mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -86,9 +86,9 @@ func FetchSignaturesForReference(ctx context.Context, ref name.Reference, opts .
 
 	signatures := make([]SignedPayload, len(l))
 	var g errgroup.Group
-	ch := make(chan sigpair)
+	ch := make(chan sigpair, len(l))
 	for i := 0; i < runtime.NumCPU(); i++ {
-		g.Go(func() (err error) {
+		g.Go(func() error {
 			for p := range ch {
 				i, sig := p.i, p.sig
 				signatures[i].Payload, err = sig.Payload()
@@ -150,9 +150,9 @@ func FetchAttestationsForReference(ctx context.Context, ref name.Reference, opts
 
 	attestations := make([]AttestationPayload, len(l))
 	var g errgroup.Group
-	ch := make(chan attpair)
+	ch := make(chan attpair, len(l))
 	for i := 0; i < runtime.NumCPU(); i++ {
-		g.Go(func() (err error) {
+		g.Go(func() error {
 			for p := range ch {
 				i, att := p.i, p.att
 				attestPayload, _ := att.Payload()

--- a/pkg/cosign/rego/rego.go
+++ b/pkg/cosign/rego/rego.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 
 	"github.com/open-policy-agent/opa/rego"
-	"knative.dev/pkg/logging"
 )
 
 // The query below should meet the following requirements:
@@ -112,7 +111,6 @@ func ValidateJSONWithModuleInput(jsonBody []byte, moduleInput string) error {
 	for _, result := range rs {
 		isCompliant, ok := result.Bindings[CosignEvaluationRule].(bool)
 		if ok && isCompliant {
-			logging.FromContext(ctx).Info("Validated policy is compliant")
 			return nil
 		}
 	}

--- a/pkg/policy/eval.go
+++ b/pkg/policy/eval.go
@@ -18,11 +18,10 @@ package policy
 import (
 	"context"
 	"fmt"
+	"log"
 
 	"cuelang.org/go/cue/cuecontext"
 	"github.com/sigstore/cosign/pkg/cosign/rego"
-
-	"knative.dev/pkg/logging"
 )
 
 // EvaluatePolicyAgainstJson is used to run a policy engine against JSON bytes.
@@ -33,7 +32,6 @@ import (
 // policyBody - String representing either cue or rego language
 // jsonBytes - Bytes to evaluate against the policyBody in the given language
 func EvaluatePolicyAgainstJSON(ctx context.Context, name, policyType string, policyBody string, jsonBytes []byte) error {
-	logging.FromContext(ctx).Debugf("Evaluating JSON: %s against policy: %s", string(jsonBytes), policyBody)
 	switch policyType {
 	case "cue":
 		cueValidationErr := evaluateCue(ctx, jsonBytes, policyBody)
@@ -53,8 +51,8 @@ func EvaluatePolicyAgainstJSON(ctx context.Context, name, policyType string, pol
 
 // evaluateCue evaluates a cue policy `evaluator` against `attestation`
 func evaluateCue(ctx context.Context, attestation []byte, evaluator string) error {
-	logging.FromContext(ctx).Infof("Evaluating attestation: %s", string(attestation))
-	logging.FromContext(ctx).Infof("Evaluator: %s", evaluator)
+	log.Printf("Evaluating attestation: %s", string(attestation))
+	log.Printf("Evaluator: %s", evaluator)
 
 	cueCtx := cuecontext.New()
 	cueEvaluator := cueCtx.CompileString(evaluator)
@@ -74,8 +72,8 @@ func evaluateCue(ctx context.Context, attestation []byte, evaluator string) erro
 
 // evaluateRego evaluates a rego policy `evaluator` against `attestation`
 func evaluateRego(ctx context.Context, attestation []byte, evaluator string) error {
-	logging.FromContext(ctx).Infof("Evaluating attestation: %s", string(attestation))
-	logging.FromContext(ctx).Infof("Evaluating evaluator: %s", evaluator)
+	log.Printf("Evaluating attestation: %s", string(attestation))
+	log.Printf("Evaluating evaluator: %s", evaluator)
 
 	return rego.ValidateJSONWithModuleInput(attestation, evaluator)
 }


### PR DESCRIPTION
- we were depending on knative/pkg for logging, now we just `log.Printf`
- we were depending on [depcheck](https://pkg.go.dev/knative.dev/pkg/depcheck) from knative, now depending on a [fork in a separate repo](https://github.com/depcheck-test/depcheck-test) 
- we were depending on knative/pkg for worker goroutine pooling, now just using [`errgroup`](https://pkg.go.dev/golang.org/x/sync/errgroup) and limiting workers to to NumCPU ourselves

Dropping knative deps should drop a bunch of transitive deps as well.

Signed-off-by: Jason Hall <jason@chainguard.dev>

#### Summary

Reducing unnecessary dependencies limits our exposure to vulnerabilities in those dependencies.

This change has no effect on binary size (`cosign` is still 83 MB 🏋️ )

#### Release Note

NONE

#### Documentation

NONE

cc @mattmoor 