### PR TITLE
verify command: support keyless verification using only a provided certificate chain with non-fulcio roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,7 +358,7 @@ Critical breaking changes include:
 # v1.12.1
 
 > # Highlights
-> * Pulls Fulcio root and intermediate when `--certificate-chain` is not passed into `verify-blob`. The v1.12.0 release introduced a regression: when `COSIGN_EXPERIMENTAL` was not set, cosign `verify-blob` would check a` --certificate` (without a `--certificate-chain` provided) against the operating system root CA bundle. In this release, Cosign checks the certificate against Fulcio's CA root instead (restoring the earlier behavior).
+> * Pulls Fulcio root and intermediate when `--certificate-chain` is not passed into `verify-blob`. The v1.12.0 release introduced a regression: when `COSIGN_EXPERIMENTAL` was not set, cosign `verify-blob` would check a `--certificate` (without a `--certificate-chain` provided) against the operating system root CA bundle. In this release, Cosign checks the certificate against Fulcio's CA root instead (restoring the earlier behavior).
 
 ## Bug Fixes
 

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -62,7 +62,7 @@ against the transparency log.`,
   cosign verify --cert cosign.crt --cert-chain chain.crt <IMAGE>
 
   # verify image using keyless verification with the given certificate
-  # chain and identity parameters, without Fulcio roots (fro BYO PKI):
+  # chain and identity parameters, without Fulcio roots (for BYO PKI):
   cosign verify --cert-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com <IMAGE>
 
   # verify image with public key provided by URL

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -61,6 +61,10 @@ against the transparency log.`,
   # verify image with local certificate and certificate chain
   cosign verify --cert cosign.crt --cert-chain chain.crt <IMAGE>
 
+  # verify image using keyless verification with the given certificate
+  # chain and identity parameters, without Fulcio roots (fro BYO PKI):
+  cosign verify --cert-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com <IMAGE>
+
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
 

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -171,15 +171,30 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		}
 	}
 	if keylessVerification(c.KeyRef, c.Sk) {
-		// This performs an online fetch of the Fulcio roots. This is needed
-		// for verifying keyless certificates (both online and offline).
-		co.RootCerts, err = fulcio.GetRoots()
-		if err != nil {
-			return fmt.Errorf("getting Fulcio roots: %w", err)
-		}
-		co.IntermediateCerts, err = fulcio.GetIntermediates()
-		if err != nil {
-			return fmt.Errorf("getting Fulcio intermediates: %w", err)
+		if c.CertChain != "" {
+			chain, err := loadCertChainFromFileOrURL(c.CertChain)
+			if err != nil {
+				return err
+			}
+			co.RootCerts = x509.NewCertPool()
+			co.RootCerts.AddCert(chain[len(chain)-1])
+			if len(chain) > 1 {
+				co.IntermediateCerts = x509.NewCertPool()
+				for _, cert := range chain[:len(chain)-1] {
+					co.IntermediateCerts.AddCert(cert)
+				}
+			}
+		} else {
+			// This performs an online fetch of the Fulcio roots. This is needed
+			// for verifying keyless certificates (both online and offline).
+			co.RootCerts, err = fulcio.GetRoots()
+			if err != nil {
+				return fmt.Errorf("getting Fulcio roots: %w", err)
+			}
+			co.IntermediateCerts, err = fulcio.GetIntermediates()
+			if err != nil {
+				return fmt.Errorf("getting Fulcio intermediates: %w", err)
+			}
 		}
 	}
 	keyRef := c.KeyRef

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -271,7 +271,8 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 
 	// NB: There are only 2 kinds of verification right now:
 	// 1. You gave us the public key explicitly to verify against so co.SigVerifier is non-nil or,
-	// 2. We're going to find an x509 certificate on the signature and verify against Fulcio root trust
+	// 2. We’re going to find an x509 certificate on the signature and verify against
+	//    Fulcio root trust (or user supplied root trust)
 	// TODO(nsmith5): Refactor this verification logic to pass back _how_ verification
 	// was performed so we don't need to use this fragile logic here.
 	fulcioVerified := (co.SigVerifier == nil)

--- a/cmd/cosign/cli/verify/verify_test.go
+++ b/cmd/cosign/cli/verify/verify_test.go
@@ -198,3 +198,20 @@ func TestVerifyCertMissingIssuer(t *testing.T) {
 		t.Fatal("verify expected 'need --certificate-oidc-issuer'")
 	}
 }
