### PR TITLE
build missing binary linux-pivkey-pkcs11key-arm64 and format indentation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,9 +13,9 @@ before:
   hooks:
     - go mod tidy
     - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
-    # if running a release we will generate the images in this step
-    # if running in the CI the CI env va is set and we dont run the ko steps
-    # this is needed because we are generating files that goreleaser was not aware to push to GH project release
+  # if running a release we will generate the images in this step
+  # if running in the CI the CI env va is set and we dont run the ko steps
+  # this is needed because we are generating files that goreleaser was not aware to push to GH project release
     - /bin/bash -c 'if [ -z "$CI" ]; then make sign-release-images; fi'
 
 gomod:
@@ -66,9 +66,34 @@ builds:
     hooks:
       pre:
         - apt-get update
-        - apt-get -y install libpcsclite-dev
+        - apt-get -y install --no-install-recommends libpcsclite-dev
     env:
-      - PKG_CONFIG_PATH="/usr/lib/x86_64-linux-gnu/pkgconfig/"
+      - PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig/
+
+  - id: linux-pivkey-pkcs11key-arm64
+    binary: cosign-linux-pivkey-pkcs11key-arm64
+    no_unique_dist_dir: true
+    main: ./cmd/cosign
+    flags:
+      - -trimpath
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    goos:
+      - linux
+    goarch:
+      - arm64
+    ldflags:
+      - "{{ .Env.LDFLAGS }}"
+    tags:
+      - pivkey
+      - pkcs11key
+    hooks:
+      pre:
+        - dpkg --add-architecture arm64
+        - apt-get update
+        - apt-get install -y --no-install-recommends libpcsclite-dev:arm64
+    env:
+      - CC=aarch64-linux-gnu-gcc
+      - PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig/
 
   - id: darwin-amd64
     binary: cosign-darwin-amd64

--- a/release/release.mk
+++ b/release/release.mk
@@ -18,7 +18,7 @@ sign-release-images: ko
 # used when need to validate the goreleaser
 .PHONY: snapshot
 snapshot:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --rm-dist --timeout 60m
+	LDFLAGS="$(LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --rm-dist --timeout 120m --parallelism 1
 
 ####################
 # copy image to GHCR


### PR DESCRIPTION
#### Summary
- build missing binary `linux-pivkey-pkcs11key-arm64`
- format indentation