### PR TITLE
verify: remove SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY test env var for using a key from rekor's API 

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -364,7 +364,7 @@ func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 		fallthrough
 	// We are provided a log entry, possibly from above, or search.
 	case e != nil:
-		if err := cosign.VerifyTLogEntry(ctx, e); err != nil {
+		if err := cosign.VerifyTLogEntry(ctx, nil, e); err != nil {
 			return err
 		}
 
@@ -488,7 +488,7 @@ func verifyRekorBundle(ctx context.Context, bundle *bundle.RekorBundle,
 		return nil, err
 	}
 
-	publicKeys, err := cosign.GetRekorPubs(ctx)
+	publicKeys, err := cosign.GetRekorPubs(ctx, nil)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving rekor public key: %w", err)
 	}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -333,7 +333,7 @@ func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 				return fmt.Errorf("marshalling pubkey: %w", err)
 			}
 		}
-		bundle, err := verifyRekorBundle(ctx, bundle, co.RekorClient, blobBytes, sig, svBytes)
+		bundle, err := verifyRekorBundle(ctx, bundle, blobBytes, sig, svBytes)
 		if err != nil {
 			// Return when the provided bundle fails verification. (Do not fallback).
 			return err
@@ -364,7 +364,7 @@ func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 		fallthrough
 	// We are provided a log entry, possibly from above, or search.
 	case e != nil:
-		if err := cosign.VerifyTLogEntry(ctx, co.RekorClient, e); err != nil {
+		if err := cosign.VerifyTLogEntry(ctx, e); err != nil {
 			return err
 		}
 
@@ -482,15 +482,13 @@ func payloadBytes(blobRef string) ([]byte, error) {
 	return blobBytes, nil
 }
 
-// TODO: RekorClient can be removed when SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY
-// is removed.
-func verifyRekorBundle(ctx context.Context, bundle *bundle.RekorBundle, rekorClient *client.Rekor,
+func verifyRekorBundle(ctx context.Context, bundle *bundle.RekorBundle,
 	blobBytes []byte, sig string, pubKeyBytes []byte) (*bundle.RekorPayload, error) {
 	if err := verifyBundleMatchesData(ctx, bundle, blobBytes, pubKeyBytes, []byte(sig)); err != nil {
 		return nil, err
 	}
 
-	publicKeys, err := cosign.GetRekorPubs(ctx, rekorClient)
+	publicKeys, err := cosign.GetRekorPubs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving rekor public key: %w", err)
 	}

--- a/pkg/cosign/env/env.go
+++ b/pkg/cosign/env/env.go
@@ -52,10 +52,9 @@ const (
 	VariableRepository       Variable = "COSIGN_REPOSITORY"
 
 	// Sigstore environment variables
-	VariableSigstoreCTLogPublicKeyFile  Variable = "SIGSTORE_CT_LOG_PUBLIC_KEY_FILE"
-	VariableSigstoreRootFile            Variable = "SIGSTORE_ROOT_FILE"
-	VariableSigstoreTrustRekorPublicKey Variable = "SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY"
-	VariableSigstoreRekorPublicKey      Variable = "SIGSTORE_REKOR_PUBLIC_KEY"
+	VariableSigstoreCTLogPublicKeyFile Variable = "SIGSTORE_CT_LOG_PUBLIC_KEY_FILE"
+	VariableSigstoreRootFile           Variable = "SIGSTORE_ROOT_FILE"
+	VariableSigstoreRekorPublicKey     Variable = "SIGSTORE_REKOR_PUBLIC_KEY"
 
 	// Other external environment variables
 	VariableGitHubToken              Variable = "GITHUB_TOKEN" //nolint:gosec
@@ -111,12 +110,6 @@ var (
 		VariableSigstoreRootFile: {
 			Description: "overrides the public good instance root CA",
 			Expects:     "path to the root CA",
-			Sensitive:   false,
-			External:    true,
-		},
-		VariableSigstoreTrustRekorPublicKey: {
-			Description: "if specified, will fetch the Rekor Public Key from the specified Rekor server and add it to RekorPubKeys. This env var is only for testing!",
-			Expects:     "any string to trigger this behavior",
 			Sensitive:   false,
 			External:    true,
 		},

--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestGetRekorPubKeys(t *testing.T) {
-	keys, err := GetRekorPubs(context.Background(), nil)
+	keys, err := GetRekorPubs(context.Background())
 	if err != nil {
 		t.Errorf("Unexpected error calling GetRekorPubs, expected nil: %v", err)
 	}

--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestGetRekorPubKeys(t *testing.T) {
-	keys, err := GetRekorPubs(context.Background())
+	keys, err := GetRekorPubs(context.Background(), nil)
 	if err != nil {
 		t.Errorf("Unexpected error calling GetRekorPubs, expected nil: %v", err)
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -447,7 +447,7 @@ func tlogValidateEntry(ctx context.Context, client *client.Rekor, sig oci.Signat
 	entryVerificationErrs := make([]string, 0)
 	for _, e := range tlogEntries {
 		entry := e
-		if err := VerifyTLogEntry(ctx, client, &entry); err != nil {
+		if err := VerifyTLogEntry(ctx, &entry); err != nil {
 			entryVerificationErrs = append(entryVerificationErrs, err.Error())
 			continue
 		}
@@ -885,7 +885,7 @@ func VerifyBundle(ctx context.Context, sig oci.Signature, rekorClient *client.Re
 		return false, err
 	}
 
-	publicKeys, err := GetRekorPubs(ctx, rekorClient)
+	publicKeys, err := GetRekorPubs(ctx)
 	if err != nil {
 		return false, fmt.Errorf("retrieving rekor public key: %w", err)
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -447,7 +447,7 @@ func tlogValidateEntry(ctx context.Context, client *client.Rekor, sig oci.Signat
 	entryVerificationErrs := make([]string, 0)
 	for _, e := range tlogEntries {
 		entry := e
-		if err := VerifyTLogEntry(ctx, &entry); err != nil {
+		if err := VerifyTLogEntry(ctx, nil, &entry); err != nil {
 			entryVerificationErrs = append(entryVerificationErrs, err.Error())
 			continue
 		}
@@ -885,7 +885,7 @@ func VerifyBundle(ctx context.Context, sig oci.Signature, rekorClient *client.Re
 		return false, err
 	}
 
-	publicKeys, err := GetRekorPubs(ctx)
+	publicKeys, err := GetRekorPubs(ctx, nil)
 	if err != nil {
 		return false, fmt.Errorf("retrieving rekor public key: %w", err)
 	}


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Scaffolding no longer requires it.

If user's still depend on this, they can use hte `SIGSTORE_REKOR_PUBLIC_KEY` and directly curl the rekor API

Related https://github.com/sigstore/cosign/issues/2122

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```
* fix!: Breaking change. This removes the insecure environment variable `SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY` that is used to fetch the public key from the API of the configured Rekor URL. Use `SIGSTORE_REKOR_PUBLIC_KEY` to configure a custom rekor public key.
* fix!: Breaking change: `GetRekorPubs` no longer requires a rekor client. Rekor public keys are no longer fetched from the Rekor API directly when `SIGSTORE_TRUST_REKOR_API_PUBLIC_KEY` is enabled.
```

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->