### PR TITLE
Make sure a cert passed in via --cert matches the bundle cert

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -26,7 +26,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
@@ -224,10 +223,8 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 				}
 			}
 			// if a cert was passed in, make sure it matches the cert in the bundle
-			if cert != nil {
-				if !reflect.DeepEqual(cert, bundleCert) {
-					return fmt.Errorf("the cert passed in does not match the cert in the provided bundle")
-				}
+			if cert != nil && !cert.Equal(bundleCert) {
+				return fmt.Errorf("the cert passed in does not match the cert in the provided bundle")
 			}
 			cert = bundleCert
 		}

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -28,7 +28,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"reflect"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
@@ -261,10 +260,8 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 				}
 			}
 			// if a cert was passed in, make sure it matches the cert in the bundle
-			if cert != nil {
-				if !reflect.DeepEqual(cert, bundleCert) {
-					return fmt.Errorf("the cert passed in does not match the cert in the provided bundle")
-				}
+			if cert != nil && !cert.Equal(bundleCert) {
+				return fmt.Errorf("the cert passed in does not match the cert in the provided bundle")
 			}
 			cert = bundleCert
 		}


### PR DESCRIPTION
This is part of https://github.com/sigstore/cosign/issues/2632, and is one of the smaller action items listed in https://github.com/sigstore/cosign/issues/2632#issuecomment-1400977569.

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>



#### Release Note
<!--

Make sure a cert passed in via --cert matches the bundle cert
-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->