### PR TITLE
Fix prompts with Windows line endings

### DIFF
--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -50,7 +50,7 @@ func (w *Env) prompt() error {
 		return err
 	}
 
-	value := strings.Trim(r, "\n")
+	value := strings.Trim(r, "\r\n")
 	switch strings.ToLower(value) {
 	case "y":
 		return nil

--- a/internal/ui/prompt_test.go
+++ b/internal/ui/prompt_test.go
@@ -37,6 +37,10 @@ func TestConfirm(t *testing.T) {
 		{"default", "\n", &ui.ErrPromptDeclined{}, "user declined"},
 		{"empty", "", &ui.ErrPromptDeclined{}, "user declined"},
 		{"invalid", "yy", &ui.ErrInvalidInput{Got: "yy", Allowed: "y, n"}, "invalid input"},
+		{"no-windows", "n\r\n", &ui.ErrPromptDeclined{}, "user declined"},
+		{"yes-windows", "y\r\n", nil, ""},
+		{"default-windows", "\r\n", &ui.ErrPromptDeclined{}, "user declined"},
+		{"invalid", "yy\r\n", &ui.ErrInvalidInput{Got: "yy", Allowed: "y, n"}, "invalid input"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Zachary Newman <zjn@chainguard.dev>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->