### PR TITLE
Add missing flags to cosign verify dockerfile/manifest

### DIFF
--- a/cmd/cosign/cli/dockerfile.go
+++ b/cmd/cosign/cli/dockerfile.go
@@ -102,6 +102,10 @@ Shell-like variables in the Dockerfile's FROM lines will be substituted with val
 					RekorURL:                     o.Rekor.URL,
 					Attachment:                   o.Attachment,
 					Annotations:                  annotations,
+					LocalImage:                   o.LocalImage,
+					Offline:                      o.CommonVerifyOptions.Offline,
+					TSACertChainPath:             o.CommonVerifyOptions.TSACertChainPath,
+					IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 				},
 				BaseOnly: o.BaseImageOnly,
 			}

--- a/cmd/cosign/cli/manifest.go
+++ b/cmd/cosign/cli/manifest.go
@@ -97,6 +97,10 @@ against the transparency log.`,
 					RekorURL:                     o.Rekor.URL,
 					Attachment:                   o.Attachment,
 					Annotations:                  annotations,
+					LocalImage:                   o.LocalImage,
+					Offline:                      o.CommonVerifyOptions.Offline,
+					TSACertChainPath:             o.CommonVerifyOptions.TSACertChainPath,
+					IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 				},
 			}
 			return v.Exec(cmd.Context(), args)


### PR DESCRIPTION
There's still deviations between the five verify commands. We should at some point sync all 5 with a refactoring.

Fixes #2827

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->