### PR TITLE
Fix option description: "sign" --> "verify"

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -55,7 +55,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 		"whether to check the claims found")
 
 	cmd.Flags().StringVar(&o.Attachment, "attachment", "",
-		"related image attachment to sign (sbom), default none")
+		"related image attachment to verify (sbom), default none")
 
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "json",
 		"output format for the signing image information (json|text)")

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -54,7 +54,7 @@ cosign dockerfile verify [flags]
 ```
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
   -a, --annotations strings                                                                      extra key=value pairs to sign
-      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment string                                                                        related image attachment to verify (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --base-image-only                                                                          only verify the base image (the last FROM image in the Dockerfile)
       --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -49,7 +49,7 @@ cosign manifest verify [flags]
 ```
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
   -a, --annotations strings                                                                      extra key=value pairs to sign
-      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment string                                                                        related image attachment to verify (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -68,7 +68,7 @@ cosign verify [flags]
 ```
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries. Don't use this for anything but testing
   -a, --annotations strings                                                                      extra key=value pairs to sign
-      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment string                                                                        related image attachment to verify (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate


### PR DESCRIPTION
This is probably a copy/paste-mistake, since the text is the same as in https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/options/sign.go

The help text was originally added by https://github.com/sigstore/cosign/pull/615

#### Release Note
NONE
