### PR TITLE
cmd/cosign/cli: invoke tempFile.Close before deletion

### DIFF
--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -146,7 +146,10 @@ func initPolicy() *cobra.Command {
 					return err
 				}
 				outfile = tempFile.Name()
-				defer os.Remove(tempFile.Name())
+				defer func() {
+					tempFile.Close()
+					os.Remove(tempFile.Name())
+				}()
 			}
 
 			files := []cremote.File{
@@ -309,7 +312,10 @@ func signPolicy() *cobra.Command {
 					return err
 				}
 				outfile = tempFile.Name()
-				defer os.Remove(tempFile.Name())
+				defer func() {
+					tempFile.Close()
+					os.Remove(tempFile.Name())
+				}()
 			}
 
 			files := []cremote.File{


### PR DESCRIPTION
Fixes potential file leaks before invoking os.Remove, a condition in which an attacker who in another process on Windows could finagle a handle to the open file handles could have them open and then even prevent os.Remove from deleting the files.

Found as part of Orijtech Inc's supply chain analysis program for the Cosmos Network/ecosystem.

Fixes #2495