### PR TITLE
Remove timestamp-server-url flag from verify commands

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -22,16 +22,12 @@ import (
 type CommonVerifyOptions struct {
 	Offline          bool // Force offline verification
 	TSACertChainPath string
-	TSAServerURL     string
 	SkipTlogVerify   bool
 }
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Offline, "offline", false,
 		"only allow offline verification")
-
-	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",
-		"url to a timestamp RFC3161 server, default none")
 
 	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-cert-chain", "",
 		"path to certificate chain PEM file for the Timestamp Authority")

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -119,7 +119,6 @@ against the transparency log.`,
 				SignatureRef:                 o.SignatureRef,
 				LocalImage:                   o.LocalImage,
 				Offline:                      o.CommonVerifyOptions.Offline,
-				TSAServerURL:                 o.CommonVerifyOptions.TSAServerURL,
 				TSACertChainPath:             o.CommonVerifyOptions.TSACertChainPath,
 				SkipTlogVerify:               o.CommonVerifyOptions.SkipTlogVerify,
 			}

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -84,7 +84,6 @@ cosign dockerfile verify [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
-      --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -78,7 +78,6 @@ cosign manifest verify [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
-      --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -84,7 +84,6 @@ cosign verify-attestation [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
-      --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none
       --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
 ```
 

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -84,7 +84,6 @@ cosign verify-blob [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
-      --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -94,7 +94,6 @@ cosign verify [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-cert-chain string                                                              path to certificate chain PEM file for the Timestamp Authority
-      --timestamp-server-url string                                                              url to a timestamp RFC3161 server, default none
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -56,7 +56,6 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	sigPayload "github.com/sigstore/sigstore/pkg/signature/payload"
-	tsaclient "github.com/sigstore/timestamp-authority/pkg/generated/client"
 	tsaverification "github.com/sigstore/timestamp-authority/pkg/verification"
 )
 
@@ -127,9 +126,6 @@ type CheckOpts struct {
 
 	// Force offline verification of the signature
 	Offline bool
-
-	// TSAClient, if set, is used to verify signatures using a RFC3161 time-stamping server.
-	TSAClient *tsaclient.TimestampAuthority
 
 	// TSACerts are the intermediate CA certs used to verify a time-stamping data.
 	TSACerts *x509.CertPool
@@ -686,8 +682,8 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 			return bundleVerified, err
 		}
 	}
-	if co.TSAClient != nil {
-		bundleVerified, err = VerifyTSABundle(ctx, sig, co.TSAClient, co.TSACerts)
+	if co.TSACerts != nil {
+		bundleVerified, err = VerifyTSABundle(ctx, sig, co.TSACerts)
 		if err != nil {
 			return false, fmt.Errorf("unable to verify TSA bundle: %w", err)
 		}
@@ -949,7 +945,7 @@ func VerifyBundle(ctx context.Context, sig oci.Signature, rekorClient *client.Re
 	return true, nil
 }
 
-func VerifyTSABundle(ctx context.Context, sig oci.Signature, tsaClient *tsaclient.TimestampAuthority, tsaCerts *x509.CertPool) (bool, error) {
+func VerifyTSABundle(ctx context.Context, sig oci.Signature, tsaCerts *x509.CertPool) (bool, error) {
 	bundle, err := sig.TSABundle()
 	if err != nil {
 		return false, err

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -462,7 +462,6 @@ func TestVerifyImageSignatureWithSigVerifierAndTSA(t *testing.T) {
 	}
 	if bundleVerified, err := VerifyImageSignature(context.TODO(), sig, v1.Hash{}, &CheckOpts{
 		SigVerifier:    sv,
-		TSAClient:      client,
 		TSACerts:       tsaCertPool,
 		SkipTlogVerify: true,
 	}); err != nil || !bundleVerified {
@@ -514,7 +513,6 @@ func TestVerifyImageSignatureWithSigVerifierAndRekorTSA(t *testing.T) {
 	}
 	if _, err := VerifyImageSignature(context.TODO(), sig, v1.Hash{}, &CheckOpts{
 		SigVerifier: sv,
-		TSAClient:   client,
 		TSACerts:    tsaCertPool,
 		RekorClient: mClient,
 	}); err == nil || !strings.Contains(err.Error(), "verifying inclusion proof") {


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
The TSAClient isn't used for verification so we could remove it from the current verification code.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->