### PR TITLE
feat: add riscv64 arch

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ builds:
       - arm
       - s390x
       - ppc64le
+      - riscv64
     goarm:
       - '7'
     ldflags:
@@ -171,6 +172,7 @@ builds:
       - arm
       - s390x
       - ppc64le
+      - riscv64
     goarm:
       - '7'
     ignore:

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -69,7 +69,7 @@ diff payload1 payload2
 # sign recursively
 ./cosign sign --key ${signing_key} -r $multiarch_img
 ./cosign verify --key ${verification_key} $multiarch_img # verify image index
-for arch in "linux/amd64" "linux/arm64" "linux/s390x" "linux/riscv64"
+for arch in "linux/amd64" "linux/arm64" "linux/s390x"
 do
     # verify sigs on discrete images
     ./cosign verify --key ${verification_key} "${multiarch_img}@$(crane digest --platform=$arch ${multiarch_img})"

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -69,7 +69,7 @@ diff payload1 payload2
 # sign recursively
 ./cosign sign --key ${signing_key} -r $multiarch_img
 ./cosign verify --key ${verification_key} $multiarch_img # verify image index
-for arch in "linux/amd64" "linux/arm64" "linux/s390x"
+for arch in "linux/amd64" "linux/arm64" "linux/s390x" "linux/riscv64"
 do
     # verify sigs on discrete images
     ./cosign verify --key ${verification_key} "${multiarch_img}@$(crane digest --platform=$arch ${multiarch_img})"


### PR DESCRIPTION
Add riscv64 to `.goreleaser.yml` `goarch`, also update `test/e2e_test_secrets.sh` (not sure about that).

Also, it looks like no `riscv64` image is available:
```console
$ docker pull gcr.io/projectsigstore/cosign:v2.0.0
v2.0.0: Pulling from projectsigstore/cosign
no matching manifest for linux/riscv64 in the manifest list entries
```
But it should, because latest `ko` version should build for `linux/riscv64` with flag `--platform=all`, how can I fix that?