### PR TITLE
Update required Go version (go.mod) to 1.19.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/cosign
 
-go 1.18
+go 1.19
 
 require (
 	cuelang.org/go v0.4.3


### PR DESCRIPTION
CI/CD (`.github/workflows/*`) has already been updated.

#### Summary

1.18 will be deprecated soon.

#### Release Note
Updated required Go version to 1.19.

#### Documentation
N/A