### PR TITLE
chore(refactor) refactors error handling with exit codes

### DIFF
--- a/cmd/cosign/errors/error_wrap_test.go
+++ b/cmd/cosign/errors/error_wrap_test.go
@@ -18,23 +18,7 @@ package errors
 import (
 	"errors"
 	"testing"
-
-	verificationError "github.com/sigstore/cosign/v2/pkg/cosign"
 )
-
-func TestWrapWithVerificationError(t *testing.T) {
-	ve := &verificationError.VerificationError{}
-	ve.SetErrorType(verificationError.ErrNoMatchingSignaturesType)
-	err := WrapError(ve)
-
-	var cosignError *CosignError
-	if errors.As(err, &cosignError) {
-		if cosignError.ExitCode() != NoMatchingSignature {
-			t.Fatalf("verification error unsuccessfully wrapped")
-		}
-		t.Logf("verification error successfully wrapped and exit code returned")
-	}
-}
 
 func TestWrapWithGenericCosignError(t *testing.T) {
 	errorText := "i am a generic cosign error"

--- a/cmd/cosign/errors/exit_code_lookup.go
+++ b/cmd/cosign/errors/exit_code_lookup.go
@@ -16,25 +16,40 @@
 package errors
 
 import (
-	verificationError "github.com/sigstore/cosign/v2/pkg/cosign"
+	"errors"
+
+	cosignError "github.com/sigstore/cosign/v2/pkg/cosign"
 )
 
-// exitCodeLookup contains a map of errorTypes and their associated exitCodes.
-var exitCodeLookup = map[string]int{
-	verificationError.ErrNoMatchingSignaturesType: NoMatchingSignature,
-	verificationError.ErrImageTagNotFoundType:     NonExistentTag,
-	verificationError.ErrNoSignaturesFoundType:    ImageWithoutSignature,
+func LookupExitCodeForError(err interface{ error }) int {
+	if noMatchingSignatureError(err) {
+		return NoMatchingSignature
+	}
+
+	if imageTagNotFoundError(err) {
+		return NonExistentTag
+	}
+
+	if noSignaturesFoundError(err) {
+		return ImageWithoutSignature
+	}
+
+	// we want to return exit code = `1` at this point because there is
+	// no valid exit code found for the error type passed, so we default to 1.
+	return 1
 }
 
-func LookupExitCodeForErrorType(errorType string) int {
-	exitCode := exitCodeLookup[errorType]
+func noMatchingSignatureError(err interface{ error }) bool {
+	var errNoMatchingSignatures *cosignError.ErrNoMatchingSignatures
+	return errors.As(err, &errNoMatchingSignatures)
+}
 
-	// if there is no entry in the lookup map for the passed errorType,
-	// then by default, it will return `0`. however, as `0` as an exitCode
-	// for success, we want to return `1` instead until there is a valid
-	// exit code entry in the map for the passed errorType.
-	if exitCode == 0 {
-		return 1
-	}
-	return exitCode
+func imageTagNotFoundError(err interface{ error }) bool {
+	var errImageTagNotFound *cosignError.ErrImageTagNotFound
+	return errors.As(err, &errImageTagNotFound)
+}
+
+func noSignaturesFoundError(err interface{ error }) bool {
+	var errNoSignaturesFound *cosignError.ErrNoSignaturesFound
+	return errors.As(err, &errNoSignaturesFound)
 }

--- a/cmd/cosign/errors/exit_code_lookup_test.go
+++ b/cmd/cosign/errors/exit_code_lookup_test.go
@@ -16,13 +16,26 @@
 package errors
 
 import (
+	"fmt"
 	"testing"
+
+	pkgError "github.com/sigstore/cosign/v2/pkg/cosign"
 )
 
-func TestDefaultExitCodeReturnIfErrorTypeDoesNotExist(t *testing.T) {
-	exitCode := LookupExitCodeForErrorType("I do not exist as an error type")
+func TestDefaultExitCodeReturnIfErrorTypeToExitCodeMappingDoesNotExist(t *testing.T) {
+	exitCode := LookupExitCodeForError(fmt.Errorf("I do not exist as an error type"))
 	if exitCode != 1 {
 		t.Fatalf("default exit code not returned when an error type doesn't exist. default should be 1")
+	}
+	t.Logf("Correct default exit code returned")
+}
+
+func TestDefaultExitCodeReturnIfErrorTypeToExitCodeMappingExists(t *testing.T) {
+	// We test with any error that is not a generic CosignError.
+	// In this case, ErrNoMatchingSignatures
+	exitCode := LookupExitCodeForError(&pkgError.ErrNoMatchingSignatures{})
+	if exitCode != NoMatchingSignature {
+		t.Fatalf("NoMatchingSignature exit code not returned when error is thrown")
 	}
 	t.Logf("Correct default exit code returned")
 }

--- a/pkg/cosign/errors.go
+++ b/pkg/cosign/errors.go
@@ -14,55 +14,56 @@
 
 package cosign
 
-import "fmt"
-
-var (
-	// NoMatchingAttestations
-	ErrNoMatchingAttestationsMessage = "no matching attestations"
-	ErrNoMatchingAttestationsType    = "NoMatchingAttestations"
-
-	// NoMatchingSignatures
-	ErrNoMatchingSignaturesType    = "NoMatchingSignatures"
-	ErrNoMatchingSignaturesMessage = "no matching signatures"
-
-	// NonExistingTagType
-	ErrImageTagNotFoundType    = "ImageTagNotFound"
-	ErrImageTagNotFoundMessage = "image tag not found"
-
-	// NoSignaturesFound
-	ErrNoSignaturesFoundType    = "NoSignaturesFound"
-	ErrNoSignaturesFoundMessage = "no signatures found for image"
-)
-
-// VerificationError is the type of Go error that is used by cosign to surface
+// VerificationFailure is the type of Go error that is used by cosign to surface
 // errors actually related to verification (vs. transient, misconfiguration,
 // transport, or authentication related issues).
-type VerificationError struct {
-	errorType string
-	message   string
+// It is now marked as deprecated and will be removed in favour of defined
+// error types with use of the ThrowError function.
+type VerificationFailure struct {
+	err error
 }
 
-// NewVerificationError constructs a new VerificationError in a manner similar
-// to fmt.Errorf
-func NewVerificationError(msg string, args ...interface{}) error {
-	return &VerificationError{
-		message: fmt.Sprintf(msg, args...),
-	}
+// ThrowError returns the error type that is passed. It acts as a
+// single consistent way of throwing errors from the pkg level.
+// As long as the error type is defined before hand, this can be
+// used to throw errors up to the calling code without discrimination
+// around the error type.
+func ThrowError(err interface{ error }) error {
+	return err
 }
 
-// Assert that we implement error at build time.
-var _ error = (*VerificationError)(nil)
-
-// Error implements error
-func (ve *VerificationError) Error() string {
-	return ve.message
+func (e *VerificationFailure) Error() string {
+	return e.err.Error()
 }
 
-// Error implements error
-func (ve *VerificationError) ErrorType() string {
-	return ve.errorType
+type ErrNoMatchingSignatures struct {
+	err error
 }
 
-func (ve *VerificationError) SetErrorType(errorType string) {
-	ve.errorType = errorType
+func (e *ErrNoMatchingSignatures) Error() string {
+	return e.err.Error()
+}
+
+type ErrImageTagNotFound struct {
+	err error
+}
+
+func (e *ErrImageTagNotFound) Error() string {
+	return e.err.Error()
+}
+
+type ErrNoSignaturesFound struct {
+	err error
+}
+
+func (e *ErrNoSignaturesFound) Error() string {
+	return e.err.Error()
+}
+
+type ErrNoMatchingAttestations struct {
+	err error
+}
+
+func (e *ErrNoMatchingAttestations) Error() string {
+	return e.err.Error()
 }

--- a/pkg/cosign/errors_test.go
+++ b/pkg/cosign/errors_test.go
@@ -15,20 +15,21 @@
 package cosign
 
 import (
-	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/pkg/errors"
 )
 
 func TestErrors(t *testing.T) {
 	for _, want := range []error{
-		NewVerificationError("not a constant %d", 3),
-		NewVerificationError("not a string %s", "i am a string"),
+		ThrowError(&VerificationFailure{errors.Errorf("not a constant %d", 3)}),
+		ThrowError(&VerificationFailure{errors.Errorf("not a string %s", "i am a string")}),
 	} {
 		t.Run(want.Error(), func(t *testing.T) {
-			verr := &VerificationError{}
+			verr := &VerificationFailure{}
 			if !errors.As(want, &verr) {
-				t.Errorf("%v is not a %T", want, &VerificationError{})
+				t.Errorf("%v is not a %T", want, &VerificationFailure{})
 			}
 
 			// Check that Is sees it as the same error through multiple

--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2022 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,17 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package errors
+package policy
 
-// WrapError takes an error type and depending on the type of error
-// passed, will access it's error message and errorType (and return
-// the associated exitCode) and wrap them in a generic `CosignError`.
-// If no custom error has been found, then it will still return a
-// `CosignError` with an error message, but the `exitCode` will be `1`.
-func WrapError(err error) error {
-	// return default cosign error with error message and default exit code
-	return &CosignError{
-		Message: err.Error(),
-		Code:    LookupExitCodeForError(err),
-	}
+type EvaluationFailure struct {
+	err error
+}
+
+func (e *EvaluationFailure) Error() string {
+	return e.err.Error()
+}
+
+// ThrowError returns the error type that is passed. It acts as a
+// single consistent way of throwing errors from the pkg level.
+// As long as the error type is defined before hand, this can be
+// used to throw errors up to the calling code without discrimination
+// around the error type.
+func ThrowError(err interface{ error }) error {
+	return err
 }


### PR DESCRIPTION
This PR refactors the way we throw errors and map them to exit codes.

Previously we had a lookup table `exitCodeLookup` that used `errorType`'s in order to lookup the correct exit code mapping to the error. This worked fine, but we found that it was slightly hacky in it's working as difficult to work with when we wanted to customise error types.

Before, to create a new error type and exit code mapping, you needed to create the `errorType`, `errorMessage`, make the explicit throw using `VerificationError`, add the lookup entry for it with the associated exit code. This was difficult to work with because we found that we had to force/shove information into the `VerificationError` (now `VerificationFailure` and is deprecated) type which become awkward and hacky. The new code hasn't change a whole lot but it is more flexible when it comes to the error types. If a user wants to add a new error type, they add the error type and associated `Error()` function, throw it using the new `ThrowError` and then add the lookup for it by using the common pattern `errors.As()`. This allows for greater flexibility in what data the errors hold and what you want to return as part of the associated `Error()` function. 

There was a difficult decision that we had to make when dealing with the trade-offs in the design of the code for exit code functionality. This was namely between:
* 1) doing the "best practice" thing and making `cosign/pkg` clueless to the exit codes which were a concern of `cosign/cmd` in combination with the awkward/inconvenient method of having to keep a map of known errors (throw from `cosign/pkg` and their associated error codes (held in `cosign/cmd`)
* 2) keeping code footprint small and doing the exit code mapping in `cosign/pkg` and throwing them to `cosign/cmd` to return back to the user. 

Although option 2 was less code involved, we did have to accept the leaking of concerns between layers and also the exit code automatic documentation would have been a bit trickier to make work.

We opt'd to go with option 1 as, although there is more code all around, we keep concerns separated.
