### PR TITLE
Update release readme

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -2,10 +2,11 @@
 
 This directory contain the files and scripts to run a cosign release.
 
-# Cutting a Sigstore Release
+# Cutting a Cosign Release
 
-1. Release notes: Create a PR to update and review release notes in CHANGELOG.md.
-  - Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
+1. Release notes: Create a PR to update and review release notes in CHANGELOG.md. 
+
+Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
 
 You can get a list of pull requests since the last release by substituting in the date of the last release and running:
 
@@ -19,47 +20,41 @@ and a list of authors by running:
 git log --pretty="* %an" --after="YYYY-MM-DD" | sort -u
 ```
 
-2. Tag the repository
+2. Open a Pull Request to update CHANGELOG.md
+
+3. Tag the repository
+
+**WARNING**: Tags should not be updated to a new ref or deleted/recreated after creation. Go provides a [checksum database](https://sum.golang.org/)
+that persists an immutable mapping between version and ref, and updating the tag will break clients that have already downloaded the release.
 
 ```shell
-$ export RELEASE_TAG=<release version, eg "v1.4.0">
+$ export RELEASE_TAG=<release version, eg "v2.0.2">
 $ git tag -s ${RELEASE_TAG} -m "${RELEASE_TAG}"
-$ git push origin ${RELEASE_TAG}
+$ git push upstream ${RELEASE_TAG}
 ```
 
+Note that `upstream` should be the upstream `sigstore/cosign` repository. You may have to change this if you've configured remotes.
 
-2. Submit the cloudbuild Job using the following command:
+4. Then go to the `Actions` tab and click on the [Cut Release workflow](https://github.com/sigstore/cosign/actions/workflows/cut-release.yml). Note you need
+to be in [this list](https://github.com/sigstore/sigstore/blob/main/.github/workflows/reusable-release.yml#L45) to trigger this workflow.
 
-```shell
-$ gcloud builds submit --config <PATH_TO_CLOUDBUILD> \
-   --substitutions _GIT_TAG=${RELEASE_TAG},_TOOL_ORG=sigstore,_TOOL_REPO=cosign,_STORAGE_LOCATION=cosign-releases,_KEY_RING=<KEY_RING>,_KEY_NAME=<KEY_NAME>,_GITHUB_USER=<GITHUB_USER> \
-   --project <GCP_PROJECT>
-```
+Click to run a workflow and insert the following parameters:
 
-Where:
+  - `Release tag`: the tag that use pushed for the release
+  - `Key ring for cosign key`: the value is `release-cosign`
+  - `Key name for cosign key`: the value is `cosign`
 
-- `PATH_TO_CLOUDBUILD` is the path where the cloudbuild.yaml can be found.
-- `GCP_PROJECT` is the GCP project where we will run the job.
-- `_GIT_TAG` is the release version we are publishing.
-- `_TOOL_ORG` is the GitHub Org we will use. Default `sigstore`.
-- `_TOOL_REPO` is the repository we will use to clone. Default `cosign`.
-- `_STORAGE_LOCATION` where to push the built artifacts. Default `cosign-releases`.
-- `_KEY_RING` key ring name of your cosign key.
-- `_KEY_NAME` key name of your  cosign key.
-- `_KEY_VERSION` version of the key stored in KMS. Default `1`.
-- `_KEY_LOCATION` location in GCP where the key is stored. Default `global`.
-- `_GITHUB_USER` GitHub user to authenticate for pushing to GHCR.
+That will trigger a CloudBuild job and will run the release using `goreleaser`, which will publish images to
+`gcr.io` and `ghcr.io`, and the binaries will be available in the GitHub release.
 
+If you have permissions to access the project, you can follow the CloudBuild job in the `projectsigstore`(https://console.cloud.google.com/cloud-build/builds?project=projectsigstore) GCP Project.
 
-3. When the job finish, without issues, you should be able to see in GitHub a draft release.
-You now can review the release, make any changes if needed and then publish to make it an official release.
+As the last step of the CloudBuild job, `goreleaser` will create a `draft release` in GitHub.
 
-4. Send an announcement email to `sigstore-dev@googlegroups.com` mailing list
+5. Navigate to the `Draft Release` in the Github repository. Click the `Publish Release` button to make the Release available.
 
-5. Tweet about the new release with a fun new trigonometry pun!
+You might want/need to add any extra notes/breaking changes notices, upgrade paths.
 
-6. Honk!
+6. Post on the `#general` and `#cosign` Slack channels.
 
-#### After the release:
-
-* Add a pending new section in CHANGELOG.md to set up for the next release
+7. If it's a significant release, send an announcement email to sigstore-dev@googlegroups.com mailing list.

--- a/release/README.md
+++ b/release/README.md
@@ -4,7 +4,7 @@ This directory contain the files and scripts to run a cosign release.
 
 # Cutting a Cosign Release
 
-1. Release notes: Create a PR to update and review release notes in CHANGELOG.md. 
+1. Release notes: Create a PR to update and review release notes in CHANGELOG.md.
 
 Check merged pull requests since the last release and make sure enhancements, bug fixes, and authors are reflected in the notes.
 


### PR DESCRIPTION
Syncing this with the internal release notes, which now use the reusable workflow rather than calling cloud build. Also adds a warning about tag mutation.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
