### PR TITLE
Check value for `cosign clean` `--type` flag

### DIFF
--- a/cmd/cosign/cli/clean.go
+++ b/cmd/cosign/cli/clean.go
@@ -50,7 +50,7 @@ func Clean() *cobra.Command {
 	return cmd
 }
 
-func CleanCmd(ctx context.Context, regOpts options.RegistryOptions, cleanType, imageRef string, force bool) error {
+func CleanCmd(ctx context.Context, regOpts options.RegistryOptions, cleanType options.CleanType, imageRef string, force bool) error {
 	ok, err := cosign.ConfirmPrompt(prompt(cleanType), force)
 	if err != nil {
 		return err
@@ -82,14 +82,16 @@ func CleanCmd(ctx context.Context, regOpts options.RegistryOptions, cleanType, i
 
 	var cleanTags []name.Tag
 	switch cleanType {
-	case "signature":
+	case options.CleanTypeSignature:
 		cleanTags = []name.Tag{sigRef}
-	case "sbom":
+	case options.CleanTypeSbom:
 		cleanTags = []name.Tag{sbomRef}
-	case "attestation":
+	case options.CleanTypeAttestation:
 		cleanTags = []name.Tag{attRef}
-	case "all":
+	case options.CleanTypeAll:
 		cleanTags = []name.Tag{sigRef, attRef, sbomRef}
+	default:
+		panic("invalid CleanType value")
 	}
 
 	for _, t := range cleanTags {
@@ -110,16 +112,16 @@ func CleanCmd(ctx context.Context, regOpts options.RegistryOptions, cleanType, i
 	return nil
 }
 
-func prompt(cleanType string) string {
+func prompt(cleanType options.CleanType) string {
 	switch cleanType {
-	case "signature":
+	case options.CleanTypeSignature:
 		return "WARNING: this will remove all signatures from the image"
-	case "sbom":
+	case options.CleanTypeSbom:
 		return "WARNING: this will remove all SBOMs from the image"
-	case "attestation":
+	case options.CleanTypeAttestation:
 		return "WARNING: this will remove all attestations from the image"
-	case "all":
+	case options.CleanTypeAll:
 		return "WARNING: this will remove all signatures, SBOMs and attestations from the image"
 	}
-	return ""
+	panic("invalid CleanType value")
 }

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -21,7 +21,7 @@ cosign clean [flags]
   -f, --force                                                                                    do not prompt for confirmation
   -h, --help                                                                                     help for clean
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
-      --type string                                                                              a type of clean: <signature|attestation|sbom|all> (default: all) (default "all")
+      --type CLEAN_TYPE                                                                          a type of clean: <signature|attestation|sbom|all> (default all)
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Before, if you passed `--type invalid` it would silently fail. Now we check the flag value.

Signed-off-by: Zachary Newman <zjn@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->