### PR TITLE
fix: add env cmd to root

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -112,6 +112,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(VerifyAttestation())
 	cmd.AddCommand(VerifyBlob())
 	cmd.AddCommand(Triangulate())
+	cmd.AddCommand(Env())
 	cmd.AddCommand(version.WithFont("starwars"))
 
 	cmd.AddCommand(cranecmd.NewCmdAuthLogin("cosign"))

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -20,6 +20,7 @@ A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign copy](cosign_copy.md)	 - Copy the supplied container image and signatures.
 * [cosign dockerfile](cosign_dockerfile.md)	 - Provides utilities for discovering images in and performing operations on Dockerfiles
 * [cosign download](cosign_download.md)	 - Provides utilities for downloading artifacts and attached artifacts in a registry
+* [cosign env](cosign_env.md)	 - Prints Cosign environment variables
 * [cosign generate](cosign_generate.md)	 - Generates (unsigned) signature payloads from the supplied container image.
 * [cosign generate-key-pair](cosign_generate-key-pair.md)	 - Generates a key-pair.
 * [cosign import-key-pair](cosign_import-key-pair.md)	 - Imports a PEM-encoded RSA or EC private key.

--- a/doc/cosign_env.md
+++ b/doc/cosign_env.md
@@ -1,0 +1,26 @@
+## cosign env
+
+Prints Cosign environment variables
+
+```
+cosign env [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for env
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
+


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->


I saw that we didn't add the env cmd to root, so, this PR will fix that.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

fix: add env cmd to root

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->