### PR TITLE
feat: add policy verification to blob attestations

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -191,6 +191,7 @@ type VerifyBlobAttestationOptions struct {
 	BundlePath    string
 
 	PredicateOptions
+	Policies    []string
 	CheckClaims bool
 
 	SecurityKey         SecurityKeyOptions
@@ -222,6 +223,9 @@ func (o *VerifyBlobAttestationOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.CheckClaims, "check-claims", true,
 		"whether to check the claims found")
+
+	cmd.Flags().StringSliceVar(&o.Policies, "policy", nil,
+		"specify CUE or Rego files will be using for validation")
 
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"path to RFC3161 timestamp FILE")

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -341,6 +341,7 @@ The blob may be specified as a path to a file.`,
 			v := verify.VerifyBlobAttestationCommand{
 				KeyOpts:                      ko,
 				PredicateType:                o.PredicateOptions.Type,
+				Policies:                     o.Policies,
 				CheckClaims:                  o.CheckClaims,
 				SignaturePath:                o.SignaturePath,
 				CertVerifyOptions:            o.CertVerify,

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -869,7 +869,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 		issuer := "issuer"
 		leafCert, _, leafPemCert, signer := keyless.genLeafCert(t, identity, issuer)
 
-		stmt := `{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`
+		stmt := `{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.2","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`
 		wrapped := dsse.WrapSigner(signer, ctypes.IntotoPayloadType)
 		signedPayload, err := wrapped.SignMessage(bytes.NewReader([]byte(stmt)), signatureoptions.WithContext(context.Background()))
 		if err != nil {
@@ -895,6 +895,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			CertChain:     "", // Chain is fetched from TUF/SIGSTORE_ROOT_FILE
 			SignaturePath: "", // Sig is fetched from bundle
 			KeyOpts:       options.KeyOpts{BundlePath: bundlePath},
+			PredicateType: "slsaprovenance",
 			IgnoreSCT:     true,
 		}
 		if err := cmd.Exec(context.Background(), blobPath); err != nil {
@@ -1201,7 +1202,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 		issuer := "issuer"
 		leafCert, _, leafPemCert, signer := keyless.genLeafCert(t, identity, issuer)
 
-		stmt := `{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"customFoo","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`
+		stmt := `{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://slsa.dev/provenance/v0.2","subject":[{"name":"subject","digest":{"sha256":"deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}}],"predicate":{}}`
 		wrapped := dsse.WrapSigner(signer, ctypes.IntotoPayloadType)
 		signedPayload, err := wrapped.SignMessage(bytes.NewReader([]byte(stmt)), signatureoptions.WithContext(context.Background()))
 		if err != nil {
@@ -1228,6 +1229,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			SignaturePath: "", // Sig is fetched from bundle
 			KeyOpts:       options.KeyOpts{BundlePath: bundlePath},
 			IgnoreSCT:     true,
+			PredicateType: "slsaprovenance",
 			CheckClaims:   false, // Intentionally false. This checks the subject claim. This is tested in verify_blob_attestation_test.go
 		}
 		if err := cmd.Exec(context.Background(), blobPath); err != nil {

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -46,6 +46,7 @@ cosign verify-blob-attestation [flags]
       --insecure-ignore-tlog                            ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --offline                                         only allow offline verification
+      --policy strings                                  specify CUE or Rego files will be using for validation
       --rekor-url string                                [EXPERIMENTAL] address of rekor STL server (default "https://rekor.sigstore.dev")
       --rfc3161-timestamp string                        path to RFC3161 timestamp FILE
       --sct string                                      path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -616,7 +616,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 			// If the --offline flag was specified, fail here. bundleVerified returns false with
 			// no error when there was no bundle provided.
 			if co.Offline {
-				return false, fmt.Errorf("offline verification failed")
+				return false, fmt.Errorf("offline verification failed: tlog presence required")
 			}
 
 			// no Rekor client provided for an online lookup


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

* Adds CUE/Rego policy verification to `verify-blob-attestation`
* Fix: fixes an issue where predicate types were not checked properly in `verify-blob-attestation`. I don't think this command was released so not a security fix....
* Adds tests for policies in verify attestation (which didn't exist??)


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* feat: adds CUE/Rego policy verification in `verify-blob-attestation`

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Part of https://github.com/sigstore/cosign/issues/2661#issuecomment-1405104771

cc @TomHennen 