### PR TITLE
bump cpanato/vault-installer to use release v0.0.2

### DIFF
--- a/.github/workflows/e2e-tests-kms.yml
+++ b/.github/workflows/e2e-tests-kms.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-      - uses: cpanato/vault-installer@57fd1958391e4c802d55ed4a26ff9a8d5812d3a9 # v0.0.1
+      - uses: cpanato/vault-installer@4246c92b8f047fdb824eb7387d86b3c7806e2bf3 # v0.0.2
         with:
           vault-release: '1.12.2'
 


### PR DESCRIPTION
#### Summary
- bump cpanato/vault-installer to use release v0.0.2
this fixes the flaky in the broken pipe when installing vault