### PR TITLE
Air gap support

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -39,7 +39,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.4.12"
+      SCAFFOLDING_RELEASE_VERSION: "v0.4.13"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -33,6 +33,9 @@ jobs:
       matrix:
         k8s-version:
         - v1.24.x
+        tuf-root:
+        - remote
+        - air-gap
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
@@ -83,10 +86,22 @@ jobs:
         echo Created image $demoimage
         popd
 
-    - name: Initialize with our custom TUF root
+    - name: Initialize with our custom TUF root pointing to remote root
+      if: ${{ matrix.tuf-root == 'remote' }}
       run: |
         TUF_MIRROR=$(kubectl -n tuf-system get ksvc tuf -ojsonpath='{.status.url}')
         ./cosign initialize --mirror $TUF_MIRROR --root ./root.json
+
+    - name: Initialize with custom TUF root pointing to local filesystem
+      if: ${{ matrix.tuf-root == 'air-gap' }}
+      run: |
+        # Grab the compressed repository for airgap testing.
+        kubectl -n tuf-system get secrets tuf-root -ojsonpath='{.data.repository}'  | base64 -d > ./repository.tar.gz
+        tar -zxvf ./repository.tar.gz
+        PWD=$(pwd)
+        ROOT=${PWD}/repository/1.root.json
+        REPOSITORY=${PWD}/repository
+        ./cosign initialize --root ${ROOT} --mirror file://${REPOSITORY}
 
     - name: Sign demoimage with cosign
       run: |

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -31,7 +31,7 @@ var _ Interface = (*InitializeOptions)(nil)
 // AddFlags implements Interface
 func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Mirror, "mirror", tuf.DefaultRemoteRoot,
-		"GCS bucket to a SigStore TUF repository or HTTP(S) base URL")
+		"GCS bucket to a SigStore TUF repository, or HTTP(S) base URL, or file:/// for local filestore remote (air-gap)")
 
 	cmd.Flags().StringVar(&o.Root, "root", "",
 		"path to trusted initial root. defaults to embedded root")

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -41,7 +41,7 @@ cosign initialize -mirror <url> -root <url>
 
 ```
   -h, --help            help for initialize
-      --mirror string   GCS bucket to a SigStore TUF repository or HTTP(S) base URL (default "https://sigstore-tuf-root.storage.googleapis.com")
+      --mirror string   GCS bucket to a SigStore TUF repository, or HTTP(S) base URL, or file:/// for local filestore remote (air-gap) (default "https://sigstore-tuf-root.storage.googleapis.com")
       --root string     path to trusted initial root. defaults to embedded root
 ```
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Use newer version of theupdateframework/go-tuf, sigstore/sigstore
https://github.com/theupdateframework/go-tuf/pull/397
https://github.com/sigstore/sigstore/pull/715

This allows one to specify a local filesystem as a TUF remote so there's no network calls related to TUF.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note

 * Add support for air gap scenarios by being able to initialize TUF root where remote is local filesystem.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->