### PR TITLE
Remove tag warning message from save/copy commands

### DIFF
--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/cosign/v2/pkg/oci/walk"
@@ -39,10 +38,6 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 	srcRef, err := name.ParseReference(srcImg, no...)
 	if err != nil {
 		return err
-	}
-	if _, ok := srcRef.(name.Digest); !ok {
-		msg := fmt.Sprintf(ui.TagReferenceMessage, srcImg)
-		ui.Warnf(ctx, msg)
 	}
 	srcRepoRef := srcRef.Context()
 

--- a/cmd/cosign/cli/save.go
+++ b/cmd/cosign/cli/save.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/layout"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
@@ -52,10 +51,6 @@ func SaveCmd(ctx context.Context, opts options.SaveOptions, imageRef string) err
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return fmt.Errorf("parsing image name %s: %w", imageRef, err)
-	}
-	if _, ok := ref.(name.Digest); !ok {
-		msg := fmt.Sprintf(ui.TagReferenceMessage, imageRef)
-		ui.Warnf(ctx, msg)
 	}
 
 	se, err := ociremote.SignedEntity(ref)


### PR DESCRIPTION
Partially undoes #2650 (CC @priyawadhwa)

We need to warn when the user might be making a statement about the wrong image, but not for downloading.

#### Release Note
NONE

#### Documentation
N/A