### PR TITLE
feat: set annotations to generate additional bash completion information

### DIFF
--- a/cmd/cosign/cli/options/attach.go
+++ b/cmd/cosign/cli/options/attach.go
@@ -61,6 +61,7 @@ func (o *AttachSBOMOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.SBOM, "sbom", "",
 		"path to the sbom, or {-} for stdin")
+	_ = cmd.Flags().SetAnnotation("sbom", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().StringVar(&o.SBOMType, "type", "spdx",
 		"type of sbom (spdx|cyclonedx|syft)")

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -52,15 +52,18 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the private key file, KMS URI or Kubernetes Secret")
+	_ = cmd.Flags().SetAnnotation("key", cobra.BashCompFilenameExt, []string{"key"})
 
 	cmd.Flags().StringVar(&o.Cert, "certificate", "",
 		"path to the X.509 certificate in PEM format to include in the OCI Signature")
+	_ = cmd.Flags().SetAnnotation("certificate", cobra.BashCompFilenameExt, []string{"cert"})
 
 	cmd.Flags().StringVar(&o.CertChain, "certificate-chain", "",
 		"path to a list of CA X.509 certificates in PEM format which will be needed "+
 			"when building the certificate chain for the signing certificate. "+
 			"Must start with the parent intermediate CA certificate of the "+
 			"signing certificate and end with the root certificate. Included in the OCI Signature")
+	_ = cmd.Flags().SetAnnotation("certificate-chain", cobra.BashCompFilenameExt, []string{"cert"})
 
 	cmd.Flags().BoolVar(&o.NoUpload, "no-upload", false,
 		"do not upload the generated attestation")

--- a/cmd/cosign/cli/options/certificate.go
+++ b/cmd/cosign/cli/options/certificate.go
@@ -38,6 +38,7 @@ var _ Interface = (*RekorOptions)(nil)
 func (o *CertVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Cert, "certificate", "",
 		"path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.")
+	_ = cmd.Flags().SetAnnotation("certificate", cobra.BashCompFilenameExt, []string{"cert"})
 
 	cmd.Flags().StringVar(&o.CertEmail, "certificate-email", "",
 		"the email expected in a valid Fulcio certificate")
@@ -67,6 +68,7 @@ func (o *CertVerifyOptions) AddFlags(cmd *cobra.Command) {
 			"when building the certificate chain for the signing certificate. "+
 			"Must start with the parent intermediate CA certificate of the "+
 			"signing certificate and end with the root certificate")
+	_ = cmd.Flags().SetAnnotation("certificate-chain", cobra.BashCompFilenameExt, []string{"cert"})
 
 	cmd.Flags().BoolVar(&o.EnforceSCT, "enforce-sct", false,
 		"whether to enforce that a certificate contain an embedded SCT, a proof of "+

--- a/cmd/cosign/cli/options/files.go
+++ b/cmd/cosign/cli/options/files.go
@@ -54,4 +54,5 @@ func (o *FilesOptions) String() string {
 func (o *FilesOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVarP(&o.Files, "files", "f", nil,
 		"<filepath>:[platform/arch]")
+	_ = cmd.Flags().SetAnnotation("files", cobra.BashCompFilenameExt, []string{})
 }

--- a/cmd/cosign/cli/options/import_key_pair.go
+++ b/cmd/cosign/cli/options/import_key_pair.go
@@ -31,4 +31,5 @@ var _ Interface = (*ImportKeyPairOptions)(nil)
 func (o *ImportKeyPairOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"import key pair to use for signing")
+	_ = cmd.Flags().SetAnnotation("key", cobra.BashCompFilenameExt, []string{})
 }

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -35,4 +35,5 @@ func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Root, "root", "",
 		"path to trusted initial root. defaults to embedded root")
+	_ = cmd.Flags().SetAnnotation("root", cobra.BashCompSubdirsInDir, []string{})
 }

--- a/cmd/cosign/cli/options/load.go
+++ b/cmd/cosign/cli/options/load.go
@@ -30,5 +30,6 @@ var _ Interface = (*LoadOptions)(nil)
 func (o *LoadOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Directory, "dir", "",
 		"path to directory where the signed image is stored on disk")
+	_ = cmd.Flags().SetAnnotation("dir", cobra.BashCompSubdirsInDir, []string{})
 	_ = cmd.MarkFlagRequired("dir")
 }

--- a/cmd/cosign/cli/options/oidc.go
+++ b/cmd/cosign/cli/options/oidc.go
@@ -64,6 +64,7 @@ func (o *OIDCOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.clientSecretFile, "oidc-client-secret-file", "",
 		"[EXPERIMENTAL] Path to file containing OIDC client secret for application")
