### PR TITLE
add generate-key-pair GitHub Enterprise server support

### DIFF
--- a/pkg/cosign/env/env.go
+++ b/pkg/cosign/env/env.go
@@ -57,6 +57,7 @@ const (
 	VariableSigstoreRekorPublicKey     Variable = "SIGSTORE_REKOR_PUBLIC_KEY"
 
 	// Other external environment variables
+	VariableGitHubHost               Variable = "GITHUB_HOST"
 	VariableGitHubToken              Variable = "GITHUB_TOKEN" //nolint:gosec
 	VariableGitHubRequestToken       Variable = "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
 	VariableGitHubRequestURL         Variable = "ACTIONS_ID_TOKEN_REQUEST_URL"
@@ -120,6 +121,12 @@ var (
 			External:    true,
 		},
 
+		VariableGitHubHost: {
+			Description: "is URL of the GitHub Enterprise instance",
+			Expects:     "string with the URL of GitHub Enterprise instance",
+			Sensitive:   false,
+			External:    true,
+		},
 		VariableGitHubToken: {
 			Description: "is a token used to authenticate with GitHub",
 			Expects:     "token generated on GitHub",


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
GitHub Enterprise Server (GHES) support for 'cosign generate-key-pair github:'

Fixes #2675

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
GitHub Enterprise Server (GHES) support for 'cosign generate-key-pair github:'

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->