### PR TITLE
update cosign image and set cosign experimental back and apply indentation

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -26,7 +26,7 @@ jobs:
   check-signature:
     runs-on: ubuntu-latest
     container:
-      image: gcr.io/projectsigstore/cosign:v2.0.0-rc.1@sha256:12d365ed4ee9bb32ba8a0fd16f6c5eae5229dc50e8d62460312cca0b5b7e0457
+      image: gcr.io/projectsigstore/cosign:v2.0.0-rc.2@sha256:3c62b38a5b7eaa4db90c328d430a705d086792869aece919559ecf381a23a4e8
 
     steps:
       - name: Check Signature

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,162 +5,163 @@ env:
   - CGO_ENABLED=1
   - DOCKER_CLI_EXPERIMENTAL=enabled
   - COSIGN_YES=true
+  - COSIGN_EXPERIMENTAL=true
   - LATEST_TAG=,latest
 
 # Prevents parallel builds from stepping on each others toes downloading modules
 before:
   hooks:
-  - go mod tidy
-  - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
-# if running a release we will generate the images in this step
-# if running in the CI the CI env va is set and we dont run the ko steps
-# this is needed because we are generating files that goreleaser was not aware to push to GH project release
-  - /bin/bash -c 'if [ -z "$CI" ]; then make sign-release-images; fi'
+    - go mod tidy
+    - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+    # if running a release we will generate the images in this step
+    # if running in the CI the CI env va is set and we dont run the ko steps
+    # this is needed because we are generating files that goreleaser was not aware to push to GH project release
+    - /bin/bash -c 'if [ -z "$CI" ]; then make sign-release-images; fi'
 
 gomod:
   proxy: true
 
 sboms:
-- artifacts: binary
+  - artifacts: binary
 
 builds:
-- id: linux
-  binary: cosign-linux-{{ .Arch }}
-  no_unique_dist_dir: true
-  main: ./cmd/cosign
-  flags:
-    - -trimpath
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  goos:
-    - linux
-  goarch:
-    - amd64
-    - arm64
-    - arm
-    - s390x
-    - ppc64le
-  goarm:
-    - '7'
-  ldflags:
-    - "{{ .Env.LDFLAGS }}"
-  env:
-    - CGO_ENABLED=0
+  - id: linux
+    binary: cosign-linux-{{ .Arch }}
+    no_unique_dist_dir: true
+    main: ./cmd/cosign
+    flags:
+      - -trimpath
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - s390x
+      - ppc64le
+    goarm:
+      - '7'
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    env:
+      - CGO_ENABLED=0
 
-- id: linux-pivkey-pkcs11key-amd64
-  binary: cosign-linux-pivkey-pkcs11key-amd64
-  no_unique_dist_dir: true
-  main: ./cmd/cosign
-  flags:
-    - -trimpath
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  goos:
-    - linux
-  goarch:
-    - amd64
-  ldflags:
-    - "{{ .Env.LDFLAGS }}"
-  tags:
-    - pivkey
-    - pkcs11key
-  hooks:
-    pre:
-      - apt-get update
-      - apt-get -y install libpcsclite-dev
-  env:
-    - PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/"
+  - id: linux-pivkey-pkcs11key-amd64
+    binary: cosign-linux-pivkey-pkcs11key-amd64
+    no_unique_dist_dir: true
+    main: ./cmd/cosign
+    flags:
+      - -trimpath
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    tags:
+      - pivkey
+      - pkcs11key
+    hooks:
+      pre:
+        - apt-get update
+        - apt-get -y install libpcsclite-dev
+    env:
+      - PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/"
 
-- id: darwin-amd64
-  binary: cosign-darwin-amd64
-  no_unique_dist_dir: true
-  env:
-    - CC=o64-clang
-    - CXX=o64-clang++
-  main: ./cmd/cosign
-  flags:
-    - -trimpath
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  goos:
-    - darwin
-  goarch:
-    - amd64
-  ldflags:
-    - "{{ .Env.LDFLAGS }}"
-  tags:
-    - pivkey
-    - pkcs11key
+  - id: darwin-amd64
+    binary: cosign-darwin-amd64
+    no_unique_dist_dir: true
+    env:
+      - CC=o64-clang
+      - CXX=o64-clang++
+    main: ./cmd/cosign
+    flags:
+      - -trimpath
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    tags:
+      - pivkey
+      - pkcs11key
 
