### PR TITLE
dnm: investigate TestInvalidBundle bundle log id

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -116,6 +116,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.SimpleClaimVerifier
 	}
+	fmt.Fprintf(os.Stdout, "WHETHER COSIGN EXPERIMENTAL IS ON: %t\n", options.EnableExperimental())
 	if options.EnableExperimental() {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -132,6 +132,10 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		if err != nil {
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
+		co.RekorPubKeys, err = cosign.GetRekorPubs(ctx)
+		if err != nil {
+			return fmt.Errorf("getting Rekor public keys: %w", err)
+		}
 	}
 	keyRef := c.KeyRef
 	certRef := c.CertRef

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -110,6 +110,10 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		if err != nil {
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
+		co.RekorPubKeys, err = cosign.GetRekorPubs(ctx)
+		if err != nil {
+			return fmt.Errorf("getting Rekor public keys: %w", err)
+		}
 	}
 	keyRef := c.KeyRef
 

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -117,6 +117,10 @@ func VerifyBlobCmd(ctx context.Context, ko options.KeyOpts, certRef, certEmail, 
 		if err != nil {
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
+		co.RekorPubKeys, err = cosign.GetRekorPubs(ctx)
+		if err != nil {
+			return fmt.Errorf("getting Rekor public keys: %w", err)
+		}
 	}
 
 	// Keys are optional!
@@ -364,7 +368,7 @@ func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 		fallthrough
 	// We are provided a log entry, possibly from above, or search.
 	case e != nil:
-		if err := cosign.VerifyTLogEntry(ctx, nil, e); err != nil {
+		if err := cosign.VerifyTLogEntry(e, co.RekorPubKeys); err != nil {
 			return err
 		}
 
@@ -488,7 +492,7 @@ func verifyRekorBundle(ctx context.Context, bundle *bundle.RekorBundle,
 		return nil, err
 	}
 
-	publicKeys, err := cosign.GetRekorPubs(ctx, nil)
+	publicKeys, err := cosign.GetRekorPubs(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving rekor public key: %w", err)
 	}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -497,7 +497,11 @@ func verifyRekorBundle(ctx context.Context, bundle *bundle.RekorBundle,
 		return nil, fmt.Errorf("retrieving rekor public key: %w", err)
 	}
 
-	pubKey, ok := publicKeys[bundle.Payload.LogID]
+	if publicKeys == nil || publicKeys.Keys == nil {
+		return nil, errors.New("rekor log public key not found for payload")
+	}
+
+	pubKey, ok := publicKeys.Keys[bundle.Payload.LogID]
 	if !ok {
 		return nil, errors.New("rekor log public key not found for payload")
 	}

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -229,10 +229,12 @@ func TestVerifyBlob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rekorPubKeys := map[string]cosign.RekorPubKey{
-		logID: {
-			PubKey: &rekorPriv.PublicKey,
-			Status: tuf.Active,
+	rekorPubKeys := cosign.TrustedRekorPubKeys{
+		Keys: map[string]cosign.RekorPubKey{
+			logID: {
+				PubKey: &rekorPriv.PublicKey,
+				Status: tuf.Active,
+			},
 		},
 	}
 
@@ -556,7 +558,7 @@ func TestVerifyBlob(t *testing.T) {
 			co := &cosign.CheckOpts{
 				SigVerifier:  tt.sigVerifier,
 				RootCerts:    rootPool,
-				RekorPubKeys: rekorPubKeys,
+				RekorPubKeys: &rekorPubKeys,
 			}
 			// if expermental is enabled, add RekorClient to co.
 			if tt.experimental {

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -423,6 +423,10 @@ func VerifyTLogEntry(e *models.LogEntryAnon, rekorPubKeys *TrustedRekorPubKeys) 
 		return errors.New("inclusion proof not provided")
 	}
 
+	if rekorPubKeys == nil || rekorPubKeys.Keys == nil {
+		return errors.New("no trusted rekor public keys provided")
+	}
+
 	hashes := [][]byte{}
 	for _, h := range e.Verification.InclusionProof.Hashes {
 		hb, _ := hex.DecodeString(h)

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -107,8 +107,7 @@ func GetRekorPubs(ctx context.Context) (*TrustedRekorPubKeys, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error reading alternate Rekor public key file: %w", err)
 		}
-		publicKeys.AddRekorPubKey(raw, tuf.Active)
-		if err != nil {
+		if publicKeys.AddRekorPubKey(raw, tuf.Active); err != nil {
 			return nil, fmt.Errorf("AddRekorPubKey: %w", err)
 		}
 	} else {
@@ -121,8 +120,7 @@ func GetRekorPubs(ctx context.Context) (*TrustedRekorPubKeys, error) {
 			return nil, err
 		}
 		for _, t := range targets {
-			publicKeys.AddRekorPubKey(t.Target, t.Status)
-			if err != nil {
+			if publicKeys.AddRekorPubKey(t.Target, t.Status); err != nil {
 				return nil, fmt.Errorf("AddRekorPubKey: %w", err)
 			}
 		}
@@ -144,8 +142,7 @@ func rekorPubsFromClient(rekorClient *client.Rekor) (*TrustedRekorPubKeys, error
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch rekor public key from rekor: %w", err)
 	}
-	publicKeys.AddRekorPubKey([]byte(pubOK.Payload), tuf.Active)
-	if err != nil {
+	if publicKeys.AddRekorPubKey([]byte(pubOK.Payload), tuf.Active); err != nil {
 		return nil, fmt.Errorf("constructRekorPubKey: %w", err)
 	}
 	return &publicKeys, nil

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -107,7 +107,7 @@ func GetRekorPubs(ctx context.Context) (*TrustedRekorPubKeys, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error reading alternate Rekor public key file: %w", err)
 		}
-		if publicKeys.AddRekorPubKey(raw, tuf.Active); err != nil {
+		if err := publicKeys.AddRekorPubKey(raw, tuf.Active); err != nil {
 			return nil, fmt.Errorf("AddRekorPubKey: %w", err)
 		}
 	} else {
@@ -120,7 +120,7 @@ func GetRekorPubs(ctx context.Context) (*TrustedRekorPubKeys, error) {
 			return nil, err
 		}
 		for _, t := range targets {
-			if publicKeys.AddRekorPubKey(t.Target, t.Status); err != nil {
+			if err := publicKeys.AddRekorPubKey(t.Target, t.Status); err != nil {
 				return nil, fmt.Errorf("AddRekorPubKey: %w", err)
 			}
 		}
@@ -142,7 +142,7 @@ func rekorPubsFromClient(rekorClient *client.Rekor) (*TrustedRekorPubKeys, error
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch rekor public key from rekor: %w", err)
 	}
-	if publicKeys.AddRekorPubKey([]byte(pubOK.Payload), tuf.Active); err != nil {
+	if err := publicKeys.AddRekorPubKey([]byte(pubOK.Payload), tuf.Active); err != nil {
 		return nil, fmt.Errorf("constructRekorPubKey: %w", err)
 	}
 	return &publicKeys, nil

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -484,5 +484,6 @@ func (t *TrustedRekorPubKeys) AddRekorPubKey(pemBytes []byte, status tuf.StatusK
 		return err
 	}
 	t.Keys[keyID] = RekorPubKey{PubKey: pubKey, Status: status}
+	fmt.Fprintf(os.Stdout, "ADDING REKOR KEY WITH KEY ID: %s\n", keyID)
 	return nil
 }

--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestGetRekorPubKeys(t *testing.T) {
-	keys, err := GetRekorPubs(context.Background(), nil)
+	keys, err := GetRekorPubs(context.Background())
 	if err != nil {
 		t.Errorf("Unexpected error calling GetRekorPubs, expected nil: %v", err)
 	}

--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -24,11 +24,11 @@ func TestGetRekorPubKeys(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error calling GetRekorPubs, expected nil: %v", err)
 	}
-	if len(keys) == 0 {
+	if len(keys.Keys) == 0 {
 		t.Errorf("expected 1 or more keys, got 0")
 	}
 	// check that the mapping of key digest to key is correct
-	for logID, key := range keys {
+	for logID, key := range keys.Keys {
 		expectedLogID, err := getLogID(key.PubKey)
 		if err != nil {
 			t.Fatalf("unexpected error generated log ID: %v", err)

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -250,7 +250,7 @@ func TestVerifyImageSignatureWithNoChain(t *testing.T) {
 	opts := []static.Option{static.WithCertChain(pemLeaf, []byte{}), static.WithBundle(rekorBundle)}
 	ociSig, _ := static.NewSignature(payload, base64.StdEncoding.EncodeToString(signature), opts...)
 
-	logId, _ := getLogID(sv.Public)
+	logID, _ := getLogID(sv.Public)
 	ecdsaKey, _ := sv.PublicKey()
 
 	// TODO(asraa): Re-enable passing test when Rekor public keys can be set in CheckOpts,
@@ -258,7 +258,7 @@ func TestVerifyImageSignatureWithNoChain(t *testing.T) {
 	verified, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{}, &CheckOpts{
 		RootCerts: rootPool,
 		RekorPubKeys: &TrustedRekorPubKeys{
-			Keys: map[string]RekorPubKey{logId: {PubKey: ecdsaKey.(*ecdsa.PublicKey), Status: tuf.Active}},
+			Keys: map[string]RekorPubKey{logID: {PubKey: ecdsaKey.(*ecdsa.PublicKey), Status: tuf.Active}},
 		},
 	})
 	if err == nil {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1397,8 +1397,6 @@ func TestInvalidBundle(t *testing.T) {
 		Force:  true,
 	}
 	must(sign.SignCmd(ro, ko, so, []string{img1}), t)
-	// verify image1
-	must(verify(pubKeyPath, img1, true, nil, ""), t)
 	// extract the bundle from image1
 	si, err := ociremote.SignedImage(imgRef, remoteOpts)
 	must(err, t)
@@ -1414,6 +1412,10 @@ func TestInvalidBundle(t *testing.T) {
 	if bund == nil {
 		t.Fail()
 	}
+	fmt.Println("*********UPLOADED BUNDLE TO LOG ID*******")
+	fmt.Println(bund.Payload.LogID)
+	// verify image1
+	must(verify(pubKeyPath, img1, true, nil, ""), t)
 
 	// Now, we move on to image2
 	// Sign image2 and DO NOT store the entry in rekor

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -44,7 +44,7 @@ echo "running tests"
 
 popd
 go build -o cosign ./cmd/cosign
-go test -tags=e2e -race $(go list ./... | grep -v third_party/)
+go test -v -tags=e2e -race ./test/
 
 # Test `cosign dockerfile verify`
 export COSIGN_EXPERIMENTAL=true


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Does this upload to prod rekor? Why are the e2e tests using prod rekor but e2e_test.sh sets up a local rekor?

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->