### PR TITLE
BREAKING: Remove non-GA APIs from sign-blob verification

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -89,7 +89,8 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	var cert *x509.Certificate
 	var bundle *bundle.RekorBundle
 
-	if !options.OneOf(c.KeyRef, c.Sk, c.CertRef) && !options.EnableExperimental() && c.BundlePath == "" {
+	// Require a certificate/key OR a local bundle file that has the cert.
+	if !options.OneOf(c.KeyRef, c.Sk, c.CertRef) && c.BundlePath == "" {
 		return &options.PubKeyParseError{}
 	}
 
@@ -239,59 +240,10 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			return fmt.Errorf("loading verifier from bundle: %w", err)
 		}
 		bundle = b.Bundle
-	// No certificate is provided: search by artifact sha in the TLOG.
-	case options.EnableExperimental():
-		uuids, err := cosign.FindTLogEntriesByPayload(ctx, co.RekorClient, blobBytes)
-		if err != nil {
-			return err
-		}
-
-		if len(uuids) == 0 {
-			return errors.New("could not find a tlog entry for provided blob")
-		}
-
-		// Iterate through and try to find a matching Rekor entry.
-		// This does not support intoto properly! c/f extractCerts and
-		// the verifier.
-		for _, u := range uuids {
-			tlogEntry, err := cosign.GetTlogEntry(ctx, co.RekorClient, u)
-			if err != nil {
-				continue
-			}
-
-			// Note that this will error out if the TLOG entry was signed with a
-			// raw public key. Again, using search on artifact sha is unreliable.
-			certs, err := extractCerts(tlogEntry)
-			if err != nil {
-				continue
-			}
-
-			cert := certs[0]
-			co.SigVerifier, err = cosign.ValidateAndUnpackCert(cert, co)
-			if err != nil {
-				continue
-			}
-
-			if err := verifyBlob(ctx, co, blobBytes, sig, cert,
-				nil, tlogEntry); err == nil {
-				// We found a succesful Rekor entry!
-				fmt.Fprintln(os.Stderr, "Verified OK")
-				return nil
-			}
-		}
-
-		// No successful Rekor entry found.
-		fmt.Fprintln(os.Stderr, `WARNING: No valid entries were found in rekor to verify this blob.
-
-Transparency log support for blobs is experimental, and occasionally an entry isn't found even if one exists.
-
-We recommend requesting the certificate/signature from the original signer of this blob and manually verifying with cosign verify-blob --cert [cert] --signature [signature].`)
-		return fmt.Errorf("could not find a valid tlog entry for provided blob, found %d invalid entries", len(uuids))
-
 	}
 
 	// Performs all blob verification.
