### PR TITLE
update e2e job to run only when push to main

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -16,7 +16,11 @@
 name: e2e-tests
 
 # Run on every push, and allow it to be run manually.
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
 
 permissions: read-all
 


### PR DESCRIPTION
#### Summary
 - update e2e job to run only when push to main

to avoid run jobs when pushing to the upstream, like dependabot 