### PR TITLE
verify: combine verification flows with substituteable verification fns

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -121,24 +121,15 @@ type CheckOpts struct {
 	Identities []Identity
 }
 
-func verifyOCISignature(ctx context.Context, verifier signature.Verifier, sig oci.Signature) error {
-	b64sig, err := sig.Base64Signature()
-	if err != nil {
-		return err
-	}
-	signature, err := base64.StdEncoding.DecodeString(b64sig)
-	if err != nil {
-		return err
-	}
-	payload, err := sig.Payload()
-	if err != nil {
-		return err
-	}
-	return verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(payload), options.WithContext(ctx))
-}
+// This is a substitutable signature verification function that can be used for verifying
+// attestations of blobs.
+type signatureVerificationFn func(
+	ctx context.Context, verifier signature.Verifier, sig payloader) error
 
 // For unit testing
 type payloader interface {
+	// no-op for attestations
+	Base64Signature() (string, error)
 	Payload() ([]byte, error)
 }
 
@@ -162,6 +153,22 @@ func verifyOCIAttestation(_ context.Context, verifier signature.Verifier, att pa
 	}
 	_, err = dssev.Verify(&env)
 	return err
+}
+
+func verifyOCISignature(ctx context.Context, verifier signature.Verifier, sig payloader) error {
+	b64sig, err := sig.Base64Signature()
+	if err != nil {
+		return err
+	}
+	signature, err := base64.StdEncoding.DecodeString(b64sig)
+	if err != nil {
+		return err
+	}
+	payload, err := sig.Payload()
+	if err != nil {
+		return err
+	}
+	return verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(payload), options.WithContext(ctx))
 }
 
 // ValidateAndUnpackCert creates a Verifier from a certificate. Veries that the certificate
@@ -594,8 +601,12 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 	return checkedSignatures, bundleVerified, nil
 }
 
-// VerifyImageSignature verifies a signature
-func VerifyImageSignature(ctx context.Context, sig oci.Signature, h v1.Hash, co *CheckOpts) (bundleVerified bool, err error) {
+// verifyInternal holds the main verification flow for blobs and attestations.
+// It verifies the certificate chain, the signature, claims, a bundle or the online
+// Rekor client.
+func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
+	verifyFn signatureVerificationFn, co *CheckOpts) (
+	bundleVerified bool, err error) {
 	verifier := co.SigVerifier
 	if verifier == nil {
 		// If we don't have a public key to check against, we can try a root cert.
@@ -628,7 +639,7 @@ func VerifyImageSignature(ctx context.Context, sig oci.Signature, h v1.Hash, co 
 		}
 	}
 
-	if err := verifyOCISignature(ctx, verifier, sig); err != nil {
+	if err := verifyFn(ctx, verifier, sig); err != nil {
 		return bundleVerified, err
 	}
 
@@ -655,8 +666,13 @@ func VerifyImageSignature(ctx context.Context, sig oci.Signature, h v1.Hash, co 
 
 		return bundleVerified, tlogValidateCertificate(ctx, co.RekorClient, sig)
 	}
-
 	return bundleVerified, nil
+}
+
+// VerifyImageSignature verifies a signature
+func VerifyImageSignature(ctx context.Context, sig oci.Signature,
+	h v1.Hash, co *CheckOpts) (bundleVerified bool, err error) {
+	return verifyInternal(ctx, sig, h, verifyOCISignature, co)
 }
 
 func loadSignatureFromFile(sigRef string, signedImgRef name.Reference, co *CheckOpts) (oci.Signatures, error) {
@@ -788,67 +804,9 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 			continue
 		}
 		if err := func(att oci.Signature) error {
-			verifier := co.SigVerifier
-			if verifier == nil {
-				// If we don't have a public key to check against, we can try a root cert.
-				cert, err := att.Cert()
-				if err != nil {
-					return err
-				}
-				if cert == nil {
-					return &VerificationError{"no certificate found on attestation"}
-				}
-				// Create a certificate pool for intermediate CA certificates, excluding the root
-				chain, err := att.Chain()
-				if err != nil {
-					return err
-				}
-				// If the chain annotation is not present or there is only a root
-				if chain == nil || len(chain) <= 1 {
-					co.IntermediateCerts = nil
-				} else if co.IntermediateCerts == nil {
-					// If the intermediate certs have not been loaded in by TUF
-					pool := x509.NewCertPool()
-					for _, cert := range chain[:len(chain)-1] {
-						pool.AddCert(cert)
-					}
-					co.IntermediateCerts = pool
-				}
-				verifier, err = ValidateAndUnpackCert(cert, co)
-				if err != nil {
-					return err
-				}
-			}
-
-			if err := verifyOCIAttestation(ctx, verifier, att); err != nil {
-				return err
-			}
-
-			// We can't check annotations without claims, both require unmarshalling the payload.
-			if co.ClaimVerifier != nil {
-				if err := co.ClaimVerifier(att, h, co.Annotations); err != nil {
-					return err
-				}
-			}
-
-			verified, err := VerifyBundle(ctx, att, co.RekorClient)
-			if err != nil && co.RekorClient == nil {
-				return fmt.Errorf("unable to verify bundle: %w", err)
-			}
+			verified, err := verifyInternal(ctx, att, h, verifyOCIAttestation, co)
 			bundleVerified = bundleVerified || verified
-
-			if !verified && co.RekorClient != nil {
-				if co.SigVerifier != nil {
-					pub, err := co.SigVerifier.PublicKey(co.PKOpts...)
-					if err != nil {
-						return err
-					}
-					return tlogValidatePublicKey(ctx, co.RekorClient, pub, att)
-				}
-
-				return tlogValidateCertificate(ctx, co.RekorClient, att)
-			}
-			return nil
+			return err
 		}(att); err != nil {
 			validationErrs = append(validationErrs, err.Error())
 			continue

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -88,6 +88,11 @@ func (m *mockAttestation) Payload() ([]byte, error) {
 	return json.Marshal(m.payload)
 }
 
+func (m *mockAttestation) Base64Signature() (string, error) {
+	b, err := json.Marshal(m.payload)
+	return string(b), err
+}
+
 func appendSlices(slices [][]byte) []byte {
 	var tmp []byte
 	for _, s := range slices {


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

This combines the verification flows for OCI attestations and blobs.

This will make it easier to add flags for validation, and cleanup the logic when the experimental flag is removed.

There is further type-specific logic contained in side bundle verification, it would be nice to separate those out as well.

You don't need to merge this, but I really hated the double logic. Please suggest something else if it would be nicer!


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->