### PR TITLE
Add TSA bundle annotation

### DIFF
--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -46,6 +46,7 @@ const (
 	// PEM-encoded PKCS #8 RSA, ECDSA or ED25519 private key
 	PrivateKeyPemType = "PRIVATE KEY"
 	BundleKey         = static.BundleAnnotationKey
+	TSABundleKey      = static.TSABundleAnnotationKey
 )
 
 // PassFunc is the function to be called to retrieve the signer password. If

--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -33,7 +33,7 @@ const (
 	certkey      = "dev.sigstore.cosign/certificate"
 	chainkey     = "dev.sigstore.cosign/chain"
 	BundleKey    = "dev.sigstore.cosign/bundle"
-	TSABundleKey = "dev.sigstore.cosign/bundle"
+	TSABundleKey = "dev.sigstore.cosign/3161timestamp"
 )
 
 type sigLayer struct {

--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -29,10 +29,11 @@ import (
 )
 
 const (
-	sigkey    = "dev.cosignproject.cosign/signature"
-	certkey   = "dev.sigstore.cosign/certificate"
-	chainkey  = "dev.sigstore.cosign/chain"
-	BundleKey = "dev.sigstore.cosign/bundle"
+	sigkey       = "dev.cosignproject.cosign/signature"
+	certkey      = "dev.sigstore.cosign/certificate"
+	chainkey     = "dev.sigstore.cosign/chain"
+	BundleKey    = "dev.sigstore.cosign/bundle"
+	TSABundleKey = "dev.sigstore.cosign/bundle"
 )
 
 type sigLayer struct {
@@ -112,6 +113,19 @@ func (s *sigLayer) Bundle() (*bundle.RekorBundle, error) {
 	var b bundle.RekorBundle
 	if err := json.Unmarshal([]byte(val), &b); err != nil {
 		return nil, fmt.Errorf("unmarshaling bundle: %w", err)
+	}
+	return &b, nil
+}
+
+// TSABundle implements oci.Signature
+func (s *sigLayer) TSABundle() (*bundle.TSABundle, error) {
+	val := s.desc.Annotations[TSABundleKey]
+	if val == "" {
+		return nil, nil
+	}
+	var b bundle.TSABundle
+	if err := json.Unmarshal([]byte(val), &b); err != nil {
+		return nil, fmt.Errorf("unmarshaling tsa bundle: %w", err)
 	}
 	return &b, nil
 }

--- a/pkg/oci/internal/signature/layer_test.go
+++ b/pkg/oci/internal/signature/layer_test.go
@@ -278,3 +278,178 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 		})
 	}
 }
