### PR TITLE
download attestation: support --platform flag

### DIFF
--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/oci"
+	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 )
 
 func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOptions options.AttestationDownloadOptions, imageRef string) error {
@@ -43,7 +46,50 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 		}
 	}
 
-	attestations, err := cosign.FetchAttestationsForReference(ctx, ref, predicateType, ociremoteOpts...)
+	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
+	if err != nil {
+		return err
+	}
+
+	idx, isIndex := se.(oci.SignedImageIndex)
+
+	// We only allow --platform on multiarch indexes
+	if attOptions.Platform != "" && !isIndex {
+		return fmt.Errorf("specified reference is not a multiarch image")
+	}
+
+	if attOptions.Platform != "" && isIndex {
+		targetPlatform, err := v1.ParsePlatform(attOptions.Platform)
+		if err != nil {
+			return fmt.Errorf("parsing platform: %w", err)
+		}
+		platforms, err := getIndexPlatforms(idx)
+		if err != nil {
+			return fmt.Errorf("getting available platforms: %w", err)
+		}
+
+		platforms = matchPlatform(targetPlatform, platforms)
+		if len(platforms) == 0 {
+			return fmt.Errorf("unable to find an SBOM for %s", targetPlatform.String())
+		}
+		if len(platforms) > 1 {
+			return fmt.Errorf(
+				"platform spec matches more than one image architecture: %s",
+				platforms.String(),
+			)
+		}
+
+		nse, err := idx.SignedImage(platforms[0].hash)
+		if err != nil {
+			return fmt.Errorf("searching for %s image: %w", platforms[0].hash.String(), err)
+		}
+		if nse == nil {
+			return fmt.Errorf("unable to find image %s", platforms[0].hash.String())
+		}
+		se = nse
+	}
+
+	attestations, err := cosign.FetchAttestations(se, predicateType)
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -70,7 +70,7 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 
 		platforms = matchPlatform(targetPlatform, platforms)
 		if len(platforms) == 0 {
-			return fmt.Errorf("unable to find an SBOM for %s", targetPlatform.String())
+			return fmt.Errorf("unable to find an attestation for %s", targetPlatform.String())
 		}
 		if len(platforms) > 1 {
 			return fmt.Errorf(

--- a/cmd/cosign/cli/options/download.go
+++ b/cmd/cosign/cli/options/download.go
@@ -24,6 +24,7 @@ type SBOMDownloadOptions struct {
 
 type AttestationDownloadOptions struct {
 	PredicateType string // Predicate type of attestation to retrieve
+	Platform      string // Platform to download attestations
 }
 
 var _ Interface = (*SBOMDownloadOptions)(nil)
@@ -40,4 +41,6 @@ func (o *SBOMDownloadOptions) AddFlags(cmd *cobra.Command) {
 func (o *AttestationDownloadOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.PredicateType, "predicate-type", "",
 		"download attestation with matching predicateType annotation")
+	cmd.Flags().StringVar(&o.Platform, "platform", "",
+		"download attestation for a specific platform image")
 }

--- a/doc/cosign_download_attestation.md
+++ b/doc/cosign_download_attestation.md
@@ -20,6 +20,7 @@ cosign download attestation [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for attestation
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --platform string                                                                          download attestation for a specific platform image
       --predicate-type string                                                                    download attestation with matching predicateType annotation
 ```
 


### PR DESCRIPTION
Similar to https://github.com/sigstore/cosign/issues/2356

#### Summary

`cosign download sbom` accepts a `--platform` flag, which chooses a platform when the provided image ref is a multi-arch image. This change adds the same support to `cosign download attestation`, using the same code and semantics.

Before:

```
cosign download attestation --predicate-type="https://spdx.dev/Document" cgr.dev/chainguard/git | jq -r '.payload' | base64 -d | jq -r '.predicate.packages[].SPDXID'
SPDXRef-Package-sha256-9d9fd8ecc9cf80c7aabd83be201b9065a09557d8e1a66d4bd8e2dbeade2c1c28
SPDXRef-Package-sha256-c28b09fd03e2fd1a4332c37062e46aa4a7a3a8755ffd78d1f7d38d80f180b70b
SPDXRef-Package-sha256-59b2854e4a3b25cdd038f3f596cbf79d9ee79ba4a82b154f396170db89264657
SPDXRef-Package-sha256-ebb516bbdb1757401bb866e4949c682e2e471113d09801170d8f798acb50aaca
SPDXRef-Package-sha256-a06b5339d37bae4d2311a68e34f94445d2709a6020595a820aa3bd4ca09aa04a
SPDXRef-Package-sha256-ebf3034b3b122f06b5f2921043a75da0c8098cae8d536401bd2014ffb90ace6d
SPDXRef-Package-sha256-29ed835d586d284e3c67eefedd77cddf844eb5a2baffc3cbf1ec5effa0ace21c
SPDXRef-Package-sha256-a043cc5723dada67915371df09674687cc8a6cde6961d6e216f7639351e0fbad
SPDXRef-Package-sha256-173c078001ecad8fbd94970ecb6dab6ea07131d3b9590ed697fe7604ead5d92b
SPDXRef-Package-https-C47C47github.comC47chainguard-imagesC47imagesC6467e49fd819fde6e6508f5a24851c10b8595c23ad
```

(this could only tell you the attestation of the multi-platform index, which contains its sub-images)

After:

```
go run ./cmd/cosign download attestation --platform=linux/amd64 --predicate-type="https://spdx.dev/Document" cgr.dev/chainguard/git | jq -r '.payload' | base64 -d | jq -r '.predicate.packages[].SPDXID'
SPDXRef-Package-sha256-59b2854e4a3b25cdd038f3f596cbf79d9ee79ba4a82b154f396170db89264657
SPDXRef-Package-https-C47C47github.comC47chainguard-imagesC47imagesC6467e49fd819fde6e6508f5a24851c10b8595c23ad
SPDXRef-Package-sha256-c2cd62db799e0c1ea4deda34c6665b3a50fbf9d898ec841d02cd54859144c344
SPDXRef-Package-SPDXRef-Package-sha256-c2cd62db799e0c1ea4deda34c6665b3a50fbf9d898ec841d02cd54859144c344-alpine-baselayout-data-3.4.3-r1
SPDXRef-Package-SPDXRef-Package-sha256-c2cd62db799e0c1ea4deda34c6665b3a50fbf9d898ec841d02cd54859144c344-alpine-keys-2.4-r1
SPDXRef-Package-SPDXRef-Package-sha256-c2cd62db799e0c1ea4deda34c6665b3a50fbf9d898ec841d02cd54859144c344-alpine-release-3.18.0-r0
SPDXRef-Package-SPDXRef-Package-sha256-c2cd62db799e0c1ea4deda34c6665b3a50fbf9d898ec841d02cd54859144c344-ca-certificates-bundle-20230506-r0
SPDXRef-Package-SPDXRef-Package-sha256-c2cd62db799e0c1ea4deda34c6665b3a50fbf9d898ec841d02cd54859144c344-musl-1.2.4-r0
...
```

(this can tell you the attested contents of a specific image within the multi-platform index)

#### Release Note

* Added `--platform` flag to `cosign download attestation`

#### Documentation

`--help` output and generated docs include this new flag.