### PR TITLE
drop windows tests for now due lack of support of crane action

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     permissions:


### PR DESCRIPTION
#### Summary
- drop windows tests for now due lack of support of crane action

I will work in the crane action to that support windows as well, but in meanwhile lets drop the windows tests