+
+func TestSignatureWithTSAAnnotation(t *testing.T) {
+	layer, err := random.Layer(300 /* byteSize */, types.DockerLayer)
+	if err != nil {
+		t.Fatalf("random.Layer() = %v", err)
+	}
+	digest, err := layer.Digest()
+	if err != nil {
+		t.Fatalf("Digest() = %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		l              *sigLayer
+		wantPayloadErr error
+		wantSig        string
+		wantSigErr     error
+		wantCert       bool
+		wantCertErr    error
+		wantChain      int
+		wantChainErr   error
+		wantBundle     *bundle.TSABundle
+		wantBundleErr  error
+	}{{
+		name: "just payload and signature",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey: "blah",
+				},
+			},
+		},
+		wantSig: "blah",
+	}, {
+		name: "with empty other keys",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:       "blah",
+					certkey:      "",
+					chainkey:     "",
+					TSABundleKey: "",
+				},
+			},
+		},
+		wantSig: "blah",
+	}, {
+		name: "missing signature",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+			},
+		},
+		wantSigErr: fmt.Errorf("signature layer %s is missing %q annotation", digest, sigkey),
+	}, {
+		name: "min plus bad bundle",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:    "blah",
+					BundleKey: `}`,
+				},
+			},
+		},
+		wantSig:       "blah",
+		wantBundleErr: errors.New(`unmarshaling tsa bundle: invalid character '}' looking for beginning of value`),
+	}, {
+		name: "min plus bad cert",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:  "blah",
+					certkey: `GARBAGE`,
+				},
+			},
+		},
+		wantSig:     "blah",
+		wantCertErr: errors.New(`error during PEM decoding`),
+	}, {
+		name: "min plus bad chain",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:   "blah",
+					chainkey: `GARBAGE`,
+				},
+			},
+		},
+		wantSig:      "blah",
+		wantChainErr: errors.New(`error during PEM decoding`),
+	}, {
+		name: "min plus TSA bundle",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey: "TSA blah",
+					// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16.
+					// The Body has been removed for brevity
+					TSABundleKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="}`,
+				},
+			},
+		},
+		wantSig: "TSA blah",
+		wantBundle: &bundle.TSABundle{
+			SignedRFC3161Timestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := test.l.Payload()
+			switch {
+			case (err != nil) != (test.wantPayloadErr != nil):
+				t.Errorf("Payload() = %v, wanted %v", err, test.wantPayloadErr)
+			case (err != nil) && (test.wantPayloadErr != nil) && err.Error() != test.wantPayloadErr.Error():
+				t.Errorf("Payload() = %v, wanted %v", err, test.wantPayloadErr)
+			case err == nil:
+				if got, _, err := v1.SHA256(bytes.NewBuffer(b)); err != nil {
+					t.Errorf("v1.SHA256() = %v", err)
+				} else if want := digest; want != got {
+					t.Errorf("v1.SHA256() = %v, wanted %v", got, want)
+				}
+			}
+
+			switch got, err := test.l.Base64Signature(); {
+			case (err != nil) != (test.wantSigErr != nil):
+				t.Errorf("Base64Signature() = %v, wanted %v", err, test.wantSigErr)
+			case (err != nil) && (test.wantSigErr != nil) && err.Error() != test.wantSigErr.Error():
+				t.Errorf("Base64Signature() = %v, wanted %v", err, test.wantSigErr)
+			case got != test.wantSig:
+				t.Errorf("Base64Signature() = %v, wanted %v", got, test.wantSig)
+			}
+
+			switch got, err := test.l.Cert(); {
+			case (err != nil) != (test.wantCertErr != nil):
+				t.Errorf("Cert() = %v, wanted %v", err, test.wantCertErr)
+			case (err != nil) && (test.wantCertErr != nil) && err.Error() != test.wantCertErr.Error():
+				t.Errorf("Cert() = %v, wanted %v", err, test.wantCertErr)
+			case (got != nil) != test.wantCert:
+				t.Errorf("Cert() = %v, wanted cert? %v", got, test.wantCert)
+			}
+
+			switch got, err := test.l.Chain(); {
+			case (err != nil) != (test.wantChainErr != nil):
+				t.Errorf("Chain() = %v, wanted %v", err, test.wantChainErr)
+			case (err != nil) && (test.wantChainErr != nil) && err.Error() != test.wantChainErr.Error():
+				t.Errorf("Chain() = %v, wanted %v", err, test.wantChainErr)
+			case len(got) != test.wantChain:
+				t.Errorf("Chain() = %v, wanted chain of length %d", got, test.wantChain)
+			}
+
+			switch got, err := test.l.TSABundle(); {
+			case (err != nil) != (test.wantBundleErr != nil):
+				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+			case (err != nil) && (test.wantBundleErr != nil) && err.Error() != test.wantBundleErr.Error():
+				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+			case !cmp.Equal(got, test.wantBundle):
+				t.Errorf("TSABundle() %s", cmp.Diff(got, test.wantBundle))
+			}
+		})
+	}
+}

--- a/pkg/oci/internal/signature/layer_test.go
+++ b/pkg/oci/internal/signature/layer_test.go
@@ -344,8 +344,8 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:    "blah",
-					BundleKey: `}`,
+					sigkey:       "blah",
+					TSABundleKey: `}`,
 				},
 			},
 		},

