### PR TITLE
RFC: When verifying, only use data after it is considered acceptable

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -453,7 +453,7 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 	for _, c := range certChain[:len(certChain)-1] {
 		subPool.AddCert(c)
 	}
-	if _, err := cosign.TrustedCert(leafCert, rootPool, subPool); err != nil {
+	if _, err := cosign.CertificateSignedByTrustedRoot(leafCert, rootPool, subPool); err != nil {
 		return nil, fmt.Errorf("unable to validate certificate chain: %w", err)
 	}
 	// Verify SCT if present in the leaf certificate.

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -164,7 +164,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		if err != nil {
 			return fmt.Errorf("getting Fulcio roots: %w", err)
 		}
-		co.IntermediateCerts, err = fulcio.GetIntermediates()
+		co.UntrustedIntermediateCerts, err = fulcio.GetIntermediates()
 		if err != nil {
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
@@ -205,7 +205,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			if err != nil {
 				return fmt.Errorf("getting Fulcio roots: %w", err)
 			}
-			co.IntermediateCerts, err = fulcio.GetIntermediates()
+			co.UntrustedIntermediateCerts, err = fulcio.GetIntermediates()
 			if err != nil {
 				return fmt.Errorf("getting Fulcio intermediates: %w", err)
 			}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -143,7 +143,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		if err != nil {
 			return fmt.Errorf("getting Fulcio roots: %w", err)
 		}
-		co.IntermediateCerts, err = fulcio.GetIntermediates()
+		co.UntrustedIntermediateCerts, err = fulcio.GetIntermediates()
 		if err != nil {
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
@@ -182,7 +182,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			if err != nil {
 				return fmt.Errorf("getting Fulcio roots: %w", err)
 			}
-			co.IntermediateCerts, err = fulcio.GetIntermediates()
+			co.UntrustedIntermediateCerts, err = fulcio.GetIntermediates()
 			if err != nil {
 				return fmt.Errorf("getting Fulcio intermediates: %w", err)
 			}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -153,7 +153,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			if err != nil {
 				return fmt.Errorf("getting Fulcio roots: %w", err)
 			}
-			co.IntermediateCerts, err = fulcio.GetIntermediates()
+			co.UntrustedIntermediateCerts, err = fulcio.GetIntermediates()
 			if err != nil {
 				return fmt.Errorf("getting Fulcio intermediates: %w", err)
 			}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -481,12 +481,12 @@ func ValidateAndUnpackCertWithChain(cert *x509.Certificate, chain []*x509.Certif
 }
 
 func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *TrustedRekorPubKeys,
-	sig oci.Signature, pem []byte) (*models.LogEntryAnon, error) {
-	b64sig, err := sig.Base64Signature()
+	untrustedSig oci.Signature, pem []byte) (*models.LogEntryAnon, error) {
+	b64sig, err := untrustedSig.Base64Signature()
 	if err != nil {
 		return nil, err
 	}
-	payload, err := sig.Payload()
+	payload, err := untrustedSig.Payload()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1062,24 +1062,24 @@ func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool)
 		return nil, fmt.Errorf("reading base64signature: %w", err)
 	}
 
-	var tsBytes []byte
+	var untrustedTSAArtifact []byte
 	if len(untrustedB64Sig) == 0 {
 		// For attestations, the Base64Signature is not set, therefore we rely on the signed payload
 		untrustedPayload, err := untrustedSig.Payload()
 		if err != nil {
 			return nil, fmt.Errorf("reading the payload: %w", err)
 		}
-		tsBytes = untrustedPayload
+		untrustedTSAArtifact = untrustedPayload
 	} else {
 		// create timestamp over raw bytes of signature
 		untrustedRawSig, err := base64.StdEncoding.DecodeString(untrustedB64Sig)
 		if err != nil {
 			return nil, err
 		}
-		tsBytes = untrustedRawSig
+		untrustedTSAArtifact = untrustedRawSig
 	}
 
-	err = tsaverification.VerifyTimestampResponse(untrustedTimestamp.SignedRFC3161Timestamp, bytes.NewReader(tsBytes), tsaCerts)
+	err = tsaverification.VerifyTimestampResponse(untrustedTimestamp.SignedRFC3161Timestamp, bytes.NewReader(untrustedTSAArtifact), tsaCerts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to verify TimestampResponse: %w", err)
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1050,10 +1050,10 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 // returns the timestamp value.
 // It returns (nil, nil) if there is no timestamp, or (nil, err) if there is an invalid timestamp.
 func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool) (*timestamp.Timestamp, error) {
-	ts, err := untrustedSig.RFC3161Timestamp()
+	untrustedTimestamp, err := untrustedSig.RFC3161Timestamp()
 	if err != nil {
 		return nil, err
-	} else if ts == nil {
+	} else if untrustedTimestamp == nil {
 		return nil, nil
 	}
 
@@ -1079,11 +1079,11 @@ func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool)
 		tsBytes = rawSig
 	}
 
-	err = tsaverification.VerifyTimestampResponse(ts.SignedRFC3161Timestamp, bytes.NewReader(tsBytes), tsaCerts)
+	err = tsaverification.VerifyTimestampResponse(untrustedTimestamp.SignedRFC3161Timestamp, bytes.NewReader(tsBytes), tsaCerts)
 	if err != nil {
 		return nil, fmt.Errorf("unable to verify TimestampResponse: %w", err)
 	}
