### PR TITLE
add --yes flag when signing the test cosign images

### DIFF
--- a/test/ci.mk
+++ b/test/ci.mk
@@ -4,8 +4,8 @@
 
 .PHONY: sign-ci-containers
 sign-ci-containers: ko
-	cosign sign --key .github/workflows/cosign-test.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosign:$(GIT_HASH)
-	cosign sign --key .github/workflows/cosign-test.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/sget:$(GIT_HASH)
+	cosign sign --yes --key .github/workflows/cosign-test.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/cosign:$(GIT_HASH)
+	cosign sign --yes --key .github/workflows/cosign-test.key -a GIT_HASH=$(GIT_HASH) ${KO_PREFIX}/sget:$(GIT_HASH)
 
 .PHONY: sign-ci-keyless-containers
 sign-ci-keyless-containers: ko


### PR DESCRIPTION


#### Summary
- add --yes flag when signing the test cosign images

failed job: https://github.com/sigstore/cosign/actions/runs/4316865353/jobs/7533203260