### PR TITLE
Remove experimental flag from cosign sign and cosign verify

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -159,7 +159,7 @@ func AttestCmd(ctx context.Context, ko options.KeyOpts, regOpts options.Registry
 	}
 
 	// Check whether we should be uploading to the transparency log
-	if sign.ShouldUploadToTlog(ctx, digest, force, noTlogUpload, ko.RekorURL) {
+	if sign.ShouldUploadToTlog(ctx, ko, digest, force, noTlogUpload) {
 		bundle, err := uploadToTlog(ctx, sv, ko.RekorURL, func(r *client.Rekor, b []byte) (*models.LogEntryAnon, error) {
 			return cosign.TLogUploadInTotoAttestation(ctx, r, signedPayload, b)
 		})

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -40,8 +40,8 @@ race conditions or (worse) malicious tampering.
 `,
 		Example: `  cosign sign --key <key path>|<kms uri> [--payload <path>] [-a key=value] [--upload=true|false] [-f] [-r] <image digest uri>
 
-  # sign a container image with Google sign-in (experimental)
-  COSIGN_EXPERIMENTAL=1 cosign sign <IMAGE DIGEST>
+  # sign a container image with the Sigstore OIDC flow
+  cosign sign <IMAGE DIGEST>
 
   # sign a container image with a local key pair file
   cosign sign --key cosign.key <IMAGE DIGEST>

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -130,6 +130,10 @@ func SignCmd(ro *options.RootOptions, ko options.KeyOpts, regOpts options.Regist
 	ctx, cancel := context.WithTimeout(context.Background(), ro.Timeout)
 	defer cancel()
 
+	if options.NOf(ko.KeyRef, ko.Sk) > 1 {
+		return &options.KeyParseError{}
+	}
+
 	sv, err := SignerFromKeyOpts(ctx, certPath, certChainPath, ko)
 	if err != nil {
 		return fmt.Errorf("getting signer: %w", err)

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -60,17 +60,13 @@ import (
 
 const TagReferenceMessage string = `WARNING: Image reference %s uses a tag, not a digest, to identify the image to sign.
 
-This can lead you to sign a different image than the intended one. Please use a
-digest (example.com/ubuntu@sha256:abc123...) rather than tag
-(example.com/ubuntu:latest) for the input to cosign. The ability to refer to
-images by tag will be removed in a future release.
+    This can lead you to sign a different image than the intended one. Please use a
+    digest (example.com/ubuntu@sha256:abc123...) rather than tag
+    (example.com/ubuntu:latest) for the input to cosign. The ability to refer to
+    images by tag will be removed in a future release.
 `
 
-func ShouldUploadToTlog(ctx context.Context, ref name.Reference, force bool, noTlogUpload bool, url string) bool {
-	// Check whether experimental is on!
-	if !options.EnableExperimental() {
-		return false
-	}
+func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Reference, force, noTlogUpload bool) bool {
 	// We are forcing publishing to the Tlog.
 	if force {
 		return true
@@ -80,9 +76,14 @@ func ShouldUploadToTlog(ctx context.Context, ref name.Reference, force bool, noT
 		return false
 	}
 
+	// If we aren't using keyless signing, we can skip the tlog
+	if !keylessSigning(ko) {
+		return false
+	}
+
 	// Check if the image is public (no auth in Get)
 	if _, err := remote.Get(ref, remote.WithContext(ctx)); err != nil {
-		fmt.Fprintf(os.Stderr, "%q appears to be a private repository, please confirm uploading to the transparency log at %q [Y/N]: ", ref.Context().String(), url)
+		fmt.Fprintf(os.Stderr, "%q appears to be a private repository, please confirm uploading to the transparency log at %q [Y/N]: ", ref.Context().String(), ko.RekorURL)
 
 		var tlogConfirmResponse string
 		if _, err := fmt.Scanln(&tlogConfirmResponse); err != nil {
@@ -126,16 +127,6 @@ func ParseOCIReference(refStr string, out io.Writer, opts ...name.Option) (name.
 func SignCmd(ro *options.RootOptions, ko options.KeyOpts, regOpts options.RegistryOptions, annotations map[string]interface{},
 	imgs []string, certPath string, certChainPath string, upload bool, outputSignature, outputCertificate string,
 	payloadPath string, force bool, recursive bool, attachment string, noTlogUpload bool) error {
-	if options.EnableExperimental() {
-		if options.NOf(ko.KeyRef, ko.Sk) > 1 {
-			return &options.KeyParseError{}
-		}
-	} else {
-		if !options.OneOf(ko.KeyRef, ko.Sk) {
-			return &options.KeyParseError{}
-		}
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), ro.Timeout)
 	defer cancel()
 
@@ -233,7 +224,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	if sv.Cert != nil {
 		s = ifulcio.NewSigner(s, sv.Cert, sv.Chain)
 	}
-	if ShouldUploadToTlog(ctx, digest, force, noTlogUpload, ko.RekorURL) {
+	if ShouldUploadToTlog(ctx, ko, digest, force, noTlogUpload) {
 		rClient, err := rekor.NewClient(ko.RekorURL)
 		if err != nil {
 			return err
@@ -527,4 +518,14 @@ func (c *SignerVerifier) Bytes(ctx context.Context) ([]byte, error) {
 		return nil, err
 	}
 	return pemBytes, nil
+}
+
+func keylessSigning(ko options.KeyOpts) bool {
+	if ko.KeyRef != "" {
+		return false
+	}
+	if ko.Sk {
+		return false
+	}
+	return true
 }

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -36,7 +36,7 @@ func Verify() *cobra.Command {
 against the transparency log.`,
 		Example: `  cosign verify --key <key path>|<key url>|<kms uri> <image uri> [<image uri> ...]
 
-  # verify cosign claims and signing certificates on the image
+  # verify cosign claims and signing certificates on the image with the transparency log
   cosign verify <IMAGE>
 
   # verify multiple images
@@ -44,9 +44,6 @@ against the transparency log.`,
 
   # additionally verify specified annotations
   cosign verify -a key1=val1 -a key2=val2 <IMAGE>
-
-  # (experimental) additionally, verify with the transparency log
-  COSIGN_EXPERIMENTAL=1 cosign verify <IMAGE>
 
   # verify image with an on-disk public key
   cosign verify --key cosign.pub <IMAGE>

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -20,8 +20,8 @@ cosign sign [flags]
 ```
   cosign sign --key <key path>|<kms uri> [--payload <path>] [-a key=value] [--upload=true|false] [-f] [-r] <image digest uri>
 
-  # sign a container image with Google sign-in (experimental)
-  COSIGN_EXPERIMENTAL=1 cosign sign <IMAGE DIGEST>
+  # sign a container image with the Sigstore OIDC flow
+  cosign sign <IMAGE DIGEST>
 
   # sign a container image with a local key pair file
   cosign sign --key cosign.key <IMAGE DIGEST>

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -16,7 +16,7 @@ cosign verify [flags]
 ```
   cosign verify --key <key path>|<key url>|<kms uri> <image uri> [<image uri> ...]
 
-  # verify cosign claims and signing certificates on the image
+  # verify cosign claims and signing certificates on the image with the transparency log
   cosign verify <IMAGE>
 
   # verify multiple images
@@ -24,9 +24,6 @@ cosign verify [flags]
 
   # additionally verify specified annotations
   cosign verify -a key1=val1 -a key2=val2 <IMAGE>
-
-  # (experimental) additionally, verify with the transparency log
-  COSIGN_EXPERIMENTAL=1 cosign verify <IMAGE>
 
   # verify image with an on-disk public key
   cosign verify --key cosign.pub <IMAGE>

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1146,16 +1146,13 @@ func TestTlog(t *testing.T) {
 	// Now verify should work!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
-	// Now we turn on the tlog!
-	defer setenv(t, env.VariableExperimental.String(), "1")()
+	// TODO: priyawadhwa@ to figure out how to add an entry to the tlog without using keyless signing
+	// We could add an --upload-tlog flag, but it's a bit weird since we have a --no-upload-tlog flag too right now.
 
-	// Verify shouldn't work since we haven't put anything in it yet.
-	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
-
-	// Sign again with the tlog env var on
-	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, "", false), t)
-	// And now verify works!
-	must(verify(pubKeyPath, imgName, true, nil, ""), t)
+	// // Sign again with the tlog env var on
+	// must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, "", false), t)
+	// // And now verify works!
+	// must(verify(pubKeyPath, imgName, true, nil, ""), t)
 }
 
 func TestNoTlog(t *testing.T) {
@@ -1184,16 +1181,19 @@ func TestNoTlog(t *testing.T) {
 	// Now verify should work!
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 
-	// Now we turn on the tlog!
-	defer setenv(t, env.VariableExperimental.String(), "1")()
+	// TODO: priyawadhwa@ to figure out how to add an entry to the tlog without using keyless signing
+	// We could add an --upload-tlog flag, but it's a bit weird since we have a --no-upload-tlog flag too right now.
 
-	// Verify shouldn't work since we haven't put anything in it yet.
-	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
+	// // Now we turn on the tlog!
+	// defer setenv(t, env.VariableExperimental.String(), "1")()
 
-	// Sign again with the tlog env var on with option to not upload tlog
-	must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, "", true), t)
-	// And verify it still fails.
-	mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
+	// // Verify shouldn't work since we haven't put anything in it yet.
+	// mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
+
+	// // Sign again with the tlog env var on with option to not upload tlog
+	// must(sign.SignCmd(ro, ko, options.RegistryOptions{}, nil, []string{imgName}, "", "", true, "", "", "", false, false, "", true), t)
+	// // And verify it still fails.
+	// mustErr(verify(pubKeyPath, imgName, true, nil, ""), t)
 }
 
 func TestGetPublicKeyCustomOut(t *testing.T) {


### PR DESCRIPTION
part 1/n for https://github.com/sigstore/cosign/issues/2255

figure there's a decent amount of refactoring to do here, but this is a good start. will have to include the other commands in follow-ups as well.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note

Remove the experimental flag from cosign sign and cosign verify, make keyless signing the default



#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->