### PR TITLE
Better help text to sign and verify SBOM

### DIFF
--- a/cmd/cosign/cli/attach.go
+++ b/cmd/cosign/cli/attach.go
@@ -70,7 +70,7 @@ func attachSBOM() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "WARNING: Attaching SBOMs this way does not sign them. If you want to sign them, use 'cosign attest -predicate %s -key <key path>' or 'cosign sign -key <key path> <sbom image>'.\n", o.SBOM)
+			fmt.Fprintf(os.Stderr, "WARNING: Attaching SBOMs this way does not sign them. If you want to sign them, use 'cosign attest --predicate %s --key <key path>' or 'cosign sign --key <key path> --attachment sbom <image uri>'.\n", o.SBOM)
 			return attach.SBOMCmd(cmd.Context(), o.Registry, o.SBOM, mediaType, args[0])
 		},
 	}

--- a/cmd/cosign/cli/download.go
+++ b/cmd/cosign/cli/download.go
@@ -68,7 +68,7 @@ func downloadSBOM() *cobra.Command {
 		Example: "  cosign download sbom <image uri>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintln(os.Stderr, "WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>' or verify its signature.")
+			fmt.Fprintln(os.Stderr, "WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>' or verify its signature using 'cosign verify --key <key path> --attachment sbom <image uri>'.")
 			_, err := download.SBOMCmd(cmd.Context(), *o, *do, args[0], cmd.OutOrStdout())
 			return err
 		},


### PR DESCRIPTION
https://github.com/sigstore/cosign/pull/615 introduced easier ways to sign and verify sbom images, but didn't document them.

This PR nudges users to these new options and also replaces the deprecated `-key` and `-predicate` options with their modern double-dash variants.