### PR TITLE
remove COSIGN_EXPERIMENTAL setting for keyless in CI

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -44,8 +44,6 @@ jobs:
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko
-      # We are only testing keyless here, so set it.
-      COSIGN_EXPERIMENTAL: "true"
       COSIGN_YES: "true"
 
     steps:


### PR DESCRIPTION
#### Summary
PR removes the `COSIGN_EXPERIMENTAL` setting for the keyless verification since it is no longer required (since https://github.com/sigstore/cosign/pull/2387).

#### Release Note
NONE

#### Documentation
no changes (though someone needs to go through the `COSIGN_EXPERIMENTAL` search hits in https://github.com/sigstore/docs and remove those that are no longer needed)
