### PR TITLE
cli: update privacy statement and confirmation

### DIFF
--- a/cmd/cosign/cli/sign/privacy/privacy.go
+++ b/cmd/cosign/cli/sign/privacy/privacy.go
@@ -19,12 +19,12 @@ import "sync"
 const (
 	// spacing is intentional to have this indented
 	Statement = `
-	Note that there may be personally identifiable information associated with this signed artifact.
-	This may include the email address associated with the account with which you authenticate.
-	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later.
-`
-	StatementConfirmation = "By typing 'y', you attest that you grant (or have permission to grant) and agree to have this information stored permanently in transparency logs."
-)
+	The Cosign service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
+	Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
+	This may include the email address associated with the account with which you authenticate your attestation and contractual Agreement.
+	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.`
+
+	StatementConfirmation = "By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.")
 
 var (
 	StatementOnce sync.Once

--- a/cmd/cosign/cli/sign/privacy/privacy.go
+++ b/cmd/cosign/cli/sign/privacy/privacy.go
@@ -22,9 +22,11 @@ const (
 	The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
 	Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
 	This may include the email address associated with the account with which you authenticate your contractual Agreement.
-	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.`
+	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.
+`
 
-	StatementConfirmation = "By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.")
+	StatementConfirmation = "By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above."
+)
 
 var (
 	StatementOnce sync.Once

--- a/cmd/cosign/cli/sign/privacy/privacy.go
+++ b/cmd/cosign/cli/sign/privacy/privacy.go
@@ -19,9 +19,9 @@ import "sync"
 const (
 	// spacing is intentional to have this indented
 	Statement = `
-	The Cosign service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
+	The sigstore service, hosted by sigstore a Series of LF Projects, LLC, is provided pursuant to the Hosted Project Tools Terms of Use, available at https://lfprojects.org/policies/hosted-project-tools-terms-of-use/.
 	Note that if your submission includes personal data associated with this signed artifact, it will be part of an immutable record.
-	This may include the email address associated with the account with which you authenticate your attestation and contractual Agreement.
+	This may include the email address associated with the account with which you authenticate your contractual Agreement.
 	This information will be used for signing this artifact and will be stored in public transparency logs and cannot be removed later, and is subject to the Immutable Record notice at https://lfprojects.org/policies/hosted-project-tools-immutable-records/.`
 
 	StatementConfirmation = "By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.")


### PR DESCRIPTION
Fixes #2796

#### Summary

This commit includes an update to the privacy statement and confirmation notice in the CLI tool, intended to tie into the Hosted Project Tools policy from LF Projects, LLC (available at https://lfprojects.org/policies/).

#### Release Note

Updated the privacy statement to align with the new Hosted Project Tools terms and notice from LF Projects, LLC

#### Documentation

N/A

cc @mkdolan for visibility