### PR TITLE
Fix flag description: "sign" --> "comment"

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -55,7 +55,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 		"whether to check the claims found")
 
 	cmd.Flags().StringVar(&o.Attachment, "attachment", "",
-		"related image attachment to sign (sbom), default none")
+		"related image attachment to verify (sbom), default none")
 
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "json",
 		"output format for the signing image information (json|text)")


### PR DESCRIPTION
This is probably a copy/paste-mistake, since the text is the same as in https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/options/sign.go

The help text was originally added by https://github.com/sigstore/cosign/pull/615

#### Release Note
NONE
