### PR TITLE
Introduce a custom error type to classify errors.

### DIFF
--- a/pkg/cosign/errors.go
+++ b/pkg/cosign/errors.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import "fmt"
+
+var (
+	// ErrNoMatchingSignatures is the error returned when there are no matching
+	// signatures during verification.
+	ErrNoMatchingSignatures = &VerificationError{"no matching signatures"}
+
+	// ErrNoMatchingAttestations is the error returned when there are no
+	// matching attestations during verification.
+	ErrNoMatchingAttestations = &VerificationError{"no matching attestations"}
+)
+
+// VerificationError is the type of Go error that is used by cosign to surface
+// errors actually related to verification (vs. transient, misconfiguration,
+// transport, or authentication related issues).
+type VerificationError struct {
+	message string
+}
+
+// NewVerificationError constructs a new VerificationError in a manner similar
+// to fmt.Errorf
+func NewVerificationError(msg string, args ...interface{}) error {
+	return &VerificationError{
+		message: fmt.Sprintf(msg, args...),
+	}
+}
+
+// Assert that we implement error at build time.
+var _ error = (*VerificationError)(nil)
+
+// Error implements error
+func (ve *VerificationError) Error() string {
+	return ve.message
+}

--- a/pkg/cosign/errors_test.go
+++ b/pkg/cosign/errors_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestErrors(t *testing.T) {
+	for _, want := range []error{
+		ErrNoMatchingAttestations,
+		ErrNoMatchingSignatures,
+		NewVerificationError("not a constant %d", 3),
+		fmt.Errorf("wrapped errors: %w", ErrNoMatchingSignatures),
+	} {
+		t.Run(want.Error(), func(t *testing.T) {
+			verr := &VerificationError{}
+			if !errors.As(want, &verr) {
+				t.Errorf("%v is not a %T", want, &VerificationError{})
+			}
+
+			// Check that Is sees it as the same error through multiple
+			// levels of wrapping.
+			wrapped := want
+			for i := 0; i < 5; i++ {
+				if !errors.Is(wrapped, want) {
+					t.Errorf("%v is not %v", wrapped, want)
+				}
+				wrapped = fmt.Errorf("wrapper: %w", wrapped)
+			}
+		})
+	}
+}

--- a/pkg/policy/eval.go
+++ b/pkg/policy/eval.go
@@ -21,6 +21,7 @@ import (
 	"log"
 
 	"cuelang.org/go/cue/cuecontext"
+	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/rego"
 )
 
@@ -36,12 +37,12 @@ func EvaluatePolicyAgainstJSON(ctx context.Context, name, policyType string, pol
 	case "cue":
 		cueValidationErr := evaluateCue(ctx, jsonBytes, policyBody)
 		if cueValidationErr != nil {
-			return fmt.Errorf("failed evaluating cue policy for %s : %s", name, cueValidationErr.Error()) // nolint
+			return cosign.NewVerificationError("failed evaluating cue policy for %s: %v", name, cueValidationErr)
 		}
 	case "rego":
 		regoValidationErr := evaluateRego(ctx, jsonBytes, policyBody)
 		if regoValidationErr != nil {
-			return fmt.Errorf("failed evaluating rego policy for type %s: %s", name, regoValidationErr.Error()) // nolint
+			return cosign.NewVerificationError("failed evaluating rego policy for type %s: %s", name, regoValidationErr)
 		}
 	default:
 		return fmt.Errorf("sorry Type %s is not supported yet", policyType)

--- a/pkg/policy/eval_test.go
+++ b/pkg/policy/eval_test.go
@@ -149,7 +149,7 @@ func TestEvalPolicy(t *testing.T) {
 		json:       cipAttestation,
 		policyType: "cue",
 		wantErr:    true,
-		wantErrSub: `failed evaluating cue policy for cluster image policy main policy, fails : failed to evaluate the policy with error: authorityMatches.keylessattMinAttestations: conflicting values 2 and "Error" (mismatched types int and string)`,
+		wantErrSub: `failed evaluating cue policy for cluster image policy main policy, fails: failed to evaluate the policy with error: authorityMatches.keylessattMinAttestations: conflicting values 2 and "Error" (mismatched types int and string)`,
 		policyFile: `package sigstore
 		import "struct"
 		import "list"


### PR DESCRIPTION
When checking signatures and evaluating policy, we may run into errors
for a variety of reasons unrelated to non-compliance, such as the registry
serving a 500.  This change introduces an error type that we can use to
produce and wrap errors in a way that we can distinguish between incidental
and verification errors in the calling logic.

After this change, we will be able to write:
```go
verr := &cosign.VerificationError{}
if errors.As(err, &verr) {
   // This is a verification error, handle accordingly.
} else {
  // This is something else, handle differently.
}
```

Related: https://github.com/sigstore/policy-controller/issues/109

#### Release Note


#### Documentation
