### PR TITLE
bump mongo dep to avoid retracted version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -267,7 +267,7 @@ require (
 	go.etcd.io/etcd/server/v3 v3.6.0-alpha.0 // indirect
 	go.etcd.io/etcd/tests/v3 v3.6.0-alpha.0 // indirect
 	go.etcd.io/etcd/v3 v3.6.0-alpha.0 // indirect
-	go.mongodb.org/mongo-driver v1.10.0 // indirect
+	go.mongodb.org/mongo-driver v1.10.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.28.0 // indirect
 	go.opentelemetry.io/otel v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1685,6 +1685,8 @@ go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4x
 go.mongodb.org/mongo-driver v1.8.3/go.mod h1:0sQWfOeY63QTntERDJJ/0SuKK0T1uVSgKCuAROlKEPY=
 go.mongodb.org/mongo-driver v1.10.0 h1:UtV6N5k14upNp4LTduX0QCufG124fSu25Wz9tu94GLg=
 go.mongodb.org/mongo-driver v1.10.0/go.mod h1:wsihk0Kdgv8Kqu1Anit4sfK+22vSFbUrAVEYRhCXrA8=
+go.mongodb.org/mongo-driver v1.10.2 h1:4Wk3cnqOrQCn0P92L3/mmurMxzdvWWs5J9jinAVKD+k=
+go.mongodb.org/mongo-driver v1.10.2/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
 go.mozilla.org/mozlog v0.0.0-20170222151521-4bb13139d403/go.mod h1:jHoPAGnDrCy6kaI2tAze5Prf0Nr0w/oNkROt2lw3n3o=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=


### PR DESCRIPTION
#### Summary

cosign depends on mongo via `github.com/go-openapi/strfmt`

mongo has retracted v0.10.0 due to a possible data corruption bug (that I don't believe affects cosign in any way at all), which means folks that `go get ./...` from the cosign repo, or any dependent of cosign, see this scary sounding warning:

```
go: warning: go.mongodb.org/mongo-driver@v1.10.0: retracted by module author: Contains a possible data corruption bug in RewrapManyDataKey when using libmongocrypt versions less than 1.5.2.
go: to switch to the latest unretracted version, run:
	go get go.mongodb.org/mongo-driver@latest
```

This bumps our dep on mongo-driver using:

```
go get -u github.com/go-openapi/strfmt@latest
```

...so the warning goes away.

see also https://github.com/ko-build/ko/issues/832


#### Release Note

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->