### PR TITLE
refactor: use internal.ui lib instead of printf directly

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -167,7 +167,7 @@ func SignCmd(ro *options.RootOptions, ko options.KeyOpts, signOpts options.SignO
 
 	var staticPayload []byte
 	if signOpts.PayloadPath != "" {
-		fmt.Fprintln(os.Stderr, "Using payload from:", signOpts.PayloadPath)
+		ui.Info(ctx, "Using payload from:", signOpts.PayloadPath)
 		staticPayload, err = os.ReadFile(filepath.Clean(signOpts.PayloadPath))
 		if err != nil {
 			return fmt.Errorf("payload from file: %w", err)
@@ -307,7 +307,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 			return fmt.Errorf("create certificate file: %w", err)
 		}
 		// TODO: maybe accept a --b64 flag as well?
-		fmt.Printf("Certificate wrote in the file %s\n", outputCertificate)
+		ui.Info(ctx, "Certificate wrote in the file %s", outputCertificate)
 	}
 
 	if !upload {
@@ -329,9 +329,9 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	// Check if we are overriding the signatures repository location
 	repo, _ := ociremote.GetEnvTargetRepository()
 	if repo.RepositoryStr() == "" {
-		fmt.Fprintln(os.Stderr, "Pushing signature to:", digest.Repository)
+		ui.Info(ctx, "Pushing signature to:", digest.Repository)
 	} else {
-		fmt.Fprintln(os.Stderr, "Pushing signature to:", repo.RepositoryStr())
+		ui.Info(ctx, "Pushing signature to:", repo.RepositoryStr())
 	}
 
 	// Publish the signatures associated with this entity
@@ -342,7 +342,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	return nil
 }
 
-func signerFromSecurityKey(keySlot string) (*SignerVerifier, error) {
+func signerFromSecurityKey(ctx context.Context, keySlot string) (*SignerVerifier, error) {
 	sk, err := pivkey.GetKeyWithSlot(keySlot)
 	if err != nil {
 		return nil, err
@@ -360,7 +360,7 @@ func signerFromSecurityKey(keySlot string) (*SignerVerifier, error) {
 	certFromPIV, err := sk.Certificate()
 	var pemBytes []byte
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "warning: no x509 certificate retrieved from the PIV token")
+		ui.Warn(ctx, "no x509 certificate retrieved from the PIV token")
 	} else {
 		pemBytes, err = cryptoutils.MarshalCertificateToPEM(certFromPIV)
 		if err != nil {
@@ -396,7 +396,7 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 		certSigner.close = pkcs11Key.Close
 
 		if certFromPKCS11 == nil {
-			fmt.Fprintln(os.Stderr, "warning: no x509 certificate retrieved from the PKCS11 token")
+			ui.Warn(ctx, "no x509 certificate retrieved from the PKCS11 token")
 		} else {
 			pemBytes, err := cryptoutils.MarshalCertificateToPEM(certFromPKCS11)
 			if err != nil {
@@ -449,7 +449,7 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 			return nil, fmt.Errorf("marshaling certificate to PEM: %w", err)
 		}
 		if certSigner.Cert != nil {
-			fmt.Fprintln(os.Stderr, "warning: overriding x509 certificate retrieved from the PKCS11 token")
+			ui.Warn(ctx, "overriding x509 certificate retrieved from the PKCS11 token")
 		}
 		leafCert = parsedCert
 		certSigner.Cert = pemBytes
@@ -531,7 +531,7 @@ func keylessSigner(ctx context.Context, ko options.KeyOpts) (*SignerVerifier, er
 
 func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, error) {
 	if ko.Sk {
-		return signerFromSecurityKey(ko.Slot)
+		return signerFromSecurityKey(ctx, ko.Slot)
 	}
 
 	if ko.KeyRef != "" {
@@ -539,7 +539,7 @@ func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath strin
 	}
 
 	// Default Keyless!
-	fmt.Fprintln(os.Stderr, "Generating ephemeral keys...")
+	ui.Info(ctx, "Generating ephemeral keys...")
 	return keylessSigner(ctx, ko)
 }
 
@@ -558,7 +558,7 @@ func (c *SignerVerifier) Close() {
 
 func (c *SignerVerifier) Bytes(ctx context.Context) ([]byte, error) {
 	if c.Cert != nil {
-		fmt.Fprintf(os.Stderr, "using ephemeral certificate:\n%s\n", string(c.Cert))
+		ui.Info(ctx, "using ephemeral certificate:\n%s", string(c.Cert))
 		return c.Cert, nil
 	}
 

--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -183,7 +183,7 @@ func TestVerifyTLogEntryOfflineFailsWithInvalidPublicKey(t *testing.T) {
 		t.Fatalf("failed to add RSA key to transparency log public keys: %v", err)
 	}
 
-	err = VerifyTLogEntryOffline(&models.LogEntryAnon{Verification: &models.LogEntryAnonVerification{InclusionProof: &models.InclusionProof{}}}, &rekorPubKeys)
+	err = VerifyTLogEntryOffline(context.Background(), &models.LogEntryAnon{Verification: &models.LogEntryAnonVerification{InclusionProof: &models.InclusionProof{}}}, &rekorPubKeys)
 	if err == nil {
 		t.Fatal("Wanted error got none")
 	}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -433,7 +433,7 @@ func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *
 	entryVerificationErrs := make([]string, 0)
 	for _, e := range tlogEntries {
 		entry := e
-		if err := VerifyTLogEntryOffline(&entry, rekorPubKeys); err != nil {
+		if err := VerifyTLogEntryOffline(ctx, &entry, rekorPubKeys); err != nil {
 			entryVerificationErrs = append(entryVerificationErrs, err.Error())
 			continue
 		}

--- a/pkg/policy/eval.go
+++ b/pkg/policy/eval.go
@@ -18,9 +18,9 @@ package policy
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"cuelang.org/go/cue/cuecontext"
+	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/cosign/rego"
 )
@@ -53,9 +53,9 @@ func EvaluatePolicyAgainstJSON(ctx context.Context, name, policyType string, pol
 }
 
 // evaluateCue evaluates a cue policy `evaluator` against `attestation`
-func evaluateCue(_ context.Context, attestation []byte, evaluator string) error {
-	log.Printf("Evaluating attestation: %s", string(attestation))
-	log.Printf("Evaluator: %s", evaluator)
+func evaluateCue(ctx context.Context, attestation []byte, evaluator string) error {
+	ui.Info(ctx, "Evaluating attestation: %s", string(attestation))
+	ui.Info(ctx, "Evaluator: %s", evaluator)
 
 	cueCtx := cuecontext.New()
 	cueEvaluator := cueCtx.CompileString(evaluator)
@@ -74,9 +74,9 @@ func evaluateCue(_ context.Context, attestation []byte, evaluator string) error 
 }
 
 // evaluateRego evaluates a rego policy `evaluator` against `attestation`
-func evaluateRego(_ context.Context, attestation []byte, evaluator string) (warnings error, errors error) {
-	log.Printf("Evaluating attestation: %s", string(attestation))
-	log.Printf("Evaluating evaluator: %s", evaluator)
+func evaluateRego(ctx context.Context, attestation []byte, evaluator string) (warnings error, errors error) {
+	ui.Info(ctx, "Evaluating attestation: %s", string(attestation))
+	ui.Info(ctx, "Evaluating evaluator: %s", evaluator)
 
 	return rego.ValidateJSONWithModuleInput(attestation, evaluator)
 }


### PR DESCRIPTION
In some of these cases, we're moving output from STDOUT to STDERR but it always should have been on STDERR.

Signed-off-by: Zachary Newman <zjn@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->