### PR TITLE
Use SOURCE_DATE_EPOCH for OCI CreatedAt times

### DIFF
--- a/internal/pkg/now/now.go
+++ b/internal/pkg/now/now.go
@@ -1,0 +1,38 @@
+//
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package now
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Now returns SOURCE_DATE_EPOCH or time.Now().
+func Now() (time.Time, error) {
+	// nolint
+	epoch := os.Getenv("SOURCE_DATE_EPOCH")
+	if epoch == "" {
+		return time.Now(), nil
+	}
+
+	seconds, err := strconv.ParseInt(epoch, 10, 64)
+	if err != nil {
+		return time.Now(), fmt.Errorf("SOURCE_DATE_EPOCH should be the number of seconds since January 1st 1970, 00:00 UTC, got: %w", err)
+	}
+	return time.Unix(seconds, 0), nil
+}

--- a/pkg/cosign/env/env.go
+++ b/pkg/cosign/env/env.go
@@ -70,6 +70,7 @@ const (
 	VariableBuildkiteAgentEndpoint    Variable = "BUILDKITE_AGENT_ENDPOINT"
 	VariableBuildkiteJobID            Variable = "BUILDKITE_JOB_ID"
 	VariableBuildkiteAgentLogLevel    Variable = "BUILDKITE_AGENT_LOG_LEVEL"
+	VariableSourceDateEpoch           Variable = "SOURCE_DATE_EPOCH"
 )
 
 var (
@@ -202,6 +203,12 @@ var (
 			Description: "is a OIDC token used to authenticate to Fulcio",
 			Expects:     "string with a OIDC token",
 			Sensitive:   true,
+			External:    true,
+		},
+		VariableSourceDateEpoch: {
+			Description: "overrides current time for reproducible builds, see https://reproducible-builds.org/docs/source-date-epoch/",
+			Expects:     "number of seconds since unix epoch",
+			Sensitive:   false,
 			External:    true,
 		},
 	}

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -16,11 +16,10 @@
 package mutate
 
 import (
-	"time"
-
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/sigstore/cosign/v2/internal/pkg/now"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 )
 
@@ -44,8 +43,13 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 		return nil, err
 	}
 
+	t, err := now.Now()
+	if err != nil {
+		return nil, err
+	}
+
 	// Set the Created date to time of execution
-	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -17,12 +17,12 @@ package static
 
 import (
 	"io"
-	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/v2/internal/pkg/now"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 )
@@ -49,8 +49,13 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 	// Add annotations from options
 	img = mutate.Annotations(img, o.Annotations).(v1.Image)
 
+	t, err := now.Now()
+	if err != nil {
+		return nil, err
+	}
+
 	// Set the Created date to time of execution
-	img, err = mutate.CreatedAt(img, v1.Time{Time: time.Now()})
+	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Using time.Now() makes this unreproducible and causes a lot of churn when re-running the same command.

Fixes https://github.com/sigstore/cosign/issues/2879

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Respect SOURCE_DATE_EPOCH in OCI object generation.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
The `CreatedAt` time in generated OCI images now respects `SOURCE_DATE_EPOCH`.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
n/a