### PR TITLE
Better feedback if specifying incompatible argument on `cosign sign --attachment`

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -16,7 +16,6 @@
 package cli
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -80,7 +79,7 @@ func Sign() *cobra.Command {
 			case "sbom", "":
 				break
 			default:
-				return flag.ErrHelp
+				return fmt.Errorf("specified image attachment %s not specified. Can be 'sbom'.", o.Attachment)
 			}
 			oidcClientSecret, err := o.OIDC.ClientSecret()
 			if err != nil {

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -79,7 +79,7 @@ func Sign() *cobra.Command {
 			case "sbom", "":
 				break
 			default:
-				return fmt.Errorf("specified image attachment %s not specified. Can be 'sbom'.", o.Attachment)
+				return fmt.Errorf("specified image attachment %s not specified. Can be 'sbom'", o.Attachment)
 			}
 			oidcClientSecret, err := o.OIDC.ClientSecret()
 			if err != nil {


### PR DESCRIPTION
Signed-off-by: chaosinthecrd <thomas.meadows@jetstack.io>

This is a tiny change, but when using the `cosign sign --attachment` flag, it didn't seem clear why I was getting an error back. Of course the reason why is that the only attachment string it will accept is `sbom`, which is making me wonder whether at least temporarily this would be better as a boolean flag `--sbom-attachment` until there are other attachment types.

I have changed the error message, just as a suggestion as I feel it makes it more clear as to what is going on as opposed to 

```
Error: flag: help requested
main.go:62: error during command execution: flag: help requested
```