### PR TITLE
    cli: Handle `-` as a CLI argument

### DIFF
--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -43,7 +43,7 @@ func main() {
 			newArg := fmt.Sprintf("-%c", arg[2])
 			ui.Warn(ctx, "the flag %s is deprecated and will be removed in a future release. Please use the flag %s.", arg, newArg)
 			os.Args[i] = newArg
-		} else if strings.HasPrefix(arg, "-") {
+		} else if strings.HasPrefix(arg, "-") && len(arg) > 1 {
 			// Handle -output, convert to --output
 			newArg := fmt.Sprintf("-%s", arg)
 			newArgType := "flag"

--- a/cmd/cosign/main.go
+++ b/cmd/cosign/main.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli"
+	"github.com/sigstore/cosign/v2/internal/ui"
 
 	// Register the provider-specific plugins
 	_ "github.com/sigstore/sigstore/pkg/signature/kms/aws"
@@ -31,6 +33,7 @@ import (
 
 func main() {
 	// Fix up flags to POSIX standard flags.
+	ctx := context.Background()
 	for i, arg := range os.Args {
 		if (strings.HasPrefix(arg, "-") && len(arg) == 2) || (strings.HasPrefix(arg, "--") && len(arg) >= 4) {
 			continue
@@ -38,7 +41,7 @@ func main() {
 		if strings.HasPrefix(arg, "--") && len(arg) == 3 {
 			// Handle --o, convert to -o
 			newArg := fmt.Sprintf("-%c", arg[2])
-			fmt.Fprintf(os.Stderr, "WARNING: the flag %s is deprecated and will be removed in a future release. Please use the flag %s.\n", arg, newArg)
+			ui.Warn(ctx, "the flag %s is deprecated and will be removed in a future release. Please use the flag %s.", arg, newArg)
 			os.Args[i] = newArg
 		} else if strings.HasPrefix(arg, "-") {
 			// Handle -output, convert to --output
@@ -48,10 +51,8 @@ func main() {
 				newArg = "version"
 				newArgType = "subcommand"
 			}
-			fmt.Fprintf(
-				os.Stderr,
-				"WARNING: the %s flag is deprecated and will be removed in a future release. "+
-					"Please use the %s %s instead.\n",
+			ui.Warn(ctx, "the %s flag is deprecated and will be removed in a future release. "+
+				"Please use the %s %s instead.",
 				arg, newArg, newArgType,
 			)
 			os.Args[i] = newArg


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Before:

```
$ cat /dev/null | COSIGN_EXPERIMENTAL=1 ./cosign attest caphill4/test:latest --type custom --predicate -
WARNING: the - flag is deprecated and will be removed in a future release. Please use the -- flag instead.
```

After there's no warning, which is good. `-output` or similar continue to warn.
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A this makes behavior consistent with docs