### PR TITLE
Breaking change: Respect tlog-upload=false, default to true

### DIFF
--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -77,7 +77,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
 		"skip confirmation prompts for non-destructive operations")
 
-	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", false,
+	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", true,
 		"whether or not to upload to the tlog")
 
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",

--- a/cmd/cosign/cli/options/policy.go
+++ b/cmd/cosign/cli/options/policy.go
@@ -82,7 +82,7 @@ func (o *PolicySignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
 		"skip confirmation prompts for non-destructive operations")
 
-	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", false,
+	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", true,
 		"whether or not to upload to the tlog")
 
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -93,7 +93,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
 		"skip confirmation prompts for non-destructive operations")
 
-	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", false,
+	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", true,
 		"whether or not to upload to the tlog")
 
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -73,7 +73,7 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
 		"skip confirmation prompts for non-destructive operations")
 
-	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", false,
+	cmd.Flags().BoolVar(&o.TlogUpload, "tlog-upload", true,
 		"whether or not to upload to the tlog")
 
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -77,7 +77,7 @@ race conditions or (worse) malicious tampering.
 
   # sign a container image and upload to the transparency log
   cosign sign --key cosign.key <IMAGE DIGEST>
-  
+
   # sign a container image and skip uploading to the transparency log
   cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>`,
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -76,7 +76,10 @@ race conditions or (worse) malicious tampering.
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign --key cosign.key legacy-registry.example.com/my/image@<DIGEST>
 
   # sign a container image and upload to the transparency log
-  cosign sign --key cosign.key --tlog-upload=true <IMAGE DIGEST>`,
+  cosign sign --key cosign.key <IMAGE DIGEST>
+  
+  # sign a container image and skip uploading to the transparency log
+  cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>`,
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -69,13 +69,8 @@ const TagReferenceMessage string = `WARNING: Image reference %s uses a tag, not 
 `
 
 func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Reference, tlogUpload bool) bool {
-	// Check if TSA signing is enabled and tlog upload is disabled
-	if !tlogUpload && ko.TSAServerURL != "" {
-		fmt.Fprintln(os.Stderr, "\nWARNING: skipping transparency log upload")
-		return false
-	}
-	// If we aren't using keyless signing and --tlog-upload=false, return
-	if !keylessSigning(ko) && !tlogUpload {
+	// return false if not uploading to the tlog has been requested
+	if !tlogUpload {
 		return false
 	}
 

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -536,13 +536,3 @@ func (c *SignerVerifier) Bytes(ctx context.Context) ([]byte, error) {
 	}
 	return pemBytes, nil
 }
-
-func keylessSigning(ko options.KeyOpts) bool {
-	if ko.KeyRef != "" {
-		return false
-	}
-	if ko.Sk {
-		return false
-	}
-	return true
-}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -142,7 +142,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		co.TSACerts = tsaCertPool
 	}
 
-	if keylessVerification(c.KeyRef, c.Sk) {
+	if !c.SkipTlogVerify {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {
@@ -436,14 +436,4 @@ func loadCertChainFromFileOrURL(path string) ([]*x509.Certificate, error) {
 		return nil, err
 	}
 	return certs, nil
-}
-
-func keylessVerification(keyRef string, sk bool) bool {
-	if keyRef != "" {
-		return false
-	}
-	if sk {
-		return false
-	}
-	return true
 }

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -150,6 +150,8 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			}
 			co.RekorClient = rekorClient
 		}
+	}
+	if keylessVerification(c.KeyRef, c.Sk) {
 		co.RootCerts, err = fulcio.GetRoots()
 		if err != nil {
 			return fmt.Errorf("getting Fulcio roots: %w", err)
@@ -436,4 +438,14 @@ func loadCertChainFromFileOrURL(path string) ([]*x509.Certificate, error) {
 		return nil, err
 	}
 	return certs, nil
+}
+
+func keylessVerification(keyRef string, sk bool) bool {
+	if keyRef != "" {
+		return false
+	}
+	if sk {
+		return false
+	}
+	return true
 }

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -121,7 +121,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		}
 		co.TSACerts = tsaCertPool
 	}
-	if keylessVerification(c.KeyRef, c.Sk) {
+	if !c.SkipTlogVerify {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -129,6 +129,8 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			}
 			co.RekorClient = rekorClient
 		}
+	}
+	if keylessVerification(c.KeyRef, c.Sk) {
 		co.RootCerts, err = fulcio.GetRoots()
 		if err != nil {
 			return fmt.Errorf("getting Fulcio roots: %w", err)

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -136,6 +136,8 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			}
 			co.RekorClient = rekorClient
 		}
+	}
+	if keylessVerification(c.KeyRef, c.Sk) {
 		// Use default TUF roots if a cert chain is not provided.
 		if c.CertChain == "" {
 			co.RootCerts, err = fulcio.GetRoots()

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -128,7 +128,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		co.TSACerts = tsaCertPool
 	}
 
-	if keylessVerification(c.KeyRef, c.Sk) {
+	if !c.SkipTlogVerify {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -276,16 +276,18 @@ func TestVerifyBlob(t *testing.T) {
 		// If online lookups to Rekor are enabled
 		experimental bool
 		// The rekor entry response when Rekor is enabled
-		rekorEntry []*models.LogEntry
-		shouldErr  bool
+		rekorEntry     []*models.LogEntry
+		skipTlogVerify bool
+		shouldErr      bool
 	}{
 		{
-			name:         "valid signature with public key",
-			blob:         blobBytes,
-			signature:    blobSignature,
-			key:          pubKeyBytes,
-			experimental: false,
-			shouldErr:    false,
+			name:           "valid signature with public key",
+			blob:           blobBytes,
+			signature:      blobSignature,
+			key:            pubKeyBytes,
+			experimental:   false,
+			shouldErr:      false,
+			skipTlogVerify: true,
 		},
 		/* TODO:
 		This currently passes without error because we don't require an experimental
@@ -327,7 +329,7 @@ func TestVerifyBlob(t *testing.T) {
 			key:          pubKeyBytes,
 			experimental: false,
 			bundlePath:   makeLocalBundleWithoutRekorBundle(t, []byte(blobSignature), pubKeyBytes),
-			shouldErr:    false,
+			shouldErr:    true,
 		},
 		{
 			name:         "valid signature with public key - bad bundle SET",
@@ -576,6 +578,7 @@ func TestVerifyBlob(t *testing.T) {
 				CertOIDCIssuer: issuer,
 				IgnoreSCT:      true,
 				CertChain:      chainPath,
+				SkipTlogVerify: tt.skipTlogVerify,
 			}
 			blobPath := writeBlobFile(t, td, string(blobBytes), "blob.txt")
 			if tt.signature != "" {

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -289,9 +289,6 @@ func TestVerifyBlob(t *testing.T) {
 			shouldErr:      false,
 			skipTlogVerify: true,
 		},
-		/* TODO:
-		This currently passes without error because we don't require an experimental
-		lookup for public keys. Add this test back in when we have a --verify-tlog-online
 		{
 			name:         "valid signature with public key - experimental no rekor fail",
 			blob:         blobBytes,
@@ -301,7 +298,6 @@ func TestVerifyBlob(t *testing.T) {
 			rekorEntry:   nil,
 			shouldErr:    true,
 		},
-		*/
 		{
 			name:         "valid signature with public key - experimental rekor entry success",
 			blob:         blobBytes,

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -64,7 +64,7 @@ cosign attest [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-server-url string                                                              url to the Timestamp RFC3161 server, default none
-      --tlog-upload                                                                              whether or not to upload to the tlog
+      --tlog-upload                                                                              whether or not to upload to the tlog (default true)
       --type string                                                                              specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
   -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -33,7 +33,7 @@ cosign policy sign [flags]
       --out string                                                                               output policy locally (default "o")
       --rekor-url string                                                                         [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --timestamp-server-url string                                                              url to the Timestamp RFC3161 server, default none
-      --tlog-upload                                                                              whether or not to upload to the tlog
+      --tlog-upload                                                                              whether or not to upload to the tlog (default true)
   -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -54,7 +54,7 @@ cosign sign-blob [flags]
       --sk                                whether to use a hardware security key
       --slot string                       security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-server-url string       url to the Timestamp RFC3161 server, default none
-      --tlog-upload                       whether or not to upload to the tlog
+      --tlog-upload                       whether or not to upload to the tlog (default true)
   -y, --yes                               skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -57,7 +57,10 @@ cosign sign [flags]
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign --key cosign.key legacy-registry.example.com/my/image@<DIGEST>
 
   # sign a container image and upload to the transparency log
-  cosign sign --key cosign.key --tlog-upload=true <IMAGE DIGEST>
+  cosign sign --key cosign.key <IMAGE DIGEST>
+
+  # sign a container image and skip uploading to the transparency log
+  cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
 ```
 
 ### Options
@@ -90,7 +93,7 @@ cosign sign [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-server-url string                                                              url to the Timestamp RFC3161 server, default none
-      --tlog-upload                                                                              whether or not to upload to the tlog
+      --tlog-upload                                                                              whether or not to upload to the tlog (default true)
       --upload                                                                                   whether to upload the signature (default true)
   -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1053,7 +1053,6 @@ func TestSignBlobRFC3161TimestampBundle(t *testing.T) {
 	if _, err := sign.SignBlobCmd(ro, ko, bp, true, "", "", false); err != nil {
 		t.Fatal(err)
 	}
-	fmt.Println(bp)
 	// Now verify should work
 	must(verifyBlobCmd.Exec(ctx, bp), t)
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -13,6 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build e2e
+// +build e2e
+
 package test
 
 import (


### PR DESCRIPTION
This changes the default for uploading to the tlog to always upload unless explicitly set to false. We no longer require checking if the flow is keyless or not, as it'll be up to the uploader to decide if they want to upload to Rekor or not.

When verifying, if you set tlog-upload=false, then you must set insecure-skip-tlog-verify=true

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
```
BREAKING: Require tlog-upload=false to not upload to Rekor. By default, signatures will be uploaded.
```

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->