### PR TITLE
Add a warning to remember how to configure a custom Gitlab host

### DIFF
--- a/pkg/cosign/git/gitlab/gitlab.go
+++ b/pkg/cosign/git/gitlab/gitlab.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/cosign/env"
 	"github.com/xanzy/go-gitlab"
@@ -70,7 +71,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		EnvironmentScope: gitlab.String("*"),
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "WARNING: if you want to use a custom Gitlab host, set the \"GITLAB_HOST\" environment variable.")
+		ui.Infof(ctx, "WARNING: if you want to use a custom Gitlab host, set the \"GITLAB_HOST\" environment variable.")
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" variable: %w", err)
 	}
 
@@ -79,7 +80,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
-	fmt.Fprintln(os.Stderr, "Password written to \"COSIGN_PASSWORD\" variable")
+	ui.Infof(ctx, "Password written to \"COSIGN_PASSWORD\" variable")
 
 	_, privateKeyResp, err := client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
 		Key:          gitlab.String("COSIGN_PRIVATE_KEY"),
@@ -97,7 +98,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
-	fmt.Fprintln(os.Stderr, "Private key written to \"COSIGN_PRIVATE_KEY\" variable")
+	ui.Infof(ctx, "Private key written to \"COSIGN_PRIVATE_KEY\" variable")
 
 	_, publicKeyResp, err := client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
 		Key:          gitlab.String("COSIGN_PUBLIC_KEY"),
@@ -115,12 +116,12 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
-	fmt.Fprintln(os.Stderr, "Public key written to \"COSIGN_PUBLIC_KEY\" variable")
+	ui.Infof(ctx, "Public key written to \"COSIGN_PUBLIC_KEY\" variable")
 
 	if err := os.WriteFile("cosign.pub", keys.PublicBytes, 0o600); err != nil {
 		return err
 	}
-	fmt.Fprintln(os.Stderr, "Public key also written to cosign.pub")
+	ui.Infof(ctx, "Public key also written to cosign.pub")
 
 	return nil
 }

--- a/pkg/cosign/git/gitlab/gitlab.go
+++ b/pkg/cosign/git/gitlab/gitlab.go
@@ -71,7 +71,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		EnvironmentScope: gitlab.String("*"),
 	})
 	if err != nil {
-		ui.Infof(ctx, "WARNING: if you are using a self-hosted gitlab please set the \"GITLAB_HOST\" your server name.")
+		ui.Warnf(ctx, "if you are using a self-hosted gitlab please set the \"GITLAB_HOST\" your server name.")
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" variable: %w", err)
 	}
 

--- a/pkg/cosign/git/gitlab/gitlab.go
+++ b/pkg/cosign/git/gitlab/gitlab.go
@@ -71,7 +71,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		EnvironmentScope: gitlab.String("*"),
 	})
 	if err != nil {
-		ui.Warnf(ctx, "if you are using a self-hosted gitlab please set the \"GITLAB_HOST\" your server name.")
+		ui.Warnf(ctx, "If you are using a self-hosted gitlab please set the \"GITLAB_HOST\" your server name.")
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" variable: %w", err)
 	}
 

--- a/pkg/cosign/git/gitlab/gitlab.go
+++ b/pkg/cosign/git/gitlab/gitlab.go
@@ -70,6 +70,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		EnvironmentScope: gitlab.String("*"),
 	})
 	if err != nil {
+		fmt.Fprintln(os.Stderr, "WARNING: if you want to use a custom Gitlab host, set the \"GITLAB_HOST\" environment variable.")
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" variable: %w", err)
 	}
 

--- a/pkg/cosign/git/gitlab/gitlab.go
+++ b/pkg/cosign/git/gitlab/gitlab.go
@@ -71,7 +71,7 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		EnvironmentScope: gitlab.String("*"),
 	})
 	if err != nil {
-		ui.Infof(ctx, "WARNING: if you want to use a custom Gitlab host, set the \"GITLAB_HOST\" environment variable.")
+		ui.Infof(ctx, "WARNING: if you are using a self-hosted gitlab please set the \"GITLAB_HOST\" your server name.")
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" variable: %w", err)
 	}
 


### PR DESCRIPTION
Resolves sigstore/cosign#2730

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Add a warning to explain how to use a custom Gitlab host.
I've also changed `fmt.Fprintln`with `ui.Infof` where applicable. 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NO