-	acceptedTimestamp := ts
+	acceptedTimestamp := untrustedTimestamp
 
 	// FIXME: tsaverification.VerifyTimestampResponse has done this parsing; we shouldn’t parse again.
 	return timestamp.ParseResponse(acceptedTimestamp.SignedRFC3161Timestamp)

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -762,8 +762,9 @@ func verifyInternal(ctx context.Context, untrustedSignature oci.Signature, h v1.
 				return false, fmt.Errorf("checking expiry on cert: %w", err)
 			}
 		}
+		acceptableCert := certWithUnverifiedExpiry
 
-		verifier, err = verifierFromTrustedCertificate(certWithUnverifiedExpiry)
+		verifier, err = verifierFromTrustedCertificate(acceptableCert)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1007,14 +1007,6 @@ func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, errors.New("no trusted rekor public keys provided")
 	}
 
-	if err := compareSigs(untrustedBundle.Payload.Body.(string), untrustedSig); err != nil {
-		return false, err
-	}
-
-	if err := comparePublicKey(untrustedBundle.Payload.Body.(string), untrustedSig, co); err != nil {
-		return false, err
-	}
-
 	pubKey, ok := co.RekorPubKeys.Keys[untrustedBundle.Payload.LogID]
 	if !ok {
 		return false, &VerificationError{"verifying bundle: rekor log public key not found for payload"}
@@ -1027,6 +1019,13 @@ func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 		fmt.Fprintf(os.Stderr, "**Info** Successfully verified Rekor entry using an expired verification key\n")
 	}
 	acceptableBundleBody := untrustedBundle.Payload.Body.(string)
+
+	if err := comparePublicKey(acceptableBundleBody, untrustedSig, co); err != nil {
+		return false, err
+	}
+	if err := compareSigs(acceptableBundleBody, untrustedSig); err != nil {
+		return false, err
+	}
 
 	payload, err := untrustedSig.Payload()
 	if err != nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1049,15 +1049,15 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 // VerifyRFC3161Timestamp verifies that the timestamp in untrustedSig is correctly signed, and if so,
 // returns the timestamp value.
 // It returns (nil, nil) if there is no timestamp, or (nil, err) if there is an invalid timestamp.
