### PR TITLE
cyclonedxxml predicate type

### DIFF
--- a/cmd/cosign/cli/options/predicate.go
+++ b/cmd/cosign/cli/options/predicate.go
@@ -28,24 +28,26 @@ import (
 )
 
 const (
-	PredicateCustom    = "custom"
-	PredicateSLSA      = "slsaprovenance"
-	PredicateSPDX      = "spdx"
-	PredicateSPDXJSON  = "spdxjson"
-	PredicateCycloneDX = "cyclonedx"
-	PredicateLink      = "link"
-	PredicateVuln      = "vuln"
+	PredicateCustom       = "custom"
+	PredicateSLSA         = "slsaprovenance"
+	PredicateSPDX         = "spdx"
+	PredicateSPDXJSON     = "spdxjson"
+	PredicateCycloneDX    = "cyclonedx"
+	PredicateCycloneDXXML = "cyclonedxxml"
+	PredicateLink         = "link"
+	PredicateVuln         = "vuln"
 )
 
 // PredicateTypeMap is the mapping between the predicate `type` option to predicate URI.
 var PredicateTypeMap = map[string]string{
-	PredicateCustom:    attestation.CosignCustomProvenanceV01,
-	PredicateSLSA:      slsa.PredicateSLSAProvenance,
-	PredicateSPDX:      in_toto.PredicateSPDX,
-	PredicateSPDXJSON:  in_toto.PredicateSPDX,
-	PredicateCycloneDX: in_toto.PredicateCycloneDX,
-	PredicateLink:      in_toto.PredicateLinkV1,
-	PredicateVuln:      attestation.CosignVulnProvenanceV01,
+	PredicateCustom:       attestation.CosignCustomProvenanceV01,
+	PredicateSLSA:         slsa.PredicateSLSAProvenance,
+	PredicateSPDX:         in_toto.PredicateSPDX,
+	PredicateSPDXJSON:     in_toto.PredicateSPDX,
+	PredicateCycloneDX:    in_toto.PredicateCycloneDX,
+	PredicateCycloneDXXML: in_toto.PredicateCycloneDX,
+	PredicateLink:         in_toto.PredicateLinkV1,
+	PredicateVuln:         attestation.CosignVulnProvenanceV01,
 }
 
 // PredicateOptions is the wrapper for predicate related options.
@@ -58,7 +60,7 @@ var _ Interface = (*PredicateOptions)(nil)
 // AddFlags implements Interface
 func (o *PredicateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Type, "type", "custom",
-		"specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI")
+		"specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|cyclonedxxml|vuln|custom) or an URI")
 }
 
 // ParsePredicateType parses the predicate `type` flag passed into a predicate URI, or validates `type` is a valid URI.

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -62,10 +62,10 @@ cosign attest [flags]
       --predicate string                                                                         path to the predicate file.
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --replace                                                                                  
+      --replace
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+      --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|cyclonedxxml|vuln|custom) or an URI (default "custom")
   -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -83,7 +83,7 @@ cosign verify-attestation [flags]
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+      --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|cyclonedxxml|vuln|custom) or an URI (default "custom")
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -206,8 +206,7 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
-	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
-	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
+	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
 	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 // indirect
 	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	cuelang.org/go v0.4.3
+	github.com/CycloneDX/cyclonedx-go v0.6.0
 	github.com/ThalesIgnite/crypto11 v1.2.5
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20220228164355-396b2034c795
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21

--- a/go.mod
+++ b/go.mod
@@ -206,7 +206,8 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
-	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
+	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/tent/canonical-json-go v0.0.0-20130607151641-96e4ba3a7613 // indirect
 	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/CycloneDX/cyclonedx-go v0.6.0 h1:SizWGbZzFTC/O/1yh072XQBMxfvsoWqd//oKCIyzFyE=
