### PR TITLE
Support TSA and Rekor verifications

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -85,12 +85,6 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.LocalImage, "local-image", false,
 		"whether the specified image is a path to an image saved locally via 'cosign save'")
-
-	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",
-		"url to a timestamp RFC3161 server, default none")
-
-	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-cert-chain", "",
-		"path to certificate chain PEM file for the Timestamp Authority")
 }
 
 // VerifyAttestationOptions is the top level wrapper for the `verify attestation` command.

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -23,6 +23,7 @@ type CommonVerifyOptions struct {
 	Offline          bool // Force offline verification
 	TSACertChainPath string
 	TSAServerURL     string
+	SkipTlogVerify   bool
 }
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
@@ -34,6 +35,9 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-cert-chain", "",
 		"path to certificate chain PEM file for the Timestamp Authority")
+
+	cmd.Flags().BoolVar(&o.SkipTlogVerify, "skip-tlog-verify", false,
+		"skip tlog verification")
 }
 
 // VerifyOptions is the top level wrapper for the `verify` command.

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -36,7 +36,7 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-cert-chain", "",
 		"path to certificate chain PEM file for the Timestamp Authority")
 
-	cmd.Flags().BoolVar(&o.SkipTlogVerify, "skip-tlog-verify", false,
+	cmd.Flags().BoolVar(&o.SkipTlogVerify, "insecure-skip-tlog-verify", false,
 		"skip tlog verification")
 }
 

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -85,6 +85,12 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.LocalImage, "local-image", false,
 		"whether the specified image is a path to an image saved locally via 'cosign save'")
+
+	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",
+		"url to a timestamp RFC3161 server, default none")
+
+	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-cert-chain", "",
+		"path to certificate chain PEM file for the Timestamp Authority")
 }
 
 // VerifyAttestationOptions is the top level wrapper for the `verify attestation` command.

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -235,7 +235,6 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		s = ifulcio.NewSigner(s, sv.Cert, sv.Chain)
 	}
 
