### PR TITLE
DNM: treat 403 as non-fatal when checking for manifests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/go-piv/piv-go v1.11.0
 	github.com/google/certificate-transparency-go v1.1.6
 	github.com/google/go-cmp v0.5.9
-	github.com/google/go-containerregistry v0.15.1
+	github.com/google/go-containerregistry v0.15.2-0.20230510171652-a927d7c995a9
 	github.com/google/go-github/v50 v50.2.0
 	github.com/in-toto/in-toto-golang v0.9.0
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,8 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-containerregistry v0.15.1 h1:RsJ9NbfxYWF8Wl4VmvkpN3zYATwuvlPq2j20zmcs63E=
-github.com/google/go-containerregistry v0.15.1/go.mod h1:wWK+LnOv4jXMM23IT/F1wdYftGWGr47Is8CG+pmHK1Q=
+github.com/google/go-containerregistry v0.15.2-0.20230510171652-a927d7c995a9 h1:kWURI8V9IfQ/w8AqwBMyVJK5b22sFXlFEMFIbNbnpf4=
+github.com/google/go-containerregistry v0.15.2-0.20230510171652-a927d7c995a9/go.mod h1:wWK+LnOv4jXMM23IT/F1wdYftGWGr47Is8CG+pmHK1Q=
 github.com/google/go-github/v50 v50.2.0 h1:j2FyongEHlO9nxXLc+LP3wuBSVU9mVxfpdYUexMpIfk=
 github.com/google/go-github/v50 v50.2.0/go.mod h1:VBY8FB6yPIjrtKhozXv4FQupxKLS6H4m6xFZlT43q8Q=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/pkg/oci/remote/signatures.go
+++ b/pkg/oci/remote/signatures.go
@@ -34,7 +34,8 @@ func Signatures(ref name.Reference, opts ...Option) (oci.Signatures, error) {
 	img, err := remoteImage(ref, o.ROpt...)
 	var te *transport.Error
 	if errors.As(err, &te) {
-		if te.StatusCode != http.StatusNotFound {
+		// some Docker registries may return 403 for non-existing tags that start with "sha256"
+		if te.StatusCode != http.StatusNotFound && te.StatusCode != http.StatusForbidden {
 			return nil, te
 		}
 		return empty.Signatures(), nil

--- a/pkg/oci/remote/signatures_test.go
+++ b/pkg/oci/remote/signatures_test.go
@@ -32,6 +32,24 @@ func TestSignaturesErrors(t *testing.T) {
 		remoteImage = ri
 	})
 
+	t.Run("403 returns empty", func(t *testing.T) {
+		remoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, &transport.Error{
+				StatusCode: http.StatusForbidden,
+			}
+		}
+
+		sigs, err := Signatures(name.MustParseReference("gcr.io/distroless/static:sha256-deadbeef.sig"))
+		if err != nil {
+			t.Fatalf("Signatures() = %v", err)
+		}
+		if sl, err := sigs.Get(); err != nil {
+			t.Fatalf("Get() = %v", err)
+		} else if len(sl) != 0 {
+			t.Fatalf("len(Get()) = %d, wanted 0", len(sl))
+		}
+	})
+
 	t.Run("404 returns empty", func(t *testing.T) {
 		remoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
 			return nil, &transport.Error{


### PR DESCRIPTION
#### Update
NB - please Do Not Merge = PR on-hold, likely will close once https://github.com/google/go-containerregistry/pull/1701 is merged and released.

#### Summary
As described in #2973, some Docker registries (ex.JFrog Artifactory) return 403 instead of 404 for a non-existent tag if that tag starts with 'sha256' - which results in a fatal error and inability to use `cosign sign`. This is a recent change - the breakage started after https://github.com/sigstore/cosign/pull/2929 ("last known good" commit https://github.com/sigstore/cosign/commit/bdf1c763158c91b23de281226a4d35ec66f71df6) and is related to or caused by upgrade of the `github.com/google/go-containerregistry` dependency.

#### Details
This change treats 403 the same way as 404 to overcome this.

It is similar and related to
https://github.com/google/go-containerregistry/pull/1691 "Make 403 non-fatal for manifest existence checks".

#### Testing
- nothing should change for the "normal" well-behaving registries
- `cosign sign` works again with the JFrog Artifactory registry

#### TODO / Followup
- change go.mod to refer to the upcoming release of github.com/google/go-containerregistry; can be done in a follow-up PR

#### Release Note
* Bug fixes and fixes of previous known issues
- Treat 403 Forbidden as non-fatal error when checking whether manifests exist

#### Documentation
no changes
