### PR TITLE
feat: implements exit code functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ cross:
 golangci-lint:
 	rm -f $(GOLANGCI_LINT_BIN) || :
 	set -e ;\
-	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2 ;\
+	GOBIN=$(GOLANGCI_LINT_DIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1 ;\
 
 lint: golangci-lint ## Run golangci-lint linter
 	$(GOLANGCI_LINT_BIN) run -n

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -29,11 +29,11 @@ import (
 	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/sign"
+	cosignError "github.com/sigstore/cosign/v2/cmd/cosign/errors"
 	"github.com/sigstore/cosign/v2/internal/pkg/cosign/tsa"
 	"github.com/sigstore/cosign/v2/pkg/blob"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
@@ -278,7 +278,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 
 			verified, bundleVerified, err := cosign.VerifyImageSignatures(ctx, ref, co)
 			if err != nil {
-				return err
+				return cosignError.WrapError(err)
 			}
 
 			PrintVerificationHeader(ref.Name(), co, bundleVerified, fulcioVerified)

--- a/cmd/cosign/errors/error_wrap.go
+++ b/cmd/cosign/errors/error_wrap.go
@@ -1,0 +1,44 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+
+	verificationError "github.com/sigstore/cosign/v2/pkg/cosign"
+)
+
+// WrapError takes an error type and depending on the type of error
+// passed, will access it's error message and errorType (and return
+// the associated exitCode) and wrap them in a generic `CosignError`.
+// If no custom error has been found, then it will still return a
+// `CosignError` with an error message, but the `exitCode` will be `1`.
+func WrapError(err error) error {
+	// VerificationError
+	var verificationError *verificationError.VerificationError
+	if errors.As(err, &verificationError) {
+		return &CosignError{
+			Message: verificationError.Error(),
+			Code:    LookupExitCodeForErrorType(verificationError.ErrorType()),
+		}
+	}
+
+	// return default cosign error with error message and default exit code
+	return &CosignError{
+		Message: err.Error(),
+		Code:    1,
+	}
+}

--- a/cmd/cosign/errors/error_wrap_test.go
+++ b/cmd/cosign/errors/error_wrap_test.go
@@ -1,0 +1,51 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	verificationError "github.com/sigstore/cosign/v2/pkg/cosign"
+)
+
+func TestWrapWithVerificationError(t *testing.T) {
+	ve := &verificationError.VerificationError{}
+	ve.SetErrorType(verificationError.ErrNoMatchingSignaturesType)
+	err := WrapError(ve)
+
+	var cosignError *CosignError
+	if errors.As(err, &cosignError) {
+		if cosignError.ExitCode() != NoMatchingSignature {
+			t.Fatalf("verification error unsuccessfully wrapped")
+		}
+		t.Logf("verification error successfully wrapped and exit code returned")
+	}
+}
+
+func TestWrapWithGenericCosignError(t *testing.T) {
+	errorText := "i am a generic cosign error"
+	err := WrapError(errors.New(errorText))
+
+	var cosignError *CosignError
+	if errors.As(err, &cosignError) {
+		if cosignError.ExitCode() == 1 && cosignError.Message == errorText {
+			t.Logf("generic cosign error successfully returned")
+			return
+		}
+		t.Fatalf("generic cosign error unsuccessfully returned")
+	}
+}

--- a/cmd/cosign/errors/errors.go
+++ b/cmd/cosign/errors/errors.go
@@ -1,0 +1,40 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+type CosignError struct {
+	Message string
+	Code    int
+}
+
+func Error(cosignError CosignError) error {
+	return &CosignError{
+		Message: cosignError.Message,
+		Code:    cosignError.Code,
+	}
+}
+
+// Assert that we implement error at build time.
+var _ error = (*CosignError)(nil)
+
+// Error implements error
+func (ce *CosignError) Error() string {
+	return ce.Message
+}
+
+func (ce *CosignError) ExitCode() int {
+	return ce.Code
+}

