### PR TITLE
Updates to Timestamp signing and verification

### DIFF
--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -79,7 +79,7 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",
 		"url to the Timestamp RFC3161 server, default none")
 
-	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp-bundle", "",
-		"write everything required to verify the blob to a FILE")
-	_ = cmd.Flags().SetAnnotation("rfc3161-timestamp-bundle", cobra.BashCompFilenameExt, []string{})
+	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
+		"write the RFC3161 timestamp to a file")
+	_ = cmd.Flags().SetAnnotation("rfc3161-timestamp", cobra.BashCompFilenameExt, []string{})
 }

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -165,7 +165,7 @@ func (o *VerifyBlobOptions) AddFlags(cmd *cobra.Command) {
 		"path to bundle FILE")
 
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
-		"path to rfc3161 timestamp FILE")
+		"path to RFC3161 timestamp FILE")
 }
 
 // VerifyDockerfileOptions is the top level wrapper for the `dockerfile verify` command.

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -164,8 +164,8 @@ func (o *VerifyBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"path to bundle FILE")
 
-	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp-bundle", "",
-		"path to timestamp bundle FILE")
+	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
+		"path to rfc3161 timestamp FILE")
 }
 
 // VerifyDockerfileOptions is the top level wrapper for the `dockerfile verify` command.

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -273,8 +273,7 @@ func signPolicy() *cobra.Command {
 					return fmt.Errorf("failed to create TSA client: %w", err)
 				}
 				// Here we get the response from the timestamped authority server
-				_, err = tsa.GetTimestampedSignature(signed.Signed, clientTSA)
-				if err != nil {
+				if _, err := tsa.GetTimestampedSignature(signed.Signed, clientTSA); err != nil {
 					return err
 				}
 			}

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -99,9 +99,9 @@ func SignBlobCmd(ro *options.RootOptions, ko options.KeyOpts, payloadPath string
 			return nil, err
 		}
 		if err := os.WriteFile(ko.RFC3161TimestampPath, ts, 0600); err != nil {
-			return nil, fmt.Errorf("create rfc3161 timestamp file: %w", err)
+			return nil, fmt.Errorf("create RFC3161 timestamp file: %w", err)
 		}
