### PR TITLE
Makefile: date format of log should not show signatures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ GIT_TAG ?= dirty-tag
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)
 GIT_HASH ?= $(shell git rev-parse HEAD)
 DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
-SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --no-show-signature --pretty=%ct)
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
 else

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ifeq (,$(shell echo $$DEBUG))
+else
+SHELL = bash -x
+endif
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin


### PR DESCRIPTION

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
if user's have git configurations like `git config --global log.showSignature=true` it will cause an issue in the Makefile variable output, like:
```shell
vbatts@possibly:~/src/github.com/sigstore/cosign$ make
[288/1916] /bin/sh: 1: Syntax error: "(" unexpected
CGO_ENABLED=0 go build -trimpath -ldflags "-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=v2.0.0-63-ge71faa1a -X sigs.k8s.io/release-utils/version.gitCommit=e71faa1af0383d860481f569ef2c01694d37b00b -X sigs.k8s.io/release-utils/version.gitTreeState="clean" -X sigs.k8s.io/release-utils/version.buildDate=" -o cosign ./cmd/cosign
```

Fixes #2834

Now it runs clean if this corner case happens:

```shell

vbatts@possibly:~/src/github.com/sigstore/cosign$ make
+ go env GOBIN
+ git diff --quiet
+ '[' 1 -eq 1 ']'
+ echo 1
+ find cmd -iname '*.go'
+ find pkg -iname '*.go'
+ find cmd -iname '*.go'
+ find pkg -iname '*.go'
+ git describe --tags --always --dirty
+ git rev-parse HEAD
+ git -c log.showSignature=false log -1 --pretty=%ct
+ git -c log.showSignature=false log -1 --pretty=%ct
+ date -u -d @1679669412 +%Y-%m-%dT%H:%M:%SZ
CGO_ENABLED=0 go build -trimpath -ldflags "-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=v2.0.0-64-gbb9af6bb-dirty -X sigs.k8s.io/release-utils/version.gitCommit=bb9af6bb1323c116e3b6b6149770aaea92ca7a95 -X sigs.k8s.io/release-utils/version.gitTreeState="dirty" -X sigs.k8s.io/release-utils/version.buildDate=2023-03-24T14:50:12Z" -o cosign ./cmd/cosign
+ CGO_ENABLED=0
+ go build -trimpath -ldflags '-buildid= -X sigs.k8s.io/release-utils/version.gitVersion=v2.0.0-64-gbb9af6bb-dirty -X sigs.k8s.io/release-utils/version.gitCommit=bb9af6bb1323c116e3b6b6149770aaea92ca7a95 -X sigs.k8s.io/release-utils/version.gitTreeState=dirty -X sigs.k8s.io/release-utils/version.buildDate=2023-03-24T14:50:12Z' -o cosign ./cmd/cosign
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->