### PR TITLE
Rename tsa bundle to RFC3161timestamp

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -381,11 +381,11 @@ func PrintVerification(imgRef string, verified []oci.Signature, output string) {
 				}
 				ss.Optional["Bundle"] = bundle
 			}
-			if tsaBundle, err := sig.TSABundle(); err == nil && tsaBundle != nil {
+			if rfc3161Timestamp, err := sig.RFC3161Timestamp(); err == nil && rfc3161Timestamp != nil {
 				if ss.Optional == nil {
 					ss.Optional = make(map[string]interface{})
 				}
-				ss.Optional["TSABundle"] = tsaBundle
+				ss.Optional["RFC3161Timestamp"] = rfc3161Timestamp
 			}
 
 			outputKeys = append(outputKeys, ss)

--- a/internal/pkg/cosign/tsa/signer.go
+++ b/internal/pkg/cosign/tsa/signer.go
@@ -94,9 +94,9 @@ func (rs *signerWrapper) Sign(ctx context.Context, payload io.Reader) (oci.Signa
 	if err != nil {
 		return nil, nil, err
 	}
-	bundle := bundle.TimestampToTSABundle(responseBytes)
+	bundle := bundle.TimestampToRFC3161Timestamp(responseBytes)
 
-	newSig, err := mutate.Signature(sig, mutate.WithTSABundle(bundle))
+	newSig, err := mutate.Signature(sig, mutate.WithRFC3161Timestamp(bundle))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cosign/bundle/tsa.go
+++ b/pkg/cosign/bundle/tsa.go
@@ -14,18 +14,18 @@
 
 package bundle
 
-// TSABundle holds metadata about timestamp RFC3161 verification data.
-type TSABundle struct {
+// RFC3161Timestamp holds metadata about timestamp RFC3161 verification data.
+type RFC3161Timestamp struct {
 	// SignedRFC3161Timestamp contains a RFC3161 signed timestamp provided by a time-stamping server.
 	// Clients MUST verify the hashed message in the message imprint
 	// against the signature in the bundle. This is encoded as base64.
 	SignedRFC3161Timestamp []byte
 }
 
-// TimestampToTSABundle receives a base64 encoded RFC3161 timestamp.
-func TimestampToTSABundle(timestampRFC3161 []byte) *TSABundle {
+// TimestampToRFC3161Timestamp receives a base64 encoded RFC3161 timestamp.
+func TimestampToRFC3161Timestamp(timestampRFC3161 []byte) *RFC3161Timestamp {
 	if timestampRFC3161 != nil {
-		return &TSABundle{
+		return &RFC3161Timestamp{
 			SignedRFC3161Timestamp: timestampRFC3161,
 		}
 	}

--- a/pkg/cosign/bundle/tsa_test.go
+++ b/pkg/cosign/bundle/tsa_test.go
@@ -21,27 +21,27 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-func TestTSABundle(t *testing.T) {
+func TestRFC3161Timestamp(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		timestampRFC3161Entry []byte
-		expectedTSABundle     *TSABundle
+		name                     string
+		timestampRFC3161Entry    []byte
+		expectedRFC3161Timestamp *RFC3161Timestamp
 	}{{
-		name:                  "nil timestamp entry",
-		timestampRFC3161Entry: nil,
-		expectedTSABundle:     nil,
+		name:                     "nil timestamp entry",
+		timestampRFC3161Entry:    nil,
+		expectedRFC3161Timestamp: nil,
 	}, {
 		name:                  "timestamp entry",
 		timestampRFC3161Entry: strfmt.Base64([]byte("signature")),
-		expectedTSABundle: &TSABundle{
+		expectedRFC3161Timestamp: &RFC3161Timestamp{
 			SignedRFC3161Timestamp: strfmt.Base64([]byte("signature")),
 		},
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotBundle := TimestampToTSABundle(tc.timestampRFC3161Entry)
-			if !reflect.DeepEqual(gotBundle, tc.expectedTSABundle) {
-				t.Errorf("TimestampToTSABundle returned %v, wanted %v", gotBundle, tc.expectedTSABundle)
+			gotBundle := TimestampToRFC3161Timestamp(tc.timestampRFC3161Entry)
+			if !reflect.DeepEqual(gotBundle, tc.expectedRFC3161Timestamp) {
+				t.Errorf("TimestampToRFC3161Timestamp returned %v, wanted %v", gotBundle, tc.expectedRFC3161Timestamp)
 			}
 		})
 	}

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -30,12 +30,12 @@ import (
 )
 
 type SignedPayload struct {
-	Base64Signature string
-	Payload         []byte
-	Cert            *x509.Certificate
-	Chain           []*x509.Certificate
-	Bundle          *bundle.RekorBundle
-	TSABundle       *bundle.TSABundle
+	Base64Signature  string
+	Payload          []byte
+	Cert             *x509.Certificate
+	Chain            []*x509.Certificate
+	Bundle           *bundle.RekorBundle
+	RFC3161Timestamp *bundle.RFC3161Timestamp
 }
 
 type LocalSignedPayload struct {
@@ -103,7 +103,7 @@ func FetchSignaturesForReference(ctx context.Context, ref name.Reference, opts .
 				return err
 			}
 
-			signatures[i].TSABundle, err = sig.TSABundle()
+			signatures[i].RFC3161Timestamp, err = sig.RFC3161Timestamp()
 			if err != nil {
 				return err
 			}

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -44,9 +44,9 @@ const (
 	// PEM-encoded ECDSA private key
 	ECPrivateKeyPemType = "EC PRIVATE KEY"
 	// PEM-encoded PKCS #8 RSA, ECDSA or ED25519 private key
-	PrivateKeyPemType = "PRIVATE KEY"
-	BundleKey         = static.BundleAnnotationKey
-	TSABundleKey      = static.TSABundleAnnotationKey
+	PrivateKeyPemType   = "PRIVATE KEY"
+	BundleKey           = static.BundleAnnotationKey
+	RFC3161TimestampKey = static.RFC3161TimestampAnnotationKey
 )
 
 // PassFunc is the function to be called to retrieve the signer password. If

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -666,9 +666,9 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		}
 	}
 	if co.TSACerts != nil {
-		bundleVerified, err = VerifyTSABundle(ctx, sig, co.TSACerts)
+		bundleVerified, err = VerifyRFC3161Timestamp(ctx, sig, co.TSACerts)
 		if err != nil {
-			return false, fmt.Errorf("unable to verify TSA bundle: %w", err)
+			return false, fmt.Errorf("unable to verify RFC3161 timestamp bundle: %w", err)
 		}
 	}
 	if co.SkipTlogVerify {
@@ -986,8 +986,8 @@ func VerifyBundle(ctx context.Context, sig oci.Signature, co *CheckOpts, rekorCl
 	return true, nil
 }
 
-func VerifyTSABundle(ctx context.Context, sig oci.Signature, tsaCerts *x509.CertPool) (bool, error) {
-	bundle, err := sig.TSABundle()
+func VerifyRFC3161Timestamp(ctx context.Context, sig oci.Signature, tsaCerts *x509.CertPool) (bool, error) {
+	bundle, err := sig.RFC3161Timestamp()
 	if err != nil {
 		return false, err
 	} else if bundle == nil {

--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -29,11 +29,11 @@ import (
 )
 
 const (
-	sigkey       = "dev.cosignproject.cosign/signature"
-	certkey      = "dev.sigstore.cosign/certificate"
-	chainkey     = "dev.sigstore.cosign/chain"
-	BundleKey    = "dev.sigstore.cosign/bundle"
-	TSABundleKey = "dev.sigstore.cosign/3161timestamp"
+	sigkey              = "dev.cosignproject.cosign/signature"
+	certkey             = "dev.sigstore.cosign/certificate"
+	chainkey            = "dev.sigstore.cosign/chain"
+	BundleKey           = "dev.sigstore.cosign/bundle"
+	RFC3161TimestampKey = "dev.sigstore.cosign/3161timestamp"
 )
 
 type sigLayer struct {
@@ -117,15 +117,15 @@ func (s *sigLayer) Bundle() (*bundle.RekorBundle, error) {
 	return &b, nil
 }
 
-// TSABundle implements oci.Signature
-func (s *sigLayer) TSABundle() (*bundle.TSABundle, error) {
-	val := s.desc.Annotations[TSABundleKey]
+// RFC3161Timestamp implements oci.Signature
+func (s *sigLayer) RFC3161Timestamp() (*bundle.RFC3161Timestamp, error) {
+	val := s.desc.Annotations[RFC3161TimestampKey]
 	if val == "" {
 		return nil, nil
 	}
-	var b bundle.TSABundle
+	var b bundle.RFC3161Timestamp
 	if err := json.Unmarshal([]byte(val), &b); err != nil {
-		return nil, fmt.Errorf("unmarshaling tsa bundle: %w", err)
+		return nil, fmt.Errorf("unmarshaling RFC3161 timestamp bundle: %w", err)
 	}
 	return &b, nil
 }

--- a/pkg/oci/internal/signature/layer_test.go
+++ b/pkg/oci/internal/signature/layer_test.go
@@ -299,7 +299,7 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 		wantCertErr    error
 		wantChain      int
 		wantChainErr   error
-		wantBundle     *bundle.TSABundle
+		wantBundle     *bundle.RFC3161Timestamp
 		wantBundleErr  error
 	}{{
 		name: "just payload and signature",
@@ -320,10 +320,10 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:       "blah",
-					certkey:      "",
-					chainkey:     "",
-					TSABundleKey: "",
+					sigkey:              "blah",
+					certkey:             "",
+					chainkey:            "",
+					RFC3161TimestampKey: "",
 				},
 			},
 		},
@@ -344,13 +344,13 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:       "blah",
-					TSABundleKey: `}`,
+					sigkey:              "blah",
+					RFC3161TimestampKey: `}`,
 				},
 			},
 		},
 		wantSig:       "blah",
-		wantBundleErr: errors.New(`unmarshaling tsa bundle: invalid character '}' looking for beginning of value`),
+		wantBundleErr: errors.New(`unmarshaling RFC3161 timestamp bundle: invalid character '}' looking for beginning of value`),
 	}, {
 		name: "min plus bad cert",
 		l: &sigLayer{
@@ -380,7 +380,7 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 		wantSig:      "blah",
 		wantChainErr: errors.New(`error during PEM decoding`),
 	}, {
-		name: "min plus TSA bundle",
+		name: "min plus RFC3161 timestamp bundle",
 		l: &sigLayer{
 			Layer: layer,
 			desc: v1.Descriptor{
@@ -389,12 +389,12 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 					sigkey: "TSA blah",
 					// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16.
 					// The Body has been removed for brevity
-					TSABundleKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="}`,
+					RFC3161TimestampKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="}`,
 				},
 			},
 		},
 		wantSig: "TSA blah",
-		wantBundle: &bundle.TSABundle{
+		wantBundle: &bundle.RFC3161Timestamp{
 			SignedRFC3161Timestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
 		},
 	}}
@@ -442,13 +442,13 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 				t.Errorf("Chain() = %v, wanted chain of length %d", got, test.wantChain)
 			}
 
-			switch got, err := test.l.TSABundle(); {
+			switch got, err := test.l.RFC3161Timestamp(); {
 			case (err != nil) != (test.wantBundleErr != nil):
-				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+				t.Errorf("RFC3161Timestamp() = %v, wanted %v", err, test.wantBundleErr)
 			case (err != nil) && (test.wantBundleErr != nil) && err.Error() != test.wantBundleErr.Error():
-				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+				t.Errorf("RFC3161Timestamp() = %v, wanted %v", err, test.wantBundleErr)
 			case !cmp.Equal(got, test.wantBundle):
-				t.Errorf("TSABundle() %s", cmp.Diff(got, test.wantBundle))
+				t.Errorf("RFC3161Timestamp() %s", cmp.Diff(got, test.wantBundle))
 			}
 		})
 	}

--- a/pkg/oci/mutate/options.go
+++ b/pkg/oci/mutate/options.go
@@ -60,12 +60,12 @@ func WithReplaceOp(ro ReplaceOp) SignOption {
 }
 
 type signatureOpts struct {
-	annotations map[string]string
-	bundle      *bundle.RekorBundle
-	tsaBundle   *bundle.TSABundle
-	cert        []byte
-	chain       []byte
-	mediaType   types.MediaType
+	annotations      map[string]string
+	bundle           *bundle.RekorBundle
+	rfc3161Timestamp *bundle.RFC3161Timestamp
+	cert             []byte
+	chain            []byte
+	mediaType        types.MediaType
 }
 
 type SignatureOption func(*signatureOpts)
@@ -84,10 +84,10 @@ func WithBundle(b *bundle.RekorBundle) SignatureOption {
 	}
 }
 
-// WithTSABundle specifies the new TSABundle the Signature should have.
-func WithTSABundle(b *bundle.TSABundle) SignatureOption {
+// WithRFC3161Timestamp specifies the new RFC3161Timestamp the Signature should have.
+func WithRFC3161Timestamp(b *bundle.RFC3161Timestamp) SignatureOption {
 	return func(so *signatureOpts) {
-		so.tsaBundle = b
+		so.rfc3161Timestamp = b
 	}
 }
 

--- a/pkg/oci/mutate/signature.go
+++ b/pkg/oci/mutate/signature.go
@@ -32,12 +32,12 @@ import (
 type sigWrapper struct {
 	wrapped oci.Signature
 
-	annotations map[string]string
-	bundle      *bundle.RekorBundle
-	tsaBundle   *bundle.TSABundle
-	cert        *x509.Certificate
-	chain       []*x509.Certificate
-	mediaType   types.MediaType
+	annotations      map[string]string
+	bundle           *bundle.RekorBundle
+	rfc3161Timestamp *bundle.RFC3161Timestamp
+	cert             *x509.Certificate
+	chain            []*x509.Certificate
+	mediaType        types.MediaType
 }
 
 var _ v1.Layer = (*sigWrapper)(nil)
@@ -93,12 +93,12 @@ func (sw *sigWrapper) Bundle() (*bundle.RekorBundle, error) {
 	return sw.wrapped.Bundle()
 }
 
-// TSABundle implements oci.Signature.
-func (sw *sigWrapper) TSABundle() (*bundle.TSABundle, error) {
-	if sw.tsaBundle != nil {
-		return sw.tsaBundle, nil
+// RFC3161Timestamp implements oci.Signature.
+func (sw *sigWrapper) RFC3161Timestamp() (*bundle.RFC3161Timestamp, error) {
+	if sw.rfc3161Timestamp != nil {
+		return sw.rfc3161Timestamp, nil
 	}
-	return sw.wrapped.TSABundle()
+	return sw.wrapped.RFC3161Timestamp()
 }
 
 // MediaType implements v1.Layer
@@ -148,7 +148,7 @@ func Signature(original oci.Signature, opts ...SignatureOption) (oci.Signature, 
 	if so.annotations != nil {
 		newAnn = copyAnnotations(so.annotations)
 		newAnn[static.SignatureAnnotationKey] = oldAnn[static.SignatureAnnotationKey]
-		for _, key := range []string{static.BundleAnnotationKey, static.CertificateAnnotationKey, static.ChainAnnotationKey, static.TSABundleAnnotationKey} {
+		for _, key := range []string{static.BundleAnnotationKey, static.CertificateAnnotationKey, static.ChainAnnotationKey, static.RFC3161TimestampAnnotationKey} {
 			if val, isSet := oldAnn[key]; isSet {
 				newAnn[key] = val
 			} else {
@@ -168,13 +168,13 @@ func Signature(original oci.Signature, opts ...SignatureOption) (oci.Signature, 
 		newAnn[static.BundleAnnotationKey] = string(b)
 	}
 
-	if so.tsaBundle != nil {
-		newSig.tsaBundle = so.tsaBundle
-		b, err := json.Marshal(so.tsaBundle)
+	if so.rfc3161Timestamp != nil {
+		newSig.rfc3161Timestamp = so.rfc3161Timestamp
+		b, err := json.Marshal(so.rfc3161Timestamp)
 		if err != nil {
 			return nil, err
 		}
-		newAnn[static.TSABundleAnnotationKey] = string(b)
+		newAnn[static.RFC3161TimestampAnnotationKey] = string(b)
 	}
 
 	if so.cert != nil {

--- a/pkg/oci/mutate/signature_test.go
+++ b/pkg/oci/mutate/signature_test.go
@@ -128,18 +128,18 @@ func assertSignaturesEqual(t *testing.T, wanted, got oci.Signature) {
 		}
 	})
 
-	t.Run("TSA Bundles match", func(t *testing.T) {
+	t.Run("RFC3161 timestamp bundles match", func(t *testing.T) {
 		t.Helper()
-		wantedBundle, err := wanted.TSABundle()
+		wantedBundle, err := wanted.RFC3161Timestamp()
 		if err != nil {
 			t.Fatalf("wanted.Bundle() returned error: %v", err)
 		}
-		gotBundle, err := got.TSABundle()
+		gotBundle, err := got.RFC3161Timestamp()
 		if err != nil {
-			t.Fatalf("got.TSABundle() returned error: %v", err)
+			t.Fatalf("got.RFC3161Timestamp() returned error: %v", err)
 		}
 		if diff := cmp.Diff(wantedBundle, gotBundle); diff != "" {
-			t.Errorf("TSABundle() mismatch (-want +got):\n%s", diff)
+			t.Errorf("RFC3161Timestamp() mismatch (-want +got):\n%s", diff)
 		}
 	})
 
@@ -326,18 +326,18 @@ func TestSignatureWithBundle(t *testing.T) {
 	assertSignaturesEqual(t, expectedSig, newSig)
 }
 
-func TestSignatureWithTSABundle(t *testing.T) {
+func TestSignatureWithRFC3161Timestamp(t *testing.T) {
 	payload := "this is the TestSignatureWithBundle content!"
 	b64sig := "b64 content2="
-	b := &bundle.TSABundle{
+	b := &bundle.RFC3161Timestamp{
 		SignedRFC3161Timestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
 	}
 	originalSig := mustCreateSignature(t, []byte(payload), b64sig)
-	expectedSig := mustCreateSignature(t, []byte(payload), b64sig, static.WithTSABundle(b))
+	expectedSig := mustCreateSignature(t, []byte(payload), b64sig, static.WithRFC3161Timestamp(b))
 
-	newSig, err := Signature(originalSig, WithTSABundle(b))
+	newSig, err := Signature(originalSig, WithRFC3161Timestamp(b))
 	if err != nil {
-		t.Fatalf("Signature(WithTSABundle()) returned error: %v", err)
+		t.Fatalf("Signature(WithRFC3161Timestamp()) returned error: %v", err)
 	}
 
 	assertSignaturesEqual(t, expectedSig, newSig)
@@ -420,7 +420,7 @@ func TestSignatureWithEverythingTSA(t *testing.T) {
 		"foo":  "bar",
 		"test": "yes",
 	}
-	b := &bundle.TSABundle{
+	b := &bundle.RFC3161Timestamp{
 		SignedRFC3161Timestamp: mustBase64Decode(t, "MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
 	}
 	mediaType := types.MediaType("test/media.type")
@@ -429,13 +429,13 @@ func TestSignatureWithEverythingTSA(t *testing.T) {
 
 	expectedSig := mustCreateSignature(t, []byte(payload), b64sig,
 		static.WithAnnotations(annotations),
-		static.WithTSABundle(b),
+		static.WithRFC3161Timestamp(b),
 		static.WithCertChain(testCertBytes, testChainBytes),
 		static.WithLayerMediaType(mediaType))
 
 	newSig, err := Signature(originalSig,
 		WithAnnotations(annotations),
-		WithTSABundle(b),
+		WithRFC3161Timestamp(b),
 		WithCertChain(testCertBytes, testChainBytes),
 		WithMediaType(mediaType))
 

--- a/pkg/oci/signature/layer.go
+++ b/pkg/oci/signature/layer.go
@@ -29,11 +29,11 @@ import (
 )
 
 const (
-	sigkey       = "dev.cosignproject.cosign/signature"
-	certkey      = "dev.sigstore.cosign/certificate"
-	chainkey     = "dev.sigstore.cosign/chain"
-	BundleKey    = "dev.sigstore.cosign/bundle"
-	TSABundleKey = "dev.sigstore.cosign/3161timestamp"
+	sigkey              = "dev.cosignproject.cosign/signature"
+	certkey             = "dev.sigstore.cosign/certificate"
+	chainkey            = "dev.sigstore.cosign/chain"
+	BundleKey           = "dev.sigstore.cosign/bundle"
+	RFC3161TimestampKey = "dev.sigstore.cosign/rfc3161timestamp"
 )
 
 type sigLayer struct {
@@ -117,15 +117,15 @@ func (s *sigLayer) Bundle() (*bundle.RekorBundle, error) {
 	return &b, nil
 }
 
-// TSABundle implements oci.Signature
-func (s *sigLayer) TSABundle() (*bundle.TSABundle, error) {
-	val := s.desc.Annotations[TSABundleKey]
+// RFC3161Timestamp implements oci.Signature
+func (s *sigLayer) RFC3161Timestamp() (*bundle.RFC3161Timestamp, error) {
+	val := s.desc.Annotations[RFC3161TimestampKey]
 	if val == "" {
 		return nil, nil
 	}
-	var b bundle.TSABundle
+	var b bundle.RFC3161Timestamp
 	if err := json.Unmarshal([]byte(val), &b); err != nil {
-		return nil, fmt.Errorf("unmarshaling tsa bundle: %w", err)
+		return nil, fmt.Errorf("unmarshaling RFC3161 timestamp bundle: %w", err)
 	}
 	return &b, nil
 }

--- a/pkg/oci/signature/layer_test.go
+++ b/pkg/oci/signature/layer_test.go
@@ -299,7 +299,7 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 		wantCertErr    error
 		wantChain      int
 		wantChainErr   error
-		wantBundle     *bundle.TSABundle
+		wantBundle     *bundle.RFC3161Timestamp
 		wantBundleErr  error
 	}{{
 		name: "just payload and signature",
@@ -320,10 +320,10 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:       "blah",
-					certkey:      "",
-					chainkey:     "",
-					TSABundleKey: "",
+					sigkey:              "blah",
+					certkey:             "",
+					chainkey:            "",
+					RFC3161TimestampKey: "",
 				},
 			},
 		},
@@ -338,19 +338,19 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 		},
 		wantSigErr: fmt.Errorf("signature layer %s is missing %q annotation", digest, sigkey),
 	}, {
-		name: "min plus bad TSA bundle",
+		name: "min plus bad RFC3161 timestamp bundle",
 		l: &sigLayer{
 			Layer: layer,
 			desc: v1.Descriptor{
 				Digest: digest,
 				Annotations: map[string]string{
-					sigkey:       "blah",
-					TSABundleKey: `}`,
+					sigkey:              "blah",
+					RFC3161TimestampKey: `}`,
 				},
 			},
 		},
 		wantSig:       "blah",
-		wantBundleErr: errors.New(`unmarshaling tsa bundle: invalid character '}' looking for beginning of value`),
+		wantBundleErr: errors.New(`unmarshaling RFC3161 timestamp bundle: invalid character '}' looking for beginning of value`),
 	}, {
 		name: "min plus bad cert",
 		l: &sigLayer{
@@ -380,7 +380,7 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 		wantSig:      "blah",
 		wantChainErr: errors.New(`error during PEM decoding`),
 	}, {
-		name: "min plus TSA bundle",
+		name: "min plus RFC3161 timestamp bundle",
 		l: &sigLayer{
 			Layer: layer,
 			desc: v1.Descriptor{
@@ -389,12 +389,12 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 					sigkey: "tsa blah",
 					// This was extracted from gcr.io/distroless/static:nonroot on 2021/09/16.
 					// The Body has been removed for brevity
-					TSABundleKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
+					RFC3161TimestampKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
 				},
 			},
 		},
 		wantSig: "tsa blah",
-		wantBundle: &bundle.TSABundle{
+		wantBundle: &bundle.RFC3161Timestamp{
 			SignedRFC3161Timestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
 		},
 	}}
@@ -442,13 +442,13 @@ func TestSignatureWithTSAAnnotation(t *testing.T) {
 				t.Errorf("Chain() = %v, wanted chain of length %d", got, test.wantChain)
 			}
 
-			switch got, err := test.l.TSABundle(); {
+			switch got, err := test.l.RFC3161Timestamp(); {
 			case (err != nil) != (test.wantBundleErr != nil):
-				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+				t.Errorf("RFC3161Timestamp() = %v, wanted %v", err, test.wantBundleErr)
 			case (err != nil) && (test.wantBundleErr != nil) && err.Error() != test.wantBundleErr.Error():
-				t.Errorf("TSABundle() = %v, wanted %v", err, test.wantBundleErr)
+				t.Errorf("RFC3161Timestamp() = %v, wanted %v", err, test.wantBundleErr)
 			case !cmp.Equal(got, test.wantBundle):
-				t.Errorf("TSABundle() %s", cmp.Diff(got, test.wantBundle))
+				t.Errorf("RFC3161Timestamp() %s", cmp.Diff(got, test.wantBundle))
 			}
 		})
 	}

--- a/pkg/oci/signatures.go
+++ b/pkg/oci/signatures.go
@@ -60,7 +60,7 @@ type Signature interface {
 	// Fulcio key in the transparency log.
 	Bundle() (*bundle.RekorBundle, error)
 
-	// TSABundle fetches the optional metadata that records a
+	// RFC3161Timestamp() fetches the optional metadata that records a
 	// RFC3161 signed timestamp.
-	TSABundle() (*bundle.TSABundle, error)
+	RFC3161Timestamp() (*bundle.RFC3161Timestamp, error)
 }

--- a/pkg/oci/static/options.go
+++ b/pkg/oci/static/options.go
@@ -27,13 +27,13 @@ import (
 type Option func(*options)
 
 type options struct {
-	LayerMediaType  types.MediaType
-	ConfigMediaType types.MediaType
-	Bundle          *bundle.RekorBundle
-	TSABundle       *bundle.TSABundle
-	Cert            []byte
-	Chain           []byte
-	Annotations     map[string]string
+	LayerMediaType   types.MediaType
+	ConfigMediaType  types.MediaType
+	Bundle           *bundle.RekorBundle
+	RFC3161Timestamp *bundle.RFC3161Timestamp
+	Cert             []byte
+	Chain            []byte
+	Annotations      map[string]string
 }
 
 func makeOptions(opts ...Option) (*options, error) {
@@ -60,12 +60,12 @@ func makeOptions(opts ...Option) (*options, error) {
 		o.Annotations[BundleAnnotationKey] = string(b)
 	}
 
-	if o.TSABundle != nil {
-		b, err := json.Marshal(o.TSABundle)
+	if o.RFC3161Timestamp != nil {
+		b, err := json.Marshal(o.RFC3161Timestamp)
 		if err != nil {
 			return nil, err
 		}
-		o.Annotations[TSABundleAnnotationKey] = string(b)
+		o.Annotations[RFC3161TimestampAnnotationKey] = string(b)
 	}
 	return o, nil
 }
@@ -98,10 +98,10 @@ func WithBundle(b *bundle.RekorBundle) Option {
 	}
 }
 
-// WithTSABundle sets the time-stamping bundle to attach to the signature
-func WithTSABundle(b *bundle.TSABundle) Option {
+// WithRFC3161Timestamp sets the time-stamping bundle to attach to the signature
+func WithRFC3161Timestamp(b *bundle.RFC3161Timestamp) Option {
 	return func(o *options) {
-		o.TSABundle = b
+		o.RFC3161Timestamp = b
 	}
 }
 

--- a/pkg/oci/static/options_test.go
+++ b/pkg/oci/static/options_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestOptions(t *testing.T) {
 	bundle := &cbundle.RekorBundle{}
-	tsaBundle := &cbundle.TSABundle{}
+	rfc3161Timestamp := &cbundle.RFC3161Timestamp{}
 
 	tests := []struct {
 		name string
@@ -93,28 +93,28 @@ func TestOptions(t *testing.T) {
 			Bundle: bundle,
 		},
 	}, {
-		name: "with TSA bundle",
-		opts: []Option{WithTSABundle(tsaBundle)},
+		name: "with RFC3161 timestamp bundle",
+		opts: []Option{WithRFC3161Timestamp(rfc3161Timestamp)},
 		want: &options{
 			LayerMediaType:  ctypes.SimpleSigningMediaType,
 			ConfigMediaType: types.OCIConfigJSON,
 			Annotations: map[string]string{
-				TSABundleAnnotationKey: "{\"SignedRFC3161Timestamp\":null}",
+				RFC3161TimestampAnnotationKey: "{\"SignedRFC3161Timestamp\":null}",
 			},
-			TSABundle: tsaBundle,
+			RFC3161Timestamp: rfc3161Timestamp,
 		},
 	}, {
 		name: "with TSA and Rekor bundle",
-		opts: []Option{WithTSABundle(tsaBundle), WithBundle(bundle)},
+		opts: []Option{WithRFC3161Timestamp(rfc3161Timestamp), WithBundle(bundle)},
 		want: &options{
 			LayerMediaType:  ctypes.SimpleSigningMediaType,
 			ConfigMediaType: types.OCIConfigJSON,
 			Annotations: map[string]string{
-				TSABundleAnnotationKey: "{\"SignedRFC3161Timestamp\":null}",
-				BundleAnnotationKey:    "{\"SignedEntryTimestamp\":null,\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"}}",
+				RFC3161TimestampAnnotationKey: "{\"SignedRFC3161Timestamp\":null}",
+				BundleAnnotationKey:           "{\"SignedEntryTimestamp\":null,\"Payload\":{\"body\":null,\"integratedTime\":0,\"logIndex\":0,\"logID\":\"\"}}",
 			},
-			TSABundle: tsaBundle,
-			Bundle:    bundle,
+			RFC3161Timestamp: rfc3161Timestamp,
+			Bundle:           bundle,
 		},
 	}}
 

--- a/pkg/oci/static/signature.go
+++ b/pkg/oci/static/signature.go
@@ -28,11 +28,11 @@ import (
 )
 
 const (
-	SignatureAnnotationKey   = "dev.cosignproject.cosign/signature"
-	CertificateAnnotationKey = "dev.sigstore.cosign/certificate"
-	ChainAnnotationKey       = "dev.sigstore.cosign/chain"
-	BundleAnnotationKey      = "dev.sigstore.cosign/bundle"
-	TSABundleAnnotationKey   = "dev.sigstore.cosign/3161timestamp"
+	SignatureAnnotationKey        = "dev.cosignproject.cosign/signature"
+	CertificateAnnotationKey      = "dev.sigstore.cosign/certificate"
+	ChainAnnotationKey            = "dev.sigstore.cosign/chain"
+	BundleAnnotationKey           = "dev.sigstore.cosign/bundle"
+	RFC3161TimestampAnnotationKey = "dev.sigstore.cosign/rfc3161timestamp"
 )
 
 // NewSignature constructs a new oci.Signature from the provided options.
@@ -86,11 +86,11 @@ func Copy(sig oci.Signature) (oci.Signature, error) {
 	}
 	opts = append(opts, WithBundle(bundle))
 
-	tsaBundle, err := sig.TSABundle()
+	rfc3161Timestamp, err := sig.RFC3161Timestamp()
 	if err != nil {
 		return nil, err
 	}
-	opts = append(opts, WithTSABundle(tsaBundle))
+	opts = append(opts, WithRFC3161Timestamp(rfc3161Timestamp))
 
 	cert, err := sig.Cert()
 	if err != nil {
@@ -169,9 +169,9 @@ func (l *staticLayer) Bundle() (*bundle.RekorBundle, error) {
 	return l.opts.Bundle, nil
 }
 
-// TSABundle implements oci.Signature
-func (l *staticLayer) TSABundle() (*bundle.TSABundle, error) {
-	return l.opts.TSABundle, nil
+// RFC3161Timestamp implements oci.Signature
+func (l *staticLayer) RFC3161Timestamp() (*bundle.RFC3161Timestamp, error) {
+	return l.opts.RFC3161Timestamp, nil
 }
 
 // Digest implements v1.Layer

--- a/pkg/oci/static/signature_test.go
+++ b/pkg/oci/static/signature_test.go
@@ -447,7 +447,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 	})
 }
 
-func TestNewSignatureCertChainAndRekorTSABundle(t *testing.T) {
+func TestNewSignatureCertChainAndRekorRFC3161Timestamp(t *testing.T) {
 	payload := "this is the other content!"
 	b64sig := "b64 content="
 
@@ -486,7 +486,7 @@ Ve/83WrFomwmNf056y1X48F9c4m3a3ozXAIxAKjRay5/aj/jsKKGIkmQatjI8uup
 Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 -----END CERTIFICATE-----
 `)
-		b = &bundle.TSABundle{
+		b = &bundle.RFC3161Timestamp{
 			SignedRFC3161Timestamp: mustDecode("MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="),
 		}
 		rekorBundle = &bundle.RekorBundle{
@@ -501,7 +501,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 	)
 
 	l, err := NewSignature([]byte(payload), b64sig,
-		WithCertChain(cert, chain), WithTSABundle(b))
+		WithCertChain(cert, chain), WithRFC3161Timestamp(b))
 	if err != nil {
 		t.Fatalf("NewSignature() = %v", err)
 	}
@@ -523,10 +523,10 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 			t.Errorf("Base64Signature() = %s, wanted %s", got, want)
 		}
 
-		if got, err := l.TSABundle(); err != nil {
-			t.Fatalf("TSABundle() = %v", err)
+		if got, err := l.RFC3161Timestamp(); err != nil {
+			t.Fatalf("RFC3161Timestamp() = %v", err)
 		} else if got != b {
-			t.Errorf("TSABundle() = %#v, wanted %#v", got, b)
+			t.Errorf("RFC3161Timestamp() = %#v, wanted %#v", got, b)
 		}
 
 		if got, err := l.Cert(); err != nil {
@@ -548,7 +548,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 			CertificateAnnotationKey: string(cert),
 			ChainAnnotationKey:       string(chain),
 
-			TSABundleAnnotationKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="}`,
+			RFC3161TimestampAnnotationKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="}`,
 		}
 		got, err := l.Annotations()
 		if err != nil {
@@ -560,7 +560,7 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 	})
 
 	newSig, err := NewSignature([]byte(payload), b64sig,
-		WithCertChain(cert, chain), WithTSABundle(b), WithBundle(rekorBundle))
+		WithCertChain(cert, chain), WithRFC3161Timestamp(b), WithBundle(rekorBundle))
 	if err != nil {
 		t.Fatalf("NewSignature() = %v", err)
 	}
@@ -588,10 +588,10 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 			t.Errorf("Bundle() = %#v, wanted %#v", got, b)
 		}
 
-		if got, err := newSig.TSABundle(); err != nil {
-			t.Fatalf("TSABundle() = %v", err)
+		if got, err := newSig.RFC3161Timestamp(); err != nil {
+			t.Fatalf("RFC3161Timestamp() = %v", err)
 		} else if got != b {
-			t.Errorf("TSABundle() = %#v, wanted %#v", got, b)
+			t.Errorf("RFC3161Timestamp() = %#v, wanted %#v", got, b)
 		}
 
 		if got, err := newSig.Cert(); err != nil {
@@ -613,8 +613,8 @@ Hr/+CxFvaJWmpYqNkLDGRU+9orzh5hI2RrcuaQ==
 			CertificateAnnotationKey: string(cert),
 			ChainAnnotationKey:       string(chain),
 
-			TSABundleAnnotationKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="}`,
-			BundleAnnotationKey:    `{"SignedEntryTimestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
+			RFC3161TimestampAnnotationKey: `{"SignedRFC3161Timestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE="}`,
+			BundleAnnotationKey:           `{"SignedEntryTimestamp":"MEUCIQClUkUqZNf+6dxBc/pxq22JIluTB7Kmip1G0FIF5E0C1wIgLqXm+IM3JYW/P/qjMZSXW+J8bt5EOqNfe3R+0A9ooFE=","Payload":{"body":"REMOVED","integratedTime":1631646761,"logIndex":693591,"logID":"c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"}}`,
 		}
 		got, err := newSig.Annotations()
 		if err != nil {

--- a/pkg/policy/attestation_test.go
+++ b/pkg/policy/attestation_test.go
@@ -55,7 +55,7 @@ func (fa *failingAttestation) Chain() ([]*x509.Certificate, error) {
 func (fa *failingAttestation) Bundle() (*bundle.RekorBundle, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
-func (fa *failingAttestation) TSABundle() (*bundle.TSABundle, error) {
+func (fa *failingAttestation) RFC3161Timestamp() (*bundle.RFC3161Timestamp, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 func (fa *failingAttestation) Digest() (v1.Hash, error) {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -528,7 +528,7 @@ func TestRekorBundle(t *testing.T) {
 	must(verify(pubKeyPath, imgName, true, nil, ""), t)
 }
 
-func TestTSABundle(t *testing.T) {
+func TestRFC3161Timestamp(t *testing.T) {
 	// turn on the tlog
 	defer setenv(t, env.VariableExperimental.String(), "1")()
 	// TODO: Replace with a full TSA mock client, related to https://github.com/sigstore/timestamp-authority/issues/146
@@ -584,7 +584,7 @@ func TestTSABundle(t *testing.T) {
 	must(verifyTSA(pubKeyPath, imgName, true, nil, "", server.URL, file.Name(), true), t)
 }
 
-func TestRekorBundleAndTSABundle(t *testing.T) {
+func TestRekorBundleAndRFC3161Timestamp(t *testing.T) {
 	// turn on the tlog
 	defer setenv(t, env.VariableExperimental.String(), "1")()
 	// TODO: Replace with a full TSA mock client, related to https://github.com/sigstore/timestamp-authority/issues/146


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

As discussed, we decided to rename the TSABundle to RFC3161Timestamp as it represents better its data used for signing and verification.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->