### PR TITLE
Loosen verification predicate type + better error messages

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -340,8 +340,8 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 
 	// This checks the predicate type -- if no error is returned and no payload is, then
 	// the attestation is not of the given predicate type.
-	if b, err := policy.AttestationToPayloadJSON(ctx, c.PredicateType, signature); b == nil && err == nil {
-		return fmt.Errorf("invalid predicate type, expected %s", c.PredicateType)
+	if b, gotPredicateType, err := policy.AttestationToPayloadJSON(ctx, c.PredicateType, signature); b == nil && err == nil {
+		return fmt.Errorf("invalid predicate type, expected %s got %s", c.PredicateType, gotPredicateType)
 	}
 
 	fmt.Fprintln(os.Stderr, "Verified OK")

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -87,6 +87,12 @@ func TestVerifyBlobAttestation(t *testing.T) {
 			signature:     dssePredicateMultipleSubjects,
 			blobPath:      blobPath,
 		}, {
+			description:   "dsse envelope has multiple subjects, one is valid, but we are looking for different predicatetype",
+			predicateType: "notreallyslsaprovenance",
+			signature:     dssePredicateMultipleSubjects,
+			blobPath:      blobPath,
+			shouldErr:     true,
+		}, {
 			description:   "dsse envelope has multiple subjects, none has correct sha256 digest",
 			predicateType: "slsaprovenance",
 			signature:     dssePredicateMultipleSubjectsInvalid,

--- a/pkg/policy/attestation.go
+++ b/pkg/policy/attestation.go
@@ -38,40 +38,52 @@ import (
 //
 // If there's no error, and payload is empty means the predicateType did not
 // match the attestation.
-func AttestationToPayloadJSON(ctx context.Context, predicateType string, verifiedAttestation oci.Signature) ([]byte, error) {
+// Returns the attestation type (PredicateType) if the payload was decoded
+// before the error happened, or in the case the predicateType that was
+// requested does not match. This is useful for callers to be able to provide
+// better error messages. For example, if there's a typo in the predicateType,
+// or the predicateType is not the one they are looking for. Without returning
+// this, it's hard for users to know which attestations/predicateTypes were
+// inspected.
+func AttestationToPayloadJSON(ctx context.Context, predicateType string, verifiedAttestation oci.Signature) ([]byte, string, error) {
 	if predicateType == "" {
-		return nil, errors.New("missing predicate type")
+		return nil, "", errors.New("missing predicate type")
+	}
+	predicateURI, ok := options.PredicateTypeMap[predicateType]
+	if !ok {
+		// Not a custom one, use it as is.
+		predicateURI = predicateType
 	}
 	var payloadData map[string]interface{}
 
 	p, err := verifiedAttestation.Payload()
 	if err != nil {
-		return nil, fmt.Errorf("getting payload: %w", err)
+		return nil, "", fmt.Errorf("getting payload: %w", err)
 	}
 
 	err = json.Unmarshal(p, &payloadData)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshaling payload data")
+		return nil, "", fmt.Errorf("unmarshaling payload data")
 	}
 
 	var decodedPayload []byte
 	if val, ok := payloadData["payload"]; ok {
 		decodedPayload, err = base64.StdEncoding.DecodeString(val.(string))
 		if err != nil {
-			return nil, fmt.Errorf("decoding payload: %w", err)
+			return nil, "", fmt.Errorf("decoding payload: %w", err)
 		}
 	} else {
-		return nil, fmt.Errorf("could not find payload in payload data")
+		return nil, "", fmt.Errorf("could not find payload in payload data")
 	}
 
 	// Only apply the policy against the requested predicate type
 	var statement in_toto.Statement
 	if err := json.Unmarshal(decodedPayload, &statement); err != nil {
-		return nil, fmt.Errorf("unmarshal in-toto statement: %w", err)
+		return nil, "", fmt.Errorf("unmarshal in-toto statement: %w", err)
 	}
-	if statement.PredicateType != predicateType {
+	if statement.PredicateType != predicateURI {
 		// This is not the predicate we're looking for, so skip it.
-		return nil, nil
+		return nil, statement.PredicateType, nil
 	}
 
 	// NB: In many (all?) of these cases, we could just return the
@@ -82,59 +94,59 @@ func AttestationToPayloadJSON(ctx context.Context, predicateType string, verifie
 	case options.PredicateCustom:
 		payload, err = json.Marshal(statement)
 		if err != nil {
-			return nil, fmt.Errorf("generating CosignStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("generating CosignStatement: %w", err)
 		}
 	case options.PredicateLink:
 		var linkStatement in_toto.LinkStatement
 		if err := json.Unmarshal(decodedPayload, &linkStatement); err != nil {
-			return nil, fmt.Errorf("unmarshaling LinkStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("unmarshaling LinkStatement: %w", err)
 		}
 		payload, err = json.Marshal(linkStatement)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling LinkStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("marshaling LinkStatement: %w", err)
 		}
 	case options.PredicateSLSA:
 		var slsaProvenanceStatement in_toto.ProvenanceStatement
 		if err := json.Unmarshal(decodedPayload, &slsaProvenanceStatement); err != nil {
-			return nil, fmt.Errorf("unmarshaling ProvenanceStatement): %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("unmarshaling ProvenanceStatement): %w", err)
 		}
 		payload, err = json.Marshal(slsaProvenanceStatement)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling ProvenanceStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("marshaling ProvenanceStatement: %w", err)
 		}
 	case options.PredicateSPDX, options.PredicateSPDXJSON:
 		var spdxStatement in_toto.SPDXStatement
 		if err := json.Unmarshal(decodedPayload, &spdxStatement); err != nil {
-			return nil, fmt.Errorf("unmarshaling SPDXStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("unmarshaling SPDXStatement: %w", err)
 		}
 		payload, err = json.Marshal(spdxStatement)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling SPDXStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("marshaling SPDXStatement: %w", err)
 		}
 	case options.PredicateCycloneDX:
 		var cyclonedxStatement in_toto.CycloneDXStatement
 		if err := json.Unmarshal(decodedPayload, &cyclonedxStatement); err != nil {
-			return nil, fmt.Errorf("unmarshaling CycloneDXStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("unmarshaling CycloneDXStatement: %w", err)
 		}
 		payload, err = json.Marshal(cyclonedxStatement)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling CycloneDXStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("marshaling CycloneDXStatement: %w", err)
 		}
 	case options.PredicateVuln:
 		var vulnStatement attestation.CosignVulnStatement
 		if err := json.Unmarshal(decodedPayload, &vulnStatement); err != nil {
-			return nil, fmt.Errorf("unmarshaling CosignVulnStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("unmarshaling CosignVulnStatement: %w", err)
 		}
 		payload, err = json.Marshal(vulnStatement)
 		if err != nil {
-			return nil, fmt.Errorf("marshaling CosignVulnStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("marshaling CosignVulnStatement: %w", err)
 		}
 	default:
 		// Valid URI type reaches here.
 		payload, err = json.Marshal(statement)
 		if err != nil {
-			return nil, fmt.Errorf("generating Statement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("generating Statement: %w", err)
 		}
 	}
-	return payload, nil
+	return payload, statement.PredicateType, nil
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Loosen the policy validation restrictions. With the move to strict RFC3986 and the fact that some of the existing attestations out there are still using the non conformant predicate types, allow validating them with non-conformant predicate types.
Also, to aid folks with the 'guess-the-existing-predicate-type' game :) if attestations are found, but they do not match the predicate type that is being looked for, print out the predicates that were found. Hope is that this will make the migration from non conformant predicate types little easier.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->