+github.com/CycloneDX/cyclonedx-go v0.6.0/go.mod h1:nQCiF4Tvrg5Ieu8qPhYMvzPGMu5I7fANZkrSsJjl5mg=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.0 h1:slsWYD/zyx7lCXoZVlvQrj0hPTM1HI4+v1sIda2yDvg=

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -17,6 +17,7 @@ package attestation
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io"
 	"reflect"
@@ -115,6 +116,8 @@ func GenerateStatement(opts GenerateOpts) (interface{}, error) {
 		return generateSPDXStatement(predicate, opts.Digest, opts.Repo, true)
 	case "cyclonedx":
 		return generateCycloneDXStatement(predicate, opts.Digest, opts.Repo)
+	case "cyclonedxxml":
+		return generateCycloneDXXMLStatement(predicate, opts.Digest, opts.Repo)
 	case "link":
 		return generateLinkStatement(predicate, opts.Digest, opts.Repo)
 	case "vuln":
@@ -250,6 +253,19 @@ func generateSPDXStatement(rawPayload []byte, digest string, repo string, parseJ
 func generateCycloneDXStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
 	var data interface{}
 	if err := json.Unmarshal(rawPayload, &data); err != nil {
+		return nil, err
+	}
+	return in_toto.SPDXStatement{
+		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateCycloneDX),
+		Predicate: CosignPredicate{
+			Data: data,
+		},
+	}, nil
+}
+
+func generateCycloneDXXMLStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
+	var data interface{}
+	if err := xml.Unmarshal(rawPayload, &data); err != nil {
 		return nil, err
 	}
 	return in_toto.SPDXStatement{

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -26,6 +26,7 @@ import (
 
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 
+	cyclonexd "github.com/CycloneDX/cyclonedx-go"
 	"github.com/in-toto/in-toto-golang/in_toto"
 )
 
@@ -264,7 +265,7 @@ func generateCycloneDXStatement(rawPayload []byte, digest string, repo string) (
 }
 
 func generateCycloneDXXMLStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
-	var data interface{}
+	var data cyclonexd.BOM
 	if err := xml.Unmarshal(rawPayload, &data); err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -265,7 +265,7 @@ func generateCycloneDXStatement(rawPayload []byte, digest string, repo string) (
 }
 
 func generateCycloneDXXMLStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
-	var data cyclonexd.BOM
+	data := cyclonexd.NewBOM()
 	if err := xml.Unmarshal(rawPayload, &data); err != nil {
 		return nil, err
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -242,6 +242,19 @@ func TestAttestVerifySPDXJSON(t *testing.T) {
 	)
 }
 
+func TestAttestVerifyCycloneDXXML(t *testing.T) {
+	attestationBytes, err := os.ReadFile("./testdata/bom-go-mod.cyclonedx.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	attestVerify(t,
+		"cyclonedxxml",
+		string(attestationBytes),
+		`predicate: Data: specVersion: "1.4"`,
+		`predicate: Data: specVersion: "7.7"`,
+	)
+}
+
 func TestAttestVerifyCycloneDXJSON(t *testing.T) {
 	attestationBytes, err := os.ReadFile("./testdata/bom-go-mod.cyclonedx.json")
 	if err != nil {

--- a/test/testdata/bom-go-mod.cyclonedx.xml
+++ b/test/testdata/bom-go-mod.cyclonedx.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" serialNumber="urn:uuid:b4c933a6-a48a-4bde-80c8-663ea0a4ec49" version="1">
+  <metadata>
+  </metadata>
+  <components>
+  </components>
+  <dependencies>
+  </dependencies>
+</bom>


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This adds to ability to unmarshal xml-formatted CycloneDX SBOMs and add them as attestation payloads.  Previous it was a little ambiguous as to which file format was expected for cyclonedx predicate types, and this removes that ambiguity.

Closes #2230 
#### Release Note
Updates available `cosign attest --type` options to include `cyclonedxxml`.  `--type cyclonedx` is unaffected and still expect a JSON formatted CycloneDX SBOM.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->