### PR TITLE
fix: panic with unsigned local image

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -540,6 +540,9 @@ func VerifyLocalImageSignatures(ctx context.Context, path string, co *CheckOpts)
 	if err != nil {
 		return nil, false, err
 	}
+	if sigs == nil {
+		return nil, false, fmt.Errorf("no signatures associated with the image saved in %s", path)
+	}
 
 	return verifySignatures(ctx, sigs, h, co)
 }


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hector@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Fixes: https://github.com/sigstore/cosign/issues/2655

For unsigned images when verified locally, the cli panics getting the signatures.

```
cosign verify --local-image ./localimage  --certificate-identity-regexp='.*'  --certificate-oidc-issuer-regexp='.*'
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x102bb700c]

goroutine 1 [running]:
github.com/sigstore/cosign/v2/pkg/cosign.verifySignatures({0x104929df0, 0x14000056080}, {0x0?, 0x0?}, {{0x103e019b5?, 0x14000faa800?}, {0x14001009900?, 0x1?}}, 0x1?)
	github.com/sigstore/cosign/v2/pkg/cosign/verify.go:548 +0x4c
github.com/sigstore/cosign/v2/pkg/cosign.VerifyLocalImageSignatures({0x104929df0, 0x14000056080}, {0x16db4f94e?, 0x140002c3f50?}, 0x140005ad840)
	github.com/sigstore/cosign/v2/pkg/cosign/verify.go:544 +0x1a0
github.com/sigstore/cosign/v2/cmd/cosign/cli/verify.(*VerifyCommand).Exec(0x140005ada10, {0x104929df0, 0x14000056080}, {0x140007ce5c0, 0x1, 0x14000184c80?})
	github.com/sigstore/cosign/v2/cmd/cosign/cli/verify/verify.go:263 +0xc90
github.com/sigstore/cosign/v2/cmd/cosign/cli.Verify.func1(0x14000825800, {0x140007ce5c0, 0x1, 0x4})
	github.com/sigstore/cosign/v2/cmd/cosign/cli/verify.go:132 +0x2c4
github.com/spf13/cobra.(*Command).execute(0x14000825800, {0x140007ce580, 0x4, 0x4})
	github.com/spf13/cobra@v1.6.1/command.go:916 +0x5c8
github.com/spf13/cobra.(*Command).ExecuteC(0x14000456600)
	github.com/spf13/cobra@v1.6.1/command.go:1044 +0x35c
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.6.1/command.go:968
main.main()
	github.com/sigstore/cosign/v2/cmd/cosign/main.go:62 +0x58
```

while with this fix you get:

```
cosign verify --local-image ./localimage  --certificate-identity-regexp='.*'  --certificate-oidc-issuer-regexp='.*'
Error: no signatures associated with local image saved in ./localimage
main.go:63: error during command execution: no signatures associated with local image saved in ./localimage
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
fix: panic when verifying unsigned local images
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->