### PR TITLE
remove double quotes, looks like it is passing as a single string to cosign and not as an array

### DIFF
--- a/release/ko-sign-release-images.sh
+++ b/release/ko-sign-release-images.sh
@@ -39,9 +39,9 @@ fi
 
 echo "Signing cosign images with GCP KMS Key..."
 
-cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat cosignImagerefs)"
-cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat sgetImagerefs)"
+cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat cosignImagerefs)
+cosign sign --force --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat sgetImagerefs)
 
 echo "Signing images with Keyless..."
-cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat cosignImagerefs)"
-cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" "$(cat sgetImagerefs)"
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat cosignImagerefs)
+cosign sign --force -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat sgetImagerefs)

--- a/scripts/sign-images-ci.sh
+++ b/scripts/sign-images-ci.sh
@@ -37,5 +37,5 @@ fi
 
 echo "Signing cosign images using Keyless..."
 
-$COSIGN_CLI sign -a sha="$GIT_HASH" -a run_id="$GITHUB_RUN_ID" -a run_attempt="$GITHUB_RUN_ATTEMPT" "$(cat cosignImagerefs)"
-$COSIGN_CLI sign -a sha="$GIT_HASH" -a run_id="$GITHUB_RUN_ID" -a run_attempt="$GITHUB_RUN_ATTEMPT" "$(cat sgetImagerefs)"
+$COSIGN_CLI sign -y -a sha="$GIT_HASH" -a run_id="$GITHUB_RUN_ID" -a run_attempt="$GITHUB_RUN_ATTEMPT" $(cat cosignImagerefs)
+$COSIGN_CLI sign -y -a sha="$GIT_HASH" -a run_id="$GITHUB_RUN_ID" -a run_attempt="$GITHUB_RUN_ATTEMPT" $(cat sgetImagerefs)


### PR DESCRIPTION
#### Summary
- `ko` now output more digests (before 0.11.2 release the output was just one) and that was passing as a unique big string to cosign failing the job

ran the fix here: https://github.com/cpanato/cosign/actions/runs/2950002823