### PR TITLE
fix handling of verify-attestation types for URIs

### DIFF
--- a/pkg/policy/attestation.go
+++ b/pkg/policy/attestation.go
@@ -39,8 +39,9 @@ import (
 // match the attestation.
 func AttestationToPayloadJSON(ctx context.Context, predicateType string, verifiedAttestation oci.Signature) ([]byte, error) {
 	// Check the predicate up front, no point in wasting time if it's invalid.
-	predicateURI, ok := options.PredicateTypeMap[predicateType]
-	if !ok {
+	predicateURI, err := options.ParsePredicateType(predicateType)
+
+	if err != nil {
 		return nil, fmt.Errorf("invalid predicate type: %s", predicateType)
 	}
 
@@ -132,7 +133,11 @@ func AttestationToPayloadJSON(ctx context.Context, predicateType string, verifie
 			return nil, fmt.Errorf("marshaling CosignVulnStatement: %w", err)
 		}
 	default:
-		return nil, fmt.Errorf("unsupported predicate type: %s", predicateType)
+		// Valid URI type reaches here.
+		payload, err = json.Marshal(statement)
+		if err != nil {
+			return nil, fmt.Errorf("generating Statement: %w", err)
+		}
 	}
 	return payload, nil
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -212,8 +212,8 @@ func TestAttestVerify(t *testing.T) {
 	attestVerify(t,
 		"slsaprovenance",
 		`{ "buildType": "x", "builder": { "id": "2" }, "recipe": {} }`,
-		`builder: id: "1"`,
-		`builder: id: "2"`,
+		`predicate: builder: id: "2"`,
+		`predicate: builder: id: "1"`,
 	)
 }
 
@@ -225,8 +225,8 @@ func TestAttestVerifySPDXJSON(t *testing.T) {
 	attestVerify(t,
 		"spdxjson",
 		string(attestationBytes),
-		`Data: spdxVersion: "SPDX-9.9"`,
-		`Data: spdxVersion: "SPDX-2.2"`,
+		`predicate: Data: spdxVersion: "SPDX-2.2"`,
+		`predicate: Data: spdxVersion: "SPDX-9.9"`,
 	)
 }
 
@@ -238,8 +238,8 @@ func TestAttestVerifyCycloneDXJSON(t *testing.T) {
 	attestVerify(t,
 		"cyclonedx",
 		string(attestationBytes),
-		`Data: specVersion: "7.7"`,
-		`Data: specVersion: "1.4"`,
+		`predicate: Data: specVersion: "1.4"`,
+		`predicate: Data: specVersion: "7.7"`,
 	)
 }
 
@@ -304,6 +304,7 @@ func attestVerify(t *testing.T, predicateType, attestation, goodCue, badCue stri
 	if err := os.WriteFile(policyPath, []byte(badCue), 0600); err != nil {
 		t.Fatal(err)
 	}
+	mustErr(verifyAttestation.Exec(ctx, []string{imgName}), t)
 
 	// Success case
 	if err := os.WriteFile(policyPath, []byte(goodCue), 0600); err != nil {
@@ -1039,7 +1040,7 @@ func TestSaveLoadAttestation(t *testing.T) {
 	verifyAttestation.PredicateType = "slsaprovenance"
 	verifyAttestation.Policies = []string{policyPath}
 	// Success case (remote)
-	cuePolicy := `builder: id: "2"`
+	cuePolicy := `predicate: builder: id: "2"`
 	if err := os.WriteFile(policyPath, []byte(cuePolicy), 0600); err != nil {
 		t.Fatal(err)
 	}

--- a/test/testdata/test-result.json
+++ b/test/testdata/test-result.json
@@ -1,0 +1,1 @@
+{"passed": true}


### PR DESCRIPTION
Signed-off-by: Akira Saso <sasoakira6114@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Close https://github.com/sigstore/cosign/issues/2158

Please feel free to close the PR if there is any requirement on verify-attestation.

I made an attestation with URI specified as the following command.
```bash
$ cat test-result.json
{"passed": true}

$ COSIGN_EXPERIMENTAL=1 cosign attest --type "https://example.com/TestResult/v1" --predicate test-result.json  otms61/test-custom-attest
```
Reviews can test this PR.

```bash
$ COSIGN_EXPERIMENTAL=1 cosign verify-attestation  --type "https://example.com/TestResult/v1" otms61/test-custom-attest
```

**before**
```bash
$ ./cosign-darwin-amd64 version
  ______   ______        _______. __    _______ .__   __.
 /      | /  __  \      /       ||  |  /  _____||  \ |  |
|  ,----'|  |  |  |    |   (----`|  | |  |  __  |   \|  |
|  |     |  |  |  |     \   \    |  | |  | |_ | |  . `  |
|  `----.|  `--'  | .----)   |   |  | |  |__| | |  |\   |
 \______| \______/  |_______/    |__|  \______| |__| \__|
cosign: A tool for Container Signing, Verification and Storage in an OCI registry.

GitVersion:    v1.10.1
GitCommit:     a39ce91fadc582e0efce3321744a79ccd3c8b39c
GitTreeState:  clean
BuildDate:     2022-08-04T16:59:14Z
GoVersion:     go1.18.5
Compiler:      gc
Platform:      darwin/amd64

$ COSIGN_EXPERIMENTAL=1 ./cosign-darwin-amd64 verify-attestation  --type "https://example.com/TestResult/v1" otms61/test-custom-attest
Error: converting to consumable policy validation: invalid predicate type: https://example.com/TestResult/v1
main.go:62: error during command execution: converting to consumable policy validation: invalid predicate type: https://example.com/TestResult/v1
```

**after**

```bash
$ COSIGN_EXPERIMENTAL=1 ./cosign verify-attestation  --type "https://example.com/TestResult/v1" otms61/test-custom-attest


Verification for otms61/test-custom-attest --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - Any certificates were verified against the Fulcio roots.
Certificate subject:  sasoakira6114@gmail.com
Certificate issuer URL:  https://accounts.google.com
{"payloadType":"application/vnd.in-toto+json","payload":"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL2V4YW1wbGUuY29tL1Rlc3RSZXN1bHQvdjEiLCJzdWJqZWN0IjpbeyJuYW1lIjoiaW5kZXguZG9ja2VyLmlvL290bXM2MS90ZXN0LWN1c3RvbS1hdHRlc3QiLCJkaWdlc3QiOnsic2hhMjU2IjoiOTIyNTE0NTgwODhjNjM4MDYxY2RhOGZkOGI0MDNiNzZkNjYxYTRkYzZiN2VlNzFiNmFmZmNmMTg3MjU1N2IyYiJ9fV0sInByZWRpY2F0ZSI6eyJwYXNzZWQiOnRydWV9fQ==","signatures":[{"keyid":"","sig":"MEYCIQDq+COzci2fcmRHZk9P5Q9FzvfgNYJ7a/gvQbQo5tjNlQIhAMeflNARYm5HHc1QXUfayrlQVFOB7RvOjsGMl9vYMZQB"}]}
```


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->