-	// TODO: For the moment you can only use the timestamped service OR the transparency log.
 	if ko.TSAServerURL != "" {
 		clientTSA, err := tsaclient.GetTimestampClient(ko.TSAServerURL)
 		if err != nil {
@@ -243,7 +242,8 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		}
 
 		s = tsa.NewSigner(s, clientTSA)
-	} else if ShouldUploadToTlog(ctx, ko, digest, ko.SkipConfirmation, tlogUpload) {
+	}
+	if ShouldUploadToTlog(ctx, ko, digest, ko.SkipConfirmation, tlogUpload) {
 		rClient, err := rekor.NewClient(ko.RekorURL)
 		if err != nil {
 			return err

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -17,6 +17,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 
@@ -120,10 +121,15 @@ against the transparency log.`,
 				Offline:                      o.CommonVerifyOptions.Offline,
 				TSAServerURL:                 o.CommonVerifyOptions.TSAServerURL,
 				TSACertChainPath:             o.CommonVerifyOptions.TSACertChainPath,
+				SkipTlogVerify:               o.CommonVerifyOptions.SkipTlogVerify,
 			}
 
 			if o.Registry.AllowInsecure {
 				v.NameOptions = append(v.NameOptions, name.Insecure)
+			}
+
+			if o.CommonVerifyOptions.SkipTlogVerify {
+				fmt.Fprintln(os.Stderr, "**Warning** Skipping tlog verification lacks of transparency and auditability verification for the signature.")
 			}
 
 			return v.Exec(cmd.Context(), args)

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -129,7 +129,7 @@ against the transparency log.`,
 			}
 
 			if o.CommonVerifyOptions.SkipTlogVerify {
-				fmt.Fprintln(os.Stderr, "**Warning** Skipping tlog verification lacks of transparency and auditability verification for the signature.")
+				fmt.Fprintln(os.Stderr, "**Warning** Skipping tlog verification is an insecure practice that lacks of transparency and auditability verification for the signature.")
 			}
 
 			return v.Exec(cmd.Context(), args)

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -78,6 +78,7 @@ type VerifyCommand struct {
 	Offline                      bool
 	TSAServerURL                 string
 	TSACertChainPath             string
+	SkipTlogVerify               bool
 }
 
 // Exec runs the verification command
@@ -117,6 +118,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		SignatureRef:                 c.SignatureRef,
 		Offline:                      c.Offline,
 		TSACertChainPath:             c.TSACertChainPath,
+		SkipTlogVerify:               c.SkipTlogVerify,
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.SimpleClaimVerifier

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -81,6 +81,7 @@ cosign dockerfile verify [flags]
       --signature string                                                                         signature content or path or remote URL
       --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
+      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -71,6 +71,7 @@ cosign dockerfile verify [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
+      --insecure-skip-tlog-verify                                                                skip tlog verification
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
@@ -81,7 +82,6 @@ cosign dockerfile verify [flags]
       --signature string                                                                         signature content or path or remote URL
       --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
-      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -65,6 +65,7 @@ cosign manifest verify [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
+      --insecure-skip-tlog-verify                                                                skip tlog verification
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
@@ -75,7 +76,6 @@ cosign manifest verify [flags]
       --signature string                                                                         signature content or path or remote URL
       --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
-      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -75,6 +75,7 @@ cosign manifest verify [flags]
       --signature string                                                                         signature content or path or remote URL
       --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
+      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -81,6 +81,7 @@ cosign verify-attestation [flags]
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sct string                                                                               path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --sk                                                                                       whether to use a hardware security key
+      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -72,6 +72,7 @@ cosign verify-attestation [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify-attestation
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
+      --insecure-skip-tlog-verify                                                                skip tlog verification
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
@@ -81,7 +82,6 @@ cosign verify-attestation [flags]
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --sct string                                                                               path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --sk                                                                                       whether to use a hardware security key
-      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -81,6 +81,7 @@ cosign verify-blob [flags]
       --sct string                                                                               path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --signature string                                                                         signature content or path or remote URL
       --sk                                                                                       whether to use a hardware security key
+      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -74,6 +74,7 @@ cosign verify-blob [flags]
       --certificate-oidc-issuer string                                                           the OIDC issuer expected in a valid Fulcio certificate, e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth
   -h, --help                                                                                     help for verify-blob
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
+      --insecure-skip-tlog-verify                                                                skip tlog verification
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --offline                                                                                  only allow offline verification
@@ -81,7 +82,6 @@ cosign verify-blob [flags]
       --sct string                                                                               path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --signature string                                                                         signature content or path or remote URL
       --sk                                                                                       whether to use a hardware security key
-      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -91,6 +91,7 @@ cosign verify [flags]
       --signature string                                                                         signature content or path or remote URL
       --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
+      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -81,6 +81,7 @@ cosign verify [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
+      --insecure-skip-tlog-verify                                                                skip tlog verification
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
@@ -91,7 +92,6 @@ cosign verify [flags]
       --signature string                                                                         signature content or path or remote URL
       --signature-digest-algorithm string                                                        digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")
       --sk                                                                                       whether to use a hardware security key
-      --skip-tlog-verify                                                                         skip tlog verification
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
       --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -693,12 +693,13 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 			return false, fmt.Errorf("unable to verify TSA bundle: %w", err)
 		}
 	}
+	if co.SkipTlogVerify {
+		return bundleVerified, nil
+	}
 
-	if !co.SkipTlogVerify {
-		bundleVerified, err = VerifyBundle(ctx, sig, co.RekorClient)
-		if err != nil {
-			return false, fmt.Errorf("error verifying bundle: %w", err)
-		}
+	bundleVerified, err = VerifyBundle(ctx, sig, co.RekorClient)
+	if err != nil {
+		return false, fmt.Errorf("error verifying bundle: %w", err)
 	}
 
 	// If the --offline flag was specified, fail here
@@ -706,7 +707,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		return false, fmt.Errorf("offline verification failed")
 	}
 
-	if !bundleVerified && co.RekorClient != nil && !co.SkipTlogVerify {
+	if !bundleVerified && co.RekorClient != nil {
 		if co.SigVerifier != nil {
 			pub, err := co.SigVerifier.PublicKey(co.PKOpts...)
 			if err != nil {

--- a/pkg/oci/static/options_test.go
+++ b/pkg/oci/static/options_test.go
@@ -103,6 +103,19 @@ func TestOptions(t *testing.T) {
 			},
 			TSABundle: tsaBundle,
 		},
+	}, {
+		name: "with TSA and Rekor bundle",
+		opts: []Option{WithTSABundle(tsaBundle), WithBundle(bundle)},
+		want: &options{
+			LayerMediaType:  ctypes.SimpleSigningMediaType,
+			ConfigMediaType: types.OCIConfigJSON,
+			Annotations: map[string]string{
+				TSABundleAnnotationKey: "{\"SignedRFC3161Timestamp\":null}",
+				BundleAnnotationKey:    "{\"SignedEntryTimestamp\":null,\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"}}",
+			},
+			TSABundle: tsaBundle,
+			Bundle:    bundle,
+		},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR adds support for signing and verification of OCI images using TSA and Rekor verifications.

related to: https://github.com/sigstore/cosign/issues/2331,

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->