### PR TITLE
Add `sign --sign-container-identity` CLI

### DIFF
--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -21,21 +21,22 @@ import (
 
 // SignOptions is the top level wrapper for the sign command.
 type SignOptions struct {
-	Key               string
-	Cert              string
-	CertChain         string
-	Upload            bool
-	Output            string // deprecated: TODO remove when the output flag is fully deprecated
-	OutputSignature   string // TODO: this should be the root output file arg.
-	OutputPayload     string
-	OutputCertificate string
-	PayloadPath       string
-	Recursive         bool
-	Attachment        string
-	SkipConfirmation  bool
-	TlogUpload        bool
-	TSAServerURL      string
-	IssueCertificate  bool
+	Key                   string
+	Cert                  string
+	CertChain             string
+	Upload                bool
+	Output                string // deprecated: TODO remove when the output flag is fully deprecated
+	OutputSignature       string // TODO: this should be the root output file arg.
+	OutputPayload         string
+	OutputCertificate     string
+	PayloadPath           string
+	Recursive             bool
+	Attachment            string
+	SkipConfirmation      bool
+	TlogUpload            bool
+	TSAServerURL          string
+	IssueCertificate      bool
+	SignContainerIdentity string
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -108,4 +109,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.IssueCertificate, "issue-certificate", false,
 		"issue a code signing certificate from Fulcio, even if a key is provided")
+
+	cmd.Flags().StringVar(&o.SignContainerIdentity, "sign-container-identity", "",
+		"manually set the .critical.docker-reference field for the signed identity, which is useful when image proxies are being used where the pull reference should match the signature")
 }

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -79,7 +79,10 @@ race conditions or (worse) malicious tampering.
   cosign sign --key cosign.key <IMAGE DIGEST>
 
   # sign a container image and skip uploading to the transparency log
-  cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>`,
+  cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
+
+  # sign a container image by manually setting the container image identity
+  cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>`,
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -221,8 +221,9 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	// The payload can be passed to skip generation.
 	if len(payload) == 0 {
 		payload, err = (&sigPayload.Cosign{
-			Image:       digest,
-			Annotations: annotations,
+			Image:           digest,
+			ClaimedIdentity: signOpts.SignContainerIdentity,
+			Annotations:     annotations,
 		}).MarshalJSON()
 		if err != nil {
 			return fmt.Errorf("payload: %w", err)

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -61,6 +61,9 @@ cosign sign [flags]
 
   # sign a container image and skip uploading to the transparency log
   cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
+
+  # sign a container image by manually setting the container image identity
+  cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>
 ```
 
 ### Options
@@ -93,6 +96,7 @@ cosign sign [flags]
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
       --registry-referrers-mode registryReferrersMode                                            mode for fetching references from the registry. allowed: legacy, oci-1-1
       --rekor-url string                                                                         address of rekor STL server (default "https://rekor.sigstore.dev")
+      --sign-container-identity string                                                           manually set the .critical.docker-reference field for the signed identity, which is useful when image proxies are being used where the pull reference should match the signature
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-server-url string                                                              url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.6.0
 	github.com/sigstore/fulcio v1.3.1
 	github.com/sigstore/rekor v1.2.1
-	github.com/sigstore/sigstore v1.6.5
+	github.com/sigstore/sigstore v1.6.6-0.20230602075123-c74dd4383337
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.6.5
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.6.5
 	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.6.5

--- a/go.sum
+++ b/go.sum
@@ -808,8 +808,8 @@ github.com/sigstore/protobuf-specs v0.1.0 h1:X0l/E2C2c79t/rI/lmSu8WAoKWsQtMqDzAM
 github.com/sigstore/protobuf-specs v0.1.0/go.mod h1:5shUCxf82hGnjUEFVWiktcxwzdtn6EfeeJssxZ5Q5HE=
 github.com/sigstore/rekor v1.2.1 h1:cEI4qn9IBvM7EkPQYl3YzCwCw97Mx8O2nHrv02XiI8U=
 github.com/sigstore/rekor v1.2.1/go.mod h1:zcFO54qIg2G1/i0sE/nvmELUOng/n0MPjTszRYByVPo=
-github.com/sigstore/sigstore v1.6.5 h1:/liHIo7YPJp6sN31DzBYDOuRPmN1xbzROMBE5DLllYM=
-github.com/sigstore/sigstore v1.6.5/go.mod h1:h+EoQsf9+6UKgNYxKhBcPgo4PZeEVfzAJxKRRIYhyN4=
+github.com/sigstore/sigstore v1.6.6-0.20230602075123-c74dd4383337 h1:DjwvoCAcj10hgyWFQn+DH/24/zjk/UdN4aPjb2NSyJw=
+github.com/sigstore/sigstore v1.6.6-0.20230602075123-c74dd4383337/go.mod h1:HvxCZNdh85qy1xOrRLCweTJyhUI1foWq9cZw1aEQotk=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.6.5 h1:SXzp0/S2fBT3O45BKBxInJ5zLqPTqN/nJRG9ZU6ZS1o=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.6.5/go.mod h1:iJ1fhlOHajTppwDbFpSrrxvteZcbDt96yOkAQZ3AWdY=
 github.com/sigstore/sigstore/pkg/signature/kms/azure v1.6.5 h1:Eq7FRpCmtWgqO0W8PTV4uEtoLfVOJfDuLYGEwCN1Cy8=


### PR DESCRIPTION
#### Summary
The `--sign-container-identity` flag allows setting the `critical.identity.docker-reference` field in the signature to a different container image reference. This is particularly useful when using proxy mirrors like `registry.k8s.io`, where end-users have no chance to actually assume the underlying registry. This change allows signing images using the mirror/proxy identifier, while validation can then happen without requiring any additional remapping.

Refers to https://github.com/containers/image/issues/1952, https://github.com/sigstore/sigstore/pull/1166
#### Release Note

Added `sign --sign-identity` CLI flag.

#### Documentation
TBD.
