### PR TITLE
cmd/cosign/cli: stop loading the entire blob into memory

### DIFF
--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -18,6 +18,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -283,7 +284,11 @@ func signPolicy() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				entry, err := cosign.TLogUpload(ctx, rekorClient, sig, signed.Signed, rekorBytes)
+				checkSum := sha256.New()
+				if _, err := checkSum.Write(signed.Signed); err != nil {
+					return err
+				}
+				entry, err := cosign.TLogUpload(ctx, rekorClient, sig, checkSum, rekorBytes)
 				if err != nil {
 					return err
 				}

--- a/internal/pkg/cosign/common.go
+++ b/internal/pkg/cosign/common.go
@@ -14,7 +14,12 @@
 
 package cosign
 
-import "os"
+import (
+	"errors"
+	"hash"
+	"io"
+	"os"
+)
 
 func FileExists(filename string) (bool, error) {
 	info, err := os.Stat(filename)
@@ -26,3 +31,34 @@ func FileExists(filename string) (bool, error) {
 	}
 	return !info.IsDir(), nil
 }
+
+// HashReader hashes while it reads.
+type HashReader struct {
+	r io.Reader
+	h hash.Hash
+}
+
+func NewHashReader(r io.Reader, h hash.Hash) HashReader {
+	return HashReader{
+		r: io.TeeReader(r, h),
+		h: h,
+	}
+}
+
+// Read implements io.Reader.
+func (h *HashReader) Read(p []byte) (n int, err error) { return h.r.Read(p) }
+
+// Sum implements hash.Hash.
+func (h *HashReader) Sum(p []byte) []byte { return h.h.Sum(p) }
+
+// Reset implements hash.Hash.
+func (h *HashReader) Reset() { h.h.Reset() }
+
+// Size implements hash.Hash.
+func (h *HashReader) Size() int { return h.h.Size() }
+
+// BlockSize implements hash.Hash.
+func (h *HashReader) BlockSize() int { return h.h.BlockSize() }
+
+// Write implements hash.Hash
+func (h *HashReader) Write(p []byte) (int, error) { return 0, errors.New("not implemented") }

--- a/internal/pkg/cosign/common_test.go
+++ b/internal/pkg/cosign/common_test.go
@@ -16,6 +16,9 @@
 package cosign
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"io"
 	"os"
 	"testing"
 )
@@ -47,5 +50,24 @@ func Test_FileExists(t *testing.T) {
 				t.Errorf("FileExists() = %v, want %v", got, tt.exists)
 			}
 		})
+	}
+}
+
+func Test_HashReader(t *testing.T) {
+	input := []byte("hello world")
+	r := NewHashReader(bytes.NewReader(input), sha256.New())
+
+	got, err := io.ReadAll(&r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got, input) {
+		t.Errorf("io.ReadAll returned %s, want %s", got, input)
+	}
+
+	gotHash := r.Sum(nil)
+	if hash := sha256.Sum256(input); !bytes.Equal(gotHash, hash[:]) {
+		t.Errorf("Sum returned %s, want %s", gotHash, hash)
 	}
 }


### PR DESCRIPTION
sign-blob always loads the entire blob into memory. This can lead to problems when signing large blob files and increased memory usage. Instead of loading the whole blob, we plumb down `io.Reader` for signing.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Fixes #2097 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->