### PR TITLE
Fix: Create a static copy of signatures as part of verification.

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -506,6 +506,11 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 	validationErrs := []string{}
 
 	for _, sig := range sl {
+		sig, err := static.Copy(sig)
+		if err != nil {
+			validationErrs = append(validationErrs, err.Error())
+			continue
+		}
 		verified, err := VerifyImageSignature(ctx, sig, h, co)
 		bundleVerified = bundleVerified || verified
 		if err != nil {
@@ -702,6 +707,11 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 
 	validationErrs := []string{}
 	for _, att := range sl {
+		att, err := static.Copy(att)
+		if err != nil {
+			validationErrs = append(validationErrs, err.Error())
+			continue
+		}
 		if err := func(att oci.Signature) error {
 			verifier := co.SigVerifier
 			if verifier == nil {


### PR DESCRIPTION
:bug: As part of verifying signatures and annotations create copies of what we are downloading to avoid later calls to `Payload()` redownloading the signature blob.

Examining trace data for policy-controller downstream, I observed that the same signature blob data was being fetched three times as part of verification.  I believe for attestations this may be even worse because we have an additional call to `Payload()` where we parse out the contents of the attestation's predicate for policy evaluation.

This change eagerly fetches the signature metadata and stores it in a clone via `static.Copy`.  This clone is what we verify, and if it fails verification is it immediately discarded.  However, if it passes verification this clone is returned as one of the "verified signatures" that the downstream logic can now access without refetching data from the registry.

UPDATE: I have confirmed downstream by manually vendoring this in that the redundant blob fetches go away and the admission webhook requests are noticeably faster.  It isn't quite 3x because of other overheads, but it is pretty considerable.

/kind bug

Signed-off-by: Matt Moore <mattmoor@chainguard.dev>

#### Release Note
Speed up some of the verification methods by eliminating redundant fetches of the signature blob data from the registry using a temporary in-memory copy.

#### Documentation