--- a/pkg/oci/mutate/options.go
+++ b/pkg/oci/mutate/options.go
@@ -62,6 +62,7 @@ func WithReplaceOp(ro ReplaceOp) SignOption {
 type signatureOpts struct {
 	annotations map[string]string
 	bundle      *bundle.RekorBundle
+	tsaBundle   *bundle.TSABundle
 	cert        []byte
 	chain       []byte
 	mediaType   types.MediaType
@@ -80,6 +81,13 @@ func WithAnnotations(annotations map[string]string) SignatureOption {
 func WithBundle(b *bundle.RekorBundle) SignatureOption {
 	return func(so *signatureOpts) {
 		so.bundle = b
+	}
+}
+
+// WithTSABundle specifies the new TSABundle the Signature should have.
+func WithTSABundle(b *bundle.TSABundle) SignatureOption {
+	return func(so *signatureOpts) {
+		so.tsaBundle = b
 	}
 }
 

--- a/pkg/oci/mutate/signature_test.go
+++ b/pkg/oci/mutate/signature_test.go
@@ -128,6 +128,21 @@ func assertSignaturesEqual(t *testing.T, wanted, got oci.Signature) {
 		}
 	})
 
+	t.Run("TSA Bundles match", func(t *testing.T) {
+		t.Helper()
+		wantedBundle, err := wanted.TSABundle()
+		if err != nil {
+			t.Fatalf("wanted.Bundle() returned error: %v", err)
+		}
+		gotBundle, err := got.TSABundle()
+		if err != nil {
+			t.Fatalf("got.TSABundle() returned error: %v", err)
+		}
+		if diff := cmp.Diff(wantedBundle, gotBundle); diff != "" {
+			t.Errorf("TSABundle() mismatch (-want +got):\n%s", diff)
+		}
+	})
+
 	t.Run("Certs match", func(t *testing.T) {
 		t.Helper()
 		wantedCert, err := wanted.Cert()
@@ -292,7 +307,7 @@ func TestSignatureWithBundle(t *testing.T) {
 	payload := "this is the TestSignatureWithBundle content!"
 	b64sig := "b64 content2="
 	b := &bundle.RekorBundle{
-		SignedEntryTimestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+		SignedEntryTimestamp: mustBase64Decode(t, "MEUCIEDcarEwRYkrxE9ne+kzEVvUhnWaauYzxhUyXOLy1hwAAiEA4VdVCvNRs+D/5o33C2KBy+q2YX3lP4Y7nqRFU+K3hi0="),
 		Payload: bundle.RekorPayload{
 			Body:           "REMOVED",
 			IntegratedTime: 1631646761,
@@ -306,6 +321,23 @@ func TestSignatureWithBundle(t *testing.T) {
 	newSig, err := Signature(originalSig, WithBundle(b))
 	if err != nil {
 		t.Fatalf("Signature(WithBundle()) returned error: %v", err)
+	}
+
+	assertSignaturesEqual(t, expectedSig, newSig)
+}
+
+func TestSignatureWithTSABundle(t *testing.T) {
+	payload := "this is the TestSignatureWithBundle content!"
+	b64sig := "b64 content2="
+	b := &bundle.TSABundle{
+		SignedRFC3161Timestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+	}
+	originalSig := mustCreateSignature(t, []byte(payload), b64sig)
+	expectedSig := mustCreateSignature(t, []byte(payload), b64sig, static.WithTSABundle(b))
+
+	newSig, err := Signature(originalSig, WithTSABundle(b))
+	if err != nil {
+		t.Fatalf("Signature(WithTSABundle()) returned error: %v", err)
 	}
 
 	assertSignaturesEqual(t, expectedSig, newSig)
@@ -371,6 +403,39 @@ func TestSignatureWithEverything(t *testing.T) {
 	newSig, err := Signature(originalSig,
 		WithAnnotations(annotations),
 		WithBundle(b),
+		WithCertChain(testCertBytes, testChainBytes),
+		WithMediaType(mediaType))
+
+	if err != nil {
+		t.Fatalf("Signature(With...) returned error: %v", err)
+	}
+
+	assertSignaturesEqual(t, expectedSig, newSig)
+}
+
+func TestSignatureWithEverythingTSA(t *testing.T) {
+	payload := "this is the TestSignatureWithEverything content!"
+	b64sig := "b64 content5="
+	annotations := map[string]string{
+		"foo":  "bar",
+		"test": "yes",
+	}
+	b := &bundle.TSABundle{
+		SignedRFC3161Timestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+	}
+	mediaType := types.MediaType("test/media.type")
+
+	originalSig := mustCreateSignature(t, []byte(payload), b64sig)
+
+	expectedSig := mustCreateSignature(t, []byte(payload), b64sig,
+		static.WithAnnotations(annotations),
+		static.WithTSABundle(b),
+		static.WithCertChain(testCertBytes, testChainBytes),
+		static.WithLayerMediaType(mediaType))
+
+	newSig, err := Signature(originalSig,
+		WithAnnotations(annotations),
+		WithTSABundle(b),
 		WithCertChain(testCertBytes, testChainBytes),
 		WithMediaType(mediaType))
 

--- a/pkg/oci/signature/layer.go
+++ b/pkg/oci/signature/layer.go
@@ -29,10 +29,11 @@ import (
 )
 
 const (
-	sigkey    = "dev.cosignproject.cosign/signature"
-	certkey   = "dev.sigstore.cosign/certificate"
-	chainkey  = "dev.sigstore.cosign/chain"
-	BundleKey = "dev.sigstore.cosign/bundle"
+	sigkey       = "dev.cosignproject.cosign/signature"
+	certkey      = "dev.sigstore.cosign/certificate"
+	chainkey     = "dev.sigstore.cosign/chain"
+	BundleKey    = "dev.sigstore.cosign/bundle"
+	TSABundleKey = "dev.sigstore.cosign/tsabundle"
 )
 
 type sigLayer struct {
@@ -112,6 +113,19 @@ func (s *sigLayer) Bundle() (*bundle.RekorBundle, error) {
 	var b bundle.RekorBundle
 	if err := json.Unmarshal([]byte(val), &b); err != nil {
 		return nil, fmt.Errorf("unmarshaling bundle: %w", err)
+	}
+	return &b, nil
+}
+
+// TSABundle implements oci.Signature
+func (s *sigLayer) TSABundle() (*bundle.TSABundle, error) {
+	val := s.desc.Annotations[TSABundleKey]
+	if val == "" {
+		return nil, nil
+	}
+	var b bundle.TSABundle
+	if err := json.Unmarshal([]byte(val), &b); err != nil {
+		return nil, fmt.Errorf("unmarshaling tsa bundle: %w", err)
 	}
 	return &b, nil
 }

--- a/pkg/oci/signature/layer.go
+++ b/pkg/oci/signature/layer.go
@@ -33,7 +33,7 @@ const (
 	certkey      = "dev.sigstore.cosign/certificate"
 	chainkey     = "dev.sigstore.cosign/chain"
 	BundleKey    = "dev.sigstore.cosign/bundle"
-	TSABundleKey = "dev.sigstore.cosign/tsabundle"
+	TSABundleKey = "dev.sigstore.cosign/3161timestamp"
 )
 
 type sigLayer struct {

--- a/pkg/oci/signature/layer_test.go
+++ b/pkg/oci/signature/layer_test.go
@@ -278,3 +278,178 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 		})
 	}
 }
+
+func TestSignatureWithTSAAnnotation(t *testing.T) {
+	layer, err := random.Layer(300 /* byteSize */, types.DockerLayer)
+	if err != nil {
+		t.Fatalf("random.Layer() = %v", err)
+	}
+	digest, err := layer.Digest()
+	if err != nil {
+		t.Fatalf("Digest() = %v", err)
+	}
+
+	tests := []struct {
+		name           string
+		l              *sigLayer
+		wantPayloadErr error
+		wantSig        string
+		wantSigErr     error
+		wantCert       bool
+		wantCertErr    error
+		wantChain      int
+		wantChainErr   error
+		wantBundle     *bundle.TSABundle
+		wantBundleErr  error
+	}{{
+		name: "just payload and signature",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey: "blah",
+				},
+			},
+		},
+		wantSig: "blah",
+	}, {
+		name: "with empty other keys",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:       "blah",
+					certkey:      "",
+					chainkey:     "",
+					TSABundleKey: "",
+				},
+			},
+		},
+		wantSig: "blah",
+	}, {
+		name: "missing signature",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+			},
+		},
+		wantSigErr: fmt.Errorf("signature layer %s is missing %q annotation", digest, sigkey),
+	}, {
+		name: "min plus bad TSA bundle",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:       "blah",
+					TSABundleKey: `}`,
+				},
+			},
+		},
+		wantSig:       "blah",
+		wantBundleErr: errors.New(`unmarshaling tsa bundle: invalid character '}' looking for beginning of value`),
+	}, {
+		name: "min plus bad cert",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:  "blah",
+					certkey: `GARBAGE`,
+				},
+			},
+		},
+		wantSig:     "blah",
+		wantCertErr: errors.New(`error during PEM decoding`),
+	}, {
+		name: "min plus bad chain",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey:   "blah",
+					chainkey: `GARBAGE`,
+				},
+			},
+		},
+		wantSig:      "blah",
+		wantChainErr: errors.New(`error during PEM decoding`),
+	}, {
+		name: "min plus TSA bundle",
+		l: &sigLayer{
+			Layer: layer,
+			desc: v1.Descriptor{
+				Digest: digest,
+				Annotations: map[string]string{
+					sigkey: "tsa blah",
+					// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16.
+					// The Body has been removed for brevity
+					TSABundleKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
+				},
+			},
+		},
+		wantSig: "tsa blah",
+		wantBundle: &bundle.TSABundle{
+			SignedRFC3161Timestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := test.l.Payload()
+			switch {
+			case (err != nil) != (test.wantPayloadErr != nil):
+				t.Errorf("Payload() = %v, wanted %v", err, test.wantPayloadErr)
+			case (err != nil) && (test.wantPayloadErr != nil) && err.Error() != test.wantPayloadErr.Error():
+				t.Errorf("Payload() = %v, wanted %v", err, test.wantPayloadErr)
+			case err == nil:
+				if got, _, err := v1.SHA256(bytes.NewBuffer(b)); err != nil {
+					t.Errorf("v1.SHA256() = %v", err)
+				} else if want := digest; want != got {
+					t.Errorf("v1.SHA256() = %v, wanted %v", got, want)
+				}
+			}
+
+			switch got, err := test.l.Base64Signature(); {
+			case (err != nil) != (test.wantSigErr != nil):
+				t.Errorf("Base64Signature() = %v, wanted %v", err, test.wantSigErr)
+			case (err != nil) && (test.wantSigErr != nil) && err.Error() != test.wantSigErr.Error():
+				t.Errorf("Base64Signature() = %v, wanted %v", err, test.wantSigErr)
+			case got != test.wantSig:
+				t.Errorf("Base64Signature() = %v, wanted %v", got, test.wantSig)
+			}
+
+			switch got, err := test.l.Cert(); {
+			case (err != nil) != (test.wantCertErr != nil):
+				t.Errorf("Cert() = %v, wanted %v", err, test.wantCertErr)
+			case (err != nil) && (test.wantCertErr != nil) && err.Error() != test.wantCertErr.Error():
+				t.Errorf("Cert() = %v, wanted %v", err, test.wantCertErr)
+			case (got != nil) != test.wantCert:
+				t.Errorf("Cert() = %v, wanted cert? %v", got, test.wantCert)
+			}
+
+			switch got, err := test.l.Chain(); {
+			case (err != nil) != (test.wantChainErr != nil):
+				t.Errorf("Chain() = %v, wanted %v", err, test.wantChainErr)
+			case (err != nil) && (test.wantChainErr != nil) && err.Error() != test.wantChainErr.Error():
+				t.Errorf("Chain() = %v, wanted %v", err, test.wantChainErr)
+			case len(got) != test.wantChain:
+				t.Errorf("Chain() = %v, wanted chain of length %d", got, test.wantChain)
+			}
+
+			switch got, err := test.l.TSABundle(); {
+			case (err != nil) != (test.wantBundleErr != nil):
+				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+			case (err != nil) && (test.wantBundleErr != nil) && err.Error() != test.wantBundleErr.Error():
+				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+			case !cmp.Equal(got, test.wantBundle):
+				t.Errorf("TSABundle() %s", cmp.Diff(got, test.wantBundle))
+			}
+		})
+	}
+}

