### PR TITLE
clone rekor repo if no rekor dir found

### DIFF
--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -18,7 +18,13 @@ set -ex
 
 echo "copying rekor repo"
 pushd $HOME
-git clone https://github.com/sigstore/rekor.git
+if [[ ! -d rekor ]]; then
+   git clone https://github.com/sigstore/rekor.git
+else
+   pushd rekor
+   git pull
+   popd
+fi
 cd rekor
 
 echo "starting services"


### PR DESCRIPTION

#### Summary
Currently if you run the `test/e2e_test.sh` two or more times, you have to manually delete the `$HOME/rekor` directory so that the e2e test could recreate it.  This small change adds check for the existing `$HOME/rekor`  directory in which case only `git pull` is done inside it.  This allows multiple e2e test runs one after another.

#### Release Note
NONE

#### Documentation
no changes required
