### PR TITLE
Fix field names in the vulnerability attestation

### DIFF
--- a/specs/COSIGN_VULN_ATTESTATION_SPEC.md
+++ b/specs/COSIGN_VULN_ATTESTATION_SPEC.md
@@ -85,13 +85,13 @@ And the final format for this is defined as follows:
 > This is the most important part of this field because it'll store the scan result as a whole. So, people might want
 > to use this field to take decisions based on them by making use of Policy Engines tooling whether allow or deny these images.
 
-**metadata.buildStartedOn string (Timestamp), required**
+**metadata.scanStartedOn string (Timestamp), required**
 
-> The timestamp of when the build started.
+> The timestamp of when the scan started.
 
-**metadata.buildFinishedOn string (Timestamp), required**
+**metadata.scanFinishedOn string (Timestamp), required**
 
-> The timestamp of when the build completed.
+> The timestamp of when the scan completed.
 
 ```shell
 $ trivy image -f json alpine:3.12


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The fields contain `buildStartedOn` and `buildFinishedOn` in [the cosign vulnerability spec](https://github.com/sigstore/cosign/blob/95b74db89941e8ec85e768f639efd4d948db06cd/specs/COSIGN_VULN_ATTESTATION_SPEC.md?plain=1#L88-L94). [The json exeample](https://github.com/sigstore/cosign/blob/95b74db89941e8ec85e768f639efd4d948db06cd/specs/COSIGN_VULN_ATTESTATION_SPEC.md?plain=1#L50-L53) and [structure field name](https://github.com/sigstore/cosign/blob/main/pkg/cosign/attestation/attestation.go#L81-L82) don't use them but use `scanStartedOn` and `scanFinishedOn`.

`scan` seems to be correct, so this PR updated the documentation about fields.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->