### PR TITLE
Correct the type used for attest

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -992,7 +992,7 @@ func TestSaveLoadAttestation(t *testing.T) {
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
 	// now, append an attestation to the image
-	slsaAttestation := `{ "builder": { "id": "2" }, "recipe": {} }`
+	slsaAttestation := `{ "buildType": "x", "builder": { "id": "2" }, "recipe": {} }`
 	slsaAttestationPath := filepath.Join(td, "attestation.slsa.json")
 	if err := os.WriteFile(slsaAttestationPath, []byte(slsaAttestation), 0600); err != nil {
 		t.Fatal(err)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1001,7 +1001,7 @@ func TestSaveLoadAttestation(t *testing.T) {
 	// Now attest the image
 	ko = options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
 	must(attest.AttestCmd(ctx, ko, options.RegistryOptions{}, imgName, "", "", false, slsaAttestationPath, false,
-		"custom", false, 30*time.Second, false), t)
+		"slsaprovenance", false, 30*time.Second, false), t)
 
 	// save the image to a temp dir
 	imageDir := t.TempDir()


### PR DESCRIPTION
_This fixes a bug in the e2e testing at head, which wasn't caught by the GHSA private fork, which doesn't run e2e testing._

Make the predicate type we attest match what we verify!

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Release Note

#### Documentation
