### PR TITLE
Add --output-attestation flag to attest-blob and remove experimental signing

### DIFF
--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -40,7 +40,7 @@ import (
 )
 
 // nolint
-func AttestBlobCmd(ctx context.Context, ko options.KeyOpts, artifactPath string, artifactHash string, certPath string, certChainPath string, predicatePath string, predicateType string, timeout time.Duration, outputSignature string) error {
+func AttestBlobCmd(ctx context.Context, ko options.KeyOpts, artifactPath string, artifactHash string, certPath string, certChainPath string, predicatePath string, predicateType string, timeout time.Duration, outputSignature, outputAttestation string) error {
 	// TODO: Add in experimental keyless mode
 	if !options.OneOf(ko.KeyRef, ko.Sk) {
 		return &options.KeyParseError{}
@@ -85,7 +85,7 @@ func AttestBlobCmd(ctx context.Context, ko options.KeyOpts, artifactPath string,
 	}
 	wrapped := dsse.WrapSigner(sv, types.IntotoPayloadType)
 
-	fmt.Fprintln(os.Stderr, "Using payload from:", predicatePath)
+	fmt.Fprintln(os.Stderr, "Using predicate from:", predicatePath)
 	predicate, err := os.Open(predicatePath)
 	if err != nil {
 		return err
@@ -122,6 +122,15 @@ func AttestBlobCmd(ctx context.Context, ko options.KeyOpts, artifactPath string,
 		fmt.Fprintf(os.Stderr, "Signature written in %s\n", outputSignature)
 	} else {
 		fmt.Fprintln(os.Stdout, string(sig))
+	}
+
+	if outputAttestation != "" {
+		if err := os.WriteFile(outputAttestation, payload, 0600); err != nil {
+			return fmt.Errorf("create signature file: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "Attestation written in %s\n", outputAttestation)
+	} else {
+		fmt.Fprintln(os.Stdout, string(payload))
 	}
 
 	return nil

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -31,11 +31,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
-	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/attestation"
-	cbundle "github.com/sigstore/cosign/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
@@ -43,21 +40,14 @@ import (
 )
 
 // nolint
-func AttestBlobCmd(ctx context.Context, ko options.KeyOpts, artifactPath string, artifactHash string, certPath string, certChainPath string, noUpload bool, predicatePath string, force bool, predicateType string, replace bool, timeout time.Duration, outputSignature string) error {
-	// A key file or token is required unless we're in experimental mode!
-	if options.EnableExperimental() {
-		if options.NOf(ko.KeyRef, ko.Sk) > 1 {
-			return &options.KeyParseError{}
-		}
-	} else {
-		if !options.OneOf(ko.KeyRef, ko.Sk) {
-			return &options.KeyParseError{}
-		}
+func AttestBlobCmd(ctx context.Context, ko options.KeyOpts, artifactPath string, artifactHash string, certPath string, certChainPath string, predicatePath string, predicateType string, timeout time.Duration, outputSignature string) error {
+	// TODO: Add in experimental keyless mode
+	if !options.OneOf(ko.KeyRef, ko.Sk) {
+		return &options.KeyParseError{}
 	}
 
 	var artifact []byte
 	var hexDigest string
-	var rekorBytes []byte
 	var err error
 
 	if artifactHash == "" {
@@ -119,61 +109,19 @@ func AttestBlobCmd(ctx context.Context, ko options.KeyOpts, artifactPath string,
 		return err
 	}
 
-	fmt.Println("Payload:")
-	fmt.Println(string(payload))
-
 	sig, err := wrapped.SignMessage(bytes.NewReader(payload), signatureoptions.WithContext(ctx))
 	if err != nil {
 		return errors.Wrap(err, "signing")
 	}
 
-	// Check whether we should be uploading to the transparency log
-	signedPayload := cosign.LocalSignedPayload{}
-	if options.EnableExperimental() {
-		rekorBytes, err := sv.Bytes(ctx)
-		if err != nil {
-			return err
-		}
-		rekorClient, err := rekor.NewClient(ko.RekorURL)
-		if err != nil {
-			return err
-		}
-		entry, err := cosign.TLogUploadInTotoAttestation(ctx, rekorClient, sig, rekorBytes)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintln(os.Stderr, "tlog entry created with index:", *entry.LogIndex)
-		signedPayload.Bundle = cbundle.EntryToBundle(entry)
-	}
-
-	// if bundle is specified, just do that and ignore the rest
-	if ko.BundlePath != "" {
-		signedPayload.Base64Signature = base64.StdEncoding.EncodeToString(sig)
-		signedPayload.Cert = base64.StdEncoding.EncodeToString(rekorBytes)
-
-		contents, err := json.Marshal(signedPayload)
-		if err != nil {
-			return err
-		}
-		if err := os.WriteFile(ko.BundlePath, contents, 0600); err != nil {
-			return fmt.Errorf("create bundle file: %w", err)
-		}
-		fmt.Printf("Bundle wrote in the file %s\n", ko.BundlePath)
-	}
-
-	// TODO: Write the certificate to file if specified via flag
 	sig = []byte(base64.StdEncoding.EncodeToString(sig))
 	if outputSignature != "" {
 		if err := os.WriteFile(outputSignature, sig, 0600); err != nil {
 			return fmt.Errorf("create signature file: %w", err)
 		}
-		fmt.Printf("Signature written in %s\n", outputSignature)
+		fmt.Fprintf(os.Stderr, "Signature written in %s\n", outputSignature)
 	} else {
-		fmt.Println(string(sig))
-	}
-
-	if rekorBytes != nil {
-		fmt.Println(string(rekorBytes))
+		fmt.Fprintln(os.Stdout, string(sig))
 	}
 
 	return nil

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -28,10 +28,7 @@ func AttestBlob() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "attest-blob",
 		Short: "Attest the supplied blob.",
-		Example: `  cosign attest-blob --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <BLOB uri>
-
-  # attach an attestation to a blob Google sign-in (experimental)
-  COSIGN_EXPERIMENTAL=1 cosign attest-blob --timeout 90s --predicate <FILE> --type <TYPE> <BLOB>
+		Example: `  cosign attest-blob --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--f] [--r] <BLOB uri>
 
   # attach an attestation to a blob with a local key pair file
   cosign attest-blob --predicate <FILE> --type <TYPE> --key cosign.key <BLOB>
@@ -50,27 +47,15 @@ func AttestBlob() *cobra.Command {
 
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			oidcClientSecret, err := o.OIDC.ClientSecret()
-			if err != nil {
-				return err
-			}
 			ko := options.KeyOpts{
-				KeyRef:                   o.Key,
-				PassFunc:                 generate.GetPass,
-				Sk:                       o.SecurityKey.Use,
-				Slot:                     o.SecurityKey.Slot,
-				FulcioURL:                o.Fulcio.URL,
-				IDToken:                  o.Fulcio.IdentityToken,
-				InsecureSkipFulcioVerify: o.Fulcio.InsecureSkipFulcioVerify,
-				RekorURL:                 o.Rekor.URL,
-				OIDCIssuer:               o.OIDC.Issuer,
-				OIDCClientID:             o.OIDC.ClientID,
-				OIDCClientSecret:         oidcClientSecret,
-				OIDCRedirectURL:          o.OIDC.RedirectURL,
+				KeyRef:   o.Key,
+				PassFunc: generate.GetPass,
+				Sk:       o.SecurityKey.Use,
+				Slot:     o.SecurityKey.Slot,
 			}
 			for _, artifact := range args {
-				if err := attest.AttestBlobCmd(cmd.Context(), ko, artifact, o.Hash, o.Cert, o.CertChain, o.NoUpload,
-					o.Predicate.Path, o.Force, o.Predicate.Type, o.Replace, ro.Timeout, o.OutputSignature); err != nil {
+				if err := attest.AttestBlobCmd(cmd.Context(), ko, artifact, o.Hash, o.Cert, o.CertChain,
+					o.Predicate.Path, o.Predicate.Type, ro.Timeout, o.OutputSignature); err != nil {
 					return errors.Wrapf(err, "attesting %s", artifact)
 				}
 			}

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -30,8 +30,8 @@ func AttestBlob() *cobra.Command {
 		Short: "Attest the supplied blob.",
 		Example: `  cosign attest-blob --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--f] [--r] <BLOB uri>
 
-  # attach an attestation to a blob with a local key pair file
-  cosign attest-blob --predicate <FILE> --type <TYPE> --key cosign.key <BLOB>
+  # attach an attestation to a blob with a local key pair file and print the attestation
+  cosign attest-blob --predicate <FILE> --type <TYPE> --key cosign.key --output-attestation <path> <BLOB>
 
   # attach an attestation to a blob with a key pair stored in Azure Key Vault
   cosign attest-blob --predicate <FILE> --type <TYPE> --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <BLOB>
@@ -55,7 +55,7 @@ func AttestBlob() *cobra.Command {
 			}
 			for _, artifact := range args {
 				if err := attest.AttestBlobCmd(cmd.Context(), ko, artifact, o.Hash, o.Cert, o.CertChain,
-					o.Predicate.Path, o.Predicate.Type, ro.Timeout, o.OutputSignature); err != nil {
+					o.Predicate.Path, o.Predicate.Type, ro.Timeout, o.OutputSignature, o.OutputAttestation); err != nil {
 					return errors.Wrapf(err, "attesting %s", artifact)
 				}
 			}

--- a/cmd/cosign/cli/options/attest_blob.go
+++ b/cmd/cosign/cli/options/attest_blob.go
@@ -22,16 +22,17 @@ import (
 
 // AttestOptions is the top level wrapper for the attest command.
 type AttestBlobOptions struct {
-	Key             string
-	Cert            string
-	CertChain       string
-	NoUpload        bool
-	Force           bool
-	Recursive       bool
-	Replace         bool
-	Timeout         time.Duration
-	Hash            string
-	OutputSignature string
+	Key               string
+	Cert              string
+	CertChain         string
+	NoUpload          bool
+	Force             bool
+	Recursive         bool
+	Replace           bool
+	Timeout           time.Duration
+	Hash              string
+	OutputSignature   string
+	OutputAttestation string
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -59,6 +60,9 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 	_ = cmd.Flags().SetAnnotation("output-signature", cobra.BashCompFilenameExt, []string{})
+
+	cmd.Flags().StringVar(&o.OutputAttestation, "output-attestation", "",
+		"write the attestation to FILE")
 
 	cmd.Flags().StringVar(&o.CertChain, "cert-chain", "",
 		"path to a list of CA X.509 certificates in PEM format which will be needed "+

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -9,13 +9,10 @@ cosign attest-blob [flags]
 ### Examples
 
 ```
-  cosign attest-blob --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <BLOB uri>
+  cosign attest-blob --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--f] [--r] <BLOB uri>
 
-  # attach an attestation to a blob Google sign-in (experimental)
-  COSIGN_EXPERIMENTAL=1 cosign attest-blob --timeout 90s --predicate <FILE> --type <TYPE> <BLOB>
-
-  # attach an attestation to a blob with a local key pair file
-  cosign attest-blob --predicate <FILE> --type <TYPE> --key cosign.key <BLOB>
+  # attach an attestation to a blob with a local key pair file and print the attestation
+  cosign attest-blob --predicate <FILE> --type <TYPE> --key cosign.key --output-attestation <path> <BLOB>
 
   # attach an attestation to a blob with a key pair stored in Azure Key Vault
   cosign attest-blob --predicate <FILE> --type <TYPE> --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <BLOB>
@@ -49,6 +46,7 @@ cosign attest-blob [flags]
       --oidc-issuer string               [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-provider string             [EXPERIMENTAL] Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github, filesystem]
       --oidc-redirect-url string         [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
+      --output-attestation string        write the attestation to FILE
       --output-signature string          write the signature to FILE
       --predicate string                 path to the predicate file.
       --rekor-url string                 [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")


### PR DESCRIPTION
We can add in experimental signing later, but for now I want to stick with just the `--key` flag so it's easier to add comprehensive tests