### PR TITLE
Breaking change: attach signature and attach sbom must use STDIN to upload raw string

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -138,13 +138,6 @@ $ cosign attach signature --signature file.sig $IMAGE_DIGEST
 Pushing signature to: dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def8.sig
 ```
 
-the base64-encoded signature:
-
-```shell
-$ cosign attach signature --signature Qr883oPOj0dj82PZ0d9mQ2lrdM0lbyLSXUkjt6ejrxtHxwe7bU6Gr27Sysgk1jagf1htO/gvkkg71oJiwWryCQ== $IMAGE_DIGEST
-Pushing signature to: dlorenc/demo:sha256-87ef60f558bad79beea6425a3b28989f01dd417164150ab3baab98dcbf04def.sig
-```
-
 or, `-` for stdin for chaining from other commands:
 
 ```shell

--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -112,14 +112,7 @@ func signatureType(sigRef string) SignatureArgType {
 	switch {
 	case sigRef == "-":
 		return StdinSignature
-	case signatureFileNotExists(sigRef):
-		return RawSignature
 	default:
 		return FileSignature
 	}
-}
-
-func signatureFileNotExists(sigRef string) bool {
-	_, err := os.Stat(sigRef)
-	return os.IsNotExist(err)
 }

--- a/cmd/cosign/cli/options/attach.go
+++ b/cmd/cosign/cli/options/attach.go
@@ -39,7 +39,7 @@ func (o *AttachSignatureOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Signature, "signature", "",
-		"the signature, path to the signature, or {-} for stdin")
+		"path to the signature, or {-} for stdin")
 
 	cmd.Flags().StringVar(&o.Payload, "payload", "",
 		"path to the payload covered by the signature (if using another format)")

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -21,7 +21,7 @@ cosign attach signature [flags]
   -h, --help                                                                                     help for signature
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --payload string                                                                           path to the payload covered by the signature (if using another format)
-      --signature string                                                                         the signature, path to the signature, or {-} for stdin
+      --signature string                                                                         path to the signature, or {-} for stdin
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION

Fixed #1307

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* `attach signature --signature=<signature>` no longer uploads literal filepath if the file `<signature>` does not exist
* `attach sbom --sbom=<sbom>` no longer uploads literal filepath if the  file `<sbom>` does not exist
* To upload raw string, you should use STDIN and `--signature=-`/`--sbom=-`:
```
echo $SIGNATURE | cosign attach signature --signature=- $IMAGE_DIGEST
echo $SBOM | cosign attach sbom --sbom=- $IMAGE_DIGEST
```



#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->