### PR TITLE
fix oidc post-merge job

### DIFF
--- a/test/sign_blob_test.sh
+++ b/test/sign_blob_test.sh
@@ -78,4 +78,4 @@ curl -X POST https://rekor.sigstore.dev/api/v1/log/entries -H 'Content-Type: app
 
 # Verifying should still work
 echo "Verifying ..."
-$COSIGN_CLI verify-blob --signature "$SIG_FILE" --cert "$CERT_FILE" "$BLOB"
+$COSIGN_CLI verify-blob --signature "$SIG_FILE" --cert "$CERT_FILE" --certificate-chain "$CERT_FILE" "$BLOB"


### PR DESCRIPTION
#### Summary
after the PR #2139 we start seeing the post merge job `Test GitHub OIDC` started to fail

looks like now we need to set the `--certificate-chain` as well


running the job locally (showing just the end) with the new flag fix the issue

```shell
... 

+ echo 'Verifying ...'
Verifying ...
+ ./cosign verify-blob --signature verify-experimental-signature --cert ./test/testdata/test_blob_cert.pem --certificate-chain ./test/testdata/test_blob_cert.pem verify-experimental-blob
tlog entry verified with uuid: 455865ce1e39af88d9c9689ca769adf26a2a315376137a87423eaf8cdedd9f47 index: 3197297
Verified OK
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->