-func VerifyRFC3161Timestamp(sig oci.Signature, tsaCerts *x509.CertPool) (*timestamp.Timestamp, error) {
-	ts, err := sig.RFC3161Timestamp()
+func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool) (*timestamp.Timestamp, error) {
+	ts, err := untrustedSig.RFC3161Timestamp()
 	if err != nil {
 		return nil, err
 	} else if ts == nil {
 		return nil, nil
 	}
 
-	b64Sig, err := sig.Base64Signature()
+	b64Sig, err := untrustedSig.Base64Signature()
 	if err != nil {
 		return nil, fmt.Errorf("reading base64signature: %w", err)
 	}
@@ -1065,7 +1065,7 @@ func VerifyRFC3161Timestamp(sig oci.Signature, tsaCerts *x509.CertPool) (*timest
 	var tsBytes []byte
 	if len(b64Sig) == 0 {
 		// For attestations, the Base64Signature is not set, therefore we rely on the signed payload
-		signedPayload, err := sig.Payload()
+		signedPayload, err := untrustedSig.Payload()
 		if err != nil {
 			return nil, fmt.Errorf("reading the payload: %w", err)
 		}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -486,11 +486,11 @@ func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *
 	if err != nil {
 		return nil, err
 	}
-	payload, err := untrustedSig.Payload()
+	untrustedPayload, err := untrustedSig.Payload()
 	if err != nil {
 		return nil, err
 	}
-	tlogEntries, err := FindTlogEntry(ctx, client, untrustedB64sig, payload, untrustedPEM)
+	tlogEntries, err := FindTlogEntry(ctx, client, untrustedB64sig, untrustedPayload, untrustedPEM)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -219,7 +219,7 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 	}
 	correctlySignedCert := untrustedCert
 
-	err = CheckCertificatePolicy(correctlySignedCert, co)
+	err = CheckCertificateIssuerAndSubject(correctlySignedCert, co)
 	if err != nil {
 		return nil, err
 	}
@@ -326,9 +326,9 @@ func validateIssuerPolicy(correctlySignedCert *x509.Certificate, co *CheckOpts) 
 	return nil
 }
 
-// CheckCertificatePolicy checks that the certificate subject and issuer match
+// CheckCertificateIssuerAndSubject checks that the certificate subject and issuer match
 // the expected values.
-func CheckCertificatePolicy(correctlySignedCert *x509.Certificate, co *CheckOpts) error {
+func CheckCertificateIssuerAndSubject(correctlySignedCert *x509.Certificate, co *CheckOpts) error {
 	if err := validateIssuerPolicy(correctlySignedCert, co); err != nil {
 		return err
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -329,16 +329,15 @@ func validateIssuerPolicy(correctlySignedCert *x509.Certificate, co *CheckOpts) 
 // CheckCertificatePolicy checks that the certificate subject and issuer match
 // the expected values.
 func CheckCertificatePolicy(correctlySignedCert *x509.Certificate, co *CheckOpts) error {
-	ce := CertExtensions{Cert: correctlySignedCert}
-
-	if err := validateCertSubject(correctlySignedCert, co); err != nil {
-		return err
-	}
-
-	if err := validateCertExtensions(ce, co); err != nil {
-		return err
-	}
 	if err := validateIssuerPolicy(correctlySignedCert, co); err != nil {
+		return err
+	}
+	certWithAceptedIssuer := correctlySignedCert
+	if err := validateCertSubject(certWithAceptedIssuer, co); err != nil {
+		return err
+	}
+	ce := CertExtensions{Cert: certWithAceptedIssuer}
+	if err := validateCertExtensions(ce, co); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -687,18 +687,18 @@ func verifyInternal(ctx context.Context, untrustedSignature oci.Signature, h v1.
 			return false, &VerificationError{"no certificate found on signature"}
 		}
 		// Create a certificate pool for intermediate CA certificates, excluding the root
-		chain, err := untrustedSignature.Chain()
+		untrustedChain, err := untrustedSignature.Chain()
 		if err != nil {
 			return false, err
 		}
 		// If there is no chain annotation present, we preserve the pools set in the CheckOpts.
-		if len(chain) > 0 {
-			if len(chain) == 1 {
+		if len(untrustedChain) > 0 {
+			if len(untrustedChain) == 1 {
 				co.IntermediateCerts = nil
 			} else if co.IntermediateCerts == nil {
 				// If the intermediate certs have not been loaded in by TUF
 				pool := x509.NewCertPool()
-				for _, cert := range chain[:len(chain)-1] {
+				for _, cert := range untrustedChain[:len(untrustedChain)-1] {
 					pool.AddCert(cert)
 				}
 				co.IntermediateCerts = pool

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -213,7 +213,7 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 	}
 
 	// Now verify the cert, then the signature.
-	chains, err := TrustedCert(untrustedCert, co.RootCerts, co.UntrustedIntermediateCerts)
+	chains, err := CertificateSignedByTrustedRoot(untrustedCert, co.RootCerts, co.UntrustedIntermediateCerts)
 	if err != nil {
 		return nil, err
 	}
@@ -1281,7 +1281,9 @@ func VerifySET(bundlePayload cbundle.RekorPayload, signature []byte, pub *ecdsa.
 	return nil
 }
 
-func TrustedCert(untrustedCert *x509.Certificate, roots *x509.CertPool, untrustedIntermediates *x509.CertPool) ([][]*x509.Certificate, error) {
+// CertificateSignedByTrustedRoot(untrustedCert verifies that untrusteCertificate is correctly signed by one of the roots in roots.
+// WARNING: The certificate might still not be trusted to sign any particular thing; that depends on other attributes of the certificate.
+func CertificateSignedByTrustedRoot(untrustedCert *x509.Certificate, roots *x509.CertPool, untrustedIntermediates *x509.CertPool) ([][]*x509.Certificate, error) {
 	chains, err := untrustedCert.Verify(x509.VerifyOptions{
 		// THIS IS IMPORTANT: WE DO NOT CHECK TIMES HERE
 		// THE CERTIFICATE IS TREATED AS TRUSTED FOREVER

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -373,34 +373,36 @@ func validateCertExtensions(ce CertExtensions, co *CheckOpts) error {
 	return nil
 }
 
-func validateCertIdentity(cert *x509.Certificate, co *CheckOpts) error {
+// validateCertIdentity validates the subject of the certificate against co.
+// It should only be called after the certificate has been determined to be correctly signed.
+func validateCertIdentity(correctlySignedCert *x509.Certificate, co *CheckOpts) error {
 	// TODO: Make it mandatory to include one of these options.
 	if co.CertEmail == "" && co.CertIdentity == "" {
 		return nil
 	}
 
-	for _, dns := range cert.DNSNames {
+	for _, dns := range correctlySignedCert.DNSNames {
 		if co.CertIdentity == dns {
 			return nil
 		}
 	}
-	for _, em := range cert.EmailAddresses {
+	for _, em := range correctlySignedCert.EmailAddresses {
 		if co.CertIdentity == em || co.CertEmail == em {
 			return nil
 		}
 	}
-	for _, ip := range cert.IPAddresses {
+	for _, ip := range correctlySignedCert.IPAddresses {
 		if co.CertIdentity == ip.String() {
 			return nil
 		}
 	}
-	for _, uri := range cert.URIs {
+	for _, uri := range correctlySignedCert.URIs {
 		if co.CertIdentity == uri.String() {
 			return nil
 		}
 	}
 
-	otherName, _ := cryptoutils.UnmarshalOtherNameSAN(cert.Extensions)
+	otherName, _ := cryptoutils.UnmarshalOtherNameSAN(correctlySignedCert.Extensions)
 	if len(otherName) > 0 && co.CertIdentity == otherName {
 		return nil
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -217,8 +217,9 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 	if err != nil {
 		return nil, err
 	}
+	correctlySignedCert := untrustedCert
 
-	err = CheckCertificatePolicy(untrustedCert, co)
+	err = CheckCertificatePolicy(correctlySignedCert, co)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 	if co.IgnoreSCT {
 		return verifier, nil
 	}
-	contains, err := ctl.ContainsSCT(untrustedCert.Raw)
+	contains, err := ctl.ContainsSCT(correctlySignedCert.Raw)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1072,11 +1072,11 @@ func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool)
 		tsBytes = untrustedPayload
 	} else {
 		// create timestamp over raw bytes of signature
-		rawSig, err := base64.StdEncoding.DecodeString(untrustedB64Sig)
+		untrustedRawSig, err := base64.StdEncoding.DecodeString(untrustedB64Sig)
 		if err != nil {
 			return nil, err
 		}
-		tsBytes = rawSig
+		tsBytes = untrustedRawSig
 	}
 
 	err = tsaverification.VerifyTimestampResponse(untrustedTimestamp.SignedRFC3161Timestamp, bytes.NewReader(tsBytes), tsaCerts)

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1026,6 +1026,7 @@ func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 	if pubKey.Status != tuf.Active {
 		fmt.Fprintf(os.Stderr, "**Info** Successfully verified Rekor entry using an expired verification key\n")
 	}
+	acceptableBundleBody := untrustedBundle.Payload.Body.(string)
 
 	payload, err := untrustedSig.Payload()
 	if err != nil {
@@ -1036,7 +1037,7 @@ func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, fmt.Errorf("reading base64signature: %w", err)
 	}
 
-	alg, bundlehash, err := bundleHash(untrustedBundle.Payload.Body.(string), signature)
+	alg, bundlehash, err := bundleHash(acceptableBundleBody, signature)
 	h := sha256.Sum256(payload)
 	payloadHash := hex.EncodeToString(h[:])
 

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -482,7 +482,7 @@ func ValidateAndUnpackCertWithChain(cert *x509.Certificate, chain []*x509.Certif
 
 func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *TrustedRekorPubKeys,
 	untrustedSig oci.Signature, untrustedPEM []byte) (*models.LogEntryAnon, error) {
-	b64sig, err := untrustedSig.Base64Signature()
+	untrustedB64sig, err := untrustedSig.Base64Signature()
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,7 @@ func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *
 	if err != nil {
 		return nil, err
 	}
-	tlogEntries, err := FindTlogEntry(ctx, client, b64sig, payload, untrustedPEM)
+	tlogEntries, err := FindTlogEntry(ctx, client, untrustedB64sig, payload, untrustedPEM)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -692,12 +692,12 @@ func verifyInternal(ctx context.Context, untrustedSignature oci.Signature, h v1.
 				return false, fmt.Errorf("rekor client not provided for online verification")
 			}
 
-			pemBytes, err := keyBytes(untrustedSignature, co)
+			untrustedPEMBytes, err := keyBytes(untrustedSignature, co)
 			if err != nil {
 				return false, err
 			}
 
-			e, err := tlogValidateEntry(ctx, co.RekorClient, co.RekorPubKeys, untrustedSignature, pemBytes)
+			e, err := tlogValidateEntry(ctx, co.RekorClient, co.RekorPubKeys, untrustedSignature, untrustedPEMBytes)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -679,11 +679,11 @@ func verifyInternal(ctx context.Context, untrustedSignature oci.Signature, h v1.
 	verifier := co.SigVerifier
 	if verifier == nil {
 		// If we don't have a public key to check against, we can try a root cert.
-		cert, err := untrustedSignature.Cert()
+		untrustedCert, err := untrustedSignature.Cert()
 		if err != nil {
 			return false, err
 		}
-		if cert == nil {
+		if untrustedCert == nil {
 			return false, &VerificationError{"no certificate found on signature"}
 		}
 		// Create a certificate pool for intermediate CA certificates, excluding the root
@@ -704,7 +704,7 @@ func verifyInternal(ctx context.Context, untrustedSignature oci.Signature, h v1.
 				co.IntermediateCerts = pool
 			}
 		}
-		verifier, err = ValidateAndUnpackCert(cert, co)
+		verifier, err = ValidateAndUnpackCert(untrustedCert, co)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -269,7 +269,7 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 func CheckCertificatePolicy(cert *x509.Certificate, co *CheckOpts) error {
 	ce := CertExtensions{Cert: cert}
 
-	if err := validateCertIdentity(cert, co); err != nil {
+	if err := validateCertSubject(cert, co); err != nil {
 		return err
 	}
 
@@ -373,9 +373,9 @@ func validateCertExtensions(ce CertExtensions, co *CheckOpts) error {
 	return nil
 }
 
-// validateCertIdentity validates the subject of the certificate against co.
+// validateCertSubject validates the subject of the certificate against co.
 // It should only be called after the certificate has been determined to be correctly signed.
-func validateCertIdentity(correctlySignedCert *x509.Certificate, co *CheckOpts) error {
+func validateCertSubject(correctlySignedCert *x509.Certificate, co *CheckOpts) error {
 	// TODO: Make it mandatory to include one of these options.
 	if co.CertEmail == "" && co.CertIdentity == "" {
 		return nil

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -266,10 +266,10 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 
 // CheckCertificatePolicy checks that the certificate subject and issuer match
 // the expected values.
-func CheckCertificatePolicy(cert *x509.Certificate, co *CheckOpts) error {
-	ce := CertExtensions{Cert: cert}
+func CheckCertificatePolicy(correctlySignedCert *x509.Certificate, co *CheckOpts) error {
+	ce := CertExtensions{Cert: correctlySignedCert}
 
-	if err := validateCertSubject(cert, co); err != nil {
+	if err := validateCertSubject(correctlySignedCert, co); err != nil {
 		return err
 	}
 
@@ -307,14 +307,14 @@ func CheckCertificatePolicy(cert *x509.Certificate, co *CheckOpts) error {
 				if err != nil {
 					return fmt.Errorf("malformed subject in identity: %s : %w", identity.SubjectRegExp, err)
 				}
-				for _, san := range getSubjectAlternateNames(cert) {
+				for _, san := range getSubjectAlternateNames(correctlySignedCert) {
 					if regex.MatchString(san) {
 						subjectMatches = true
 						break
 					}
 				}
 			case identity.Subject != "":
-				for _, san := range getSubjectAlternateNames(cert) {
+				for _, san := range getSubjectAlternateNames(correctlySignedCert) {
 					if san == identity.Subject {
 						subjectMatches = true
 						break

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1299,8 +1299,9 @@ func bundleKey(bundleBody string) (string, error) {
 	return intotodObj.PublicKey.String(), nil
 }
 
-func VerifySET(bundlePayload cbundle.RekorPayload, signature []byte, pub *ecdsa.PublicKey) error {
-	contents, err := json.Marshal(bundlePayload)
+// VerifySET verifies that untrustedSignature is correctly signing untrustedBundlePayload with pub.
+func VerifySET(untrustedBundlePayload cbundle.RekorPayload, untrustedSignature []byte, pub *ecdsa.PublicKey) error {
+	contents, err := json.Marshal(untrustedBundlePayload)
 	if err != nil {
 		return fmt.Errorf("marshaling: %w", err)
 	}
@@ -1311,7 +1312,7 @@ func VerifySET(bundlePayload cbundle.RekorPayload, signature []byte, pub *ecdsa.
 
 	// verify the SET against the public key
 	hash := sha256.Sum256(canonicalized)
-	if !ecdsa.VerifyASN1(pub, hash[:], signature) {
+	if !ecdsa.VerifyASN1(pub, hash[:], untrustedSignature) {
 		return &VerificationError{"unable to verify SET"}
 	}
 	return nil

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -993,8 +993,9 @@ func getBundleIntegratedTime(sig oci.Signature) (time.Time, error) {
 	return time.Unix(bundle.Payload.IntegratedTime, 0), nil
 }
 
-// This verifies an offline bundle contained in the sig against the trusted
-// Rekor publicKeys.
+// VerifyBundle returns true if untrustedSig contains an offline Rekor bundle corectly signed
+// by the trusted Rekor public keys, and the bundle attests
+// to recording untrustedSig’s public key, signature and payload.
 func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 	untrustedBundle, err := untrustedSig.Bundle()
 	if err != nil {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -732,7 +732,12 @@ func verifyInternal(ctx context.Context, untrustedSignature oci.Signature, h v1.
 				co.UntrustedIntermediateCerts = untrustedPool
 			}
 		}
-		verifier, err = ValidateAndUnpackCert(untrustedCert, co)
+		if err := validateCertIssuanceAndSubject(untrustedCert, co); err != nil {
+			return false, err
+		}
+		correctlyIssuedCert := untrustedCert
+
+		verifier, err = verifierFromTrustedCertificate(correctlyIssuedCert)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -697,11 +697,11 @@ func verifyInternal(ctx context.Context, untrustedSignature oci.Signature, h v1.
 				co.UntrustedIntermediateCerts = nil
 			} else if co.UntrustedIntermediateCerts == nil {
 				// If the intermediate certs have not been loaded in by TUF
-				pool := x509.NewCertPool()
+				untrustedPool := x509.NewCertPool()
 				for _, cert := range untrustedChain[:len(untrustedChain)-1] {
-					pool.AddCert(cert)
+					untrustedPool.AddCert(cert)
 				}
-				co.UntrustedIntermediateCerts = pool
+				co.UntrustedIntermediateCerts = untrustedPool
 			}
 		}
 		verifier, err = ValidateAndUnpackCert(untrustedCert, co)

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1031,12 +1031,12 @@ func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 	if err != nil {
 		return false, fmt.Errorf("reading payload: %w", err)
 	}
-	signature, err := untrustedSig.Base64Signature()
+	untrustedSignature, err := untrustedSig.Base64Signature()
 	if err != nil {
 		return false, fmt.Errorf("reading base64signature: %w", err)
 	}
 
-	alg, bundlehash, err := bundleHash(acceptableBundleBody, signature)
+	alg, bundlehash, err := bundleHash(acceptableBundleBody, untrustedSignature)
 	h := sha256.Sum256(untrustedPayload)
 	payloadHash := hex.EncodeToString(h[:])
 

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -995,8 +995,8 @@ func getBundleIntegratedTime(sig oci.Signature) (time.Time, error) {
 
 // This verifies an offline bundle contained in the sig against the trusted
 // Rekor publicKeys.
-func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
-	bundle, err := sig.Bundle()
+func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
+	bundle, err := untrustedSig.Bundle()
 	if err != nil {
 		return false, err
 	} else if bundle == nil {
@@ -1007,11 +1007,11 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, errors.New("no trusted rekor public keys provided")
 	}
 
-	if err := compareSigs(bundle.Payload.Body.(string), sig); err != nil {
+	if err := compareSigs(bundle.Payload.Body.(string), untrustedSig); err != nil {
 		return false, err
 	}
 
-	if err := comparePublicKey(bundle.Payload.Body.(string), sig, co); err != nil {
+	if err := comparePublicKey(bundle.Payload.Body.(string), untrustedSig, co); err != nil {
 		return false, err
 	}
 
@@ -1027,11 +1027,11 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 		fmt.Fprintf(os.Stderr, "**Info** Successfully verified Rekor entry using an expired verification key\n")
 	}
 
-	payload, err := sig.Payload()
+	payload, err := untrustedSig.Payload()
 	if err != nil {
 		return false, fmt.Errorf("reading payload: %w", err)
 	}
-	signature, err := sig.Base64Signature()
+	signature, err := untrustedSig.Base64Signature()
 	if err != nil {
 		return false, fmt.Errorf("reading base64signature: %w", err)
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -214,12 +214,6 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 	}
 	correctlySignedCert := untrustedCert
 
-	err = CheckCertificateIssuerAndSubject(correctlySignedCert, co)
-	if err != nil {
-		return nil, err
-	}
-
-	// If IgnoreSCT is set, skip the SCT check
 	if !co.IgnoreSCT {
 		contains, err := ctl.ContainsSCT(correctlySignedCert.Raw)
 		if err != nil {
@@ -254,8 +248,14 @@ func ValidateAndUnpackCert(untrustedCert *x509.Certificate, co *CheckOpts) (sign
 			}
 		}
 	}
+	correctlyIssuedCert := correctlySignedCert
 
-	verifier, err := signature.LoadVerifier(correctlySignedCert.PublicKey, crypto.SHA256)
+	err = CheckCertificateIssuerAndSubject(correctlyIssuedCert, co)
+	if err != nil {
+		return nil, err
+	}
+
+	verifier, err := signature.LoadVerifier(correctlyIssuedCert.PublicKey, crypto.SHA256)
 	if err != nil {
 		return nil, fmt.Errorf("invalid certificate found on signature: %w", err)
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1057,13 +1057,13 @@ func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool)
 		return nil, nil
 	}
 
-	b64Sig, err := untrustedSig.Base64Signature()
+	untrustedB64Sig, err := untrustedSig.Base64Signature()
 	if err != nil {
 		return nil, fmt.Errorf("reading base64signature: %w", err)
 	}
 
 	var tsBytes []byte
-	if len(b64Sig) == 0 {
+	if len(untrustedB64Sig) == 0 {
 		// For attestations, the Base64Signature is not set, therefore we rely on the signed payload
 		signedPayload, err := untrustedSig.Payload()
 		if err != nil {
@@ -1072,7 +1072,7 @@ func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool)
 		tsBytes = signedPayload
 	} else {
 		// create timestamp over raw bytes of signature
-		rawSig, err := base64.StdEncoding.DecodeString(b64Sig)
+		rawSig, err := base64.StdEncoding.DecodeString(untrustedB64Sig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1281,14 +1281,14 @@ func VerifySET(bundlePayload cbundle.RekorPayload, signature []byte, pub *ecdsa.
 	return nil
 }
 
-func TrustedCert(cert *x509.Certificate, roots *x509.CertPool, intermediates *x509.CertPool) ([][]*x509.Certificate, error) {
-	chains, err := cert.Verify(x509.VerifyOptions{
+func TrustedCert(untrustedCert *x509.Certificate, roots *x509.CertPool, untrustedIntermediates *x509.CertPool) ([][]*x509.Certificate, error) {
+	chains, err := untrustedCert.Verify(x509.VerifyOptions{
 		// THIS IS IMPORTANT: WE DO NOT CHECK TIMES HERE
 		// THE CERTIFICATE IS TREATED AS TRUSTED FOREVER
 		// WE CHECK THAT THE SIGNATURES WERE CREATED DURING THIS WINDOW
-		CurrentTime:   cert.NotBefore,
+		CurrentTime:   untrustedCert.NotBefore,
 		Roots:         roots,
-		Intermediates: intermediates,
+		Intermediates: untrustedIntermediates,
 		KeyUsages: []x509.ExtKeyUsage{
 			x509.ExtKeyUsageCodeSigning,
 		},

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -481,7 +481,7 @@ func ValidateAndUnpackCertWithChain(cert *x509.Certificate, chain []*x509.Certif
 }
 
 func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *TrustedRekorPubKeys,
-	untrustedSig oci.Signature, pem []byte) (*models.LogEntryAnon, error) {
+	untrustedSig oci.Signature, untrustedPEM []byte) (*models.LogEntryAnon, error) {
 	b64sig, err := untrustedSig.Base64Signature()
 	if err != nil {
 		return nil, err
@@ -490,7 +490,7 @@ func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *
 	if err != nil {
 		return nil, err
 	}
-	tlogEntries, err := FindTlogEntry(ctx, client, b64sig, payload, pem)
+	tlogEntries, err := FindTlogEntry(ctx, client, b64sig, payload, untrustedPEM)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1065,11 +1065,11 @@ func VerifyRFC3161Timestamp(untrustedSig oci.Signature, tsaCerts *x509.CertPool)
 	var tsBytes []byte
 	if len(untrustedB64Sig) == 0 {
 		// For attestations, the Base64Signature is not set, therefore we rely on the signed payload
-		signedPayload, err := untrustedSig.Payload()
+		untrustedPayload, err := untrustedSig.Payload()
 		if err != nil {
 			return nil, fmt.Errorf("reading the payload: %w", err)
 		}
-		tsBytes = signedPayload
+		tsBytes = untrustedPayload
 	} else {
 		// create timestamp over raw bytes of signature
 		rawSig, err := base64.StdEncoding.DecodeString(untrustedB64Sig)

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1027,7 +1027,7 @@ func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, err
 	}
 
-	payload, err := untrustedSig.Payload()
+	untrustedPayload, err := untrustedSig.Payload()
 	if err != nil {
 		return false, fmt.Errorf("reading payload: %w", err)
 	}
@@ -1037,7 +1037,7 @@ func VerifyBundle(untrustedSig oci.Signature, co *CheckOpts) (bool, error) {
 	}
 
 	alg, bundlehash, err := bundleHash(acceptableBundleBody, signature)
-	h := sha256.Sum256(payload)
+	h := sha256.Sum256(untrustedPayload)
 	payloadHash := hex.EncodeToString(h[:])
 
 	if alg != "sha256" || bundlehash != payloadHash {

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1201,7 +1201,7 @@ func TestCompareSigs(t *testing.T) {
 	}
 }
 
-func TestTrustedCertSuccess(t *testing.T) {
+func TestCertificateSignedByTrustedRootSuccess(t *testing.T) {
 	rootCert, rootKey, _ := test.GenerateRootCa()
 	subCert, subKey, _ := test.GenerateSubordinateCa(rootCert, rootKey)
 	leafCert, _, _ := test.GenerateLeafCert("subject", "oidc-issuer", subCert, subKey)
@@ -1211,7 +1211,7 @@ func TestTrustedCertSuccess(t *testing.T) {
 	subPool := x509.NewCertPool()
 	subPool.AddCert(subCert)
 
-	chains, err := TrustedCert(leafCert, rootPool, subPool)
+	chains, err := CertificateSignedByTrustedRoot(leafCert, rootPool, subPool)
 	if err != nil {
 		t.Fatalf("expected no error verifying certificate, got %v", err)
 	}
@@ -1223,14 +1223,14 @@ func TestTrustedCertSuccess(t *testing.T) {
 	}
 }
 
-func TestTrustedCertSuccessNoIntermediates(t *testing.T) {
+func TestCertificateSignedByTrustedRootSuccessNoIntermediates(t *testing.T) {
 	rootCert, rootKey, _ := test.GenerateRootCa()
 	leafCert, _, _ := test.GenerateLeafCert("subject", "oidc-issuer", rootCert, rootKey)
 
 	rootPool := x509.NewCertPool()
 	rootPool.AddCert(rootCert)
 
-	_, err := TrustedCert(leafCert, rootPool, nil)
+	_, err := CertificateSignedByTrustedRoot(leafCert, rootPool, nil)
 	if err != nil {
 		t.Fatalf("expected no error verifying certificate, got %v", err)
 	}
@@ -1238,7 +1238,7 @@ func TestTrustedCertSuccessNoIntermediates(t *testing.T) {
 
 // Tests that verification succeeds if both a root and subordinate pool are
 // present, but a chain is built with only the leaf and root certificates.
-func TestTrustedCertSuccessChainFromRoot(t *testing.T) {
+func TestCertificateSignedByTrustedRootSuccessChainFromRoot(t *testing.T) {
 	rootCert, rootKey, _ := test.GenerateRootCa()
 	leafCert, _, _ := test.GenerateLeafCert("subject", "oidc-issuer", rootCert, rootKey)
 	subCert, _, _ := test.GenerateSubordinateCa(rootCert, rootKey)
@@ -1248,7 +1248,7 @@ func TestTrustedCertSuccessChainFromRoot(t *testing.T) {
 	subPool := x509.NewCertPool()
 	subPool.AddCert(subCert)
 
-	_, err := TrustedCert(leafCert, rootPool, subPool)
+	_, err := CertificateSignedByTrustedRoot(leafCert, rootPool, subPool)
 	if err != nil {
 		t.Fatalf("expected no error verifying certificate, got %v", err)
 	}

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -555,7 +555,7 @@ func TestValidateAndUnpackCertSuccess(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	if err != nil {
 		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
@@ -580,7 +580,7 @@ func TestValidateAndUnpackCertSuccessAllowAllValues(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	if err != nil {
 		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
@@ -636,7 +636,7 @@ func TestValidateAndUnpackCertSuccessWithDnsSan(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	if err != nil {
 		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
@@ -670,7 +670,7 @@ func TestValidateAndUnpackCertSuccessWithEmailSan(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	if err != nil {
 		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
@@ -704,7 +704,7 @@ func TestValidateAndUnpackCertSuccessWithIpAddressSan(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	if err != nil {
 		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
@@ -738,7 +738,7 @@ func TestValidateAndUnpackCertSuccessWithUriSan(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	if err != nil {
 		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
@@ -772,7 +772,7 @@ func TestValidateAndUnpackCertSuccessWithOtherNameSan(t *testing.T) {
 	if err != nil {
 		t.Errorf("ValidateAndUnpackCert expected no error, got err = %v", err)
 	}
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	if err != nil {
 		t.Errorf("CheckCertificatePolicy expected no error, got err = %v", err)
 	}
@@ -820,7 +820,7 @@ func TestValidateAndUnpackCertInvalidOidcIssuer(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected oidc issuer not found in certificate")
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	require.Contains(t, err.Error(), "expected oidc issuer not found in certificate")
 }
 
@@ -843,7 +843,7 @@ func TestValidateAndUnpackCertInvalidEmail(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected identity not found in certificate")
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	require.Contains(t, err.Error(), "expected identity not found in certificate")
 }
 
@@ -868,7 +868,7 @@ func TestValidateAndUnpackCertInvalidGithubWorkflowTrigger(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Trigger not found in certificate")
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Trigger not found in certificate")
 }
 
@@ -893,7 +893,7 @@ func TestValidateAndUnpackCertInvalidGithubWorkflowSHA(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow SHA not found in certificate")
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow SHA not found in certificate")
 }
 
@@ -918,7 +918,7 @@ func TestValidateAndUnpackCertInvalidGithubWorkflowName(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Name not found in certificate")
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Name not found in certificate")
 }
 
@@ -943,7 +943,7 @@ func TestValidateAndUnpackCertInvalidGithubWorkflowRepository(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Repository not found in certificate")
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Repository not found in certificate")
 }
 
@@ -968,7 +968,7 @@ func TestValidateAndUnpackCertInvalidGithubWorkflowRef(t *testing.T) {
 
 	_, err := ValidateAndUnpackCert(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Ref not found in certificate")
-	err = CheckCertificatePolicy(leafCert, co)
+	err = CheckCertificateIssuerAndSubject(leafCert, co)
 	require.Contains(t, err.Error(), "expected GitHub Workflow Ref not found in certificate")
 }
 
@@ -1152,7 +1152,7 @@ func TestValidateAndUnpackCertWithIdentities(t *testing.T) {
 			}
 		}
 		// Test CheckCertificatePolicy
-		err = CheckCertificatePolicy(leafCert, co)
+		err = CheckCertificateIssuerAndSubject(leafCert, co)
 		if err == nil && tc.wantErrSubstring != "" {
 			t.Errorf("Expected error %s got none", tc.wantErrSubstring)
 		} else if err != nil {

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -349,7 +349,7 @@ func TestVerifyImageSignatureWithExistingSub(t *testing.T) {
 	ociSig, _ := static.NewSignature(payload,
 		base64.StdEncoding.EncodeToString(signature),
 		static.WithCertChain(pemLeaf, appendSlices([][]byte{pemSub, pemRoot})))
-	verified, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{}, &CheckOpts{RootCerts: rootPool, IntermediateCerts: subPool, IgnoreSCT: true, SkipTlogVerify: true})
+	verified, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{}, &CheckOpts{RootCerts: rootPool, UntrustedIntermediateCerts: subPool, IgnoreSCT: true, SkipTlogVerify: true})
 	if err == nil {
 		t.Fatal("expected error while verifying signature")
 	}

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -96,7 +96,7 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("getting Fulcio roots: %w", err)
 		}
-		co.IntermediateCerts, err = fulcio.GetIntermediates()
+		co.UntrustedIntermediateCerts, err = fulcio.GetIntermediates()
 		if err != nil {
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}


### PR DESCRIPTION
#### Summary
`pkg/cosign.verifyInternal` keeps growing conditions (A) at the end of the function, long after already relying (B) on data that is constrained by these conditions. It effectively makes the outcome of B indeterminate until A happens; that’s hard to track, and A might not happen at all if the function returns early. This makes me _nervous_: personally for me, it makes following the operation and rules of the code much harder than I think is necessary.

So, this is a move somewhat towards, but not completely, the verification organization suggested in https://github.com/sigstore/cosign/pull/1648#discussion_r856479474.

Most data in `verifyInternal`, and closest utility functions, is now stored with variables named `untrusted…`. Only after _all_ checks on that data are done, it may be stored in a variable named `acceptable…`.

Testing relies on existing unit tests; no new tests were added.

See individual commit messages for details. Most of the commits are trivial variable renames.

Behavior changes:
- Certificate expiry is now not tested if we don’t rely on the certificate at all (if the user provides a trusted public key)
- If we do rely on the certificate, we now always test expiry against _some_ time. Previously that didn’t happen if there was no RFC 3161 timestamp and Rekor log presence was opted out. (I.e. this should allow using ordinary X.509 CA certificates without relying on a timestamp / Rekor at all, the way the TLS ecosystem does.)
- If there is a RFC 3161 timestamp, and Rekor log presence is processed but not required, we only require the certificate to be valid as of the timestamp, not as of the current time.

Basic summary of the ordering changes:
- The verification flow now:
  - _First_ ensures timestamp / Rekor presence; that obtains a trusted signature creation timestamp, if any
  - Then, if necessary, validates the certificate (requires the timestamp from previous step)
  - Cryptographically verifies the signature/payload
  - Only at the very end, processes the payload
- `VerifyBundle` now _first_ ensures that the entry was actually stored on Rekor, and only afterwards uses it to see whether it matches the supposedly-logged signature.

#### Release Note
Certificate expiry checking was made a bit more accurate.

#### Documentation
N/A.