### PR TITLE
Use TUF from scaffolding for validating cosign.

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -32,21 +32,15 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-        - v1.22.x
-        # Try without this one now, might have problems with job restartings
-        # may require upstream changes.
-        - v1.23.x
         - v1.24.x
 
     env:
-      KNATIVE_VERSION: "1.5.0"
+      KNATIVE_VERSION: "1.6.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.3.0"
+      SCAFFOLDING_RELEASE_VERSION: "v0.4.2"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko
-      # Trust the custom Rekor API endpoint for fetching the Public Key from it.
-      SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY: "true"
       # We are only testing keyless here, so set it.
       COSIGN_EXPERIMENTAL: "true"
 
@@ -67,8 +61,11 @@ jobs:
       run: |
         make cosign
 
-    - name: Install cluster + cosign
+    - name: Install cluster + sigstore
       uses: sigstore/scaffolding/actions/setup@main
+      with:
+        legacy-variables: "false"
+        k8s-version: ${{ matrix.k8s-version }}
 
     - name: Create sample image - demoimage
       run: |
@@ -85,6 +82,10 @@ jobs:
         echo "demoimage=$demoimage" >> $GITHUB_ENV
         echo Created image $demoimage
         popd
+
+    - name: Initialize with our custom TUF root
+      TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url})
+      ./cosign initialize --mirror $TUF_MIRROR --root ./root.json
 
     - name: Sign demoimage with cosign
       run: |

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -84,7 +84,7 @@ jobs:
         popd
 
     - name: Initialize with our custom TUF root
-      TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url})
+      TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}'')
       ./cosign initialize --mirror $TUF_MIRROR --root ./root.json
 
     - name: Sign demoimage with cosign

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -84,8 +84,9 @@ jobs:
         popd
 
     - name: Initialize with our custom TUF root
-      TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
-      ./cosign initialize --mirror $TUF_MIRROR --root ./root.json
+      run: |
+        TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
+        ./cosign initialize --mirror $TUF_MIRROR --root ./root.json
 
     - name: Sign demoimage with cosign
       run: |

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -35,7 +35,6 @@ jobs:
         - v1.24.x
 
     env:
-      KNATIVE_VERSION: "1.6.0"
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
       SCAFFOLDING_RELEASE_VERSION: "v0.4.2"
       GO111MODULE: on
@@ -66,6 +65,7 @@ jobs:
       with:
         legacy-variables: "false"
         k8s-version: ${{ matrix.k8s-version }}
+        version: ${{ env.SCAFFOLDING_RELEASE_VERSION }}
 
     - name: Create sample image - demoimage
       run: |

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -84,7 +84,7 @@ jobs:
         popd
 
     - name: Initialize with our custom TUF root
-      TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}'')
+      TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
       ./cosign initialize --mirror $TUF_MIRROR --root ./root.json
 
     - name: Sign demoimage with cosign


### PR DESCRIPTION
Now that scaffolding supports TUF, add tests with it for cosign. Previously these were done with various env variables, now use cosign initialize to use the TUF root.

@asraa 

Signed-off-by: Ville Aikas <vaikas@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->