### PR TITLE
cmd: Change error message from KeyParseError to PubKeyParseError for …

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -78,7 +78,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 
 	// Key, sk, and cert are mutually exclusive.
 	if options.NOf(c.KeyRef, c.Sk, c.CertRef) > 1 {
-		return &options.KeyParseError{}
+		return &options.PubKeyParseError{}
 	}
 
 	var identities []cosign.Identity


### PR DESCRIPTION
Hi.


I was using `cosign verify-blob` and just realized a bad error message was used when using both `--key` and `--cert`.
So, this commit corrects this problem by using the corresponding error message.


Best regards.