+
+func TestVerifyKeylessVerification(t *testing.T) {
+	ctx := context.Background()
+	verifyCommand := VerifyCommand{
+		CertRef: "cert.pem",
+		CertVerifyOptions: options.CertVerifyOptions{
+			CertIdentity:         "identity",
+			CertOidcIssuerRegexp: ".*",
+		},
+	}
+
+	err := verifyCommand.Exec(ctx, []string{"foo", "bar", "baz"})
+	t.Logf("INFO: verifyCommand error: %v", err)
+	if err == nil {
+		t.Fatal("verify expected 'need --certificate-oidc-issuer'")
+	}
+}

--- a/cmd/cosign/cli/verify/verify_test.go
+++ b/cmd/cosign/cli/verify/verify_test.go
@@ -198,20 +198,3 @@ func TestVerifyCertMissingIssuer(t *testing.T) {
 		t.Fatal("verify expected 'need --certificate-oidc-issuer'")
 	}
 }
-
-func TestVerifyKeylessVerification(t *testing.T) {
-	ctx := context.Background()
-	verifyCommand := VerifyCommand{
-		CertRef: "cert.pem",
-		CertVerifyOptions: options.CertVerifyOptions{
-			CertIdentity:         "identity",
-			CertOidcIssuerRegexp: ".*",
-		},
-	}
-
-	err := verifyCommand.Exec(ctx, []string{"foo", "bar", "baz"})
-	t.Logf("INFO: verifyCommand error: %v", err)
-	if err == nil {
-		t.Fatal("verify expected 'need --certificate-oidc-issuer'")
-	}
-}

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -38,6 +38,10 @@ cosign verify [flags]
   # verify image with local certificate and certificate chain
   cosign verify --cert cosign.crt --cert-chain chain.crt <IMAGE>
 
+  # verify image using keyless verification with the given certificate
+  # chain and identity parameters, without Fulcio roots (fro BYO PKI):
+  cosign verify --cert-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com <IMAGE>
+
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
 

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -39,7 +39,7 @@ cosign verify [flags]
   cosign verify --cert cosign.crt --cert-chain chain.crt <IMAGE>
 
   # verify image using keyless verification with the given certificate
-  # chain and identity parameters, without Fulcio roots (fro BYO PKI):
+  # chain and identity parameters, without Fulcio roots (for BYO PKI):
   cosign verify --cert-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com <IMAGE>
 
   # verify image with public key provided by URL


### PR DESCRIPTION
This is a continuation of the work started by @nsmith5 in #2631 and uses the code of that PR rebased on the current trunk.  

Fixes https://github.com/sigstore/cosign/issues/2630

Summary

This change adds support for verifying keyless signatures from the specified `--certificate-chain` instead of assuming Fulcio and loading its roots and without requiring to pass the certificate in addition to the certificate chain.

As @haydentherapper noted in the comment below, the keyless verification without the Fulcio certificate roots is already possible but requires passing both certificate-chain and certificate.
This would allow folks to more easily verify signatures from a custom CA (see https://github.com/sigstore/cosign/issues/2630 for additional discussion).

Release Note

Allow verifying signatures from a custom CA without needing leaf certificate
Documentation

Will attach an PR for docs here if folks agree on the parent issue that its worth doing

TODO

The TODO list as this idea is still in discussion etc. 

- [x] Add PR for docs with examples of this kind of verification (done: https://github.com/sigstore/docs/pull/153)

- [x]  Add some end to end tests of this (done: https://github.com/dmitris/cosign-keyless)