--- a/cmd/cosign/errors/exit_code_lookup.go
+++ b/cmd/cosign/errors/exit_code_lookup.go
@@ -1,0 +1,38 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	verificationError "github.com/sigstore/cosign/v2/pkg/cosign"
+)
+
+// exitCodeLookup contains a map of errorTypes and their associated exitCodes.
+var exitCodeLookup = map[string]int{
+	verificationError.ErrNoMatchingSignaturesType: NoMatchingSignature,
+}
+
+func LookupExitCodeForErrorType(errorType string) int {
+	exitCode := exitCodeLookup[errorType]
+
+	// if there is no entry in the lookup map for the passed errorType,
+	// then by default, it will return `0`. however, as `0` as an exitCode
+	// for success, we want to return `1` instead until there is a valid
+	// exit code entry in the map for the passed errorType.
+	if exitCode == 0 {
+		return 1
+	}
+	return exitCode
+}

--- a/cmd/cosign/errors/exit_code_lookup_test.go
+++ b/cmd/cosign/errors/exit_code_lookup_test.go
@@ -1,0 +1,28 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"testing"
+)
+
+func TestDefaultExitCodeReturnIfErrorTypeDoesNotExist(t *testing.T) {
+	exitCode := LookupExitCodeForErrorType("I do not exist as an error type")
+	if exitCode != 1 {
+		t.Fatalf("default exit code not returned when an error type doesn't exist. default should be 1")
+	}
+	t.Logf("Correct default exit code returned")
+}

--- a/cmd/cosign/errors/exit_codes.go
+++ b/cmd/cosign/errors/exit_codes.go
@@ -1,0 +1,35 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+// Exit codes for cosign.
+// To allow for document generation of exit codes the following convention is
+// to be followed.
+// Convention:
+//   | // comment that explains the error
+//   | const NamedConstant = ERRORCODE
+//
+// This is so when `make docgen` is run, the cosign_exit-codes.md doc is automatically
+// generated inside of the docs dir following the format of "Exit Code : Comment".
+
+// Error verifying image due to no signature
+const ImageWithoutSignature = 10
+
+// Error verifying image due to non-existent tag
+const NonExistentTag = 11
+
+// Error verifying image due to no matching signature
+const NoMatchingSignature = 12

