### PR TITLE
fix: removes attestation payload from attest-blob's output & no base64 encoding

### DIFF
--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -127,7 +126,6 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 		return errors.Wrap(err, "signing")
 	}
 
-	sig = []byte(base64.StdEncoding.EncodeToString(sig))
 	if c.OutputSignature != "" {
 		if err := os.WriteFile(c.OutputSignature, sig, 0600); err != nil {
 			return fmt.Errorf("create signature file: %w", err)
@@ -142,8 +140,6 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 			return fmt.Errorf("create signature file: %w", err)
 		}
 		fmt.Fprintf(os.Stderr, "Attestation written in %s\n", c.OutputAttestation)
-	} else {
-		fmt.Fprintln(os.Stdout, string(payload))
 	}
 
 	return nil

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -84,14 +84,10 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	if err != nil {
 		return fmt.Errorf("reading %s: %w", c.SignaturePath, err)
 	}
-	decodedSig, err := base64.StdEncoding.DecodeString(string(encodedSig))
-	if err != nil {
-		return fmt.Errorf("decoding signature: %w", err)
-	}
 
 	// Verify the signature on the attestation against the provided public key
 	env := ssldsse.Envelope{}
-	if err := json.Unmarshal(decodedSig, &env); err != nil {
+	if err := json.Unmarshal(encodedSig, &env); err != nil {
 		return fmt.Errorf("marshaling envelope: %w", err)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/sigstore/cosign/issues/2497

* fix!: This writes and prints the signature (DSSE envelope) output as the JSON, NOT base64-encoded. Previously, this would base64-encode the envelope
* fix!: This removes printing the attestation JSON to the std output. This confuses piping the output, since now both the DSSE envelope and the attestation are printed.
* fix!: `verify-blob-attestation` now expects a JSON DSSE envelope (NOT base64-encoded)

BREAKINGCHANGE
* `verify-blob-attestation` expects the JSON DSSE envelope. Previously, this was expected to be base64-encoded.
* `attest-blob` outputs only the JSON DSSE envelope. Previously, it also printed the intoto attestation payload and the DSSE envelope was additionally base64-encoded.

Signed-off-by: Asra Ali <asraa@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->