### PR TITLE
Add a new time-stamping bundle to record rfc3161 verification data

### DIFF
--- a/pkg/cosign/bundle/tsa.go
+++ b/pkg/cosign/bundle/tsa.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+// TSABundle holds metadata about timestamp RFC3161 verification data.
+type TSABundle struct {
+	// SignedRFC3161Timestamp contains a RFC3161 signed timestamp provided by a time-stamping server.
+	// Clients MUST verify the hashed message in the message imprint
+	// against the signature in the bundle. This is encoded as base64.
+	SignedRFC3161Timestamp []byte
+}
+
+// TimestampToTSABundle receives a base64 encoded RFC3161 timestamp.
+func TimestampToTSABundle(timestampRFC3161 []byte) *TSABundle {
+	if timestampRFC3161 != nil {
+		return &TSABundle{
+			SignedRFC3161Timestamp: timestampRFC3161,
+		}
+	}
+	return nil
+}

--- a/pkg/cosign/bundle/tsa_test.go
+++ b/pkg/cosign/bundle/tsa_test.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+)
+
+func TestTSABundle(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		timestampRFC3161Entry []byte
+		expectedTSABundle     *TSABundle
+	}{{
+		name:                  "nil timestamp entry",
+		timestampRFC3161Entry: nil,
+		expectedTSABundle:     nil,
+	}, {
+		name:                  "timestamp entry",
+		timestampRFC3161Entry: strfmt.Base64([]byte("signature")),
+		expectedTSABundle: &TSABundle{
+			SignedRFC3161Timestamp: strfmt.Base64([]byte("signature")),
+		},
+	}}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotBundle := TimestampToTSABundle(tc.timestampRFC3161Entry)
+			if !reflect.DeepEqual(gotBundle, tc.expectedTSABundle) {
+				t.Errorf("TimestampToTSABundle returned %v, wanted %v", gotBundle, tc.expectedTSABundle)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change is related to https://github.com/sigstore/cosign/issues/2331 and a continuation of the work started in https://github.com/sigstore/cosign/pull/2435. We aim to add a new bundle to keep the existing RekorBundle due to backwards compatibility issues. This new TSABundle will be used in a different annotation. This TSABundle stores the response of an entry from a time-stamping RFC3161 server encoded in base64. The goal is to reuse this field together with other data to verify an artifact signature against a time-stamping server.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->