### PR TITLE
fix: fix blob verification output with sharded rekor tlogs

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -362,7 +362,7 @@ func verifyRekorEntry(ctx context.Context, ko options.KeyOpts, e *models.LogEntr
 		return err
 	}
 
-	fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %s index: %d\n", hex.EncodeToString(uuid), *e.Verification.InclusionProof.LogIndex)
+	fmt.Fprintf(os.Stderr, "tlog entry verified with uuid: %s index: %d\n", hex.EncodeToString(uuid), *e.LogIndex)
 	if cert == nil {
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

See https://github.com/sigstore/sigstore-python/issues/184#issuecomment-1213563031

When verifying blobs that were placed on sharded rekor instances (staging), the blob verification outputs the local log-index.

For e.g.

```
$ SIGSTORE_REKOR_PUBLIC_KEY=rekor.staging.pub COSIGN_EXPERIMENTAL=1 ./cosign verify-blob --signature python.sig --cert python-cert.pem --rekor-url https://rekor.sigstage.dev python-readme.md 
used alt pubkey
tlog entry verified with uuid: 3b5007afc2bb375d4078ad93e72537c9c3e8e1a21556d716cac7ee06b544950c index: 71
Verified OK
```

This corresponds to log index 532.
```
$ ./rekor get --uuid 3b5007afc2bb375d4078ad93e72537c9c3e8e1a21556d716cac7ee06b544950c --rekor_server https://rekor.sigstage.dev --format json | jq -r '.LogIndex'
532
```

This is because `InclusionProof` returns the "local" log index.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->