### PR TITLE
chore: fix documentation and warning on using untrusted rekor key

### DIFF
--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -55,11 +55,12 @@ type RekorPubKey struct {
 
 const (
 	// If specified, you can specify an oob Public Key that Rekor uses using
-	// this ENV variable. This ENV var is only for testing purposes.
+	// this ENV variable.
 	altRekorPublicKey = "SIGSTORE_REKOR_PUBLIC_KEY"
 	// Add Rekor API Public Key
 	// If specified, will fetch the Rekor Public Key from the specified Rekor
-	// server and add it to RekorPubKeys.
+	// server and add it to RekorPubKeys. This ENV var is only for testing
+	// purposes, as users should distribute keys out of band.
 	// TODO(vaikas): Implement storing state like Rekor does so that if tree
 	// state ever changes, it will make lots of noise.
 	addRekorPublicKeyFromRekor = "SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY"
@@ -90,7 +91,6 @@ func GetRekorPubs(ctx context.Context, rekorClient *client.Rekor) (map[string]Re
 	altRekorPub := os.Getenv(altRekorPublicKey)
 
 	if altRekorPub != "" {
-		fmt.Fprintf(os.Stderr, "**Warning ('%s' is only for testing)** Using a non-standard public key for Rekor: %s\n", altRekorPublicKey, altRekorPub)
 		raw, err := os.ReadFile(altRekorPub)
 		if err != nil {
 			return nil, fmt.Errorf("error reading alternate Rekor public key file: %w", err)
@@ -130,6 +130,7 @@ func GetRekorPubs(ctx context.Context, rekorClient *client.Rekor) (map[string]Re
 	// additionally fetch it here.
 	addRekorPublic := os.Getenv(addRekorPublicKeyFromRekor)
 	if addRekorPublic != "" && rekorClient != nil {
+		fmt.Fprintf(os.Stderr, "**Warning ('%s' is only for testing)** Fetching public key from Rekor API directly\n", addRekorPublicKeyFromRekor)
 		pubOK, err := rekorClient.Pubkey.GetPublicKey(nil)
 		if err != nil {
 			return nil, fmt.Errorf("unable to fetch rekor public key from rekor: %w", err)


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fetching the Rekor key directly from the API is trusted.

Fixes a mistake in documentation from https://github.com/sigstore/cosign/pull/2040/

See https://github.com/sigstore/cosign/issues/2122

`SIGSTORE_REKOR_PUBLIC_KEY` COULD be used, as it specifies the rekor public key out of band.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->