### PR TITLE
Define a new sigstore Bundle type to include additional verification data and materials

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -47,7 +47,7 @@ import (
 
 type tlogUploadFn func(*client.Rekor, []byte) (*models.LogEntryAnon, error)
 
-func uploadToTlog(ctx context.Context, sv *sign.SignerVerifier, rekorURL string, upload tlogUploadFn) (*cbundle.RekorBundle, error) {
+func uploadToTlog(ctx context.Context, sv *sign.SignerVerifier, rekorURL string, upload tlogUploadFn) (*cbundle.Bundle, error) {
 	rekorBytes, err := sv.Bytes(ctx)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func uploadToTlog(ctx context.Context, sv *sign.SignerVerifier, rekorURL string,
 		return nil, err
 	}
 	fmt.Fprintln(os.Stderr, "tlog entry created with index:", *entry.LogIndex)
-	return cbundle.EntryToBundle(entry), nil
+	return cbundle.EntryToBundle(entry, []byte{}, []byte{}, []byte{}, ""), nil
 }
 
 // nolint

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -79,7 +79,7 @@ func SignBlobCmd(ro *options.RootOptions, ko options.KeyOpts, regOpts options.Re
 			return nil, err
 		}
 		fmt.Fprintln(os.Stderr, "tlog entry created with index:", *entry.LogIndex)
-		signedPayload.Bundle = cbundle.EntryToBundle(entry)
+		signedPayload.Bundle = cbundle.EntryToBundle(entry, []byte{}, []byte{}, []byte{}, "")
 	}
 
 	// if bundle is specified, just do that and ignore the rest

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -87,7 +87,7 @@ type VerifyBlobCmd struct {
 // nolint
 func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	var cert *x509.Certificate
-	var bundle *bundle.RekorBundle
+	var bundle *bundle.Bundle
 
 	if !options.OneOf(c.KeyRef, c.Sk, c.CertRef) && !options.EnableExperimental() && c.BundlePath == "" {
 		return &options.PubKeyParseError{}
@@ -312,7 +312,7 @@ We recommend requesting the certificate/signature from the original signer of th
 // clean up the args into CheckOpts or use KeyOpts here to resolve different KeyOpts.
 func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 	blobBytes []byte, sig string, cert *x509.Certificate,
-	bundle *bundle.RekorBundle, e *models.LogEntryAnon) error {
+	bundle *bundle.Bundle, e *models.LogEntryAnon) error {
 	if cert != nil {
 		// This would have already be done in the main entrypoint, but do this for robustness.
 		var err error
@@ -504,7 +504,7 @@ func payloadBytes(blobRef string) ([]byte, error) {
 	return blobBytes, nil
 }
 
-func verifyRekorBundle(ctx context.Context, bundle *bundle.RekorBundle,
+func verifyRekorBundle(ctx context.Context, bundle *bundle.Bundle,
 	blobBytes []byte, sig string, pubKeyBytes []byte) (*bundle.RekorPayload, error) {
 	if err := verifyBundleMatchesData(ctx, bundle, blobBytes, pubKeyBytes, []byte(sig)); err != nil {
 		return nil, err
@@ -530,7 +530,7 @@ func verifyRekorBundle(ctx context.Context, bundle *bundle.RekorBundle,
 	return &bundle.Payload, nil
 }
 
-func verifyBundleMatchesData(ctx context.Context, bundle *bundle.RekorBundle, blobBytes, certBytes, sigBytes []byte) error {
+func verifyBundleMatchesData(ctx context.Context, bundle *bundle.Bundle, blobBytes, certBytes, sigBytes []byte) error {
 	eimpl, kind, apiVersion, err := unmarshalEntryImpl(bundle.Payload.Body.(string))
 	if err != nil {
 		return err

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -552,7 +552,7 @@ func TestVerifyBlob(t *testing.T) {
 				co.RekorClient = &mClient
 			}
 
-			var bundle *bundle.RekorBundle
+			var bundle *bundle.Bundle
 			b, err := cosign.FetchLocalSignedPayloadFromPath(tt.bundlePath)
 			if err == nil && b.Bundle != nil {
 				bundle = b.Bundle
@@ -650,14 +650,18 @@ func makeLocalBundle(t *testing.T, rekorSigner signature.ECDSASignerVerifier,
 	b := cosign.LocalSignedPayload{
 		Base64Signature: base64.StdEncoding.EncodeToString(sig),
 		Cert:            string(svBytes),
-		Bundle: &bundle.RekorBundle{
-			Payload: bundle.RekorPayload{
-				Body:           e.Body,
-				IntegratedTime: *e.IntegratedTime,
-				LogIndex:       *e.LogIndex,
-				LogID:          *e.LogID,
+		Bundle: &bundle.Bundle{
+			VerificationData: bundle.VerificationData{
+				Payload: bundle.RekorPayload{
+					Body:           e.Body,
+					IntegratedTime: *e.IntegratedTime,
+					LogIndex:       *e.LogIndex,
+					LogID:          *e.LogID,
+				},
+				TimestampVerificationData: bundle.TimestampVerificationData{
+					SignedEntryTimestamp: e.Verification.SignedEntryTimestamp,
+				},
 			},
-			SignedEntryTimestamp: e.Verification.SignedEntryTimestamp,
 		},
 	}
 
@@ -1263,13 +1267,17 @@ func createBundle(_ *testing.T, sig []byte, certPem []byte, logID string, integr
 	b := &cosign.LocalSignedPayload{
 		Base64Signature: base64.StdEncoding.EncodeToString(sig),
 		Cert:            string(certPem),
-		Bundle: &bundle.RekorBundle{
-			SignedEntryTimestamp: []byte{},
-			Payload: bundle.RekorPayload{
-				LogID:          logID,
-				IntegratedTime: integratedTime,
-				LogIndex:       1,
-				Body:           rekorEntry,
+		Bundle: &bundle.Bundle{
+			VerificationData: bundle.VerificationData{
+				TimestampVerificationData: bundle.TimestampVerificationData{
+					SignedEntryTimestamp: []byte{},
+				},
+				Payload: bundle.RekorPayload{
+					LogID:          logID,
+					IntegratedTime: integratedTime,
+					LogIndex:       1,
+					Body:           rekorEntry,
+				},
 			},
 		},
 	}

--- a/internal/pkg/cosign/rekor/signer.go
+++ b/internal/pkg/cosign/rekor/signer.go
@@ -35,13 +35,13 @@ import (
 
 type tlogUploadFn func(*client.Rekor, []byte) (*models.LogEntryAnon, error)
 
-func uploadToTlog(rekorBytes []byte, rClient *client.Rekor, upload tlogUploadFn) (*cbundle.RekorBundle, error) {
+func uploadToTlog(rekorBytes []byte, rClient *client.Rekor, upload tlogUploadFn) (*cbundle.Bundle, error) {
 	entry, err := upload(rClient, rekorBytes)
 	if err != nil {
 		return nil, err
 	}
 	fmt.Fprintln(os.Stderr, "tlog entry created with index:", *entry.LogIndex)
-	return cbundle.EntryToBundle(entry), nil
+	return cbundle.EntryToBundle(entry, []byte{}, []byte{}, []byte{}, ""), nil
 }
 
 // signerWrapper calls a wrapped, inner signer then uploads either the Cert or Pub(licKey) of the results to Rekor, then adds the resulting `Bundle`

--- a/pkg/cosign/bundle/bundle.go
+++ b/pkg/cosign/bundle/bundle.go
@@ -1,0 +1,86 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"github.com/sigstore/rekor/pkg/generated/models"
+)
+
+type Bundle struct {
+	VerificationData
+	VerificationMaterial
+}
+
+// VerificationData contains extra data that can be used to verify things
+// such as transparency logs and timestamped verifications.
+type VerificationData struct {
+	// RekorPayload holds metadata about recording a Signature's ephemeral key to
+	// a Rekor transparency log.
+	// Use Payload instead of TransparencyLogEntry to keep backwards compatibility.
+	Payload RekorPayload
+
+	// TimestampVerificationData holds metadata about a timestamped verification.
+	TimestampVerificationData
+}
+
+// VerificationMaterial captures details on the materials used to verify
+// signatures or any additional timestamped verifications.
+type VerificationMaterial struct {
+	// A chain of X.509 certificates.
+	CertBytes []byte
+
+	// PublicKeyIdentifier optional unauthenticated hint on which key to use.
+	PublicKeyIdentifier string
+}
+
+// TimestampVerificationData contains various timestamped data following RFC3161.
+type TimestampVerificationData struct {
+	// SignedEntryTimestamp holds metadata about a timestamped counter signature over the artifacts signature.
+	SignedEntryTimestamp []byte
+
+	// EntryTimestampAuthority contains the recorded entry from timestamp authority server.
+	EntryTimestampAuthority []byte
+}
+
+func EntryToBundle(tLogEntry *models.LogEntryAnon, signedEntryTimestamp, entryTimestampAuthority, certBytes []byte, pubKeyID string) *Bundle {
+	b := &Bundle{}
+	// If none of the verification data is configured then return nil
+	if (tLogEntry == nil || tLogEntry.Verification == nil) && len(entryTimestampAuthority) == 0 {
+		return nil
+	}
+	// Add Transparency log entry and a signed timestamp value
+	if tLogEntry != nil && tLogEntry.Verification != nil {
+		b.Payload = RekorPayload{
+			Body:           tLogEntry.Body,
+			IntegratedTime: *tLogEntry.IntegratedTime,
+			LogIndex:       *tLogEntry.LogIndex,
+			LogID:          *tLogEntry.LogID,
+		}
+		b.SignedEntryTimestamp = tLogEntry.Verification.SignedEntryTimestamp
+
+		if len(signedEntryTimestamp) > 0 {
+			b.SignedEntryTimestamp = signedEntryTimestamp
+		}
+	}
+	// Set the EntryTimestampAuthority from the timestamp authority server
+	if len(entryTimestampAuthority) > 0 {
+		b.EntryTimestampAuthority = entryTimestampAuthority
+	}
+	if len(certBytes) > 0 || pubKeyID != "" {
+		b.CertBytes = certBytes
+		b.PublicKeyIdentifier = pubKeyID
+	}
+	return b
+}

--- a/pkg/cosign/bundle/rekor.go
+++ b/pkg/cosign/bundle/rekor.go
@@ -14,33 +14,11 @@
 
 package bundle
 
-import "github.com/sigstore/rekor/pkg/generated/models"
-
-// RekorBundle holds metadata about recording a Signature's ephemeral key to
+// RekorPayload holds metadata about recording a Signature's ephemeral key to
 // a Rekor transparency log.
-type RekorBundle struct {
-	SignedEntryTimestamp []byte
-	Payload              RekorPayload
-}
-
 type RekorPayload struct {
 	Body           interface{} `json:"body"`
 	IntegratedTime int64       `json:"integratedTime"`
 	LogIndex       int64       `json:"logIndex"`
 	LogID          string      `json:"logID"`
-}
-
-func EntryToBundle(entry *models.LogEntryAnon) *RekorBundle {
-	if entry.Verification == nil {
-		return nil
-	}
-	return &RekorBundle{
-		SignedEntryTimestamp: entry.Verification.SignedEntryTimestamp,
-		Payload: RekorPayload{
-			Body:           entry.Body,
-			IntegratedTime: *entry.IntegratedTime,
-			LogIndex:       *entry.LogIndex,
-			LogID:          *entry.LogID,
-		},
-	}
 }

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -34,13 +34,13 @@ type SignedPayload struct {
 	Payload         []byte
 	Cert            *x509.Certificate
 	Chain           []*x509.Certificate
-	Bundle          *bundle.RekorBundle
+	Bundle          *bundle.Bundle
 }
 
 type LocalSignedPayload struct {
-	Base64Signature string              `json:"base64Signature"`
-	Cert            string              `json:"cert,omitempty"`
-	Bundle          *bundle.RekorBundle `json:"rekorBundle,omitempty"`
+	Base64Signature string         `json:"base64Signature"`
+	Cert            string         `json:"cert,omitempty"`
+	Bundle          *bundle.Bundle `json:"rekorBundle,omitempty"`
 }
 
 type Signatures struct {

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -199,7 +199,7 @@ func signEntry(ctx context.Context, t *testing.T, signer signature.Signer, entry
 	return signature
 }
 
-func CreateTestBundle(ctx context.Context, t *testing.T, rekor signature.Signer, leaf []byte) *bundle.RekorBundle {
+func CreateTestBundle(ctx context.Context, t *testing.T, rekor signature.Signer, leaf []byte) *bundle.Bundle {
 	// generate log ID according to rekor public key
 	pk, _ := rekor.PublicKey(nil)
 	keyID, _ := getLogID(pk)
@@ -211,9 +211,13 @@ func CreateTestBundle(ctx context.Context, t *testing.T, rekor signature.Signer,
 	}
 	// Sign with root.
 	signature := signEntry(ctx, t, rekor, pyld)
-	b := &bundle.RekorBundle{
-		SignedEntryTimestamp: strfmt.Base64(signature),
-		Payload:              pyld,
+	b := &bundle.Bundle{
+		VerificationData: bundle.VerificationData{
+			Payload: pyld,
+			TimestampVerificationData: bundle.TimestampVerificationData{
+				SignedEntryTimestamp: strfmt.Base64(signature),
+			},
+		},
 	}
 	return b
 }

--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -104,12 +104,12 @@ func (s *sigLayer) Chain() ([]*x509.Certificate, error) {
 }
 
 // Bundle implements oci.Signature
-func (s *sigLayer) Bundle() (*bundle.RekorBundle, error) {
+func (s *sigLayer) Bundle() (*bundle.Bundle, error) {
 	val := s.desc.Annotations[BundleKey]
 	if val == "" {
 		return nil, nil
 	}
-	var b bundle.RekorBundle
+	var b bundle.Bundle
 	if err := json.Unmarshal([]byte(val), &b); err != nil {
 		return nil, fmt.Errorf("unmarshaling bundle: %w", err)
 	}

--- a/pkg/oci/internal/signature/layer_test.go
+++ b/pkg/oci/internal/signature/layer_test.go
@@ -57,7 +57,7 @@ func TestSignature(t *testing.T) {
 		wantCertErr    error
 		wantChain      int
 		wantChainErr   error
-		wantBundle     *bundle.RekorBundle
+		wantBundle     *bundle.Bundle
 		wantBundleErr  error
 	}{{
 		name: "just payload and signature",
@@ -152,13 +152,17 @@ func TestSignature(t *testing.T) {
 			},
 		},
 		wantSig: "blah",
-		wantBundle: &bundle.RekorBundle{
-			SignedEntryTimestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
-			Payload: bundle.RekorPayload{
-				Body:           "REMOVED",
-				IntegratedTime: 1631646761,
-				LogIndex:       693591,
-				LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+		wantBundle: &bundle.Bundle{
+			VerificationData: bundle.VerificationData{
+				Payload: bundle.RekorPayload{
+					Body:           "REMOVED",
+					IntegratedTime: 1631646761,
+					LogIndex:       693591,
+					LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+				},
+				TimestampVerificationData: bundle.TimestampVerificationData{
+					SignedEntryTimestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+				},
 			},
 		},
 	}, {

--- a/pkg/oci/mutate/options.go
+++ b/pkg/oci/mutate/options.go
@@ -61,7 +61,7 @@ func WithReplaceOp(ro ReplaceOp) SignOption {
 
 type signatureOpts struct {
 	annotations map[string]string
-	bundle      *bundle.RekorBundle
+	bundle      *bundle.Bundle
 	cert        []byte
 	chain       []byte
 	mediaType   types.MediaType
@@ -77,7 +77,7 @@ func WithAnnotations(annotations map[string]string) SignatureOption {
 }
 
 // WithBundle specifies the new Bundle the Signature should have.
-func WithBundle(b *bundle.RekorBundle) SignatureOption {
+func WithBundle(b *bundle.Bundle) SignatureOption {
 	return func(so *signatureOpts) {
 		so.bundle = b
 	}

--- a/pkg/oci/mutate/signature.go
+++ b/pkg/oci/mutate/signature.go
@@ -33,7 +33,7 @@ type sigWrapper struct {
 	wrapped oci.Signature
 
 	annotations map[string]string
-	bundle      *bundle.RekorBundle
+	bundle      *bundle.Bundle
 	cert        *x509.Certificate
 	chain       []*x509.Certificate
 	mediaType   types.MediaType
@@ -85,7 +85,7 @@ func (sw *sigWrapper) Chain() ([]*x509.Certificate, error) {
 }
 
 // Bundle implements oci.Signature.
-func (sw *sigWrapper) Bundle() (*bundle.RekorBundle, error) {
+func (sw *sigWrapper) Bundle() (*bundle.Bundle, error) {
 	if sw.bundle != nil {
 		return sw.bundle, nil
 	}

--- a/pkg/oci/mutate/signature_test.go
+++ b/pkg/oci/mutate/signature_test.go
@@ -291,13 +291,17 @@ func TestSignatureWithAnnotations(t *testing.T) {
 func TestSignatureWithBundle(t *testing.T) {
 	payload := "this is the TestSignatureWithBundle content!"
 	b64sig := "b64 content2="
-	b := &bundle.RekorBundle{
-		SignedEntryTimestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
-		Payload: bundle.RekorPayload{
-			Body:           "REMOVED",
-			IntegratedTime: 1631646761,
-			LogIndex:       693591,
-			LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+	b := &bundle.Bundle{
+		VerificationData: bundle.VerificationData{
+			TimestampVerificationData: bundle.TimestampVerificationData{
+				SignedEntryTimestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+			},
+			Payload: bundle.RekorPayload{
+				Body:           "REMOVED",
+				IntegratedTime: 1631646761,
+				LogIndex:       693591,
+				LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+			},
 		},
 	}
 	originalSig := mustCreateSignature(t, []byte(payload), b64sig)
@@ -349,15 +353,20 @@ func TestSignatureWithEverything(t *testing.T) {
 		"foo":  "bar",
 		"test": "yes",
 	}
-	b := &bundle.RekorBundle{
-		SignedEntryTimestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
-		Payload: bundle.RekorPayload{
-			Body:           "REMOVED",
-			IntegratedTime: 1631646761,
-			LogIndex:       693591,
-			LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+	b := &bundle.Bundle{
+		VerificationData: bundle.VerificationData{
+			TimestampVerificationData: bundle.TimestampVerificationData{
+				SignedEntryTimestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+			},
+			Payload: bundle.RekorPayload{
+				Body:           "REMOVED",
+				IntegratedTime: 1631646761,
+				LogIndex:       693591,
+				LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+			},
 		},
 	}
+
 	mediaType := types.MediaType("test/media.type")
 
 	originalSig := mustCreateSignature(t, []byte(payload), b64sig)

--- a/pkg/oci/signature/layer.go
+++ b/pkg/oci/signature/layer.go
@@ -104,12 +104,12 @@ func (s *sigLayer) Chain() ([]*x509.Certificate, error) {
 }
 
 // Bundle implements oci.Signature
-func (s *sigLayer) Bundle() (*bundle.RekorBundle, error) {
+func (s *sigLayer) Bundle() (*bundle.Bundle, error) {
 	val := s.desc.Annotations[BundleKey]
 	if val == "" {
 		return nil, nil
 	}
-	var b bundle.RekorBundle
+	var b bundle.Bundle
 	if err := json.Unmarshal([]byte(val), &b); err != nil {
 		return nil, fmt.Errorf("unmarshaling bundle: %w", err)
 	}

--- a/pkg/oci/signature/layer_test.go
+++ b/pkg/oci/signature/layer_test.go
@@ -57,7 +57,7 @@ func TestSignature(t *testing.T) {
 		wantCertErr    error
 		wantChain      int
 		wantChainErr   error
-		wantBundle     *bundle.RekorBundle
+		wantBundle     *bundle.Bundle
 		wantBundleErr  error
 	}{{
 		name: "just payload and signature",
@@ -152,13 +152,17 @@ func TestSignature(t *testing.T) {
 			},
 		},
 		wantSig: "blah",
-		wantBundle: &bundle.RekorBundle{
-			SignedEntryTimestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
-			Payload: bundle.RekorPayload{
-				Body:           "REMOVED",
-				IntegratedTime: 1631646761,
-				LogIndex:       693591,
-				LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+		wantBundle: &bundle.Bundle{
+			VerificationData: bundle.VerificationData{
+				TimestampVerificationData: bundle.TimestampVerificationData{
+					SignedEntryTimestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+				},
+				Payload: bundle.RekorPayload{
+					Body:           "REMOVED",
+					IntegratedTime: 1631646761,
+					LogIndex:       693591,
+					LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+				},
 			},
 		},
 	}, {

--- a/pkg/oci/signatures.go
+++ b/pkg/oci/signatures.go
@@ -58,5 +58,5 @@ type Signature interface {
 
 	// Bundle fetches the optional metadata that records the ephemeral
 	// Fulcio key in the transparency log.
-	Bundle() (*bundle.RekorBundle, error)
+	Bundle() (*bundle.Bundle, error)
 }

--- a/pkg/oci/static/options.go
+++ b/pkg/oci/static/options.go
@@ -29,7 +29,7 @@ type Option func(*options)
 type options struct {
 	LayerMediaType  types.MediaType
 	ConfigMediaType types.MediaType
-	Bundle          *bundle.RekorBundle
+	Bundle          *bundle.Bundle
 	Cert            []byte
 	Chain           []byte
 	Annotations     map[string]string
@@ -84,7 +84,7 @@ func WithAnnotations(ann map[string]string) Option {
 }
 
 // WithBundle sets the bundle to attach to the signature
-func WithBundle(b *bundle.RekorBundle) Option {
+func WithBundle(b *bundle.Bundle) Option {
 	return func(o *options) {
 		o.Bundle = b
 	}

--- a/pkg/oci/static/options_test.go
+++ b/pkg/oci/static/options_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestOptions(t *testing.T) {
-	bundle := &bundle.RekorBundle{}
+	bundle := &bundle.Bundle{}
 
 	tests := []struct {
 		name string
@@ -87,7 +87,7 @@ func TestOptions(t *testing.T) {
 			LayerMediaType:  ctypes.SimpleSigningMediaType,
 			ConfigMediaType: types.OCIConfigJSON,
 			Annotations: map[string]string{
-				BundleAnnotationKey: "{\"SignedEntryTimestamp\":null,\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"}}",
+				BundleAnnotationKey: "{\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"},\"SignedEntryTimestamp\":null,\"EntryTimestampAuthority\":null,\"CertBytes\":null,\"PublicKeyIdentifier\":\"\"}",
 			},
 			Bundle: bundle,
 		},

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -158,7 +158,7 @@ func (l *staticLayer) Chain() ([]*x509.Certificate, error) {
 }
 
 // Bundle implements oci.Signature
-func (l *staticLayer) Bundle() (*bundle.RekorBundle, error) {
+func (l *staticLayer) Bundle() (*bundle.Bundle, error) {
 	return l.opts.Bundle, nil
 }
 

--- a/pkg/oci/static/signature_test.go
+++ b/pkg/oci/static/signature_test.go
@@ -375,13 +375,17 @@ Ve/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uup
 Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 -----END CERTIFICATE-----
 `)
-		b = &bundle.RekorBundle{
-			SignedEntryTimestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
-			Payload: bundle.RekorPayload{
-				Body:           "REMOVED",
-				IntegratedTime: 1631646761,
-				LogIndex:       693591,
-				LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+		b = &bundle.Bundle{
+			VerificationData: bundle.VerificationData{
+				TimestampVerificationData: bundle.TimestampVerificationData{
+					SignedEntryTimestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+				},
+				Payload: bundle.RekorPayload{
+					Body:           "REMOVED",
+					IntegratedTime: 1631646761,
+					LogIndex:       693591,
+					LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+				},
 			},
 		}
 	)
@@ -435,7 +439,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 			ChainAnnotationKey:       string(chain),
 			// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16.
 			// The Body has been removed for brevity
-			BundleAnnotationKey: `{"SignedEntryTimestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
+			BundleAnnotationKey: `{"Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"},"SignedEntryTimestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","EntryTimestampAuthority":null,"CertBytes":null,"PublicKeyIdentifier":""}`,
 		}
 		got, err := l.Annotations()
 		if err != nil {

--- a/pkg/policy/attestation_test.go
+++ b/pkg/policy/attestation_test.go
@@ -52,7 +52,7 @@ func (fa *failingAttestation) Cert() (*x509.Certificate, error) {
 func (fa *failingAttestation) Chain() ([]*x509.Certificate, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
-func (fa *failingAttestation) Bundle() (*bundle.RekorBundle, error) {
+func (fa *failingAttestation) Bundle() (*bundle.Bundle, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 func (fa *failingAttestation) Digest() (v1.Hash, error) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

As part of this effort https://github.com/sigstore/cosign/issues/2331, I'm proposing renaming the original RekorBundle type to a more generic sigstore Bundle type that includes additional data. The new fields added to the sigstore Bundle are inspired from the protobuf specification here: https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_bundle.proto. 

The next actions include adding support to use a Timestamp Authority server (sigstore/timestamp-authority) to guarantee a signature happened during the cert's validity period. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->