--- a/pkg/oci/signatures.go
+++ b/pkg/oci/signatures.go
@@ -59,4 +59,8 @@ type Signature interface {
 	// Bundle fetches the optional metadata that records the ephemeral
 	// Fulcio key in the transparency log.
 	Bundle() (*bundle.RekorBundle, error)
+
+	// TSABundle fetches the optional metadata that records a
+	// RFC3161 signed timestamp.
+	TSABundle() (*bundle.TSABundle, error)
 }

--- a/pkg/oci/static/options.go
+++ b/pkg/oci/static/options.go
@@ -30,6 +30,7 @@ type options struct {
 	LayerMediaType  types.MediaType
 	ConfigMediaType types.MediaType
 	Bundle          *bundle.RekorBundle
+	TSABundle       *bundle.TSABundle
 	Cert            []byte
 	Chain           []byte
 	Annotations     map[string]string
@@ -59,6 +60,13 @@ func makeOptions(opts ...Option) (*options, error) {
 		o.Annotations[BundleAnnotationKey] = string(b)
 	}
 
+	if o.TSABundle != nil {
+		b, err := json.Marshal(o.TSABundle)
+		if err != nil {
+			return nil, err
+		}
+		o.Annotations[TSABundleAnnotationKey] = string(b)
+	}
 	return o, nil
 }
 
