### PR TITLE
Resolves #522 set Created date to time of execution

### DIFF
--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -40,9 +40,12 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 	}
 
 	img, err := mutate.Append(base, adds...)
+	if err != nil {
+		return nil, err
+	}
 
 	// Set the Created date to time of execution
-	img, _ = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -16,7 +16,6 @@
 package mutate
 
 import (
-	"log"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -42,13 +41,8 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 
 	img, err := mutate.Append(base, adds...)
 
-	imgCfg, _ := img.ConfigFile()
-
 	// Set the Created date to time of execution
-	if imgCfg.Created.Time.IsZero() {
-		log.Println("Signed Entry Date was Zero, Setting to current time")
-		img, _ = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
-	}
+	img, _ = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
 
 	if err != nil {
 		return nil, err

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -43,7 +43,6 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 
 	// Set the Created date to time of execution
 	img, _ = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -16,6 +16,7 @@
 package mutate
 
 import (
+	"log"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -40,11 +41,18 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 	}
 
 	img, err := mutate.Append(base, adds...)
+
+	imgCfg, _ := img.ConfigFile()
+
+	// Set the Created date to time of execution
+	if imgCfg.Created.Time.IsZero() {
+		log.Println("Signed Entry Date was Zero, Setting to current time")
+		img, _ = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+	}
+
 	if err != nil {
 		return nil, err
 	}
-	// Set the Created date to time of execution
-	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
 
 	return &sigAppender{
 		Image: img,

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -16,6 +16,8 @@
 package mutate
 
 import (
+	"time"
+
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -36,10 +38,14 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 			Annotations: ann,
 		})
 	}
+
 	img, err := mutate.Append(base, adds...)
 	if err != nil {
 		return nil, err
 	}
+	// Set the Created date to time of execution
+	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+
 	return &sigAppender{
 		Image: img,
 		base:  base,

--- a/pkg/oci/mutate/signatures_test.go
+++ b/pkg/oci/mutate/signatures_test.go
@@ -17,7 +17,6 @@ package mutate
 
 import (
 	"testing"
-	"time"
 
 	"github.com/sigstore/cosign/pkg/oci/empty"
 	"github.com/sigstore/cosign/pkg/oci/static"
@@ -72,8 +71,9 @@ func TestAppendSignatures(t *testing.T) {
 		t.Errorf("len(Get()) = %d, wanted %d", got, want)
 	}
 
-	testCfg, _ := threeSig.ConfigFile()
-	if testCfg.Created.Time.IsZero() {
-		t.Errorf("Date of Signature was Zero. Should be %s", time.Now())
+	if testCfg, err := threeSig.ConfigFile(); err != nil {
+		t.Fatalf("Get() = %v", err)
+	} else if testCfg.Created.Time.IsZero() {
+		t.Errorf("Date of Signature was Zero")
 	}
 }

--- a/pkg/oci/mutate/signatures_test.go
+++ b/pkg/oci/mutate/signatures_test.go
@@ -72,7 +72,7 @@ func TestAppendSignatures(t *testing.T) {
 	}
 
 	if testCfg, err := threeSig.ConfigFile(); err != nil {
-		t.Fatalf("Get() = %v", err)
+		t.Fatalf("ConfigFile() = %v", err)
 	} else if testCfg.Created.Time.IsZero() {
 		t.Errorf("Date of Signature was Zero")
 	}

--- a/pkg/oci/mutate/signatures_test.go
+++ b/pkg/oci/mutate/signatures_test.go
@@ -17,6 +17,7 @@ package mutate
 
 import (
 	"testing"
+	"time"
 
 	"github.com/sigstore/cosign/pkg/oci/empty"
 	"github.com/sigstore/cosign/pkg/oci/static"
@@ -69,5 +70,10 @@ func TestAppendSignatures(t *testing.T) {
 		t.Fatalf("Get() = %v", err)
 	} else if got, want := len(sl), 3; got != want {
 		t.Errorf("len(Get()) = %d, wanted %d", got, want)
+	}
+
+	testCfg, _ := threeSig.ConfigFile()
+	if testCfg.Created.Time.IsZero() {
+		t.Errorf("Date of Signature was Zero. Should be %s", time.Now())
 	}
 }

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -43,6 +43,10 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 		Layer: layer,
 	})
 
+	if err != nil {
+		return nil, err
+	}
+
 	// Set the Created date to time of execution
 	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
 

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -42,14 +42,12 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 	img, err := mutate.Append(base, mutate.Addendum{
 		Layer: layer,
 	})
-
 	if err != nil {
 		return nil, err
 	}
 
 	// Set the Created date to time of execution
 	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
-
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -17,7 +17,6 @@ package static
 
 import (
 	"io"
-	"log"
 	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -44,13 +43,8 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 		Layer: layer,
 	})
 
-	imgCfg, _ := img.ConfigFile()
-
 	// Set the Created date to time of execution
-	if imgCfg.Created.Time.IsZero() {
-		log.Println("Signed Entry Date was Zero, Setting to current time")
-		img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
-	}
+	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
 
 	if err != nil {
 		return nil, err

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -17,6 +17,8 @@ package static
 
 import (
 	"io"
+	"log"
+	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -41,6 +43,15 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 	img, err := mutate.Append(base, mutate.Addendum{
 		Layer: layer,
 	})
+
+	imgCfg, _ := img.ConfigFile()
+
+	// Set the Created date to time of execution
+	if imgCfg.Created.Time.IsZero() {
+		log.Println("Signed Entry Date was Zero, Setting to current time")
+		img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/static/file_test.go
+++ b/pkg/oci/static/file_test.go
@@ -120,4 +120,14 @@ func TestNewFile(t *testing.T) {
 			t.Errorf("Payload() = %s, wanted %s", got, want)
 		}
 	})
+
+	t.Run("check date", func(t *testing.T) {
+		fileCfg, err := file.ConfigFile()
+		if err != nil {
+			t.Fatalf("FileCfg() = %v", err)
+		}
+		if fileCfg.Created.Time.IsZero() {
+			t.Errorf("Date of Signature was Zero")
+		}
+	})
 }

--- a/pkg/oci/static/file_test.go
+++ b/pkg/oci/static/file_test.go
@@ -124,7 +124,7 @@ func TestNewFile(t *testing.T) {
 	t.Run("check date", func(t *testing.T) {
 		fileCfg, err := file.ConfigFile()
 		if err != nil {
-			t.Fatalf("FileCfg() = %v", err)
+			t.Fatalf("ConfigFile() = %v", err)
 		}
 		if fileCfg.Created.Time.IsZero() {
 			t.Errorf("Date of Signature was Zero")


### PR DESCRIPTION
#### Summary

This commit sets the Created date of the signature to the date of execution of the signing action.

#### Release Note

`-changed: Signatures do now use the created timestamp based on the local time of signing`

#### Documentation

`n/a`