### PR TITLE
Update e2e tests

### DIFF
--- a/.github/workflows/e2e-tests-kms.yml
+++ b/.github/workflows/e2e-tests-kms.yml
@@ -1,0 +1,70 @@
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: e2e-tests
+
+# Run on every push, and allow it to be run manually.
+on:
+  push:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!doc/**'
+      - '!**.txt'
+      - '!images/**'
+      - '!LICENSE'
+      - 'test/**'
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  e2e-tests:
+    # Skip if running in a fork that might not have secrets configured.
+    if: ${{ github.repository == 'sigstore/cosign' }}
+    name: Run tests
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # v3.4.0
+        with:
+          go-version: '1.19'
+          check-latest: true
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
+        with:
+          workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-cosign'
+          service_account: 'github-actions-e2e@projectsigstore.iam.gserviceaccount.com'
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
+
+      - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4 # v0.2
+
+      - name: gcloud auth configure-docker
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Run e2e_test_secrets_kms.sh
+        shell: bash
+        run: ./test/e2e_test_secrets_kms.sh

--- a/.github/workflows/e2e-tests-kms.yml
+++ b/.github/workflows/e2e-tests-kms.yml
@@ -28,43 +28,39 @@ on:
       - 'test/**'
     branches:
       - "main"
+  pull_request:
   workflow_dispatch:
 
 jobs:
-  e2e-tests:
-    # Skip if running in a fork that might not have secrets configured.
-    if: ${{ github.repository == 'sigstore/cosign' }}
-    name: Run tests
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+  e2e-kms:
+    runs-on: ubuntu-latest
+    services:
+      vault:
+        image: hashicorp/vault:latest
+        env:
+          VAULT_DEV_ROOT_TOKEN_ID: root
+        options: >-
+          --health-cmd "VAULT_ADDR=http://127.0.0.1:8200 vault status"
+          --health-interval 1s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 8200:8200
 
-    permissions:
-      id-token: write
-      contents: read
-
+    env:
+      VAULT_TOKEN: "root"
+      VAULT_ADDR: "http://localhost:8200"
     steps:
-      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
-      - uses: actions/setup-go@d0a58c1c4d2b25278816e339b944508c875f3613 # v3.4.0
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+      - uses: innovationnorway/setup-vault@v1
         with:
-          go-version: '1.19'
-          check-latest: true
-
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
-        with:
-          workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-cosign'
-          service_account: 'github-actions-e2e@projectsigstore.iam.gserviceaccount.com'
-
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
+          version: '~1.4'
 
       - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4 # v0.2
 
-      - name: gcloud auth configure-docker
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
-
-      - name: Run e2e_test_secrets_kms.sh
-        shell: bash
-        run: ./test/e2e_test_secrets_kms.sh
+      - name: enable vault transit
+        run: vault secrets enable transit
+      - name: Acceptance Tests
+        run: |
+          ./test/e2e_test_secrets_kms.sh

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,21 +28,16 @@ on:
       - 'test/**'
     branches:
       - "main"
+  pull_request:
   workflow_dispatch:
 
 jobs:
   e2e-tests:
-    # Skip if running in a fork that might not have secrets configured.
-    if: ${{ github.repository == 'sigstore/cosign' }}
     name: Run tests
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
-
-    permissions:
-      id-token: write
-      contents: read
 
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -51,19 +46,7 @@ jobs:
           go-version: '1.19'
           check-latest: true
 
-      - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
-        with:
-          workload_identity_provider: 'projects/498091336538/locations/global/workloadIdentityPools/githubactions/providers/sigstore-cosign'
-          service_account: 'github-actions-e2e@projectsigstore.iam.gserviceaccount.com'
-
-      - name: Setup gcloud
-        uses: google-github-actions/setup-gcloud@d51b5346f85640ec2aa2fa057354d2b82c2fcbce # v1.0.1
-
       - uses: imjasonh/setup-crane@e82f1b9a8007d399333baba4d75915558e9fb6a4 # v0.2
-
-      - name: gcloud auth configure-docker
-        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
       - name: Run e2e_test_secrets.sh
         shell: bash

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,8 +32,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  e2e-tests:
-    name: Run tests
+  e2e-secrets:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest]

--- a/cmd/cosign/cli/policy_init.go
+++ b/cmd/cosign/cli/policy_init.go
@@ -239,7 +239,7 @@ func signPolicy() *cobra.Command {
 			}
 
 			result := &bytes.Buffer{}
-			if err := sget.New(imgName+"@"+dgst.String(), "", result).Do(ctx); err != nil {
+			if err := sget.New(imgName+"@"+dgst.String(), "", o.Rekor.URL, result).Do(ctx); err != nil {
 				return fmt.Errorf("error getting result: %w", err)
 			}
 			b, err := io.ReadAll(result)

--- a/cmd/sget/cli/commands.go
+++ b/cmd/sget/cli/commands.go
@@ -51,7 +51,7 @@ func New() *cobra.Command {
 				return err
 			}
 			defer wc.Close()
-			return sget.New(ro.ImageRef, ro.PublicKey, wc).Do(cmd.Context())
+			return sget.New(ro.ImageRef, ro.PublicKey, ro.RekorURL, wc).Do(cmd.Context())
 		},
 	}
 	ro.AddFlags(cmd)

--- a/cmd/sget/cli/options/root.go
+++ b/cmd/sget/cli/options/root.go
@@ -26,6 +26,7 @@ type RootOptions struct {
 	OutputFile string
 	PublicKey  string
 	ImageRef   string
+	RekorURL   string
 }
 
 var _ options.Interface = (*RootOptions)(nil)
@@ -37,4 +38,7 @@ func (o *RootOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.PublicKey, "key", "",
 		"path to the public key file, URL, or KMS URI")
+
+	cmd.Flags().StringVar(&o.RekorURL, "rekor-url", options.DefaultRekorURL,
+		"[EXPERIMENTAL] address of rekor STL server")
 }

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -100,7 +100,6 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 	}
 
 	if co.SigVerifier != nil || options.EnableExperimental() {
-		fmt.Println("2>>>>")
 		// NB: There are only 2 kinds of verification right now:
 		// 1. You gave us the public key explicitly to verify against so co.SigVerifier is non-nil or,
 		// 2. We're going to find an x509 certificate on the signature and verify against Fulcio root trust

--- a/pkg/sget/sget.go
+++ b/pkg/sget/sget.go
@@ -28,16 +28,18 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/cmd/cosign/cli/verify"
 	"github.com/sigstore/cosign/pkg/cosign"
 	ociremote "github.com/sigstore/cosign/pkg/oci/remote"
 	sigs "github.com/sigstore/cosign/pkg/signature"
 )
 
-func New(image, key string, out io.Writer) *SecureGet {
+func New(image, key, rekorURL string, out io.Writer) *SecureGet {
 	return &SecureGet{
 		ImageRef: image,
 		KeyRef:   key,
+		RekorURL: rekorURL,
 		Out:      out,
 	}
 }
@@ -45,6 +47,7 @@ func New(image, key string, out io.Writer) *SecureGet {
 type SecureGet struct {
 	ImageRef string
 	KeyRef   string
+	RekorURL string
 	Out      io.Writer
 }
 
@@ -63,6 +66,18 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 		ClaimVerifier:      cosign.SimpleClaimVerifier,
 		RegistryClientOpts: []ociremote.Option{ociremote.WithRemoteOptions(opts...)},
 	}
+
+	rekorClient, err := rekor.NewClient(sg.RekorURL)
+	if err != nil {
+		return fmt.Errorf("creating Rekor client: %w", err)
+	}
+	co.RekorClient = rekorClient
+
+	co.RekorPubKeys, err = cosign.GetRekorPubs(ctx)
+	if err != nil {
+		return fmt.Errorf("getting Rekor public keys: %w", err)
+	}
+
 	if _, ok := ref.(name.Tag); ok {
 		if sg.KeyRef == "" && !options.EnableExperimental() {
 			return errors.New("public key must be specified when fetching by tag, you must fetch by digest or supply a public key")
@@ -85,6 +100,7 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 	}
 
 	if co.SigVerifier != nil || options.EnableExperimental() {
+		fmt.Println("2>>>>")
 		// NB: There are only 2 kinds of verification right now:
 		// 1. You gave us the public key explicitly to verify against so co.SigVerifier is non-nil or,
 		// 2. We're going to find an x509 certificate on the signature and verify against Fulcio root trust
@@ -100,7 +116,6 @@ func (sg *SecureGet) Do(ctx context.Context) error {
 		if err != nil {
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
-
 		sp, bundleVerified, err := cosign.VerifyImageSignatures(ctx, ref, co)
 		if err != nil {
 			return err

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1283,7 +1283,7 @@ func TestUploadBlob(t *testing.T) {
 	}
 
 	// Now download it with sget (this should fail by tag)
-	if err := sget.New(imgName, "", os.Stdout).Do(ctx); err == nil {
+	if err := sget.New(imgName, "", "", os.Stdout).Do(ctx); err == nil {
 		t.Error("expected download to fail")
 	}
 
@@ -1299,7 +1299,7 @@ func TestUploadBlob(t *testing.T) {
 	result := &bytes.Buffer{}
 
 	// But pass by digest
-	if err := sget.New(imgName+"@"+dgst.String(), "", result).Do(ctx); err != nil {
+	if err := sget.New(imgName+"@"+dgst.String(), "", "", result).Do(ctx); err != nil {
 		t.Fatal(err)
 	}
 	b, err := io.ReadAll(result)

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -137,7 +137,7 @@ cat /dev/urandom | head -n 10 | base64 > randomblob
 
 # upload blob and sign it
 dgst=$(./cosign upload blob -f randomblob ${blobimg})
-./cosign sign --key ${signing_key} ${dgst}
+./cosign sign --key ${signing_key} --tlog-upload=true ${dgst}
 ./cosign verify --key ${verification_key} ${dgst} # For sanity
 
 # sget w/ signature verification should work via tag or digest

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -137,7 +137,7 @@ cat /dev/urandom | head -n 10 | base64 > randomblob
 
 # upload blob and sign it
 dgst=$(./cosign upload blob -f randomblob ${blobimg})
-./cosign sign --key ${signing_key} --tlog-upload=true ${dgst}
+./cosign sign --key ${signing_key} ${dgst}
 ./cosign verify --key ${verification_key} ${dgst} # For sanity
 
 # sget w/ signature verification should work via tag or digest
@@ -157,7 +157,19 @@ if ( ! cmp -s randomblob verified_randomblob_from_digest ); then false; fi
 if ( ! cmp -s randomblob verified_randomblob_from_tag ); then false; fi
 if ( ! cmp -s randomblob randomblob_from_digest ); then false; fi
 
-# TODO: tlog
+# clean up a bit
+crane delete $blobimg || true
+crane delete $dgst || true
+
+# upload blob and sign it
+cat /dev/urandom | head -n 10 | base64 > randomblob
+dgst=$(./cosign upload blob -f randomblob ${blobimg})
+./cosign sign --key ${signing_key} --tlog-upload=false ${dgst}
+./cosign verify --key ${verification_key} --insecure-skip-tlog-verify=true ${dgst} # For sanity
+
+# clean up a bit
+crane delete $blobimg || true
+crane delete $dgst || true
 
 # What else needs auth?
 echo "SUCCESS"

--- a/test/e2e_test_secrets_kms.sh
+++ b/test/e2e_test_secrets_kms.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -ex
+
+go build -o cosign ./cmd/cosign
+go build -o sget ./cmd/sget
+tmp=$(mktemp -d -t cosign-e2e-secrets.XXXX)
+cp cosign $tmp/
+cp sget $tmp/
+
+pushd $tmp
+
+pass="$RANDOM"
+export COSIGN_PASSWORD=$pass
+
+BASE_TEST_REPO=${BASE_TEST_REPO:-ttl.sh/cosign-ci}
+TEST_INSTANCE_REPO="${BASE_TEST_REPO}/$(date +'%Y/%m/%d')/$RANDOM"
+
+## KMS using env variables!
+TEST_KMS=${TEST_KMS:-gcpkms://projects/projectsigstore/locations/global/keyRings/e2e-test/cryptoKeys/test}
+(crane delete $(./cosign triangulate $img)) || true
+COSIGN_KMS=$TEST_KMS ./cosign generate-key-pair
+signing_key=$TEST_KMS
+
+if (./cosign verify --key ${verification_key} $img); then false; fi
+COSIGN_KEY=${signing_key} ./cosign sign $img
+COSIGN_KEY=${verification_key} ./cosign verify $img
+
+if (./cosign verify -a foo=bar --key ${verification_key} $img); then false; fi
+COSIGN_KEY=${signing_key} ./cosign sign -a foo=bar $img
+COSIGN_KEY=${verification_key} ./cosign verify -a foo=bar $img
+
+# store signatures in a different repo
+export COSIGN_REPOSITORY=${TEST_INSTANCE_REPO}/subbedrepo
+(crane delete $(./cosign triangulate $img)) || true
+COSIGN_KEY=${signing_key} ./cosign sign $img
+COSIGN_KEY=${verification_key} ./cosign verify $img
+unset COSIGN_REPOSITORY
+
+# test stdin interaction for private key password
+stdin_password=${COSIGN_PASSWORD}
+unset COSIGN_PASSWORD
+(crane delete $(./cosign triangulate $img)) || true
+echo $stdin_password | ./cosign sign --key ${signing_key} --output-signature interactive.sig  $img
+COSIGN_KEY=${verification_key} COSIGN_SIGNATURE=interactive.sig ./cosign verify $img
+export COSIGN_PASSWORD=${stdin_password}
+
+# What else needs auth?
+echo "SUCCESS"


### PR DESCRIPTION
#### Summary

- convert the e2e tests that needed GCP Project to run to use public infra (ttl.sh and self-hosted vault) to run on pull requests as well

The original tests only run as post-submit jobs because it requires the OIDC token to authenticate in the GCP project to push images to the GCR and uses GCP KMS, and to run that in pull requests we will need the `pull_request_target` which can be dangerous because users might retrieve secrets and use for other things.

The refactor consists in split the existing tests in two and use ttl.sh to push the images and hashicorp vault running as a service in the CI for the KMS tests.

Let me know if this is ok or we still prefer to have the job only as post submit

cc @haydentherapper @dlorenc @hectorj2f @priyawadhwa 


FIxes: https://github.com/sigstore/cosign/issues/2531