### PR TITLE
insecure-skip-tlog-verify: rename and adapt the cert expiration check

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -22,7 +22,7 @@ import (
 type CommonVerifyOptions struct {
 	Offline          bool // Force offline verification
 	TSACertChainPath string
-	SkipTlogVerify   bool
+	IgnoreTlog       bool
 }
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
@@ -33,8 +33,8 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 		"path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. "+
 			"Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp")
 
-	cmd.Flags().BoolVar(&o.SkipTlogVerify, "insecure-skip-tlog-verify", false,
-		"skip transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts "+
+	cmd.Flags().BoolVar(&o.IgnoreTlog, "insecure-ignore-tlog", false,
+		"ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts "+
 			"cannot be publicly verified when not included in a log")
 }
 

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -118,14 +118,14 @@ against the transparency log.`,
 				LocalImage:                   o.LocalImage,
 				Offline:                      o.CommonVerifyOptions.Offline,
 				TSACertChainPath:             o.CommonVerifyOptions.TSACertChainPath,
-				SkipTlogVerify:               o.CommonVerifyOptions.SkipTlogVerify,
+				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 			}
 
 			if o.Registry.AllowInsecure {
 				v.NameOptions = append(v.NameOptions, name.Insecure)
 			}
 
-			if o.CommonVerifyOptions.SkipTlogVerify {
+			if o.CommonVerifyOptions.IgnoreTlog {
 				fmt.Fprintln(os.Stderr, "**Warning** Skipping tlog verification is an insecure practice that lacks of transparency and auditability verification for the signature.")
 			}
 
@@ -210,7 +210,7 @@ against the transparency log.`,
 				NameOptions:                  o.Registry.NameOptions(),
 				Offline:                      o.CommonVerifyOptions.Offline,
 				TSACertChainPath:             o.CommonVerifyOptions.TSACertChainPath,
-				SkipTlogVerify:               o.CommonVerifyOptions.SkipTlogVerify,
+				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 			}
 
 			return v.Exec(cmd.Context(), args)
@@ -295,7 +295,7 @@ The blob may be specified as a path to a file or - for stdin.`,
 				IgnoreSCT:                    o.CertVerify.IgnoreSCT,
 				SCTRef:                       o.CertVerify.SCT,
 				Offline:                      o.CommonVerifyOptions.Offline,
-				SkipTlogVerify:               o.CommonVerifyOptions.SkipTlogVerify,
+				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 			}
 			if err := verifyBlobCmd.Exec(cmd.Context(), args[0]); err != nil {
 				return fmt.Errorf("verifying blob %s: %w", args, err)
@@ -354,7 +354,7 @@ The blob may be specified as a path to a file.`,
 				IgnoreSCT:                    o.CertVerify.IgnoreSCT,
 				SCTRef:                       o.CertVerify.SCT,
 				Offline:                      o.CommonVerifyOptions.Offline,
-				SkipTlogVerify:               o.CommonVerifyOptions.SkipTlogVerify,
+				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 			}
 			if len(args) != 1 {
 				return fmt.Errorf("no path to blob passed in, run `cosign verify-blob-attestation -h` for more help")

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -75,7 +75,7 @@ type VerifyCommand struct {
 	NameOptions                  []name.Option
 	Offline                      bool
 	TSACertChainPath             string
-	SkipTlogVerify               bool
+	IgnoreTlog                   bool
 }
 
 // Exec runs the verification command
@@ -121,7 +121,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		SignatureRef:                 c.SignatureRef,
 		Identities:                   identities,
 		Offline:                      c.Offline,
-		SkipTlogVerify:               c.SkipTlogVerify,
+		IgnoreTlog:                   c.IgnoreTlog,
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.SimpleClaimVerifier
@@ -152,7 +152,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		co.TSARootCertificates = roots
 	}
 
