### PR TITLE
Fix README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For instance:
 ```shell
 $ SRC_IMAGE=busybox
 $ SRC_DIGEST=$(crane digest busybox)
-$ IMAGE_URI=ttl.sh/$(uuidgen | head -c 8):1h
+$ IMAGE_URI=ttl.sh/$(uuidgen | head -c 8 | tr 'A-Z' 'a-z')
 $ crane cp $SRC_IMAGE@$SRC_DIGEST $IMAGE_URI:1h
 $ IMAGE_URI_DIGEST=$IMAGE_URI@$SRC_DIGEST
 ```
@@ -185,7 +185,7 @@ You can publish an artifact with `cosign upload blob`:
 $ echo "my first artifact" > artifact
 $ BLOB_SUM=$(shasum -a 256 artifact | cut -d' ' -f 1)
 c69d72c98b55258f9026f984e4656f0e9fd3ef024ea3fac1d7e5c7e6249f1626  artifact
-$ BLOB_NAME=my-artifact-$(uuidgen | head -c 8)
+BLOB_NAME=my-artifact-(uuidgen | head -c 8 | tr 'A-Z' 'a-z')
 $ BLOB_URI=ttl.sh/$BLOB_NAME:1h
 $ BLOB_URI_DIGEST=$(cosign upload blob -f artifact $BLOB_URI)
 Uploading file from [artifact] to [ttl.sh/my-artifact-f42c22e0:5m] with media type [text/plain]


### PR DESCRIPTION
They were broken before.

`uuidgen` gives uppercase letters; OCI registries hate uppercase letters.

Signed-off-by: Zachary Newman <zjn@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A