### PR TITLE
Rego: add support for custom error/warning messages when evaluating rego rules

### DIFF
--- a/pkg/cosign/rego/rego.go
+++ b/pkg/cosign/rego/rego.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/open-policy-agent/opa/rego"
 )
@@ -116,16 +115,12 @@ func ValidateJSONWithModuleInput(jsonBody []byte, moduleInput string) (warnings 
 		return nil, err
 	}
 
-	var response []interface{}
-	var isComplaint bool
 	for _, result := range rs {
-		switch reflect.TypeOf(result.Bindings[CosignEvaluationRule]) {
-		case reflect.TypeOf(response):
-			return evaluateRegoEvalMapResult(query, result.Bindings[CosignEvaluationRule].([]interface{}))
-		case reflect.TypeOf(isComplaint):
-			fmt.Printf("isComplaint %v\n", isComplaint)
-			isComplaint, ok := result.Bindings[CosignEvaluationRule].(bool)
-			if ok && isComplaint {
+		switch response := result.Bindings[CosignEvaluationRule].(type) {
+		case []interface{}:
+			return evaluateRegoEvalMapResult(query, response)
+		case bool:
+			if response {
 				return nil, nil
 			}
 		}

--- a/pkg/cosign/rego/rego_test.go
+++ b/pkg/cosign/rego/rego_test.go
@@ -214,8 +214,8 @@ func TestValidateJSONWithModuleInput(t *testing.T) {
 					warnMsg := ""
 					response :={
 						"result" : result,
-						"errors" : errorMsg,
-						"warnings": warnMsg,
+						"error" : errorMsg,
+						"warning": warnMsg,
 					}
 				}
 			`,

--- a/pkg/cosign/rego/rego_test.go
+++ b/pkg/cosign/rego/rego_test.go
@@ -151,6 +151,7 @@ func TestValidateJSONWithModuleInput(t *testing.T) {
 		policy   string
 		pass     bool
 		errorMsg string
+		warnMsg  string
 	}{
 		{
 			name:     "passing policy attestations",
@@ -199,16 +200,42 @@ func TestValidateJSONWithModuleInput(t *testing.T) {
 			pass:     false,
 			errorMsg: "policy is not compliant for query 'isCompliant = data.sigstore.isCompliant'",
 		},
+		{
+			name:     "not passing policy attestations",
+			jsonBody: attestationsJSONBody,
+			policy: `
+				package sigstore
+
+				isCompliant[response] {
+					attestationsKeylessATT := input.authorityMatches.keylessatt.attestations
+					result = (count(attestationsKeylessATT) == 1000)
+
+					errorMsg := "attestationsKeylessATT is not equal to 1000"
+					warnMsg := ""
+					response :={
+						"result" : result,
+						"errors" : errorMsg,
+						"warnings": warnMsg,
+					}
+				}
+			`,
+			pass:     false,
+			errorMsg: "policy is not compliant for query 'isCompliant = data.sigstore.isCompliant' with errors: attestationsKeylessATT is not equal to 1000",
+		},
 	}
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := ValidateJSONWithModuleInput([]byte(tt.jsonBody), tt.policy); (err == nil) != tt.pass {
+			warn, err := ValidateJSONWithModuleInput([]byte(tt.jsonBody), tt.policy)
+			if (err == nil) != tt.pass {
 				t.Fatalf("Unexpected result: %v", err)
 			} else if err != nil {
 				if fmt.Sprintf("%s", err) != tt.errorMsg {
 					t.Errorf("Expected error %q, got %q", tt.errorMsg, err)
 				}
+			}
+			if warn != nil && tt.warnMsg != "" && tt.warnMsg != warn.Error() {
+				t.Errorf("Expected warning %q, got %q", tt.warnMsg, warn)
 			}
 		})
 	}

--- a/pkg/policy/eval_test.go
+++ b/pkg/policy/eval_test.go
@@ -217,8 +217,8 @@ func TestEvalPolicy(t *testing.T) {
 
 				response := {
 					"result" : result,
-					"errors" : errorMsg,
-					"warnings" : warnMsg
+					"error" : errorMsg,
+					"warning" : warnMsg
 				}
 			}`,
 		}, {
@@ -237,8 +237,8 @@ func TestEvalPolicy(t *testing.T) {
 
 				response := {
 					"result" : result,
-					"errors" : errorMsg,
-					"warnings" : warnMsg
+					"error" : errorMsg,
+					"warning" : warnMsg
 				}
 			}`,
 		}, {
@@ -261,8 +261,8 @@ func TestEvalPolicy(t *testing.T) {
 
 				response := {
 					"result" : result,
-					"errors" : errorMsg,
-					"warnings" : warnMsg
+					"error" : errorMsg,
+					"warning" : warnMsg
 				}
 			}`,
 		}}

--- a/pkg/policy/eval_test.go
+++ b/pkg/policy/eval_test.go
@@ -82,12 +82,13 @@ func TestEvalPolicy(t *testing.T) {
 	// TODO(vaikas): Consider moving the attestations/cue files into testdata
 	// directory.
 	tests := []struct {
-		name       string
-		json       string
-		policyType string
-		policyFile string
-		wantErr    bool
-		wantErrSub string
+		name        string
+		json        string
+		policyType  string
+		policyFile  string
+		wantErr     bool
+		wantErrSub  string
+		wantWarnSub string
 	}{{
 		name:       "custom attestation, mismatched predicateType",
 		json:       customAttestation,
@@ -198,19 +199,91 @@ func TestEvalPolicy(t *testing.T) {
 				keySignature := input.authorityMatches.keysignature.signatures
 				count(keySignature) == 1
 			}`,
+		}, {
+			name:       "Rego cluster image policy main policy succeed with empty error msg",
+			json:       cipAttestation,
+			policyType: "rego",
+			policyFile: `package sigstore
+			isCompliant[response] {
+			    attestationsKeylessATT := input.authorityMatches.keylessatt.attestations
+				result = (count(attestationsKeylessATT) == 1)
+				attestationsKeyATT := input.authorityMatches.keyatt.attestations
+				result = (count(attestationsKeyATT) == 1)
+				keySignature := input.authorityMatches.keysignature.signatures
+				result = (count(keySignature) == 1)
+
+				errorMsg = ""
+				warnMsg = ""
+
+				response := {
+					"result" : result,
+					"errors" : errorMsg,
+					"warnings" : warnMsg
+				}
+			}`,
+		}, {
+			name:       "Rego cluster image policy main policy, fails with custom error msg",
+			json:       cipAttestation,
+			policyType: "rego",
+			wantErr:    true,
+			wantErrSub: `Not found expected list of attestations`,
+			policyFile: `package sigstore
+			isCompliant[response] {
+			    attestationsKeylessATT := input.authorityMatches.keylessatt.attestations
+				result = (count(attestationsKeylessATT) == 1000)
+
+				errorMsg = "Not found expected list of attestations"
+				warnMsg = ""
+
+				response := {
+					"result" : result,
+					"errors" : errorMsg,
+					"warnings" : warnMsg
+				}
+			}`,
+		}, {
+			name:        "Rego cluster image policy main policy, returns a custom warning msg",
+			json:        cipAttestation,
+			policyType:  "rego",
+			wantErr:     false,
+			wantWarnSub: `Throw warning error even if succeeded`,
+			policyFile: `package sigstore
+			isCompliant[response] {
+				attestationsKeylessATT := input.authorityMatches.keylessatt.attestations
+				result = (count(attestationsKeylessATT) == 1)
+				attestationsKeyATT := input.authorityMatches.keyatt.attestations
+				result = (count(attestationsKeyATT) == 1)
+				keySignature := input.authorityMatches.keysignature.signatures
+				result = (count(keySignature) == 1)
+
+				errorMsg = ""
+				warnMsg = "Throw warning error even if succeeded"
+
+				response := {
+					"result" : result,
+					"errors" : errorMsg,
+					"warnings" : warnMsg
+				}
+			}`,
 		}}
 	for _, tc := range tests {
 		ctx := context.Background()
-		err := EvaluatePolicyAgainstJSON(ctx, tc.name, tc.policyType, tc.policyFile, []byte(tc.json))
+		warn, err := EvaluatePolicyAgainstJSON(ctx, tc.name, tc.policyType, tc.policyFile, []byte(tc.json))
 		if tc.wantErr {
 			if err == nil {
 				t.Errorf("Did not get an error, wanted %s", tc.wantErrSub)
 			} else if !strings.Contains(err.Error(), tc.wantErrSub) {
 				t.Errorf("Unexpected error, want: %s got: %s", tc.wantErrSub, err.Error())
 			}
+			if tc.wantWarnSub != "" && !strings.Contains(warn.Error(), tc.wantWarnSub) {
+				t.Errorf("Unexpected warning, want: %s got: %s", tc.wantErrSub, err.Error())
+			}
 		} else {
 			if !tc.wantErr && err != nil {
 				t.Errorf("Unexpected error, wanted none, got: %s", err.Error())
+			}
+			if tc.wantWarnSub != "" && !strings.Contains(warn.Error(), tc.wantWarnSub) {
+				t.Errorf("Unexpected warning, want: %s got: %s", tc.wantWarnSub, warn.Error())
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
This PR adds support for handling more complex evaluation rules in Rego. It enables to return custom warning or error messages following a new template: 

```
package sigstore

isComplaint[response] {
   result := ( ... Rego logic evaluated here to a boolean ....) 
   
   errorMsg := "Your custom error message..."
   warnMsg := ""
   response :={
	"result" : result,
	"warnings" warnMsg,
	"errors" : errorMsg,
  }
}
```

closes: https://github.com/sigstore/cosign/issues/2570 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->