### PR TITLE
Allow users to pass in a path for the --identity-token flag

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 
+	"go.step.sm/crypto/jose"
 	"golang.org/x/term"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
@@ -122,7 +123,10 @@ func NewSigner(ctx context.Context, ko options.KeyOpts) (*Signer, error) {
 		return nil, fmt.Errorf("creating Fulcio client: %w", err)
 	}
 
-	idToken := ko.IDToken
+	idToken, err := idToken(ko.IDToken)
+	if err != nil {
+		return nil, fmt.Errorf("getting id token: %w", err)
+	}
 	var provider providers.Interface
 	// If token is not set in the options, get one from the provders
 	if idToken == "" && providers.Enabled(ctx) && !ko.OIDCDisableProviders {
@@ -209,4 +213,17 @@ func NewClient(fulcioURL string) (api.LegacyClient, error) {
 	}
 	fClient := api.NewClient(fulcioServer, api.WithUserAgent(options.UserAgent()))
 	return fClient, nil
+}
+
+// idToken allows users to either pass in an identity token directly
+// or a path to an identity token via the --identity-token flag
+func idToken(s string) (string, error) {
+	// If this is a valid raw token or is empty, just return it
+	if _, err := jose.ParseSigned(s); err == nil || s == "" {
+		return s, nil
+	}
+
+	// Otherwise, if this is a path to a token return the contents
+	c, err := os.ReadFile(s)
+	return string(c), err
 }

--- a/cmd/cosign/cli/options/fulcio.go
+++ b/cmd/cosign/cli/options/fulcio.go
@@ -37,7 +37,7 @@ func (o *FulcioOptions) AddFlags(cmd *cobra.Command) {
 		"[EXPERIMENTAL] address of sigstore PKI server")
 
 	cmd.Flags().StringVar(&o.IdentityToken, "identity-token", "",
-		"[EXPERIMENTAL] identity token to use for certificate from fulcio")
+		"[EXPERIMENTAL] identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.")
 
 	cmd.Flags().BoolVar(&o.InsecureSkipFulcioVerify, "insecure-skip-verify", false,
 		"[EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).")

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -46,7 +46,7 @@ cosign attest [flags]
       --certificate-chain string                                                                 path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Included in the OCI Signature
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for attest
-      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret

--- a/doc/cosign_policy_sign.md
+++ b/doc/cosign_policy_sign.md
@@ -20,7 +20,7 @@ cosign policy sign [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
-      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --namespace string                                                                         registry namespace that the root policy belongs to (default "ns")

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -37,7 +37,7 @@ cosign sign-blob [flags]
       --bundle string                    write everything required to verify the blob to a FILE
       --fulcio-url string                [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                             help for sign-blob
-      --identity-token string            [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --identity-token string            [EXPERIMENTAL] identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify             [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                       path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string            [EXPERIMENTAL] OIDC client ID for application (default "sigstore")

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -75,7 +75,7 @@ cosign sign [flags]
       --certificate-chain string                                                                 path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Included in the OCI Signature
       --fulcio-url string                                                                        [EXPERIMENTAL] address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
-      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio
+      --identity-token string                                                                    [EXPERIMENTAL] identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify                                                                     [EXPERIMENTAL] skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/transparency-dev/merkle v0.0.1
 	github.com/withfig/autocomplete-tools/integrations/cobra v1.2.1
 	github.com/xanzy/go-gitlab v0.77.0
+	go.step.sm/crypto v0.23.1
 	golang.org/x/crypto v0.4.0
 	golang.org/x/oauth2 v0.3.0
 	golang.org/x/sync v0.1.0
@@ -238,7 +239,6 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/otel v1.11.1 // indirect
 	go.opentelemetry.io/otel/trace v1.11.1 // indirect
-	go.step.sm/crypto v0.23.1 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.23.0 // indirect


### PR DESCRIPTION
Seems cleaner to pass in a file name than to pass in an entire token.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>



#### Release Note
Allow users to pass in a path for the --identity-token flag

