### PR TITLE
bump scaffold in tests to use release v0.4.5

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -36,7 +36,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.4.4"
+      SCAFFOLDING_RELEASE_VERSION: "v0.4.5"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko


### PR DESCRIPTION
#### Summary
- bump scaffold in tests to use release v0.4.5