### PR TITLE
Check error on chain verification failure

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -166,7 +166,7 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 			}
 			co.SigVerifier, err = cosign.ValidateAndUnpackCertWithChain(cert, chain, co)
 			if err != nil {
-				return err
+				return fmt.Errorf("verifying certRef with certChain: %w", err)
 			}
 		}
 	case ko.BundlePath != "":
@@ -197,6 +197,9 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 					return fmt.Errorf("getting Fulcio intermediates: %w", err)
 				}
 				co.SigVerifier, err = cosign.ValidateAndUnpackCert(cert, co)
+				if err != nil {
+					return fmt.Errorf("verifying certificate from bundle: %w", err)
+				}
 			} else {
 				// Verify certificate with chain
 				chain, err := loadCertChainFromFileOrURL(certChain)
@@ -205,7 +208,7 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 				}
 				co.SigVerifier, err = cosign.ValidateAndUnpackCertWithChain(cert, chain, co)
 				if err != nil {
-					return fmt.Errorf("verifying certificate with chain: %w", err)
+					return fmt.Errorf("verifying certificate from bundle with chain: %w", err)
 				}
 			}
 		}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -204,6 +204,9 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail,
 					return err
 				}
 				co.SigVerifier, err = cosign.ValidateAndUnpackCertWithChain(cert, chain, co)
+				if err != nil {
+					return fmt.Errorf("verifying certificate with chain: %w", err)
+				}
 			}
 		}
 		if err != nil {

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -1033,6 +1033,55 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			t.Fatalf("expected success specifying the intermediates, got %v", err)
 		}
 	})
+	t.Run("Explicit Fulcio mismatched chain failure", func(t *testing.T) {
+		identity := "hello@foo.com"
+		issuer := "issuer"
+		leafCert, _, leafPemCert, signer := keyless.genLeafCert(t, identity, issuer)
+
+		// Create blob
+		blob := "someblob"
+
+		// Sign blob with private key
+		sig, err := signer.SignMessage(bytes.NewReader([]byte(blob)))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Create bundle
+		entry := genRekorEntry(t, hashedrekord.KIND, hashedrekord.New().DefaultVersion(), []byte(blob), leafPemCert, sig)
+		b := createBundle(t, sig, leafPemCert, keyless.rekorLogID, leafCert.NotBefore.Unix()+1, entry)
+		b.Bundle.SignedEntryTimestamp = keyless.rekorSignPayload(t, b.Bundle.Payload)
+		bundlePath := writeBundleFile(t, keyless.td, b, "bundle.json")
+		blobPath := writeBlobFile(t, keyless.td, blob, "blob.txt")
+
+		rootCert, _, _ := test.GenerateRootCa()
+		rootPemCert, _ := cryptoutils.MarshalCertificateToPEM(rootCert)
+		tmpChainFile, err := os.CreateTemp(t.TempDir(), "cosign_fulcio_root_*.cert")
+		if err != nil {
+			t.Fatalf("failed to create temp chain file: %v", err)
+		}
+		defer tmpChainFile.Close()
+		if _, err := tmpChainFile.Write(rootPemCert); err != nil {
+			t.Fatalf("failed to write chain file: %v", err)
+		}
+
+		// Verify command
+		err = VerifyBlobCmd(context.Background(),
+			options.KeyOpts{BundlePath: bundlePath},
+			"",                  /*certRef*/
+			identity,            /*certEmail*/
+			issuer,              /*certOidcIssuer*/
+			tmpChainFile.Name(), /*certChain*/
+			"",                  /*sigRef*/ // Sig is fetched from bundle
+			blobPath,            /*blobRef*/
+			// GitHub identity flags start
+			"", "", "", "", "",
+			// GitHub identity flags end
+			false /*enforceSCT*/)
+		if err == nil || !strings.Contains(err.Error(), "verifying certificate with chain: x509: certificate signed by unknown authority") {
+			t.Fatalf("expected error with mismatched root, got %v", err)
+		}
+	})
 }
 
 func TestVerifyBlobCmdInvalidRootCA(t *testing.T) {

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -1078,7 +1078,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			"", "", "", "", "",
 			// GitHub identity flags end
 			false /*enforceSCT*/)
-		if err == nil || !strings.Contains(err.Error(), "verifying certificate with chain: x509: certificate signed by unknown authority") {
+		if err == nil || !strings.Contains(err.Error(), "verifying certificate from bundle with chain: x509: certificate signed by unknown authority") {
 			t.Fatalf("expected error with mismatched root, got %v", err)
 		}
 	})


### PR DESCRIPTION
This fails certificate verification at the correct step.

err was declared in the else scope, but was not checked before exiting the conditional. Therefore, if a failure occurred, we didn't return an error. However, later in the code, in verifyBlob, we do an extra check for if the certificate is valid. Because we haven't set the root and intermediate certs yet, cert verification fails.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->