### PR TITLE
Fix unset PassFunc

### DIFF
--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/attest"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/spf13/cobra"
 )
@@ -53,6 +54,7 @@ func AttestBlob() *cobra.Command {
 				PredicatePath:     o.Predicate.Path,
 				OutputSignature:   o.OutputSignature,
 				OutputAttestation: o.OutputAttestation,
+				PassFunc:          generate.GetPass,
 			}
 			return v.Exec(cmd.Context(), args[0])
 		},


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
Resolved sigstore/cosign#2545

#### Summary

Fixing issue #2545 

#### Release Note

* Bug fix for incorrect key password handling on attest-blob command.
