### PR TITLE
added `cosign inspect` command

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -102,6 +102,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(GenerateKeyPair())
 	cmd.AddCommand(ImportKeyPair())
 	cmd.AddCommand(Initialize())
+	cmd.AddCommand(Inspect())
 	cmd.AddCommand(Load())
 	cmd.AddCommand(Manifest())
 	cmd.AddCommand(PIVTool())

--- a/cmd/cosign/cli/inspect.go
+++ b/cmd/cosign/cli/inspect.go
@@ -1,0 +1,47 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/cmd/cosign/cli/verify"
+)
+
+func Inspect() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inspect",
+		Short: "inspect the supplied container image, signed in keyless mode.",
+		Long:  `inspect is useful for debugging images signed in keyless mode. It doesn't perform any verification and prints all signatures attached to the supplied image.`,
+		Example: `cosign inspect <image uri> [<image uri> ...]
+
+  # inspect a single image
+  cosign inspect <IMAGE>
+
+  # inspect multiple images
+  cosign inspect <IMAGE_1> <IMAGE_2> ...`,
+
+		Args:             cobra.MinimumNArgs(1),
+		PersistentPreRun: options.BindViper,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			v := verify.VerifyCommand{}
+			return v.Exec(cmd.Context(), args)
+		},
+	}
+
+	return cmd
+}


### PR DESCRIPTION
Signed-off-by: Naman <namanlakhwani@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

closes: #2210 

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Use `inspect` instead of `verify` to see the bundle. It doesn't perform any verification and prints what's present.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->