### PR TITLE
Fix timestamp verification, add verify-blob tests

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -268,7 +268,6 @@ func TestVerifyBlob(t *testing.T) {
 	}
 	rfc3161Timestamp = &bundle.RFC3161Timestamp{SignedRFC3161Timestamp: tsRespBytes.Bytes()}
 	unexpiredTSPath := writeTimestampFile(t, td, rfc3161Timestamp, "unexpiredrfc3161TS.json")
-	fmt.Println(unexpiredTSPath)
 	tsChain, err = tsaClient.Timestamp.GetTimestampCertChain(nil)
 	if err != nil {
 		t.Fatalf("unexpected error getting timestamp chain: %v", err)

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -40,11 +40,9 @@ import (
 	"github.com/go-openapi/swag"
 	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/internal/pkg/cosign/payload"
-	"github.com/sigstore/cosign/internal/pkg/cosign/tsa"
+	"github.com/sigstore/cosign/internal/pkg/cosign/tsa/mock"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sigstore/cosign/pkg/cosign/bundle"
-	"github.com/sigstore/cosign/pkg/oci"
 	sigs "github.com/sigstore/cosign/pkg/signature"
 	ctypes "github.com/sigstore/cosign/pkg/types"
 	"github.com/sigstore/cosign/test"
@@ -59,9 +57,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
-	tsaclient "github.com/sigstore/timestamp-authority/pkg/client"
-	"github.com/sigstore/timestamp-authority/pkg/server"
-	"github.com/spf13/viper"
+	"github.com/sigstore/timestamp-authority/pkg/generated/client/timestamp"
 )
 
 func TestSignaturesRef(t *testing.T) {
@@ -239,6 +235,49 @@ func TestVerifyBlob(t *testing.T) {
 	otherBytes := []byte("bar")
 	otherSignature := makeSignature(otherBytes)
 
+	// initialize timestamp for expired and unexpired certificates
+	expiredTSAOpts := mock.TSAClientOptions{Time: time.Now().Add(-time.Hour), Message: []byte(blobSignature)}
+	unexpiredTSAOpts := mock.TSAClientOptions{Time: time.Now(), Message: []byte(blobSignature)}
+	tsaClient, err := mock.NewTSAClient(expiredTSAOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsChain, err := tsaClient.Timestamp.GetTimestampCertChain(nil)
+	if err != nil {
+		t.Fatalf("unexpected error getting timestamp chain: %v", err)
+	}
+	expiredTSACertChainPath := filepath.Join(td, "exptsacertchain.pem")
+	if err := os.WriteFile(expiredTSACertChainPath, []byte(tsChain.Payload), 0644); err != nil {
+		t.Fatal(err)
+	}
+	var tsRespBytes bytes.Buffer
+	_, err = tsaClient.Timestamp.GetTimestampResponse(&timestamp.GetTimestampResponseParams{}, &tsRespBytes)
+	if err != nil {
+		t.Fatalf("unable to generate a timestamp response: %v", err)
+	}
+	rfc3161Timestamp := &bundle.RFC3161Timestamp{SignedRFC3161Timestamp: tsRespBytes.Bytes()}
+	expiredTSPath := writeTimestampFile(t, td, rfc3161Timestamp, "expiredrfc3161TS.json")
+	tsaClient, err = mock.NewTSAClient(unexpiredTSAOpts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsRespBytes.Reset()
+	_, err = tsaClient.Timestamp.GetTimestampResponse(&timestamp.GetTimestampResponseParams{}, &tsRespBytes)
+	if err != nil {
+		t.Fatalf("unable to generate a timestamp response: %v", err)
+	}
+	rfc3161Timestamp = &bundle.RFC3161Timestamp{SignedRFC3161Timestamp: tsRespBytes.Bytes()}
+	unexpiredTSPath := writeTimestampFile(t, td, rfc3161Timestamp, "unexpiredrfc3161TS.json")
+	fmt.Println(unexpiredTSPath)
+	tsChain, err = tsaClient.Timestamp.GetTimestampCertChain(nil)
+	if err != nil {
+		t.Fatalf("unexpected error getting timestamp chain: %v", err)
+	}
+	unexpiredTSACertChainPath := filepath.Join(td, "unexptsacertchain.pem")
+	if err := os.WriteFile(unexpiredTSACertChainPath, []byte(tsChain.Payload), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	tts := []struct {
 		name       string
 		blob       []byte
@@ -250,6 +289,8 @@ func TestVerifyBlob(t *testing.T) {
 		rekorEntry     []*models.LogEntry
 		skipTlogVerify bool
 		shouldErr      bool
+		tsPath         string
+		tsChainPath    string
 	}{
 		{
 			name:           "valid signature with public key",
@@ -501,10 +542,58 @@ func TestVerifyBlob(t *testing.T) {
 				expiredLeafPem, true)},
 			shouldErr: true,
 		},
-		// TODO: Add tests for TSA:
-		// * With or without bundle
-		// * Mismatched signature
-		// * Unexpired and expired certificate
+		{
+			name:      "valid signature with expired certificate - good bundle, good timestamp",
+			blob:      blobBytes,
+			signature: blobSignature,
+			cert:      expiredLeafCert,
+			bundlePath: makeLocalBundle(t, *rekorSigner, blobBytes, []byte(blobSignature),
+				expiredLeafPem, true),
+			tsPath:      expiredTSPath,
+			tsChainPath: expiredTSACertChainPath,
+			shouldErr:   false,
+		},
+		{
+			name:           "valid signature with expired certificate - no bundle, good timestamp",
+			blob:           blobBytes,
+			signature:      blobSignature,
+			cert:           expiredLeafCert,
+			tsPath:         expiredTSPath,
+			tsChainPath:    expiredTSACertChainPath,
+			skipTlogVerify: true,
+			shouldErr:      false,
+		},
+		{
+			name:           "mismatched signature with expired certificate",
+			blob:           otherBytes,
+			signature:      otherSignature,
+			cert:           expiredLeafCert,
+			tsPath:         expiredTSPath,
+			tsChainPath:    expiredTSACertChainPath,
+			skipTlogVerify: true,
+			shouldErr:      true,
+		},
+		{
+			name:      "valid signature with unexpired certificate - good bundle, good timestamp",
+			blob:      blobBytes,
+			signature: blobSignature,
+			cert:      unexpiredLeafCert,
+			bundlePath: makeLocalBundle(t, *rekorSigner, blobBytes, []byte(blobSignature),
+				unexpiredCertPem, true),
+			tsPath:      unexpiredTSPath,
+			tsChainPath: unexpiredTSACertChainPath,
+			shouldErr:   false,
+		},
+		{
+			name:           "valid signature with unexpired certificate - no bundle, good timestamp",
+			blob:           blobBytes,
+			signature:      blobSignature,
+			cert:           unexpiredLeafCert,
+			tsPath:         unexpiredTSPath,
+			tsChainPath:    unexpiredTSACertChainPath,
+			skipTlogVerify: true,
+			shouldErr:      false,
+		},
 	}
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
@@ -523,8 +612,11 @@ func TestVerifyBlob(t *testing.T) {
 			// Verify command
 			cmd := VerifyBlobCmd{
 				KeyOpts: options.KeyOpts{
-					BundlePath: tt.bundlePath,
-					RekorURL:   testServer.URL},
+					BundlePath:           tt.bundlePath,
+					RekorURL:             testServer.URL,
+					RFC3161TimestampPath: tt.tsPath,
+					TSACertChainPath:     tt.tsChainPath,
+				},
 				CertEmail:      identity,
 				CertOIDCIssuer: issuer,
 				IgnoreSCT:      true,
@@ -970,51 +1062,33 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 		// Create blob
 		blob := "someblob"
 
-		// TODO: Replace with a full TSA mock client, related to https://github.com/sigstore/timestamp-authority/issues/146
-		viper.Set("timestamp-signer", "memory")
-		apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
-		server := httptest.NewServer(apiServer.GetHandler())
-		t.Cleanup(server.Close)
-
-		client, err := tsaclient.GetTimestampClient(server.URL)
+		// Sign blob with private key
+		sig, err := signer.SignMessage(bytes.NewReader([]byte(blob)))
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
-		payloadSigner := payload.NewSigner(signer)
-		tsaSigner := tsa.NewSigner(payloadSigner, client)
-		var sigTSA oci.Signature
-		sigTSA, _, err = tsaSigner.Sign(context.Background(), bytes.NewReader([]byte(blob)))
+		// Initialize timestamp with mock client
+		tsaClient, err := mock.NewTSAClient((mock.TSAClientOptions{Time: time.Now(), Message: sig}))
 		if err != nil {
-			t.Fatalf("error signing the payload with the rekor and tsa clients: %v", err)
+			t.Fatal(err)
 		}
-
-		rfc3161Timestamp, err := sigTSA.RFC3161Timestamp()
-		if err != nil {
-			t.Fatalf("unexpected error getting rfc3161 timestamp bundle: %v", err)
-		}
-		tsPath := writeTimestampFile(t, keyless.td, rfc3161Timestamp, "rfc3161TS.json")
-
-		chain, err := client.Timestamp.GetTimestampCertChain(nil)
+		tsChain, err := tsaClient.Timestamp.GetTimestampCertChain(nil)
 		if err != nil {
 			t.Fatalf("unexpected error getting timestamp chain: %v", err)
 		}
-
 		tsaCertChainPath := filepath.Join(keyless.td, "tsacertchain.pem")
-		if err := os.WriteFile(tsaCertChainPath, []byte(chain.Payload), 0644); err != nil {
+		if err := os.WriteFile(tsaCertChainPath, []byte(tsChain.Payload), 0644); err != nil {
 			t.Fatal(err)
 		}
-		defer os.Remove(tsaCertChainPath)
+		var tsRespBytes bytes.Buffer
+		_, err = tsaClient.Timestamp.GetTimestampResponse(&timestamp.GetTimestampResponseParams{}, &tsRespBytes)
+		if err != nil {
+			t.Fatalf("unable to generate a timestamp response: %v", err)
+		}
+		rfc3161Timestamp := &bundle.RFC3161Timestamp{SignedRFC3161Timestamp: tsRespBytes.Bytes()}
+		tsPath := writeTimestampFile(t, keyless.td, rfc3161Timestamp, "rfc3161TS.json")
 
-		// Create bundle
-		b64Sig, err := sigTSA.Base64Signature()
-		if err != nil {
-			t.Fatal(err)
-		}
-		sig, err := base64.StdEncoding.DecodeString(b64Sig)
-		if err != nil {
-			t.Fatal(err)
-		}
 		entry := genRekorEntry(t, hashedrekord.KIND, hashedrekord.New().DefaultVersion(), []byte(blob), leafPemCert, sig)
 		b := createBundle(t, sig, leafPemCert, keyless.rekorLogID, leafCert.NotBefore.Unix()+1, entry)
 		b.Bundle.SignedEntryTimestamp = keyless.rekorSignPayload(t, b.Bundle.Payload)

--- a/internal/pkg/cosign/tsa/mock/mock_tsa_client.go
+++ b/internal/pkg/cosign/tsa/mock/mock_tsa_client.go
@@ -1,0 +1,158 @@
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mock
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/asn1"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/go-openapi/runtime"
+	"github.com/pkg/errors"
+
+	"github.com/digitorus/timestamp"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/timestamp-authority/pkg/generated/client"
+	ts "github.com/sigstore/timestamp-authority/pkg/generated/client/timestamp"
+	"github.com/sigstore/timestamp-authority/pkg/signer"
+)
+
+// TSAClient creates RFC3161 timestamps and implements client.TimestampAuthority.
+// Messages to sign can either be provided in the initializer or through the request.
+// Time can be provided in the initializer, or defaults to time.Now().
+// All other timestamp parameters are hardcoded.
+type TSAClient struct {
+	Signer       crypto.Signer
+	CertChain    []*x509.Certificate
+	CertChainPEM string
+	Time         time.Time
+	Message      []byte
+}
+
+// TSAClientOptions provide customization for the mock TSA client.
+type TSAClientOptions struct {
+	// Time is an optional timestamp. Default is time.Now().
+	Time time.Time
+	// Message is the pre-hashed message to sign over, typically a raw signature.
+	Message []byte
+	// Signer is an optional signer created out of band. Client creates one if not set.
+	Signer crypto.Signer
+}
+
+func NewTSAClient(o TSAClientOptions) (*client.TimestampAuthority, error) {
+	sv := o.Signer
+	if sv == nil {
+		var err error
+		sv, _, err = signature.NewECDSASignerVerifier(elliptic.P256(), rand.Reader, crypto.SHA256)
+		if err != nil {
+			return nil, err
+		}
+	}
+	certChain, err := signer.NewTimestampingCertWithChain(context.Background(), sv)
+	if err != nil {
+		return nil, errors.Wrap(err, "generating timestamping cert chain")
+	}
+	certChainPEM, err := cryptoutils.MarshalCertificatesToPEM(certChain)
+	if err != nil {
+		return nil, fmt.Errorf("marshal certificates to PEM: %w", err)
+	}
+
+	return &client.TimestampAuthority{
+		Timestamp: &TSAClient{
+			Signer:       sv,
+			CertChain:    certChain,
+			CertChainPEM: string(certChainPEM),
+			Time:         o.Time,
+			Message:      o.Message,
+		},
+	}, nil
+}
+
+func (c *TSAClient) GetTimestampCertChain(_ *ts.GetTimestampCertChainParams, _ ...ts.ClientOption) (*ts.GetTimestampCertChainOK, error) {
+	return &ts.GetTimestampCertChainOK{Payload: c.CertChainPEM}, nil
+}
+
+func (c *TSAClient) GetTimestampResponse(params *ts.GetTimestampResponseParams, w io.Writer, _ ...ts.ClientOption) (*ts.GetTimestampResponseCreated, error) {
+	var hashAlg crypto.Hash
+	var hashedMessage []byte
+
+	if params.Request != nil {
+		requestBytes, err := io.ReadAll(params.Request)
+		if err != nil {
+			return nil, err
+		}
+
+		req, err := timestamp.ParseRequest(requestBytes)
+		if err != nil {
+			return nil, err
+		}
+		hashAlg = req.HashAlgorithm
+		hashedMessage = req.HashedMessage
+	} else {
+		hashAlg = crypto.SHA256
+		h := hashAlg.New()
+		h.Write(c.Message)
+		hashedMessage = h.Sum(nil)
+	}
+
+	nonce, err := cryptoutils.GenerateSerialNumber()
+	if err != nil {
+		return nil, err
+	}
+	duration, _ := time.ParseDuration("1s")
+
+	tsStruct := timestamp.Timestamp{
+		HashAlgorithm:     hashAlg,
+		HashedMessage:     hashedMessage,
+		Nonce:             nonce,
+		Policy:            asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 2},
+		Ordering:          false,
+		Accuracy:          duration,
+		Qualified:         false,
+		AddTSACertificate: true,
+	}
+
+	if c.Time.IsZero() {
+		tsStruct.Time = time.Now()
+	} else {
+		tsStruct.Time = c.Time
+	}
+
+	resp, err := tsStruct.CreateResponse(c.CertChain[0], c.Signer)
+	if err != nil {
+		return nil, err
+	}
+
+	// write response to provided buffer and payload
+	if w != nil {
+		_, err := w.Write(resp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &ts.GetTimestampResponseCreated{Payload: bytes.NewBuffer(resp)}, nil
+}
+
+func (c *TSAClient) SetTransport(transport runtime.ClientTransport) {
+	// nothing to do
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -496,9 +496,7 @@ func TestAttestationReplace(t *testing.T) {
 }
 
 func TestAttestationRFC3161Timestamp(t *testing.T) {
-	// turn on the tlog
-	defer setenv(t, env.VariableExperimental.String(), "1")()
-	// TODO: Replace with a full TSA mock client, related to https://github.com/sigstore/timestamp-authority/issues/146
+	// TSA server needed to create timestamp
 	viper.Set("timestamp-signer", "memory")
 	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())
@@ -620,9 +618,7 @@ func TestRekorBundle(t *testing.T) {
 }
 
 func TestRFC3161Timestamp(t *testing.T) {
-	// turn on the tlog
-	defer setenv(t, env.VariableExperimental.String(), "1")()
-	// TODO: Replace with a full TSA mock client, related to https://github.com/sigstore/timestamp-authority/issues/146
+	// TSA server needed to create timestamp
 	viper.Set("timestamp-signer", "memory")
 	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())
@@ -676,9 +672,7 @@ func TestRFC3161Timestamp(t *testing.T) {
 }
 
 func TestRekorBundleAndRFC3161Timestamp(t *testing.T) {
-	// turn on the tlog
-	defer setenv(t, env.VariableExperimental.String(), "1")()
-	// TODO: Replace with a full TSA mock client, related to https://github.com/sigstore/timestamp-authority/issues/146
+	// TSA server needed to create timestamp
 	viper.Set("timestamp-signer", "memory")
 	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())
@@ -983,9 +977,7 @@ func TestSignBlobBundle(t *testing.T) {
 }
 
 func TestSignBlobRFC3161TimestampBundle(t *testing.T) {
-	// turn on the tlog
-	defer setenv(t, env.VariableExperimental.String(), "1")()
-	// TODO: Replace with a full TSA mock client, related to https://github.com/sigstore/timestamp-authority/issues/146
+	// TSA server needed to create timestamp
 	viper.Set("timestamp-signer", "memory")
 	apiServer := server.NewRestAPIServer("localhost", 0, []string{"http"}, 10*time.Second, 10*time.Second)
 	server := httptest.NewServer(apiServer.GetHandler())


### PR DESCRIPTION
While adding unit tests for verify-blob with timestamping, I found that we try to verify with the current time if no bundle is provided, even if we have a timestamp. I cleaned up this function to check the timestamp time and bundle time if either are provided, and if neither is provided, check against the current time.

I also added a mock client to clean up tests. I'll move this mock client over to the timestamp-authority repo.

Signed-off-by: Hayden Blauzvern <hblauzvern@google.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->