-		fmt.Printf("RFC3161 timestamp bundle written to file %s\n", ko.RFC3161TimestampPath)
+		fmt.Fprintf(os.Stderr, "RFC3161 timestamp written to file %s\n", ko.RFC3161TimestampPath)
 	}
 	if ShouldUploadToTlog(ctx, ko, nil, tlogUpload) {
 		rekorBytes, err = sv.Bytes(ctx)

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -301,6 +301,7 @@ The blob may be specified as a path to a file or - for stdin.`,
 				IgnoreSCT:                    o.CertVerify.IgnoreSCT,
 				SCTRef:                       o.CertVerify.SCT,
 				Offline:                      o.CommonVerifyOptions.Offline,
+				SkipTlogVerify:               o.CommonVerifyOptions.SkipTlogVerify,
 			}
 			if err := verifyBlobCmd.Exec(cmd.Context(), args[0]); err != nil {
 				return fmt.Errorf("verifying blob %s: %w", args, err)

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -75,7 +75,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 
 	// Require a certificate/key OR a local bundle file that has the cert.
 	if options.NOf(c.KeyRef, c.CertRef, c.Sk, c.BundlePath) == 0 {
-		return fmt.Errorf("please provide a cert to verify against via --certificate or a bundle via --bundle")
+		return fmt.Errorf("provide a key with --key or --sk, a certificate to verify against with --certificate, or a bundle with --bundle")
 	}
 
 	// Key, sk, and cert are mutually exclusive.

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -523,6 +523,10 @@ func TestVerifyBlob(t *testing.T) {
 				expiredLeafPem, true)},
 			shouldErr: true,
 		},
+		// TODO: Add tests for TSA:
+		// * With or without bundle
+		// * Mismatched signature
+		// * Unexpired and expired certificate
 	}
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -33,29 +33,29 @@ cosign sign-blob [flags]
 ### Options
 
 ```
-      --b64                               whether to base64 encode the output (default true)
-      --bundle string                     write everything required to verify the blob to a FILE
-      --fulcio-url string                 [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
-  -h, --help                              help for sign-blob
-      --identity-token string             [EXPERIMENTAL] identity token to use for certificate from fulcio
-      --insecure-skip-verify              [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
-      --key string                        path to the private key file, KMS URI or Kubernetes Secret
-      --oidc-client-id string             [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
-      --oidc-client-secret-file string    [EXPERIMENTAL] Path to file containing OIDC client secret for application
-      --oidc-disable-ambient-providers    [EXPERIMENTAL] Disable ambient OIDC providers. When true, ambient credentials will not be read
-      --oidc-issuer string                [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
-      --oidc-provider string              [EXPERIMENTAL] Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github, filesystem]
-      --oidc-redirect-url string          [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
-      --output string                     write the signature to FILE
-      --output-certificate string         write the certificate to FILE
-      --output-signature string           write the signature to FILE
-      --rekor-url string                  [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --rfc3161-timestamp-bundle string   write everything required to verify the blob to a FILE
-      --sk                                whether to use a hardware security key
-      --slot string                       security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --timestamp-server-url string       url to the Timestamp RFC3161 server, default none
-      --tlog-upload                       whether or not to upload to the tlog (default true)
-  -y, --yes                               skip confirmation prompts for non-destructive operations
+      --b64                              whether to base64 encode the output (default true)
+      --bundle string                    write everything required to verify the blob to a FILE
+      --fulcio-url string                [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
+  -h, --help                             help for sign-blob
+      --identity-token string            [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --insecure-skip-verify             [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
+      --key string                       path to the private key file, KMS URI or Kubernetes Secret
+      --oidc-client-id string            [EXPERIMENTAL] OIDC client ID for application (default "sigstore")
+      --oidc-client-secret-file string   [EXPERIMENTAL] Path to file containing OIDC client secret for application
+      --oidc-disable-ambient-providers   [EXPERIMENTAL] Disable ambient OIDC providers. When true, ambient credentials will not be read
+      --oidc-issuer string               [EXPERIMENTAL] OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
+      --oidc-provider string             [EXPERIMENTAL] Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github, filesystem]
+      --oidc-redirect-url string         [EXPERIMENTAL] OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
+      --output string                    write the signature to FILE
+      --output-certificate string        write the certificate to FILE
+      --output-signature string          write the signature to FILE
+      --rekor-url string                 [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
+      --rfc3161-timestamp string         write the RFC3161 timestamp to a file
+      --sk                               whether to use a hardware security key
+      --slot string                      security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
+      --timestamp-server-url string      url to the Timestamp RFC3161 server, default none
+      --tlog-upload                      whether or not to upload to the tlog (default true)
+  -y, --yes                              skip confirmation prompts for non-destructive operations
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -79,7 +79,7 @@ cosign verify-blob [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --offline                                                                                  only allow offline verification
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --rfc3161-timestamp-bundle string                                                          path to timestamp bundle FILE
+      --rfc3161-timestamp string                                                                 path to rfc3161 timestamp FILE
       --sct string                                                                               path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --signature string                                                                         signature content or path or remote URL
       --sk                                                                                       whether to use a hardware security key

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -79,7 +79,7 @@ cosign verify-blob [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --offline                                                                                  only allow offline verification
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
-      --rfc3161-timestamp string                                                                 path to rfc3161 timestamp FILE
+      --rfc3161-timestamp string                                                                 path to RFC3161 timestamp FILE
       --sct string                                                                               path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --signature string                                                                         signature content or path or remote URL
       --sk                                                                                       whether to use a hardware security key

--- a/internal/pkg/cosign/tsa/signer.go
+++ b/internal/pkg/cosign/tsa/signer.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"os"
@@ -36,12 +37,13 @@ import (
 	ts "github.com/sigstore/timestamp-authority/pkg/generated/client/timestamp"
 )
 
+// GetTimestampedSignature queries a timestamp authority to fetch an RFC3161 timestamp. sigBytes is an
+// opaque blob, but is typically a signature over an artifact.
 func GetTimestampedSignature(sigBytes []byte, tsaClient *tsaclient.TimestampAuthority) ([]byte, error) {
 	requestBytes, err := createTimestampAuthorityRequest(sigBytes, crypto.SHA256, "")
 	if err != nil {
 		return nil, err
 	}
-	fmt.Fprintln(os.Stderr, "Calling TSA authority ...")
 	params := ts.NewGetTimestampResponseParams()
 	params.SetTimeout(time.Second * 10)
 	params.Request = io.NopCloser(bytes.NewReader(requestBytes))
@@ -58,7 +60,7 @@ func GetTimestampedSignature(sigBytes []byte, tsaClient *tsaclient.TimestampAuth
 		return nil, err
 	}
 
-	fmt.Fprintln(os.Stderr, "Timestamp fetched with time:", ts.Time)
+	fmt.Fprintln(os.Stderr, "Timestamp fetched with time: ", ts.Time)
 
 	return respBytes.Bytes(), nil
 }
@@ -84,8 +86,14 @@ func (rs *signerWrapper) Sign(ctx context.Context, payload io.Reader) (oci.Signa
 		return nil, nil, err
 	}
 
-	// Here we get the response from the timestamped authority server
-	responseBytes, err := GetTimestampedSignature([]byte(b64Sig), rs.tsaClient)
+	// create timestamp over raw bytes of signature
+	rawSig, err := base64.StdEncoding.DecodeString(b64Sig)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// fetch rfc3161 timestamp from timestamp authority
+	responseBytes, err := GetTimestampedSignature(rawSig, rs.tsaClient)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/cosign/bundle/tsa.go
+++ b/pkg/cosign/bundle/tsa.go
@@ -16,9 +16,10 @@ package bundle
 
 // RFC3161Timestamp holds metadata about timestamp RFC3161 verification data.
 type RFC3161Timestamp struct {
-	// SignedRFC3161Timestamp contains a RFC3161 signed timestamp provided by a time-stamping server.
-	// Clients MUST verify the hashed message in the message imprint
-	// against the signature in the bundle. This is encoded as base64.
+	// SignedRFC3161Timestamp contains a DER encoded TimeStampResponse.
+	// See https://www.rfc-editor.org/rfc/rfc3161.html#section-2.4.2
+	// Clients MUST verify the hashed message in the message imprint,
+	// typically using the artifact signature.
 	SignedRFC3161Timestamp []byte
 }
 

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -39,10 +39,9 @@ type SignedPayload struct {
 }
 
 type LocalSignedPayload struct {
-	Base64Signature  string                   `json:"base64Signature"`
-	Cert             string                   `json:"cert,omitempty"`
-	Bundle           *bundle.RekorBundle      `json:"rekorBundle,omitempty"`
-	RFC3161Timestamp *bundle.RFC3161Timestamp `json:"rfc3161Timestamp,omitempty"`
+	Base64Signature string              `json:"base64Signature"`
+	Cert            string              `json:"cert,omitempty"`
+	Bundle          *bundle.RekorBundle `json:"rekorBundle,omitempty"`
 }
 
 type Signatures struct {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -666,7 +666,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		}
 	}
 	if co.TSACerts != nil {
-		bundleVerified, err = VerifyRFC3161Timestamp(ctx, sig, co.TSACerts)
+		err = VerifyRFC3161Timestamp(sig, co.TSACerts)
 		if err != nil {
 			return false, fmt.Errorf("unable to verify RFC3161 timestamp bundle: %w", err)
 		}
@@ -986,22 +986,22 @@ func VerifyBundle(ctx context.Context, sig oci.Signature, co *CheckOpts, rekorCl
 	return true, nil
 }
 
-func VerifyRFC3161Timestamp(ctx context.Context, sig oci.Signature, tsaCerts *x509.CertPool) (bool, error) {
-	bundle, err := sig.RFC3161Timestamp()
+func VerifyRFC3161Timestamp(sig oci.Signature, tsaCerts *x509.CertPool) error {
+	ts, err := sig.RFC3161Timestamp()
 	if err != nil {
-		return false, err
-	} else if bundle == nil {
-		return false, nil
+		return err
+	} else if ts == nil {
+		return nil
 	}
 
 	b64Sig, err := sig.Base64Signature()
 	if err != nil {
-		return false, fmt.Errorf("reading base64signature: %w", err)
+		return fmt.Errorf("reading base64signature: %w", err)
 	}
 
 	cert, err := sig.Cert()
 	if err != nil {
-		return false, err
+		return err
 	}
 
 	var tsBytes []byte
@@ -1009,36 +1009,36 @@ func VerifyRFC3161Timestamp(ctx context.Context, sig oci.Signature, tsaCerts *x5
 		// For attestations, the Base64Signature is not set, therefore we rely on the signed payload
 		signedPayload, err := sig.Payload()
 		if err != nil {
-			return false, fmt.Errorf("reading the payload: %w", err)
+			return fmt.Errorf("reading the payload: %w", err)
 		}
 		tsBytes = signedPayload
 	} else {
 		// create timestamp over raw bytes of signature
 		rawSig, err := base64.StdEncoding.DecodeString(b64Sig)
 		if err != nil {
-			return false, err
+			return err
 		}
 		tsBytes = rawSig
 	}
 
-	err = tsaverification.VerifyTimestampResponse(bundle.SignedRFC3161Timestamp, bytes.NewReader(tsBytes), tsaCerts)
+	err = tsaverification.VerifyTimestampResponse(ts.SignedRFC3161Timestamp, bytes.NewReader(tsBytes), tsaCerts)
 	if err != nil {
-		return false, fmt.Errorf("unable to verify TimestampResponse: %w", err)
+		return fmt.Errorf("unable to verify TimestampResponse: %w", err)
 	}
 
 	if cert != nil {
-		ts, err := timestamp.ParseResponse(bundle.SignedRFC3161Timestamp)
+		ts, err := timestamp.ParseResponse(ts.SignedRFC3161Timestamp)
 		if err != nil {
-			return false, fmt.Errorf("error parsing response into timestamp: %w", err)
+			return fmt.Errorf("error parsing response into timestamp: %w", err)
 		}
 		// Verify the cert against the integrated time.
 		// Note that if the caller requires the certificate to be present, it has to ensure that itself.
 		if err := CheckExpiry(cert, ts.Time); err != nil {
-			return false, fmt.Errorf("checking expiry on cert: %w", err)
+			return fmt.Errorf("checking expiry on certificate: %w", err)
 		}
 	}
 
-	return true, nil
+	return nil
 }
 
 // compare bundle signature to the signature we are verifying

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -466,7 +466,7 @@ func TestVerifyImageSignatureWithSigVerifierAndTSA(t *testing.T) {
 		SigVerifier:    sv,
 		TSACerts:       tsaCertPool,
 		SkipTlogVerify: true,
-	}); err != nil || !bundleVerified {
+	}); err != nil || bundleVerified { // bundle is not verified since there's no Rekor bundle
 		t.Fatalf("unexpected error while verifying signature, got %v", err)
 	}
 }

--- a/specs/SIGNATURE_SPEC.md
+++ b/specs/SIGNATURE_SPEC.md
@@ -129,6 +129,11 @@ Gyp4apdU7AXEwysEQIb034aPrTlpmxh90SnTZFs2DHOvCjCPPAmoWfuQUwPhSPRb
 
 For instructions on using the `bundle` for verification, see [USAGE.md](../USAGE.md#verify-a-signature-was-added-to-the-transparency-log).
 
+* `rfc3161timestamp` string
+
+  This OPTIONAL property contains a JSON formatted `RFC3161Timestamp` bundle containing the timestamp response from a
+  timestamp authority.
+
 ## Storage
 
 `cosign` image signatures are stored in an OCI registry and are designed to make use of the existing specifications.

--- a/specs/SIGNATURE_SPEC.md
+++ b/specs/SIGNATURE_SPEC.md
@@ -131,7 +131,7 @@ For instructions on using the `bundle` for verification, see [USAGE.md](../USAGE
 
 * `rfc3161timestamp` string
 
-  This OPTIONAL property contains a JSON formatted `RFC3161Timestamp` bundle containing the timestamp response from a
+  This OPTIONAL property contains a JSON formatted `RFC3161Timestamp` containing the timestamp response from a
   timestamp authority.
 
 ## Storage

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -997,8 +997,8 @@ func TestSignBlobRFC3161TimestampBundle(t *testing.T) {
 		os.RemoveAll(td1)
 	})
 	bp := filepath.Join(td1, blob)
-	tsPath := filepath.Join(td1, "rfc3161TimestampBundle.sig")
 	bundlePath := filepath.Join(td1, "bundle.sig")
+	tsPath := filepath.Join(td1, "rfc3161Timestamp.json")
 
 	if err := os.WriteFile(bp, []byte(blob), 0644); err != nil {
 		t.Fatal(err)
@@ -1030,6 +1030,7 @@ func TestSignBlobRFC3161TimestampBundle(t *testing.T) {
 
 	ko1 := options.KeyOpts{
 		KeyRef:               pubKeyPath1,
+		BundlePath:           bundlePath,
 		RFC3161TimestampPath: tsPath,
 		TSACertChainPath:     file.Name(),
 		BundlePath:           bundlePath,
@@ -1045,6 +1046,7 @@ func TestSignBlobRFC3161TimestampBundle(t *testing.T) {
 	ko := options.KeyOpts{
 		KeyRef:               privKeyPath1,
 		PassFunc:             passFunc,
+		BundlePath:           bundlePath,
 		RFC3161TimestampPath: tsPath,
 		TSAServerURL:         server.URL,
 		RekorURL:             rekorURL,

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1033,7 +1033,6 @@ func TestSignBlobRFC3161TimestampBundle(t *testing.T) {
 		BundlePath:           bundlePath,
 		RFC3161TimestampPath: tsPath,
 		TSACertChainPath:     file.Name(),
-		BundlePath:           bundlePath,
 	}
 	// Verify should fail on a bad input
 	verifyBlobCmd := cliverify.VerifyBlobCmd{
@@ -1050,7 +1049,6 @@ func TestSignBlobRFC3161TimestampBundle(t *testing.T) {
 		RFC3161TimestampPath: tsPath,
 		TSAServerURL:         server.URL,
 		RekorURL:             rekorURL,
-		BundlePath:           bundlePath,
 	}
 	if _, err := sign.SignBlobCmd(ro, ko, bp, true, "", "", false); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
* Switch to using the raw signature rather than base64 signature for OCI and blob signing
* For blob signing, write only the timestamp to disk, not the LocalSignedPayload (since that's already written with the bundle. I want to avoid conflating the Rekor bundle with the TS)
* For blob verification, expect only a timestamp in the file. If you don't pass a bundle, you'll need to also pass the signature by flag
* Some nits from the previous PR

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->