### PR TITLE
Fix: Drop the `CosignPredicate` wrapper around SBOM attestations.

### DIFF
--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -241,9 +241,7 @@ func generateSPDXStatement(rawPayload []byte, digest string, repo string, parseJ
 	}
 	return in_toto.SPDXStatement{
 		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateSPDX),
-		Predicate: CosignPredicate{
-			Data: data,
-		},
+		Predicate:       data,
 	}, nil
 }
 
@@ -254,9 +252,7 @@ func generateCycloneDXStatement(rawPayload []byte, digest string, repo string) (
 	}
 	return in_toto.SPDXStatement{
 		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateCycloneDX),
-		Predicate: CosignPredicate{
-			Data: data,
-		},
+		Predicate:       data,
 	}, nil
 }
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -260,8 +260,8 @@ func TestAttestVerifySPDXJSON(t *testing.T) {
 	attestVerify(t,
 		"spdxjson",
 		string(attestationBytes),
-		`predicate: Data: spdxVersion: "SPDX-2.2"`,
-		`predicate: Data: spdxVersion: "SPDX-9.9"`,
+		`predicate: spdxVersion: "SPDX-2.2"`,
+		`predicate: spdxVersion: "SPDX-9.9"`,
 	)
 }
 
@@ -273,8 +273,8 @@ func TestAttestVerifyCycloneDXJSON(t *testing.T) {
 	attestVerify(t,
 		"cyclonedx",
 		string(attestationBytes),
-		`predicate: Data: specVersion: "1.4"`,
-		`predicate: Data: specVersion: "7.7"`,
+		`predicate: specVersion: "1.4"`,
+		`predicate: specVersion: "7.7"`,
 	)
 }
 


### PR DESCRIPTION
:bug: This change drops the `CosignPredicate` that `cosign` wraps around SPDX/CycloneDX attestations.

Currently `cosign` wraps SPDX and CycloneDX attestations produced via their shortnames (`cosign attest --type {spdxjson|cyclonedx}`) in a `CosignPredicate` envelope.

However, the whole point of the in-toto `predicateType` is to specify the schema of the `predicate`, and despite using the SPDX and Cyclone predicate type URIs, this envelope violates their schema with the extra layer.

Moreover, if users were to attest these SBOMs with the explicit predicate type URI:
```
cosign attest --type https://spdx.dev/Document ...
```

Then `cosign` will NOT add this additional envelope, which makes it effectively impossible to know the schema to use for policy validation based strictly on the `predicateType` because even `cosign` will produce these attestations both ways.

Fixes: https://github.com/sigstore/cosign/issues/2126

/kind bug

#### Release Note

BREAKING: This change removes the `CosignPredicate` envelope that wraps the predicates of SPDX and CycloneDX attestations, which was a violation of the schema specified via their `predicateType` field.


#### Documentation
