### PR TITLE
move `verify-blob` function to "pkg/cosign" to be consistent with `verify`

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -109,14 +109,15 @@ func (o *VerifyAttestationOptions) AddFlags(cmd *cobra.Command) {
 
 // VerifyBlobOptions is the top level wrapper for the `verify blob` command.
 type VerifyBlobOptions struct {
-	Key        string
-	Signature  string
-	BundlePath string
+	Key          string
+	SignatureRef string
+	BundlePath   string
 
-	SecurityKey SecurityKeyOptions
-	CertVerify  CertVerifyOptions
-	Rekor       RekorOptions
-	Registry    RegistryOptions
+	SecurityKey     SecurityKeyOptions
+	CertVerify      CertVerifyOptions
+	Rekor           RekorOptions
+	Registry        RegistryOptions
+	SignatureDigest SignatureDigestOptions
 }
 
 var _ Interface = (*VerifyBlobOptions)(nil)
@@ -127,11 +128,12 @@ func (o *VerifyBlobOptions) AddFlags(cmd *cobra.Command) {
 	o.Rekor.AddFlags(cmd)
 	o.CertVerify.AddFlags(cmd)
 	o.Registry.AddFlags(cmd)
+	o.SignatureDigest.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the public key file, KMS URI or Kubernetes Secret")
 
-	cmd.Flags().StringVar(&o.Signature, "signature", "",
+	cmd.Flags().StringVar(&o.SignatureRef, "signature", "",
 		"signature content or path or remote URL")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -208,7 +208,7 @@ func (c *VerifyBlobCommand) Exec(ctx context.Context, blobRefs []string) error {
 		return err
 	}
 
-	verified, bundleVerified, err := cosign.VerifyBlobSignature(ctx, blobBytes, cert, chain, b64sig, bundle, co)
+	verified, bundleVerified, err := cosign.VerifyBlobSignature(ctx, blobBytes, b64sig, bundle, co)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -31,10 +31,10 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/pkg/blob"
 	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/cosign/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/pkg/cosign/pivkey"
 	"github.com/sigstore/cosign/pkg/cosign/pkcs11key"
 	sigs "github.com/sigstore/cosign/pkg/signature"
-
 	"github.com/sigstore/sigstore/pkg/signature"
 )
 
@@ -117,6 +117,7 @@ func (c *VerifyBlobCommand) Exec(ctx context.Context, blobRefs []string) error {
 	var pubKey signature.Verifier
 	var cert *x509.Certificate
 	var chain []*x509.Certificate
+	var bundle *bundle.RekorBundle
 	switch {
 	case keyRef != "":
 		pubKey, err = sigs.PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, c.HashAlgorithm)
@@ -145,6 +146,7 @@ func (c *VerifyBlobCommand) Exec(ctx context.Context, blobRefs []string) error {
 		if b.Cert == "" {
 			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
 		}
+		bundle = b.Bundle
 		// cert can either be a cert or public key
 		certBytes := []byte(b.Cert)
 		if isb64(certBytes) {
@@ -206,7 +208,7 @@ func (c *VerifyBlobCommand) Exec(ctx context.Context, blobRefs []string) error {
 		return err
 	}
 
-	verified, bundleVerified, err := cosign.VerifyBlobSignature(ctx, blobBytes, cert, chain, b64sig, bundlePath, co)
+	verified, bundleVerified, err := cosign.VerifyBlobSignature(ctx, blobBytes, cert, chain, b64sig, bundle, co)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -15,13 +15,11 @@
 package verify
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/cosign/pkg/cosign"
 )
 
@@ -93,51 +91,5 @@ func TestSignaturesBundle(t *testing.T) {
 	}
 	if gotb64Sig != b64sig {
 		t.Fatalf("unexpected encoded signature, expected: %s got: %s", b64sig, gotb64Sig)
-	}
-}
-
-func TestIsIntotoDSSEWithEnvelopes(t *testing.T) {
-	tts := []struct {
-		envelope     dsse.Envelope
-		isIntotoDSSE bool
-	}{
-		{
-			envelope: dsse.Envelope{
-				PayloadType: "application/vnd.in-toto+json",
-				Payload:     base64.StdEncoding.EncodeToString([]byte("This is a test")),
-				Signatures:  []dsse.Signature{},
-			},
-			isIntotoDSSE: true,
-		},
-	}
-	for _, tt := range tts {
-		envlopeBytes, _ := json.Marshal(tt.envelope)
-		got := isIntotoDSSE(envlopeBytes)
-		if got != tt.isIntotoDSSE {
-			t.Fatalf("unexpected envelope content")
-		}
-	}
-}
-
-func TestIsIntotoDSSEWithBytes(t *testing.T) {
-	tts := []struct {
-		envelope     []byte
-		isIntotoDSSE bool
-	}{
-		{
-			envelope:     []byte("This is no valid"),
-			isIntotoDSSE: false,
-		},
-		{
-			envelope:     []byte("MEUCIQDBmE1ZRFjUVic1hzukesJlmMFG1JqWWhcthnhawTeBNQIga3J9/WKsNlSZaySnl8V360bc2S8dIln2/qo186EfjHA="),
-			isIntotoDSSE: false,
-		},
-	}
-	for _, tt := range tts {
-		envlopeBytes, _ := json.Marshal(tt.envelope)
-		got := isIntotoDSSE(envlopeBytes)
-		if got != tt.isIntotoDSSE {
-			t.Fatalf("unexpected envelope content")
-		}
 	}
 }

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -79,6 +79,7 @@ cosign verify-blob [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --signature string                                                                         signature content or path or remote URL
+      --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
 ```

--- a/go.mod
+++ b/go.mod
@@ -303,3 +303,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace (
+	"github.com/sigstore/cosign" => ./
+)

--- a/go.mod
+++ b/go.mod
@@ -303,7 +303,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace (
-	"github.com/sigstore/cosign" => ./
-)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/mozillazg/docker-credential-acr-helper v0.3.0
 	github.com/open-policy-agent/opa v0.43.0
+	github.com/pkg/errors v0.9.1
 	github.com/secure-systems-lab/go-securesystemslib v0.4.0
 	github.com/sigstore/fulcio v0.5.3
 	github.com/sigstore/rekor v0.11.0
@@ -219,7 +220,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.13.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/pkg/cosign/verify_blob.go
+++ b/pkg/cosign/verify_blob.go
@@ -47,6 +47,12 @@ type blobSignature struct {
 }
 
 func newBundleSignature(blobBytes []byte, b64sig string, bundle *bundle.RekorBundle) (*blobSignature, error) {
+	if blobBytes == nil {
+		return nil, errors.New("blobBytes must be non nil")
+	}
+	if b64sig == "" {
+		return nil, errors.New("b64sig must be non empty string")
+	}
 	return &blobSignature{
 		payload: blobBytes,
 		b64sig:  b64sig,

--- a/pkg/cosign/verify_blob.go
+++ b/pkg/cosign/verify_blob.go
@@ -42,18 +42,14 @@ import (
 type blobSignature struct {
 	payload []byte
 	b64sig  string
-	cert    *x509.Certificate
-	chain   []*x509.Certificate
 	bundle  *bundle.RekorBundle
 	v1.Layer
 }
 
-func newBundleSignature(blobBytes []byte, b64sig string, cert *x509.Certificate, chain []*x509.Certificate, bundle *bundle.RekorBundle) (*blobSignature, error) {
+func newBundleSignature(blobBytes []byte, b64sig string, bundle *bundle.RekorBundle) (*blobSignature, error) {
 	return &blobSignature{
 		payload: blobBytes,
 		b64sig:  b64sig,
-		cert:    cert,
-		chain:   chain,
 		bundle:  bundle,
 	}, nil
 }
@@ -71,11 +67,11 @@ func (s *blobSignature) Base64Signature() (string, error) {
 }
 
 func (s *blobSignature) Cert() (*x509.Certificate, error) {
-	return s.cert, nil
+	return nil, errors.New("no cert in blobSignature")
 }
 
 func (s *blobSignature) Chain() ([]*x509.Certificate, error) {
-	return s.chain, nil
+	return nil, errors.New("no cert chain in blobSignature")
 }
 
 func (s *blobSignature) Bundle() (*bundle.RekorBundle, error) {
@@ -83,8 +79,8 @@ func (s *blobSignature) Bundle() (*bundle.RekorBundle, error) {
 }
 
 // VerifyBlobSignature verifies a signature
-func VerifyBlobSignature(ctx context.Context, blobBytes []byte, cert *x509.Certificate, chain []*x509.Certificate, b64sig string, bundle *bundle.RekorBundle, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
-	sig, err := newBundleSignature(blobBytes, b64sig, cert, chain, bundle)
+func VerifyBlobSignature(ctx context.Context, blobBytes []byte, b64sig string, bundle *bundle.RekorBundle, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
+	sig, err := newBundleSignature(blobBytes, b64sig, bundle)
 	if err != nil {
 		return checkedSignatures, bundleVerified, errors.Wrap(err, "failed to create bundle signature")
 	}

--- a/pkg/cosign/verify_blob.go
+++ b/pkg/cosign/verify_blob.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Sigstore Authors.
+// Copyright 2022 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cosign/verify_blob.go
+++ b/pkg/cosign/verify_blob.go
@@ -1,0 +1,221 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/go-openapi/runtime"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/pkg/errors"
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
+	"github.com/sigstore/cosign/pkg/cosign/bundle"
+	"github.com/sigstore/cosign/pkg/oci"
+	ctypes "github.com/sigstore/cosign/pkg/types"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/types"
+	hashedrekord "github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1"
+	rekord "github.com/sigstore/rekor/pkg/types/rekord/v0.0.1"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/dsse"
+)
+
+type blobSignature struct {
+	payload []byte
+	b64sig  string
+	cert    *x509.Certificate
+	chain   []*x509.Certificate
+	bundle  *bundle.RekorBundle
+	v1.Layer
+}
+
+func newBundleSignature(blobBytes []byte, b64sig string, cert *x509.Certificate, chain []*x509.Certificate, bundle *bundle.RekorBundle) (*blobSignature, error) {
+	return &blobSignature{
+		payload: blobBytes,
+		b64sig:  b64sig,
+		cert:    cert,
+		chain:   chain,
+		bundle:  bundle,
+	}, nil
+}
+
+func (s *blobSignature) Annotations() (map[string]string, error) {
+	return nil, nil
+}
+
+func (s *blobSignature) Payload() ([]byte, error) {
+	return s.payload, nil
+}
+
+func (s *blobSignature) Base64Signature() (string, error) {
+	return s.b64sig, nil
+}
+
+func (s *blobSignature) Cert() (*x509.Certificate, error) {
+	return s.cert, nil
+}
+
+func (s *blobSignature) Chain() ([]*x509.Certificate, error) {
+	return s.chain, nil
+}
+
+func (s *blobSignature) Bundle() (*bundle.RekorBundle, error) {
+	return s.bundle, nil
+}
+
+// VerifyBlobSignature verifies a signature
+func VerifyBlobSignature(ctx context.Context, blobBytes []byte, cert *x509.Certificate, chain []*x509.Certificate, b64sig string, bundle *bundle.RekorBundle, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
+	sig, err := newBundleSignature(blobBytes, b64sig, cert, chain, bundle)
+	if err != nil {
+		return checkedSignatures, bundleVerified, errors.Wrap(err, "failed to create bundle signature")
+	}
+
+	verifiers := []signature.Verifier{}
+	if co.SigVerifier != nil {
+		verifiers = append(verifiers, co.SigVerifier)
+	} else {
+		uuids, err := FindTLogEntriesByPayload(ctx, co.RekorClient, blobBytes)
+		if err != nil {
+			return checkedSignatures, bundleVerified, errors.Wrap(err, "failed to get tlog entries by payload")
+		}
+		if len(uuids) == 0 {
+			return checkedSignatures, bundleVerified, errors.New("could not find a tlog entry for provided blob")
+		}
+		for _, u := range uuids {
+			tlogEntry, err := GetTlogEntry(ctx, co.RekorClient, u)
+			if err != nil {
+				continue
+			}
+			certs, err := extractCerts(tlogEntry)
+			if err != nil {
+				continue
+			}
+			cert := certs[0]
+			verifier, err := ValidateAndUnpackCert(cert, co)
+			if err != nil {
+				continue
+			}
+			// Use the DSSE verifier if the payload is a DSSE with the In-Toto format.
+			if isIntotoDSSE(blobBytes) {
+				verifier = dsse.WrapVerifier(verifier)
+			}
+			verifiers = append(verifiers, verifier)
+		}
+	}
+
+	var validSigExists bool
+	for _, verifier := range verifiers {
+		if err := verifyOCISignature(ctx, verifier, sig); err != nil {
+			continue
+		}
+		bundleVerified = true
+		validSigExists = true
+		break
+	}
+	if !validSigExists {
+		fmt.Fprintln(os.Stderr, `WARNING: No valid entries were found in rekor to verify this blob.
+Transparency log support for blobs is experimental, and occasionally an entry isn't found even if one exists.
+We recommend requesting the certificate/signature from the original signer of this blob and manually verifying with cosign verify-blob --cert [cert] --signature [signature].`)
+		return checkedSignatures, bundleVerified, fmt.Errorf("could not find a valid tlog entry for provided blob, found %d invalid entries", len(verifiers))
+	}
+
+	if validSigExists {
+		fmt.Fprintln(os.Stderr, "Verified OK")
+		checkedSignatures = append(checkedSignatures, sig)
+	}
+
+	if !validSigExists && co.RekorClient != nil {
+		if co.SigVerifier != nil {
+			pub, err := co.SigVerifier.PublicKey(co.PKOpts...)
+			if err != nil {
+				return checkedSignatures, bundleVerified, errors.Wrap(err, "failed to get pubkey")
+			}
+			return checkedSignatures, bundleVerified, tlogValidatePublicKey(ctx, co.RekorClient, pub, sig)
+		}
+
+		return checkedSignatures, bundleVerified, tlogValidateCertificate(ctx, co.RekorClient, sig)
+	}
+
+	return checkedSignatures, bundleVerified, nil
+}
+
+func extractCerts(e *models.LogEntryAnon) ([]*x509.Certificate, error) {
+	b, err := base64.StdEncoding.DecodeString(e.Body.(string))
+	if err != nil {
+		return nil, err
+	}
+
+	pe, err := models.UnmarshalProposedEntry(bytes.NewReader(b), runtime.JSONConsumer())
+	if err != nil {
+		return nil, err
+	}
+
+	eimpl, err := types.NewEntry(pe)
+	if err != nil {
+		return nil, err
+	}
+
+	var publicKeyB64 []byte
+	switch e := eimpl.(type) {
+	case *rekord.V001Entry:
+		publicKeyB64, err = e.RekordObj.Signature.PublicKey.Content.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+	case *hashedrekord.V001Entry:
+		publicKeyB64, err = e.HashedRekordObj.Signature.PublicKey.Content.MarshalText()
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("unexpected tlog entry type")
+	}
+
+	publicKey, err := base64.StdEncoding.DecodeString(string(publicKeyB64))
+	if err != nil {
+		return nil, err
+	}
+
+	certs, err := cryptoutils.UnmarshalCertificatesFromPEM(publicKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(certs) == 0 {
+		return nil, errors.New("no certs found in pem tlog")
+	}
+
+	return certs, err
+}
+
+// isIntotoDSSE checks whether a payload is a Dead Simple Signing Envelope with the In-Toto format.
+func isIntotoDSSE(blobBytes []byte) bool {
+	DSSEenvelope := ssldsse.Envelope{}
+	if err := json.Unmarshal(blobBytes, &DSSEenvelope); err != nil {
+		return false
+	}
+	if DSSEenvelope.PayloadType != ctypes.IntotoPayloadType {
+		return false
+	}
+
+	return true
+}

--- a/pkg/cosign/verify_blob_test.go
+++ b/pkg/cosign/verify_blob_test.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+)
+
+func TestIsIntotoDSSEWithEnvelopes(t *testing.T) {
+	tts := []struct {
+		envelope     dsse.Envelope
+		isIntotoDSSE bool
+	}{
+		{
+			envelope: dsse.Envelope{
+				PayloadType: "application/vnd.in-toto+json",
+				Payload:     base64.StdEncoding.EncodeToString([]byte("This is a test")),
+				Signatures:  []dsse.Signature{},
+			},
+			isIntotoDSSE: true,
+		},
+	}
+	for _, tt := range tts {
+		envlopeBytes, _ := json.Marshal(tt.envelope)
+		got := isIntotoDSSE(envlopeBytes)
+		if got != tt.isIntotoDSSE {
+			t.Fatalf("unexpected envelope content")
+		}
+	}
+}
+
+func TestIsIntotoDSSEWithBytes(t *testing.T) {
+	tts := []struct {
+		envelope     []byte
+		isIntotoDSSE bool
+	}{
+		{
+			envelope:     []byte("This is no valid"),
+			isIntotoDSSE: false,
+		},
+		{
+			envelope:     []byte("MEUCIQDBmE1ZRFjUVic1hzukesJlmMFG1JqWWhcthnhawTeBNQIga3J9/WKsNlSZaySnl8V360bc2S8dIln2/qo186EfjHA="),
+			isIntotoDSSE: false,
+		},
+	}
+	for _, tt := range tts {
+		envlopeBytes, _ := json.Marshal(tt.envelope)
+		got := isIntotoDSSE(envlopeBytes)
+		if got != tt.isIntotoDSSE {
+			t.Fatalf("unexpected envelope content")
+		}
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -115,7 +115,6 @@ var verifyBlob = func(keyRef, sigRef, blobRef, bundlePath string) error {
 		SignatureRef:  sigRef,
 		BundlePath:    bundlePath,
 		RekorURL:      rekorURL,
-		Attachment:    attachment,
 		HashAlgorithm: crypto.SHA256,
 	}
 
@@ -633,8 +632,6 @@ func TestSignBlob(t *testing.T) {
 	_, privKeyPath1, pubKeyPath1 := keypair(t, td1)
 	_, _, pubKeyPath2 := keypair(t, td2)
 
-	ctx := context.Background()
-
 	// Verify should fail on a bad input
 	mustErr(verifyBlob(pubKeyPath1, "badsig", blob, ""), t)
 	mustErr(verifyBlob(pubKeyPath2, "badsig", blob, ""), t)
@@ -667,8 +664,6 @@ func TestSignBlobBundle(t *testing.T) {
 	}
 
 	_, privKeyPath1, pubKeyPath1 := keypair(t, td1)
-
-	ctx := context.Background()
 
 	// Verify should fail on a bad input
 	mustErr(verifyBlob(pubKeyPath1, "", blob, bundlePath), t)


### PR DESCRIPTION
Signed-off-by: Hirokuni-Kitahara1 <hirokuni.kitahara1@ibm.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR solves the issue https://github.com/sigstore/cosign/issues/2222 by moving the core function of `verify-blob` from "cmd/cosign/cli/verify" package to "pkg/cosign" package.
The new function `VerifyBlobSignature()` is based on basically the same design as `VerifyImageSignature()`, which is the core function of `verify` command.
Also the arguments of `VerifyBlobSignature()` are all non-filepath information such as []byte, so it is easy for developers to invoke this function even on some read-only environment.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->