### PR TITLE
Improve error message when no sigs/atts are found for an image

### DIFF
--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -75,7 +75,7 @@ func FetchSignaturesForReference(ctx context.Context, ref name.Reference, opts .
 		return nil, fmt.Errorf("fetching signatures: %w", err)
 	}
 	if len(l) == 0 {
-		return nil, fmt.Errorf("no signatures associated with %v: %w", ref, err)
+		return nil, fmt.Errorf("no signatures associated with %s", ref)
 	}
 
 	g := pool.New(runtime.NumCPU())
@@ -125,7 +125,7 @@ func FetchAttestationsForReference(ctx context.Context, ref name.Reference, opts
 		return nil, fmt.Errorf("fetching attestations: %w", err)
 	}
 	if len(l) == 0 {
-		return nil, fmt.Errorf("no attestations associated with %v: %w", ref, err)
+		return nil, fmt.Errorf("no attestations associated with %s", ref)
 	}
 
 	g := pool.New(runtime.NumCPU())


### PR DESCRIPTION
Signed-off-by: Jason Hall <jason@chainguard.dev>

Before this change, if you `cosign download attestation $image` and none were found:

```
Error: no attestations associated with ghcr.io/distroless/static: %!w(<nil>)
```

After this change:

```
Error: no attestations associated with ghcr.io/distroless/static
```

At this point in the code, the `err` is known to be `nil` -- if there was an error, you'd get the message `fetching attestations: whatever error happened`.

#### Release Note

NONE 

#### Documentation

N/A