### PR TITLE
Verify the certificate chain against the Fulcio root trust by default

### DIFF
--- a/cmd/cosign/cli/options/certificate.go
+++ b/cmd/cosign/cli/options/certificate.go
@@ -37,7 +37,7 @@ var _ Interface = (*RekorOptions)(nil)
 // AddFlags implements Interface
 func (o *CertVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Cert, "certificate", "",
-		"path to the public certificate")
+		"path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.")
 
 	cmd.Flags().StringVar(&o.CertEmail, "certificate-email", "",
 		"the email expected in a valid Fulcio certificate")

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -119,11 +119,16 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 			EnforceSCT:                   enforceSCT,
 		}
 		if certChain == "" {
-			err = cosign.CheckCertificatePolicy(cert, co)
+			// If no certChain is passed, the Fulcio root certificate will be used
+			co.RootCerts, err = fulcio.GetRoots()
 			if err != nil {
-				return err
+				return fmt.Errorf("getting Fulcio roots: %w", err)
 			}
-			verifier, err = signature.LoadVerifier(cert.PublicKey, crypto.SHA256)
+			co.IntermediateCerts, err = fulcio.GetIntermediates()
+			if err != nil {
+				return fmt.Errorf("getting Fulcio intermediates: %w", err)
+			}
+			verifier, err = cosign.ValidateAndUnpackCert(cert, co)
 			if err != nil {
 				return err
 			}

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -57,7 +57,7 @@ cosign dockerfile verify [flags]
       --attachment string                                                                        related image attachment to sign (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --base-image-only                                                                          only verify the base image (the last FROM image in the Dockerfile)
-      --certificate string                                                                       path to the public certificate
+      --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate
       --certificate-email string                                                                 the email expected in a valid Fulcio certificate
       --certificate-github-workflow-name string                                                  contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -51,7 +51,7 @@ cosign manifest verify [flags]
   -a, --annotations strings                                                                      extra key=value pairs to sign
       --attachment string                                                                        related image attachment to sign (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
-      --certificate string                                                                       path to the public certificate
+      --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate
       --certificate-email string                                                                 the email expected in a valid Fulcio certificate
       --certificate-github-workflow-name string                                                  contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -61,7 +61,7 @@ cosign verify-attestation [flags]
 ```
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
-      --certificate string                                                                       path to the public certificate
+      --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate
       --certificate-email string                                                                 the email expected in a valid Fulcio certificate
       --certificate-github-workflow-name string                                                  contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -64,7 +64,7 @@ cosign verify-blob [flags]
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --bundle string                                                                            path to bundle FILE
-      --certificate string                                                                       path to the public certificate
+      --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate
       --certificate-email string                                                                 the email expected in a valid Fulcio certificate
       --certificate-github-workflow-name string                                                  contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -70,7 +70,7 @@ cosign verify [flags]
   -a, --annotations strings                                                                      extra key=value pairs to sign
       --attachment string                                                                        related image attachment to sign (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
-      --certificate string                                                                       path to the public certificate
+      --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate
       --certificate-email string                                                                 the email expected in a valid Fulcio certificate
       --certificate-github-workflow-name string                                                  contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
See https://github.com/sigstore/cosign/issues/2134

Currently, the verification performed by `cosign verify-blob --cert` does not verify the certificate chain, so you cannot guarantee that the certificate was correctly issued by Fulcio. So you need to explicitly pass Fulcio's root certificate via the `--cert-chain` option.

```
cosign initialize
cat ~/.sigstore/root/targets/fulcio_intermediate_v1.crt.pem > fulcio_chained.crt.pem
echo >> fulcio_chained.crt.pem
cat ~/.sigstore/root/targets/fulcio.crt.pem >> fulcio_chained.crt.pem
echo >> fulcio_chained.crt.pem
cat ~/.sigstore/root/targets/fulcio_v1.crt.pem >> fulcio_chained.crt.pem

cosign verify-blob --cert checksum.txt.pem --cert-chanin fulcio_chained.crt.pem ...
```

However, this way of getting root certificates is not secure. Ideally, it should be retrieved by a TUF client. After discussing this matter in #2134, @haydentherapper says that there is room for changing the default behavior.

This PR will change the default behavior from not verifying the certificate chain if `--cert-chain` is not passed to verifying the certificate chain against the Fulcio root trust getting by a TUF client.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Changed the default behavior from not verifying the certificate chain if `--cert-chain` is not passed to verifying the certificate chain against the Fulcio root trust getting by a TUF client.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

- The description of the `--certificate` option needs to be changed.