-	if !c.SkipTlogVerify {
+	if !c.IgnoreTlog {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -64,7 +64,7 @@ type VerifyAttestationCommand struct {
 	NameOptions                  []name.Option
 	Offline                      bool
 	TSACertChainPath             string
-	SkipTlogVerify               bool
+	IgnoreTlog                   bool
 }
 
 // Exec runs the verification command
@@ -101,7 +101,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		IgnoreSCT:                    c.IgnoreSCT,
 		Identities:                   identities,
 		Offline:                      c.Offline,
-		SkipTlogVerify:               c.SkipTlogVerify,
+		IgnoreTlog:                   c.IgnoreTlog,
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
@@ -137,7 +137,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		co.TSAIntermediateCertificates = intermediates
 		co.TSARootCertificates = roots
 	}
-	if !c.SkipTlogVerify {
+	if !c.IgnoreTlog {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -62,7 +62,7 @@ type VerifyBlobCmd struct {
 	IgnoreSCT                    bool
 	SCTRef                       string
 	Offline                      bool
-	SkipTlogVerify               bool
+	IgnoreTlog                   bool
 }
 
 // nolint
@@ -108,7 +108,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		IgnoreSCT:                    c.IgnoreSCT,
 		Identities:                   identities,
 		Offline:                      c.Offline,
-		SkipTlogVerify:               c.SkipTlogVerify,
+		IgnoreTlog:                   c.IgnoreTlog,
 	}
 	if c.RFC3161TimestampPath != "" && c.KeyOpts.TSACertChainPath == "" {
 		return fmt.Errorf("timestamp-certificate-chain is required to validate a RFC3161 timestamp")
@@ -138,7 +138,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		co.TSARootCertificates = roots
 	}
 
-	if !c.SkipTlogVerify {
+	if !c.IgnoreTlog {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -61,10 +61,10 @@ type VerifyBlobAttestationCommand struct {
 	CertGithubWorkflowRepository string
 	CertGithubWorkflowRef        string
 
-	IgnoreSCT      bool
-	SCTRef         string
-	Offline        bool
-	SkipTlogVerify bool
+	IgnoreSCT  bool
+	SCTRef     string
+	Offline    bool
+	IgnoreTlog bool
 
 	CheckClaims   bool
 	PredicateType string
@@ -106,7 +106,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		CertGithubWorkflowRef:        c.CertGithubWorkflowRef,
 		IgnoreSCT:                    c.IgnoreSCT,
 		Offline:                      c.Offline,
-		SkipTlogVerify:               c.SkipTlogVerify,
+		IgnoreTlog:                   c.IgnoreTlog,
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
@@ -159,7 +159,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		co.TSARootCertificates = roots
 	}
 
-	if !c.SkipTlogVerify {
+	if !c.IgnoreTlog {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -104,11 +104,11 @@ func TestVerifyBlobAttestation(t *testing.T) {
 			sigRef := writeBlobFile(t, td, string(decodedSig), "signature")
 
 			cmd := VerifyBlobAttestationCommand{
-				KeyOpts:        options.KeyOpts{KeyRef: keyRef},
-				SignaturePath:  sigRef,
-				SkipTlogVerify: true,
-				CheckClaims:    true,
-				PredicateType:  test.predicateType,
+				KeyOpts:       options.KeyOpts{KeyRef: keyRef},
+				SignaturePath: sigRef,
+				IgnoreTlog:    true,
+				CheckClaims:   true,
+				PredicateType: test.predicateType,
 			}
 			err = cmd.Exec(ctx, test.blobPath)
 

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -573,9 +573,9 @@ func TestVerifyBlob(t *testing.T) {
 					CertIdentity:   identity,
 					CertOidcIssuer: issuer,
 				},
-				IgnoreSCT:      true,
-				CertChain:      chainPath,
-				SkipTlogVerify: tt.skipTlogVerify,
+				IgnoreSCT:  true,
+				CertChain:  chainPath,
+				IgnoreTlog: tt.skipTlogVerify,
 			}
 			blobPath := writeBlobFile(t, td, string(blobBytes), "blob.txt")
 			if tt.signature != "" {

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -72,7 +72,7 @@ cosign dockerfile verify [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
-      --insecure-skip-tlog-verify                                                                skip transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
+      --insecure-ignore-tlog                                                                     ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -66,7 +66,7 @@ cosign manifest verify [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
-      --insecure-skip-tlog-verify                                                                skip transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
+      --insecure-ignore-tlog                                                                     ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -73,7 +73,7 @@ cosign verify-attestation [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify-attestation
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
-      --insecure-skip-tlog-verify                                                                skip transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
+      --insecure-ignore-tlog                                                                     ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -43,7 +43,7 @@ cosign verify-blob-attestation [flags]
       --check-claims                                    whether to check the claims found (default true)
   -h, --help                                            help for verify-blob-attestation
       --insecure-ignore-sct                             when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
-      --insecure-skip-tlog-verify                       skip transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
+      --insecure-ignore-tlog                            ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --offline                                         only allow offline verification
       --rekor-url string                                [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -72,7 +72,7 @@ cosign verify-blob [flags]
       --certificate-oidc-issuer-regexp string           A regular expression alternative to --certificate-oidc-issuer. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.
   -h, --help                                            help for verify-blob
       --insecure-ignore-sct                             when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
-      --insecure-skip-tlog-verify                       skip transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
+      --insecure-ignore-tlog                            ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --offline                                         only allow offline verification
       --rekor-url string                                [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -82,7 +82,7 @@ cosign verify [flags]
       --check-claims                                                                             whether to check the claims found (default true)
   -h, --help                                                                                     help for verify
       --insecure-ignore-sct                                                                      when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
-      --insecure-skip-tlog-verify                                                                skip transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
+      --insecure-ignore-tlog                                                                     ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -137,8 +137,8 @@ type CheckOpts struct {
 	// TSAIntermediateCertificates are the set of intermediates for chain building
 	TSAIntermediateCertificates []*x509.Certificate
 
-	// SkipTlogVerify skip tlog verification
-	SkipTlogVerify bool
+	// IgnoreTlog skip tlog verification
+	IgnoreTlog bool
 }
 
 // This is a substitutable signature verification function that can be used for verifying
@@ -596,7 +596,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		}
 	}
 
-	if !co.SkipTlogVerify {
+	if !co.IgnoreTlog {
 		bundleVerified, err = VerifyBundle(sig, co)
 		if err != nil {
 			return false, fmt.Errorf("error verifying bundle: %w", err)
@@ -708,6 +708,10 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		// if no timestamp has been provided, use the current time
 		if !expirationChecked {
 			if err := CheckExpiry(cert, time.Now()); err != nil {
+				// If certificate is expired and not signed timestamp was provided then error the following message. Otherwise throw an expiration error.
+				if co.IgnoreTlog && acceptableRFC3161Time == nil {
+					return false, &VerificationError{"expected a signed timestamp from the bundle"}
+				}
 				return false, fmt.Errorf("checking expiry on certificate with bundle: %w", err)
 			}
 		}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -710,7 +710,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 			if err := CheckExpiry(cert, time.Now()); err != nil {
 				// If certificate is expired and not signed timestamp was provided then error the following message. Otherwise throw an expiration error.
 				if co.IgnoreTlog && acceptableRFC3161Time == nil {
-					return false, &VerificationError{"expected a signed timestamp from the bundle"}
+					return false, &VerificationError{"expected a signed timestamp to verify an expired certificate"}
 				}
 				return false, fmt.Errorf("checking expiry on certificate with bundle: %w", err)
 			}

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -155,10 +155,10 @@ func TestVerifyImageSignature(t *testing.T) {
 		static.WithCertChain(pemLeaf, appendSlices([][]byte{pemSub, pemRoot})))
 	verified, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{},
 		&CheckOpts{
-			RootCerts:      rootPool,
-			IgnoreSCT:      true,
-			SkipTlogVerify: true,
-			Identities:     []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}}})
+			RootCerts:  rootPool,
+			IgnoreSCT:  true,
+			IgnoreTlog: true,
+			Identities: []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}}})
 	if err != nil {
 		t.Fatalf("unexpected error while verifying signature, expected no error, got %v", err)
 	}
@@ -191,7 +191,7 @@ func TestVerifyImageSignatureMultipleSubs(t *testing.T) {
 		base64.StdEncoding.EncodeToString(signature), static.WithCertChain(pemLeaf, appendSlices([][]byte{pemSub3, pemSub2, pemSub1, pemRoot})))
 	verified, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{}, &CheckOpts{
 		RootCerts: rootPool,
-		IgnoreSCT: true, SkipTlogVerify: true,
+		IgnoreSCT: true, IgnoreTlog: true,
 		Identities: []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}}})
 	if err != nil {
 		t.Fatalf("unexpected error while verifying signature, expected no error, got %v", err)
@@ -363,10 +363,10 @@ func TestVerifyImageSignatureWithOnlyRoot(t *testing.T) {
 	ociSig, _ := static.NewSignature(payload, base64.StdEncoding.EncodeToString(signature), static.WithCertChain(pemLeaf, pemRoot))
 	verified, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{},
 		&CheckOpts{
-			RootCerts:      rootPool,
-			IgnoreSCT:      true,
-			Identities:     []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
-			SkipTlogVerify: true})
+			RootCerts:  rootPool,
+			IgnoreSCT:  true,
+			Identities: []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
+			IgnoreTlog: true})
 	if err != nil {
 		t.Fatalf("unexpected error while verifying signature, expected no error, got %v", err)
 	}
@@ -393,10 +393,10 @@ func TestVerifyImageSignatureWithMissingSub(t *testing.T) {
 	ociSig, _ := static.NewSignature(payload, base64.StdEncoding.EncodeToString(signature), static.WithCertChain(pemLeaf, pemRoot))
 	verified, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{},
 		&CheckOpts{
-			RootCerts:      rootPool,
-			IgnoreSCT:      true,
-			Identities:     []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
-			SkipTlogVerify: true})
+			RootCerts:  rootPool,
+			IgnoreSCT:  true,
+			Identities: []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
+			IgnoreTlog: true})
 	if err == nil {
 		t.Fatal("expected error while verifying signature")
 	}
