### PR TITLE
fix: set scaffolding version instead of main

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -36,7 +36,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.4.12"
+      SCAFFOLDING_RELEASE_VERSION: "v0.4.13"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko
@@ -63,9 +63,9 @@ jobs:
     - name: Install cluster + sigstore
       uses: sigstore/scaffolding/actions/setup@main
       with:
+        version: "v0.4.13"
         legacy-variables: "false"
         k8s-version: ${{ matrix.k8s-version }}
-        version: ${{ env.SCAFFOLDING_RELEASE_VERSION }}
 
     - name: Create sample image - demoimage
       run: |


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->


CI tests are failing due to changes in Fulcio that affect the current Scaffolding main branch:
<img width="618" alt="Screenshot 2022-11-10 at 13 37 56" src="https://user-images.githubusercontent.com/3602792/201093646-8d1a4d9f-08df-4c99-be51-fe8257e16abd.png">

We got Fulcio changes from its main branch expecting to spin up a grpc server. Therefore, we should set scaffolding to a stable version instead of main (temporary)

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->