+	_ = cmd.Flags().SetAnnotation("oidc-client-secret-file", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().StringVar(&o.RedirectURL, "oidc-redirect-url", "",
 		"[EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.")

--- a/cmd/cosign/cli/options/pkcs11_tool.go
+++ b/cmd/cosign/cli/options/pkcs11_tool.go
@@ -45,6 +45,7 @@ var _ Interface = (*PKCS11ToolListKeysUrisOptions)(nil)
 func (o *PKCS11ToolListKeysUrisOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.ModulePath, "module-path", "",
 		"absolute path to the PKCS11 module")
+	_ = cmd.Flags().SetAnnotation("module-path", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().UintVar(&o.SlotID, "slot-id", 0,
 		"id of the PKCS11 slot, uses 0 if empty")

--- a/cmd/cosign/cli/options/policy.go
+++ b/cmd/cosign/cli/options/policy.go
@@ -39,6 +39,7 @@ func (o *PolicyInitOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.OutFile, "out", "o",
 		"output policy locally")
+	_ = cmd.Flags().SetAnnotation("out", cobra.BashCompSubdirsInDir, []string{})
 
 	cmd.Flags().StringVar(&o.Issuer, "issuer", "",
 		"trusted issuer to use for identity tokens, e.g. https://accounts.google.com")

--- a/cmd/cosign/cli/options/public_key.go
+++ b/cmd/cosign/cli/options/public_key.go
@@ -34,7 +34,9 @@ func (o *PublicKeyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the private key file, KMS URI or Kubernetes Secret")
+	_ = cmd.Flags().SetAnnotation("key", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().StringVar(&o.OutFile, "outfile", "",
 		"path to a payload file to use rather than generating one")
+	_ = cmd.Flags().SetAnnotation("outfile", cobra.BashCompFilenameExt, []string{})
 }

--- a/cmd/cosign/cli/options/root.go
+++ b/cmd/cosign/cli/options/root.go
@@ -37,6 +37,7 @@ var _ Interface = (*RootOptions)(nil)
 func (o *RootOptions) AddFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&o.OutputFile, "output-file", "",
 		"log output to a file")
+	_ = cmd.Flags().SetAnnotation("output-file", cobra.BashCompFilenameExt, []string{})
 
 	cmd.PersistentFlags().BoolVarP(&o.Verbose, "verbose", "d", false,
 		"log debug output")

--- a/cmd/cosign/cli/options/save.go
+++ b/cmd/cosign/cli/options/save.go
@@ -30,5 +30,6 @@ var _ Interface = (*SaveOptions)(nil)
 func (o *SaveOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Directory, "dir", "",
 		"path to dir where the signed image should be stored on disk")
+	_ = cmd.Flags().SetAnnotation("dir", cobra.BashCompSubdirsInDir, []string{})
 	_ = cmd.MarkFlagRequired("dir")
 }

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -56,27 +56,33 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the private key file, KMS URI or Kubernetes Secret")
+	_ = cmd.Flags().SetAnnotation("key", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().StringVar(&o.Cert, "certificate", "",
 		"path to the X.509 certificate in PEM format to include in the OCI Signature")
+	_ = cmd.Flags().SetAnnotation("certificate", cobra.BashCompFilenameExt, []string{"cert"})
 
 	cmd.Flags().StringVar(&o.CertChain, "certificate-chain", "",
 		"path to a list of CA X.509 certificates in PEM format which will be needed "+
 			"when building the certificate chain for the signing certificate. "+
 			"Must start with the parent intermediate CA certificate of the "+
 			"signing certificate and end with the root certificate. Included in the OCI Signature")
+	_ = cmd.Flags().SetAnnotation("certificate-chain", cobra.BashCompFilenameExt, []string{"cert"})
 
 	cmd.Flags().BoolVar(&o.Upload, "upload", true,
 		"whether to upload the signature")
 
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
+	_ = cmd.Flags().SetAnnotation("output-signature", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
+	_ = cmd.Flags().SetAnnotation("output-certificate", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().StringVar(&o.PayloadPath, "payload", "",
 		"path to a payload file to use rather than generating one")
+	_ = cmd.Flags().SetAnnotation("payload", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().BoolVarP(&o.Force, "force", "f", false,
 		"skip warnings and confirmations")

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -48,21 +48,25 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the private key file, KMS URI or Kubernetes Secret")
+	_ = cmd.Flags().SetAnnotation("key", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().BoolVar(&o.Base64Output, "b64", true,
 		"whether to base64 encode the output")
 
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
+	_ = cmd.Flags().SetAnnotation("output-signature", cobra.BashCompFilenameExt, []string{})
 
 	// TODO: remove when output flag is fully deprecated
 	cmd.Flags().StringVar(&o.Output, "output", "", "write the signature to FILE")
 
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
+	_ = cmd.Flags().SetAnnotation("key", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")
+	_ = cmd.Flags().SetAnnotation("bundle", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
 		"skip confirmation prompts for non-destructive operations")

--- a/cmd/cosign/cli/options/upload.go
+++ b/cmd/cosign/cli/options/upload.go
@@ -51,5 +51,6 @@ func (o *UploadWASMOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVarP(&o.File, "file", "f", "",
 		"path to the wasm file to upload")
+	_ = cmd.Flags().SetAnnotation("file", cobra.BashCompFilenameExt, []string{})
 	_ = cmd.MarkFlagRequired("file")
 }

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -49,6 +49,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the public key file, KMS URI or Kubernetes Secret")
+	_ = cmd.Flags().SetAnnotation("key", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().BoolVar(&o.CheckClaims, "check-claims", true,
 		"whether to check the claims found")


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

FYI: @developer-guy and @fedeci 

#### Summary

This PR is related to #2186 and set arbitrary annotations on a flag in the `FlagSet`. This is used by spf13/cobra programs which want to generate additional bash completion information and in this case for the Fig autocomplete spec.



This will add the `template: ["filepaths",]` to the flag

```json
...
 {
        name: ["--key",],
        description: "path to the public key file, KMS URI or Kubernetes Secret",
        args: [{name: "key", template: ["filepaths",],},],
 }
...
```

After this PR, we can finally start to create the GitHub Action to autogenerate and push to the Fig repository.



#### Release Note

NONE

#### Documentation

NONE