### PR TITLE
Fix BYO-root with intermediate to fetch intermediates from annotation

### DIFF
--- a/internal/pkg/cosign/fulcio/fulcioroots/fulcioroots.go
+++ b/internal/pkg/cosign/fulcio/fulcioroots/fulcioroots.go
@@ -59,7 +59,8 @@ func GetIntermediates() (*x509.CertPool, error) {
 
 func initRoots() (*x509.CertPool, *x509.CertPool, error) {
 	rootPool := x509.NewCertPool()
-	intermediatePool := x509.NewCertPool()
+	// intermediatePool should be nil if no intermediates are found
+	var intermediatePool *x509.CertPool
 
 	rootEnv := os.Getenv(altRoot)
 	if rootEnv != "" {
@@ -76,6 +77,9 @@ func initRoots() (*x509.CertPool, *x509.CertPool, error) {
 			if bytes.Equal(cert.RawSubject, cert.RawIssuer) {
 				rootPool.AddCert(cert)
 			} else {
+				if intermediatePool == nil {
+					intermediatePool = x509.NewCertPool()
+				}
 				intermediatePool.AddCert(cert)
 			}
 		}

--- a/internal/pkg/cosign/fulcio/fulcioroots/fulcioroots_test.go
+++ b/internal/pkg/cosign/fulcio/fulcioroots/fulcioroots_test.go
@@ -16,13 +16,19 @@ package fulcioroots
 
 import (
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/sigstore/cosign/test"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 )
 
+func resetState() {
+	rootsOnce = sync.Once{}
+}
+
 func TestGetFulcioRoots(t *testing.T) {
+	t.Cleanup(resetState)
 	rootCert, rootPriv, _ := test.GenerateRootCa()
 	rootPemCert, _ := cryptoutils.MarshalCertificateToPEM(rootCert)
 	subCert, _, _ := test.GenerateSubordinateCa(rootCert, rootPriv)
@@ -42,17 +48,46 @@ func TestGetFulcioRoots(t *testing.T) {
 	}
 	t.Setenv("SIGSTORE_ROOT_FILE", tmpCertFile.Name())
 
-	if rootCertPool, re := Get(); err != nil {
-		t.Fatalf("failed to get roots: %v", re)
+	if rootCertPool, err := Get(); err != nil {
+		t.Fatalf("failed to get roots: %v", err)
 	} else if len(rootCertPool.Subjects()) != 1 { // nolint:staticcheck
 		// ignore deprecation error because certificates do not contain from SystemCertPool
 		t.Errorf("expected 1 root certificate, got 0")
 	}
 
-	if subCertPool, ie := GetIntermediates(); err != nil {
-		t.Fatalf("failed to get intermediates: %v", ie)
+	if subCertPool, err := GetIntermediates(); err != nil {
+		t.Fatalf("failed to get intermediates: %v", err)
 	} else if len(subCertPool.Subjects()) != 1 { // nolint:staticcheck
 		// ignore deprecation error because certificates do not contain from SystemCertPool
 		t.Errorf("expected 1 intermediate certificate, got 0")
+	}
+}
+
+func TestGetFulcioRootsWithoutIntermediate(t *testing.T) {
+	t.Cleanup(resetState)
+	rootCert, _, _ := test.GenerateRootCa()
+	rootPemCert, _ := cryptoutils.MarshalCertificateToPEM(rootCert)
+
+	tmpCertFile, err := os.CreateTemp(t.TempDir(), "cosign_fulcio_root_*.cert")
+	if err != nil {
+		t.Fatalf("failed to create temp cert file: %v", err)
+	}
+	defer tmpCertFile.Close()
+	if _, err := tmpCertFile.Write(rootPemCert); err != nil {
+		t.Fatalf("failed to write cert file: %v", err)
+	}
+	t.Setenv("SIGSTORE_ROOT_FILE", tmpCertFile.Name())
+
+	if rootCertPool, err := Get(); err != nil {
+		t.Fatalf("failed to get roots: %v", err)
+	} else if len(rootCertPool.Subjects()) != 1 { // nolint:staticcheck
+		// ignore deprecation error because certificates do not contain from SystemCertPool
+		t.Errorf("expected 1 root certificate, got 0")
+	}
+
+	if subCertPool, err := GetIntermediates(); err != nil {
+		t.Fatalf("failed to get intermediates: %v", err)
+	} else if subCertPool != nil {
+		t.Errorf("expected no intermediate cert pool")
 	}
 }


### PR DESCRIPTION
This fixes a regression where intermediates, when not present in the intermediate certificate pool, would be fetched from the OCI chain annotation.

Ref #1554, which includes more details

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fixed bug where intermediate certificates were not automatically read from the OCI chain annotation

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->