### PR TITLE
minor typos fix - 1st contib (test)

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -2043,7 +2043,7 @@ func registryClientOpts(ctx context.Context) []remote.Option {
 	}
 }
 
-// If a signature has a bundle, but *not for that signature*, cosign verification should fail
+// If a signature has a bundle, but *not for that signature*, cosign verification should fail.
 // This test is pretty long, so here are the basic points:
 //  1. Sign image1 with a keypair, store entry in rekor
 //  2. Sign image2 with keypair, DO NOT store entry in rekor

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -51,7 +51,7 @@ crane cp ghcr.io/distroless/alpine-base $multiarch_img
 # `initialize`
 ./cosign initialize
 
-## Generate (also test output redirection
+## Generate (also test output redirection)
 ./cosign generate $img > payload1
 ./cosign generate --output-file=payload2 $img
 diff payload1 payload2


### PR DESCRIPTION
tiny trivial changes in comments to trigger e2e tests (getting a failure locally)