@@ -87,6 +95,13 @@ func WithAnnotations(ann map[string]string) Option {
 func WithBundle(b *bundle.RekorBundle) Option {
 	return func(o *options) {
 		o.Bundle = b
+	}
+}
+
+// WithTSABundle sets the time-stamping bundle to attach to the signature
+func WithTSABundle(b *bundle.TSABundle) Option {
+	return func(o *options) {
+		o.TSABundle = b
 	}
 }
 

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -32,6 +32,7 @@ const (
 	CertificateAnnotationKey = "dev.sigstore.cosign/certificate"
 	ChainAnnotationKey       = "dev.sigstore.cosign/chain"
 	BundleAnnotationKey      = "dev.sigstore.cosign/bundle"
+	TSABundleAnnotationKey   = "dev.sigstore.cosign/tsabundle"
 )
 
 // NewSignature constructs a new oci.Signature from the provided options.
@@ -160,6 +161,11 @@ func (l *staticLayer) Chain() ([]*x509.Certificate, error) {
 // Bundle implements oci.Signature
 func (l *staticLayer) Bundle() (*bundle.RekorBundle, error) {
 	return l.opts.Bundle, nil
+}
+
+// TSABundle implements oci.Signature
+func (l *staticLayer) TSABundle() (*bundle.TSABundle, error) {
+	return l.opts.TSABundle, nil
 }
 
 // Digest implements v1.Layer

--- a/pkg/policy/attestation_test.go
+++ b/pkg/policy/attestation_test.go
@@ -55,6 +55,9 @@ func (fa *failingAttestation) Chain() ([]*x509.Certificate, error) {
 func (fa *failingAttestation) Bundle() (*bundle.RekorBundle, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
+func (fa *failingAttestation) TSABundle() (*bundle.TSABundle, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
 func (fa *failingAttestation) Digest() (v1.Hash, error) {
 	return v1.Hash{}, fmt.Errorf("unimplemented")
 }


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change is related to https://github.com/sigstore/cosign/issues/2331. This PR adds a new annotation for the TSA Bundle.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->