### PR TITLE
fix: fix cert chain validation for verify-blob in non-experimental mode

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -107,7 +107,7 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 			co.RekorClient = rekorClient
 		}
 	}
-	if certRef == "" || options.EnableExperimental() {
+	if options.EnableExperimental() {
 		co.RootCerts, err = fulcio.GetRoots()
 		if err != nil {
 			return fmt.Errorf("getting Fulcio roots: %w", err)
@@ -145,6 +145,14 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 			return err
 		}
 		if certChain == "" {
+			co.RootCerts, err = fulcio.GetRoots()
+			if err != nil {
+				return fmt.Errorf("getting Fulcio roots: %w", err)
+			}
+			co.IntermediateCerts, err = fulcio.GetIntermediates()
+			if err != nil {
+				return fmt.Errorf("getting Fulcio intermediates: %w", err)
+			}
 			co.SigVerifier, err = cosign.ValidateAndUnpackCert(cert, co)
 			if err != nil {
 				return err
@@ -178,10 +186,20 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 			// check if cert is actually a public key
 			co.SigVerifier, err = sigs.LoadPublicKeyRaw(certBytes, crypto.SHA256)
 		} else {
+			if certChain == "" {
+				co.RootCerts, err = fulcio.GetRoots()
+				if err != nil {
+					return fmt.Errorf("getting Fulcio roots: %w", err)
+				}
+				co.IntermediateCerts, err = fulcio.GetIntermediates()
+				if err != nil {
+					return fmt.Errorf("getting Fulcio intermediates: %w", err)
+				}
+			}
 			co.SigVerifier, err = cosign.ValidateAndUnpackCert(cert, co)
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("loading verifier from bundle: %w", err)
 		}
 		bundle = b.Bundle
 	// No certificate is provided: search by artifact sha in the TLOG.

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -1038,7 +1038,7 @@ func TestVerifyBlobCmdInvalidRootCA(t *testing.T) {
 	keyless := newKeylessStack(t)
 	// Change the keyless stack.
 	_ = newKeylessStack(t)
-	t.Run("Invalid certificate root explicit certRef", func(t *testing.T) {
+	t.Run("Invalid certificate root when specifying cert via certRef", func(t *testing.T) {
 		identity := "hello@foo.com"
 		issuer := "issuer"
 		leafCert, _, leafPemCert, signer := keyless.genLeafCert(t, identity, issuer)
@@ -1077,7 +1077,7 @@ func TestVerifyBlobCmdInvalidRootCA(t *testing.T) {
 			t.Fatalf("expected error with invalid root CA, got %v", err)
 		}
 	})
-	t.Run("Invalid certificate root explicit bundle", func(t *testing.T) {
+	t.Run("Invalid certificate root when specifying cert in bundle", func(t *testing.T) {
 		identity := "hello@foo.com"
 		issuer := "issuer"
 		leafCert, _, leafPemCert, signer := keyless.genLeafCert(t, identity, issuer)

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -955,7 +955,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			t.Fatalf("expected error with mismatched issuer, got %v", err)
 		}
 	})
-	t.Run("Intermediate root not explicit in non-experimental mode", func(t *testing.T) {
+	t.Run("Implicit Fulcio chain with bundle in non-experimental mode", func(t *testing.T) {
 		identity := "hello@foo.com"
 		issuer := "issuer"
 		leafCert, _, leafPemCert, signer := keyless.genLeafCert(t, identity, issuer)
@@ -994,7 +994,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			t.Fatalf("expected success without specifying the intermediates, got %v", err)
 		}
 	})
-	t.Run("Intermediate root explicit in non-experimental mode", func(t *testing.T) {
+	t.Run("Explicit Fulcio chain with bundle in non-experimental mode", func(t *testing.T) {
 		identity := "hello@foo.com"
 		issuer := "issuer"
 		leafCert, _, leafPemCert, signer := keyless.genLeafCert(t, identity, issuer)


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
* fix: Pulls Fulcio root and intermediate when `--certificate-chain` is not passed into `verify-blob`.

In non-experimental mode, we incorrectly only loaded Fulcio roots to verify against when `certRef == ""`. 

When a `certRef != ""` in non-experimental mode, like, user provides cert with offline bundle without specifying a custom cert chain, then we would NOT load in the Fulcio roots. This would cause certificate validation failure.

Instead, whenever `certChain == ""` we will load in fulcio roots in non-experimental mode, either if you provide a cert or a bundle.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* fix: Pulls Fulcio root and intermediate when `--certificate-chain` is not passed into `verify-blob`. The v1.12.0 release introduced a regression: when `COSIGN_EXPERIMENTAL` was not set, cosign `verify-blob` would check a` --certificate` (without a `--certificate-chain` provided) against the operating system root CA bundle. In this release, Cosign checks the certificate against Fulcio's CA root instead (restoring the earlier behavior).

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->