### PR TITLE
Remove experimental mode from cosign attest and verify-attestation

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -33,8 +33,8 @@ func Attest() *cobra.Command {
 		Short: "Attest the supplied container image.",
 		Example: `  cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <image uri>
 
-  # attach an attestation to a container image Google sign-in (experimental)
-  COSIGN_EXPERIMENTAL=1 cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>
+  # attach an attestation to a container image Google sign-in
+  cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>
 
   # attach an attestation to a container image with a local key pair file
   cosign attest --predicate <FILE> --type <TYPE> --key cosign.key <IMAGE>

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -81,15 +81,9 @@ type AttestCommand struct {
 
 // nolint
 func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
-	// A key file or token is required unless we're in experimental mode!
-	if options.EnableExperimental() {
-		if options.NOf(c.KeyRef, c.Sk) > 1 {
-			return &options.KeyParseError{}
-		}
-	} else {
-		if !options.OneOf(c.KeyRef, c.Sk) {
-			return &options.KeyParseError{}
-		}
+	// We can't have both a key and a security key
+	if options.NOf(c.KeyRef, c.Sk) > 1 {
+		return &options.KeyParseError{}
 	}
 
 	predicateURI, err := options.ParsePredicateType(c.PredicateType)

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -142,7 +142,7 @@ func VerifyAttestation() *cobra.Command {
 against the transparency log.`,
 		Example: `  cosign verify-attestation --key <key path>|<key url>|<kms uri> <image uri> [<image uri> ...]
 
-  # verify cosign attestations on the image
+  # verify cosign attestations on the image against the transparency log
   cosign verify-attestation <IMAGE>
 
   # verify multiple images
@@ -150,9 +150,6 @@ against the transparency log.`,
 
   # additionally verify specified annotations
   cosign verify-attestation -a key1=val1 -a key2=val2 <IMAGE>
-
-  # (experimental) additionally, verify with the transparency log
-  COSIGN_EXPERIMENTAL=1 cosign verify-attestation <IMAGE>
 
   # verify image with public key
   cosign verify-attestation --key cosign.pub <IMAGE>

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -73,8 +73,9 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		return flag.ErrHelp
 	}
 
-	if !options.OneOf(c.KeyRef, c.Sk, c.CertRef) && !options.EnableExperimental() {
-		return &options.PubKeyParseError{}
+	// We can't have both a key and a security key
+	if options.NOf(c.KeyRef, c.Sk) > 1 {
+		return &options.KeyParseError{}
 	}
 
 	ociremoteOpts, err := c.ClientOpts(ctx)
@@ -97,7 +98,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 	}
-	if options.EnableExperimental() {
+	if keylessVerification(c.KeyRef, c.Sk) {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -11,8 +11,8 @@ cosign attest [flags]
 ```
   cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <image uri>
 
-  # attach an attestation to a container image Google sign-in (experimental)
-  COSIGN_EXPERIMENTAL=1 cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>
+  # attach an attestation to a container image Google sign-in
+  cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>
 
   # attach an attestation to a container image with a local key pair file
   cosign attest --predicate <FILE> --type <TYPE> --key cosign.key <IMAGE>

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -16,7 +16,7 @@ cosign verify-attestation [flags]
 ```
   cosign verify-attestation --key <key path>|<key url>|<kms uri> <image uri> [<image uri> ...]
 
-  # verify cosign attestations on the image
+  # verify cosign attestations on the image against the transparency log
   cosign verify-attestation <IMAGE>
 
   # verify multiple images
@@ -24,9 +24,6 @@ cosign verify-attestation [flags]
 
   # additionally verify specified annotations
   cosign verify-attestation -a key1=val1 -a key2=val2 <IMAGE>
-
-  # (experimental) additionally, verify with the transparency log
-  COSIGN_EXPERIMENTAL=1 cosign verify-attestation <IMAGE>
 
   # verify image with public key
   cosign verify-attestation --key cosign.pub <IMAGE>


### PR DESCRIPTION
Signed-off-by: Priya Wadhwa <priya@chainguard.dev>

Ref #2255 

#### Release Note
Remove experimental mode from cosign attest and verify-attestation

