### PR TITLE
Move in-toto go upgrades to tagged releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.12.0
 	github.com/google/go-github/v45 v45.2.0
-	github.com/in-toto/in-toto-golang v0.4.1-0.20221018183522-731d0640b65f
+	github.com/in-toto/in-toto-golang v0.5.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/miekg/pkcs11 v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -876,8 +876,8 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/in-toto/in-toto-golang v0.4.1-0.20221018183522-731d0640b65f h1:7giWxcSH1gUqLfQEB7XnTBc29+A0DvNxZY5XKoemhME=
-github.com/in-toto/in-toto-golang v0.4.1-0.20221018183522-731d0640b65f/go.mod h1:/Rq0IZHLV7Ku5gielPT4wPHJfH1GdHMCq8+WPxw8/BE=
+github.com/in-toto/in-toto-golang v0.5.0 h1:hb8bgwr0M2hGdDsLjkJ3ZqJ8JFLL/tgYdAxF/XEFBbY=
+github.com/in-toto/in-toto-golang v0.5.0/go.mod h1:/Rq0IZHLV7Ku5gielPT4wPHJfH1GdHMCq8+WPxw8/BE=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=


### PR DESCRIPTION

#### Summary

This commit bumps the in-toto version to the latest tagged intoto golang release (v0.5.0) to switch the dependency import from commits to tags.

This should enable dependabot to take over version bumps.

/cc @adityasaky 
/assign @cpanato 

Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>

#### Release Note



#### Documentation