-	if err := verifyBlob(ctx, co, blobBytes, sig, cert, bundle, nil); err != nil {
+	if err := verifyBlob(ctx, co, blobBytes, sig, cert, bundle); err != nil {
 		return err
 	}
 
@@ -302,17 +254,16 @@ We recommend requesting the certificate/signature from the original signer of th
 /* Verify Blob main entry point. This will perform the following:
    1. Verifies the signature on the blob using the provided verifier.
    2. Checks for transparency log entry presence:
-        a. Verifies the Rekor entry in the bundle, if provided. OR
+        a. Verifies the Rekor entry in the bundle, if provided. This works offline OR
         b. If we don't have a Rekor entry retrieved via cert, do an online lookup (assuming
            we are in experimental mode).
-        c. Uses the provided Rekor entry (may have been retrieved through Rekor SearchIndex) OR
    3. If a certificate is provided, check it's expiration.
 */
 // TODO: Make a version of this public. This could be VerifyBlobCmd, but we need to
 // clean up the args into CheckOpts or use KeyOpts here to resolve different KeyOpts.
 func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 	blobBytes []byte, sig string, cert *x509.Certificate,
-	bundle *bundle.RekorBundle, e *models.LogEntryAnon) error {
+	bundle *bundle.RekorBundle) error {
 	if cert != nil {
 		// This would have already be done in the main entrypoint, but do this for robustness.
 		var err error
@@ -363,8 +314,9 @@ func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 		validityTime = time.Unix(bundle.IntegratedTime, 0)
 		fmt.Fprintf(os.Stderr, "tlog entry verified offline\n")
 	// b. We can make an online lookup to the transparency log since we don't have an entry.
-	case co.RekorClient != nil && e == nil:
+	case co.RekorClient != nil:
 		var tlogFindErr error
+		var e *models.LogEntryAnon
 		if cert == nil {
 			pub, err := co.SigVerifier.PublicKey(co.PKOpts...)
 			if err != nil {
@@ -382,10 +334,6 @@ func verifyBlob(ctx context.Context, co *cosign.CheckOpts,
 			fmt.Fprintf(os.Stderr, "could not find entry in tlog: %s", tlogFindErr)
 			return tlogFindErr
 		}
-		// Fallthrough here to verify the TLOG entry and compute the integrated time.
-		fallthrough
-	// We are provided a log entry, possibly from above, or search.
-	case e != nil:
 		if err := cosign.VerifyTLogEntry(ctx, nil, e); err != nil {
 			return err
 		}
@@ -656,45 +604,6 @@ func unmarshalEntryImpl(e string) (types.EntryImpl, string, string, error) {
 		return nil, "", "", err
 	}
 	return entry, pe.Kind(), entry.APIVersion(), nil
-}
-
-func extractCerts(e *models.LogEntryAnon) ([]*x509.Certificate, error) {
-	eimpl, _, _, err := unmarshalEntryImpl(e.Body.(string))
-	if err != nil {
-		return nil, err
-	}
-
-	var publicKeyB64 []byte
-	switch e := eimpl.(type) {
-	case *rekord_v001.V001Entry:
-		publicKeyB64, err = e.RekordObj.Signature.PublicKey.Content.MarshalText()
-		if err != nil {
-			return nil, err
-		}
-	case *hashedrekord_v001.V001Entry:
-		publicKeyB64, err = e.HashedRekordObj.Signature.PublicKey.Content.MarshalText()
-		if err != nil {
-			return nil, err
-		}
-	default:
-		return nil, errors.New("unexpected tlog entry type")
-	}
-
-	publicKey, err := base64.StdEncoding.DecodeString(string(publicKeyB64))
-	if err != nil {
-		return nil, err
-	}
-
-	certs, err := cryptoutils.UnmarshalCertificatesFromPEM(publicKey)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(certs) == 0 {
-		return nil, errors.New("no certs found in pem tlog")
-	}
-
-	return certs, err
 }
 
 // isIntotoDSSE checks whether a payload is a Dead Simple Signing Envelope with the In-Toto format.

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -558,7 +558,7 @@ func TestVerifyBlob(t *testing.T) {
 				bundle = b.Bundle
 			}
 
-			err = verifyBlob(ctx, co, tt.blob, tt.signature, tt.cert, bundle, nil)
+			err = verifyBlob(ctx, co, tt.blob, tt.signature, tt.cert, bundle)
 			if (err != nil) != tt.shouldErr {
 				t.Fatalf("verifyBlob()= %s, expected shouldErr=%t ", err, tt.shouldErr)
 			}

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -38,7 +38,6 @@ import (
 	"github.com/sigstore/cosign/pkg/cosign/env"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
-	"github.com/sigstore/rekor/pkg/generated/client/index"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/rekor/pkg/types"
 	hashedrekord_v001 "github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1"
@@ -385,21 +384,6 @@ func FindTlogEntry(ctx context.Context, rekorClient *client.Rekor,
 	}
 
 	return results, nil
-}
-
-func FindTLogEntriesByPayload(ctx context.Context, rekorClient *client.Rekor, payload []byte) (uuids []string, err error) {
-	params := index.NewSearchIndexParamsWithContext(ctx)
-	params.Query = &models.SearchIndex{}
-
-	h := sha256.New()
-	h.Write(payload)
-	params.Query.Hash = fmt.Sprintf("sha256:%s", strings.ToLower(hex.EncodeToString(h.Sum(nil))))
-
-	searchIndex, err := rekorClient.Index.SearchIndex(params)
-	if err != nil {
-		return nil, err
-	}
-	return searchIndex.GetPayload(), nil
 }
 
 // VerityTLogEntry verifies a TLog entry.


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Fixes https://github.com/sigstore/cosign/issues/2419

Requires users to provide a bundle or a certificate and signature so that we can recreate the Rekor entry and not search by payload hash using the non-GA Rekor endpoint.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* verify-blob: Removes the use of a non-GA API from sign-blob. Users are required to provide a `--bundle` OR both the `--signature` and `--certificate`/`--key` to the `verify-blob` command.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->