### PR TITLE
feat: adds NonExistentTag Exit Code to Error

### DIFF
--- a/cmd/cosign/errors/exit_code_lookup.go
+++ b/cmd/cosign/errors/exit_code_lookup.go
@@ -22,6 +22,8 @@ import (
 // exitCodeLookup contains a map of errorTypes and their associated exitCodes.
 var exitCodeLookup = map[string]int{
 	verificationError.ErrNoMatchingSignaturesType: NoMatchingSignature,
+	verificationError.ErrImageTagNotFoundType:     NonExistentTag,
+	verificationError.ErrNoSignaturesFoundType:    ImageWithoutSignature,
 }
 
 func LookupExitCodeForErrorType(errorType string) int {

--- a/pkg/cosign/errors.go
+++ b/pkg/cosign/errors.go
@@ -24,6 +24,14 @@ var (
 	// NoMatchingSignatures
 	ErrNoMatchingSignaturesType    = "NoMatchingSignatures"
 	ErrNoMatchingSignaturesMessage = "no matching signatures"
+
+	// NonExistingTagType
+	ErrImageTagNotFoundType    = "ImageTagNotFound"
+	ErrImageTagNotFoundMessage = "image tag not found"
+
+	// NoSignaturesFound
+	ErrNoSignaturesFoundType    = "NoSignaturesFound"
+	ErrNoSignaturesFoundMessage = "no signatures found for image"
 )
 
 // VerificationError is the type of Go error that is used by cosign to surface


### PR DESCRIPTION
Fixes rest of of https://github.com/sigstore/cosign/issues/948 

As described in #948 _"Currently if you run cosign verify against a non existing image, against a not signed image, against a signed image with a different key, the exit status is the same (1)"_ . https://github.com/sigstore/cosign/pull/2673 implements exit codes for the scenario of an image being signed with a different key, this PR addresses the non existing image and no signatures found.

#### Summary
- adds the exit code to when `cosign` throws an error due to a user trying to verify an image tag that doesn't exist.
- adds functionality with associated exit code for when there are no signatures found for an image