-- id: darwin-arm64
-  binary: cosign-darwin-arm64
-  no_unique_dist_dir: true
-  env:
-    - CC=aarch64-apple-darwin21.4-clang
-    - CXX=aarch64-apple-darwin21.4-clang++
-  main: ./cmd/cosign
-  flags:
-    - -trimpath
-  goos:
-    - darwin
-  goarch:
-    - arm64
-  tags:
-    - pivkey
-    - pkcs11key
-  ldflags:
-    - "{{.Env.LDFLAGS}}"
+  - id: darwin-arm64
+    binary: cosign-darwin-arm64
+    no_unique_dist_dir: true
+    env:
+      - CC=aarch64-apple-darwin21.4-clang
+      - CXX=aarch64-apple-darwin21.4-clang++
+    main: ./cmd/cosign
+    flags:
+      - -trimpath
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    tags:
+      - pivkey
+      - pkcs11key
+    ldflags:
+      - "{{.Env.LDFLAGS}}"
 
-- id: windows-amd64
-  binary: cosign-windows-amd64
-  no_unique_dist_dir: true
-  env:
-    - CC=x86_64-w64-mingw32-gcc
-    - CXX=x86_64-w64-mingw32-g++
-  main: ./cmd/cosign
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  flags:
-    - -trimpath
-  goos:
-    - windows
-  goarch:
-    - amd64
-  ldflags:
-    - -buildmode=exe
-    - "{{ .Env.LDFLAGS }}"
-  tags:
-    - pivkey
-    - pkcs11key
+  - id: windows-amd64
+    binary: cosign-windows-amd64
+    no_unique_dist_dir: true
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    main: ./cmd/cosign
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    goos:
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      - -buildmode=exe
+      - "{{ .Env.LDFLAGS }}"
+    tags:
+      - pivkey
+      - pkcs11key
 
-- id: sget
-  binary: sget-{{ .Os }}-{{ .Arch }}
-  no_unique_dist_dir: true
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  main: ./cmd/sget
-  flags:
-    - -trimpath
-  goos:
-    - linux
-    - darwin
-    - windows
-  goarch:
-    - amd64
-    - arm64
-    - arm
-    - s390x
-    - ppc64le
-  goarm:
-    - 7
-  ignore:
-    - goos: windows
-      goarch: arm64
-    - goos: windows
-      goarch: arm
-    - goos: windows
-      goarch: s390x
-    - goos: windows
-      goarch: ppc64le
-  ldflags:
-    - "{{ .Env.LDFLAGS }}"
-  env:
-    - CGO_ENABLED=0
+  - id: sget
+    binary: sget-{{ .Os }}-{{ .Arch }}
+    no_unique_dist_dir: true
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    main: ./cmd/sget
+    flags:
+      - -trimpath
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+      - s390x
+      - ppc64le
+    goarm:
+      - '7'
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+      - goos: windows
+        goarch: s390x
+      - goos: windows
+        goarch: ppc64le
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    env:
+      - CGO_ENABLED=0
 
 signs:
   - id: cosign
@@ -224,9 +225,9 @@ nfpms:
         type: "symlink"
 
 archives:
-- format: binary
-  name_template: "{{ .Binary }}"
-  allow_different_binary_count: true
+  - format: binary
+    name_template: "{{ .Binary }}"
+    allow_different_binary_count: true
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
         echo "Checking out ${_GIT_TAG}"
         git checkout ${_GIT_TAG}
 
-  - name: 'gcr.io/projectsigstore/cosign:v2.0.0-rc.1@sha256:12d365ed4ee9bb32ba8a0fd16f6c5eae5229dc50e8d62460312cca0b5b7e0457'
+  - name: 'gcr.io/projectsigstore/cosign:v2.0.0-rc.2@sha256:3c62b38a5b7eaa4db90c328d430a705d086792869aece919559ecf381a23a4e8'
     dir: "go/src/sigstore/cosign"
     env:
       - TUF_ROOT=/tmp
@@ -59,6 +59,7 @@ steps:
       - GIT_TAG=${_GIT_TAG}
       - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
       - COSIGN_YES=true
+      - COSIGN_EXPERIMENTAL=true
       - KO_PREFIX=gcr.io/${PROJECT_ID}
     secretEnv:
       - GITHUB_TOKEN
@@ -82,6 +83,7 @@ steps:
       - GIT_TAG=${_GIT_TAG}
       - KO_PREFIX=gcr.io/${PROJECT_ID}
       - COSIGN_YES=true
+      - COSIGN_EXPERIMENTAL=true
       - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
       - GITHUB_USER=${_GITHUB_USER}
     secretEnv:


### PR DESCRIPTION
#### Summary
update cosign image and set cosign experimental back and apply indentation

the experimental flag is still required because when we sign the images we are using `cosign` from the builder image and not the one we build in the in-release.
will change that in a near future, but lets use this for now