@@ -438,7 +438,7 @@ func TestVerifyImageSignatureWithExistingSub(t *testing.T) {
 			IntermediateCerts: subPool,
 			IgnoreSCT:         true,
 			Identities:        []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
-			SkipTlogVerify:    true})
+			IgnoreTlog:        true})
 	if err == nil {
 		t.Fatal("expected error while verifying signature")
 	}
@@ -556,7 +556,7 @@ func TestVerifyImageSignatureWithSigVerifierAndTSA(t *testing.T) {
 		TSACertificate:              leaves[0],
 		TSAIntermediateCertificates: intermediates,
 		TSARootCertificates:         roots,
-		SkipTlogVerify:              true,
+		IgnoreTlog:                  true,
 	}); err != nil || bundleVerified { // bundle is not verified since there's no Rekor bundle
 		t.Fatalf("unexpected error while verifying signature, got %v", err)
 	}

--- a/test/e2e_test.ps1
+++ b/test/e2e_test.ps1
@@ -36,7 +36,7 @@ $verification_key = "cosign.pub"
 
 $test_img = "ghcr.io/distroless/static"
 Write-Output $pass | .\cosign.exe sign --key $signing_key --output-signature interactive.sig --tlog-upload=false $test_img
-.\cosign.exe verify --key $verification_key --signature interactive.sig --insecure-skip-tlog-verify=true $test_img
+.\cosign.exe verify --key $verification_key --signature interactive.sig --insecure-ignore-tlog=true $test_img
 
 Pop-Location
 

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -167,7 +167,7 @@ crane delete $dgst || true
 cat /dev/urandom | head -n 10 | base64 > randomblob
 dgst=$(./cosign upload blob -f randomblob ${blobimg})
 ./cosign sign --key ${signing_key} --tlog-upload=false ${dgst}
-./cosign verify --key ${verification_key} --insecure-skip-tlog-verify=true ${dgst} # For sanity
+./cosign verify --key ${verification_key} --insecure-ignore-tlog=true ${dgst} # For sanity
 
 # clean up a bit
 crane delete $blobimg || true


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

closes: https://github.com/sigstore/cosign/issues/2590

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Based on the discussion in https://github.com/sigstore/cosign/issues/2590, we decided to rename the flag from `insecure-skip-tlog-verify` to `insecure-ignore-tlog`. Likewise, we also decided to throw an error expecting a signed timestamp whenever users ignore the tlog validation and no timestamp-rfc3161 was present.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->