### PR TITLE
Support outputing a certificate without uploading to the tlog

### DIFF
--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 )
 
@@ -147,15 +148,23 @@ func SignBlobCmd(ro *options.RootOptions, ko options.KeyOpts, regOpts options.Re
 		}
 	}
 
-	if outputCertificate != "" && len(rekorBytes) > 0 {
-		bts := rekorBytes
-		if b64 {
-			bts = []byte(base64.StdEncoding.EncodeToString(rekorBytes))
+	if outputCertificate != "" {
+		signer, err := sv.Bytes(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("error getting signer: %w", err)
 		}
-		if err := os.WriteFile(outputCertificate, bts, 0600); err != nil {
-			return nil, fmt.Errorf("create certificate file: %w", err)
+		cert, err := cryptoutils.UnmarshalCertificatesFromPEM(signer)
+		// signer is a certificate
+		if err == nil && len(cert) == 1 {
+			bts := signer
+			if b64 {
+				bts = []byte(base64.StdEncoding.EncodeToString(signer))
+			}
+			if err := os.WriteFile(outputCertificate, bts, 0600); err != nil {
+				return nil, fmt.Errorf("create certificate file: %w", err)
+			}
+			fmt.Printf("Certificate wrote in the file %s\n", outputCertificate)
 		}
-		fmt.Printf("Certificate wrote in the file %s\n", outputCertificate)
 	}
 
 	return sig, nil


### PR DESCRIPTION
If you don't upload to the tlog, then rekorbytes is not set. This change:
* Checks if the signer is actually a certificate
* Outputs the certificate when requested

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Support persisting a certificate without uploading to Rekor

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->