### PR TITLE
remove GODEBUG: x509sha1=1 setting for e2e tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,9 +117,6 @@ jobs:
           kind create cluster
 
       - name: Run end-to-end tests
-        env:
-          # See #2091 for the issue describing this temp workaround.
-          GODEBUG: x509sha1=1
         run: ./test/e2e_test.sh
 
       - name: Collect diagnostics


### PR DESCRIPTION
#### Summary
PR removes one `GODEBUG: x509sha1=1` setting which is no longer needed.

Related issue: https://github.com/sigstore/cosign/issues/2091
/cc @haydentherapper @imjasonh  

#### Release Note
NONE


#### Documentation
no changes
