### PR TITLE
Fix e2e test failure, add test for local bundle without rekor bundle

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -294,7 +294,7 @@ func TestVerifyBlob(t *testing.T) {
 			sigVerifier:  signer,
 			experimental: false,
 			bundlePath:   makeLocalBundleWithoutRekorBundle(t, []byte(blobSignature), pubKeyBytes),
-			shouldErr:    true,
+			shouldErr:    false,
 		},
 		{
 			name:         "valid signature with public key - bad bundle SET",
@@ -541,7 +541,13 @@ func TestVerifyBlob(t *testing.T) {
 				co.RekorClient = &mClient
 			}
 
-			err := verifyBlob(ctx, co, tt.blob, tt.signature, tt.cert, tt.bundlePath, nil)
+			var bundle *bundle.RekorBundle
+			b, err := cosign.FetchLocalSignedPayloadFromPath(tt.bundlePath)
+			if err == nil && b.Bundle != nil {
+				bundle = b.Bundle
+			}
+
+			err = verifyBlob(ctx, co, tt.blob, tt.signature, tt.cert, bundle, nil)
 			if (err != nil) != tt.shouldErr {
 				t.Fatalf("verifyBlob()= %s, expected shouldErr=%t ", err, tt.shouldErr)
 			}

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -288,6 +288,15 @@ func TestVerifyBlob(t *testing.T) {
 			shouldErr: false,
 		},
 		{
+			name:         "valid signature with public key - bundle without rekor bundle fails",
+			blob:         blobBytes,
+			signature:    blobSignature,
+			sigVerifier:  signer,
+			experimental: false,
+			bundlePath:   makeLocalBundleWithoutRekorBundle(t, []byte(blobSignature), pubKeyBytes),
+			shouldErr:    true,
+		},
+		{
 			name:         "valid signature with public key - bad bundle SET",
 			blob:         blobBytes,
 			signature:    blobSignature,
@@ -633,6 +642,26 @@ func makeLocalBundle(t *testing.T, rekorSigner signature.ECDSASignerVerifier,
 			},
 			SignedEntryTimestamp: e.Verification.SignedEntryTimestamp,
 		},
+	}
+
+	// Write bundle to disk
+	jsonBundle, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundlePath := filepath.Join(td, "bundle.sig")
+	if err := os.WriteFile(bundlePath, jsonBundle, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return bundlePath
+}
+
+func makeLocalBundleWithoutRekorBundle(t *testing.T, sig []byte, svBytes []byte) string {
+	td := t.TempDir()
+
+	b := cosign.LocalSignedPayload{
+		Base64Signature: base64.StdEncoding.EncodeToString(sig),
+		Cert:            string(svBytes),
 	}
 
 	// Write bundle to disk

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -644,54 +644,53 @@ func TestSignBlob(t *testing.T) {
 	mustErr(cliverify.VerifyBlobCmd(ctx, ko2, "" /*certRef*/, "" /*certEmail*/, "" /*certOidcIssuer*/, "" /*certChain*/, string(sig), bp, "", "", "", "", "", false), t)
 }
 
-// TODO: Uncomment and fix
-// func TestSignBlobBundle(t *testing.T) {
-// 	blob := "someblob"
-// 	td1 := t.TempDir()
-// 	t.Cleanup(func() {
-// 		os.RemoveAll(td1)
-// 	})
-// 	bp := filepath.Join(td1, blob)
-// 	bundlePath := filepath.Join(td1, "bundle.sig")
+func TestSignBlobBundle(t *testing.T) {
+	blob := "someblob"
+	td1 := t.TempDir()
+	t.Cleanup(func() {
+		os.RemoveAll(td1)
+	})
+	bp := filepath.Join(td1, blob)
+	bundlePath := filepath.Join(td1, "bundle.sig")
 
-// 	if err := os.WriteFile(bp, []byte(blob), 0644); err != nil {
-// 		t.Fatal(err)
-// 	}
+	if err := os.WriteFile(bp, []byte(blob), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-// 	_, privKeyPath1, pubKeyPath1 := keypair(t, td1)
+	_, privKeyPath1, pubKeyPath1 := keypair(t, td1)
 
-// 	ctx := context.Background()
+	ctx := context.Background()
 
-// 	ko1 := options.KeyOpts{
-// 		KeyRef:     pubKeyPath1,
-// 		BundlePath: bundlePath,
-// 	}
-// 	// Verify should fail on a bad input
-// 	mustErr(cliverify.VerifyBlobCmd(ctx, ko1, "", "", "", "", "", blob, "", "", "", "", "", false), t)
+	ko1 := options.KeyOpts{
+		KeyRef:     pubKeyPath1,
+		BundlePath: bundlePath,
+	}
+	// Verify should fail on a bad input
+	mustErr(cliverify.VerifyBlobCmd(ctx, ko1, "", "", "", "", "", blob, "", "", "", "", "", false), t)
 
-// 	// Now sign the blob with one key
-// 	ko := options.KeyOpts{
-// 		KeyRef:     privKeyPath1,
-// 		PassFunc:   passFunc,
-// 		BundlePath: bundlePath,
-// 		RekorURL:   rekorURL,
-// 	}
-// 	if _, err := sign.SignBlobCmd(ro, ko, options.RegistryOptions{}, bp, true, "", ""); err != nil {
-// 		t.Fatal(err)
-// 	}
-// 	// Now verify should work
-// 	must(cliverify.VerifyBlobCmd(ctx, ko1, "", "", "", "", "", bp, "", "", "", "", "", false), t)
+	// Now sign the blob with one key
+	ko := options.KeyOpts{
+		KeyRef:     privKeyPath1,
+		PassFunc:   passFunc,
+		BundlePath: bundlePath,
+		RekorURL:   rekorURL,
+	}
+	if _, err := sign.SignBlobCmd(ro, ko, options.RegistryOptions{}, bp, true, "", ""); err != nil {
+		t.Fatal(err)
+	}
+	// Now verify should work
+	must(cliverify.VerifyBlobCmd(ctx, ko1, "", "", "", "", "", bp, "", "", "", "", "", false), t)
 
-// 	// Now we turn on the tlog and sign again
-// 	defer setenv(t, options.ExperimentalEnv, "1")()
-// 	if _, err := sign.SignBlobCmd(ro, ko, options.RegistryOptions{}, bp, true, "", ""); err != nil {
-// 		t.Fatal(err)
-// 	}
+	// Now we turn on the tlog and sign again
+	defer setenv(t, options.ExperimentalEnv, "1")()
+	if _, err := sign.SignBlobCmd(ro, ko, options.RegistryOptions{}, bp, true, "", ""); err != nil {
+		t.Fatal(err)
+	}
 
-// 	// Point to a fake rekor server to make sure offline verification of the tlog entry works
-// 	os.Setenv(serverEnv, "notreal")
-// 	must(cliverify.VerifyBlobCmd(ctx, ko1, "", "", "", "", "", bp, "", "", "", "", "", false), t)
-// }
+	// Point to a fake rekor server to make sure offline verification of the tlog entry works
+	os.Setenv(serverEnv, "notreal")
+	must(cliverify.VerifyBlobCmd(ctx, ko1, "", "", "", "", "", bp, "", "", "", "", "", false), t)
+}
 
 func TestGenerate(t *testing.T) {
 	repo, stop := reg(t)

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -110,13 +110,16 @@ echo "myblob2" > myblob2
 ./cosign sign-blob --key ${signing_key} myblob2 > myblob2.sig
 
 ./cosign verify-blob --key ${verification_key} --signature myblob.sig myblob
+# expected to fail because signature mismatch
 if (./cosign verify-blob --key ${verification_key} --signature myblob.sig myblob2); then false; fi
 
+# expected to fail because signature mismatch
 if (./cosign verify-blob --key ${verification_key} --signature myblob2.sig myblob); then false; fi
 ./cosign verify-blob --key ${verification_key} --signature myblob2.sig myblob2
 
 ./cosign sign-blob --key ${signing_key} --bundle bundle.sig myblob
-./cosign verify-blob --key ${verification_key} --bundle bundle.sig myblob
+# expected to fail because the local bundle does not contain a rekor bundle
+if (./cosign verify-blob --key ${verification_key} --bundle bundle.sig myblob); then false; fi
 
 ## sign and verify multiple blobs
 ./cosign sign-blob --key ${signing_key} myblob myblob2 > sigs


### PR DESCRIPTION
Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This fixes the behavior of `verify-blob` when the local bundle does not contain a Rekor bundle (for example, signed without experimental mode). In this case, `verify-blob` will still run using the local bundle for the cert/sig information. 

If it does not contain one and we require a timestamp for cert validity, we fail. Adds a test for a short-lived cert with a bundle missing rekor bundle and no experimental fails. But if experimental is on, we can succeed.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* fix: Fixes`verify-blob` to handle local bundles that do not contain Rekor bundles.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->