--- a/cmd/cosign/errors/generate_docs.go
+++ b/cmd/cosign/errors/generate_docs.go
@@ -1,0 +1,106 @@
+//
+// Copyright 2022 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+	"go/ast"
+	godoc "go/doc"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// GenerateExitCodeDocs will generate documentation for the exit codes
+// that the cosign application will throw. Inspired by elemental-cli who
+// convieniently solved this problem prior: https://github.com/rancher/elemental-cli/blob/main/docs/generate_docs.go
+// there was no need to change (apart from some file paths) due to it
+// giving us exactly what we want without error.
+func GenerateExitCodeDocs(dir string) error {
+	fset := token.NewFileSet()
+	files := []*ast.File{
+		mustParse(fset, "./cmd/cosign/errors/exit_codes.go"),
+	}
+	p, err := godoc.NewFromFiles(fset, files, "github.com/sigstore/cosign")
+	if err != nil {
+		panic(err)
+	}
+	// nolint prealloc
+	var (
+		exitCodes []*ErrorCode
+		used      map[int]bool
+	)
+
+	used = make(map[int]bool)
+
+	for _, c := range p.Consts {
+		// Cast it, its safe as these are constants
+		v := c.Decl.Specs[0].(*ast.ValueSpec)
+		val := v.Values[0].(*ast.BasicLit)
+		code, _ := strconv.Atoi(val.Value)
+
+		if _, ok := used[code]; ok {
+			return fmt.Errorf("duplicate exit-code found: %v", code)
+		}
+
+		used[code] = true
+		exitCodes = append(exitCodes, &ErrorCode{code: code, doc: c.Doc})
+	}
+
+	sort.Slice(exitCodes, func(i, j int) bool {
+		return exitCodes[i].code < exitCodes[j].code
+	})
+
+	exitCodesFile, err := os.Create(dir + "/cosign_exit_codes.md")
+
+	if err != nil {
+		fmt.Print(err)
+		return err
+	}
+
+	defer func() {
+		_ = exitCodesFile.Close()
+	}()
+
+	_, _ = exitCodesFile.WriteString("# Exit codes for cosign CLI\n\n")
+	_, _ = exitCodesFile.WriteString("> The following exit codes may be subject to change\n\n")
+	_, _ = exitCodesFile.WriteString("| Exit code | Meaning |\n")
+	_, _ = exitCodesFile.WriteString("| :----: | :---- |\n")
+	for _, code := range exitCodes {
+		_, err = exitCodesFile.WriteString(fmt.Sprintf("| %d | %s|\n", code.code, strings.Replace(code.doc, "\n", "", 1)))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func mustParse(fset *token.FileSet, filename string) *ast.File {
+	f, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+type ErrorCode struct {
+	code int
+	doc  string
+}

--- a/cmd/help/main.go
+++ b/cmd/help/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli"
+	errors "github.com/sigstore/cosign/v2/cmd/cosign/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 )
@@ -31,6 +32,11 @@ func main() {
 		SilenceUsage: true,
 		Args:         cobra.NoArgs,
 		RunE: func(*cobra.Command, []string) error {
+			err := errors.GenerateExitCodeDocs(dir)
+			if err != nil {
+				fmt.Println(err)
+				os.Exit(1)
+			}
 			return doc.GenMarkdownTree(cli.New(), dir)
 		},
 	}

--- a/doc/cosign_exit_codes.md
+++ b/doc/cosign_exit_codes.md
@@ -1,0 +1,9 @@
+# Exit codes for cosign CLI
+
+> The following exit codes may be subject to change
+
+| Exit code | Meaning |
+| :----: | :---- |
+| 10 | Error verifying image due to no signature|
+| 11 | Error verifying image due to non-existent tag|
+| 12 | Error verifying image due to no matching signature|

--- a/pkg/cosign/errors.go
+++ b/pkg/cosign/errors.go
@@ -17,20 +17,21 @@ package cosign
 import "fmt"
 
 var (
-	// ErrNoMatchingSignatures is the error returned when there are no matching
-	// signatures during verification.
-	ErrNoMatchingSignatures = &VerificationError{"no matching signatures"}
+	// NoMatchingAttestations
+	ErrNoMatchingAttestationsMessage = "no matching attestations"
+	ErrNoMatchingAttestationsType    = "NoMatchingAttestations"
 
-	// ErrNoMatchingAttestations is the error returned when there are no
-	// matching attestations during verification.
-	ErrNoMatchingAttestations = &VerificationError{"no matching attestations"}
+	// NoMatchingSignatures
+	ErrNoMatchingSignaturesType    = "NoMatchingSignatures"
+	ErrNoMatchingSignaturesMessage = "no matching signatures"
 )
 
 // VerificationError is the type of Go error that is used by cosign to surface
 // errors actually related to verification (vs. transient, misconfiguration,
 // transport, or authentication related issues).
 type VerificationError struct {
-	message string
+	errorType string
+	message   string
 }
 
 // NewVerificationError constructs a new VerificationError in a manner similar
@@ -47,4 +48,13 @@ var _ error = (*VerificationError)(nil)
 // Error implements error
 func (ve *VerificationError) Error() string {
 	return ve.message
+}
+
+// Error implements error
+func (ve *VerificationError) ErrorType() string {
+	return ve.errorType
+}
+
+func (ve *VerificationError) SetErrorType(errorType string) {
+	ve.errorType = errorType
 }

--- a/pkg/cosign/errors_test.go
+++ b/pkg/cosign/errors_test.go
@@ -22,10 +22,8 @@ import (
 
 func TestErrors(t *testing.T) {
 	for _, want := range []error{
-		ErrNoMatchingAttestations,
-		ErrNoMatchingSignatures,
 		NewVerificationError("not a constant %d", 3),
-		fmt.Errorf("wrapped errors: %w", ErrNoMatchingSignatures),
+		NewVerificationError("not a string %s", "i am a string"),
 	} {
 		t.Run(want.Error(), func(t *testing.T) {
 			verr := &VerificationError{}


### PR DESCRIPTION
#### Summary
- adds exit code functionality that allows for cosign to return sensible exit codes for specific errors. the exit code document generation is automatically baked into the `docgen` step.
- adds first exit code for "no matching signatures" and added two more ready for addition in future PR.
- is backwards compatible and will throw exit code 1 for all non defined error types/exit code permutations.
- updates version of linter to use when running `make lint` as it was 4 versions behind the one used in Actions workflow.

Addresses some of https://github.com/sigstore/cosign/issues/948 (further PR's to address completely)

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>