### PR TITLE
Feature: adds '--allow-insecure-registry' for cosign load

### DIFF
--- a/cmd/cosign/cli/load.go
+++ b/cmd/cosign/cli/load.go
@@ -17,12 +17,16 @@ package cli
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/pkg/oci/layout"
-	"github.com/sigstore/cosign/v2/pkg/oci/remote"
+
+	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -45,16 +49,25 @@ func Load() *cobra.Command {
 	return cmd
 }
 
-func LoadCmd(_ context.Context, opts options.LoadOptions, imageRef string) error {
+func LoadCmd(ctx context.Context, opts options.LoadOptions, imageRef string) error {
 	ref, err := name.ParseReference(imageRef)
 	if err != nil {
 		return fmt.Errorf("parsing image name %s: %w", imageRef, err)
 	}
 
+	remoteOpts := []remote.Option{
+		remote.WithContext(ctx),
+		remote.WithUserAgent(options.UserAgent()),
+	}
 	// get the signed image from disk
 	sii, err := layout.SignedImageIndex(opts.Directory)
 	if err != nil {
 		return fmt.Errorf("signed image index: %w", err)
 	}
-	return remote.WriteSignedImageIndexImages(ref, sii)
+
+	if opts.AllowInsecure {
+		remoteOpts = append(remoteOpts, remote.WithTransport(&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}})) // #nosec G402
+	}
+
+	return ociremote.WriteSignedImageIndexImages(ref, sii, ociremote.WithRemoteOptions(remoteOpts...))
 }

--- a/cmd/cosign/cli/options/load.go
+++ b/cmd/cosign/cli/options/load.go
@@ -21,19 +21,17 @@ import (
 
 // LoadOptions is the top level wrapper for the load command.
 type LoadOptions struct {
-	Directory     string
-	AllowInsecure bool
+	Directory string
+	Registry  RegistryOptions
 }
 
 var _ Interface = (*LoadOptions)(nil)
 
 // AddFlags implements Interface
 func (o *LoadOptions) AddFlags(cmd *cobra.Command) {
+	o.Registry.AddFlags(cmd)
 	cmd.Flags().StringVar(&o.Directory, "dir", "",
 		"path to directory where the signed image is stored on disk")
 	_ = cmd.Flags().SetAnnotation("dir", cobra.BashCompSubdirsInDir, []string{})
 	_ = cmd.MarkFlagRequired("dir")
-
-	cmd.Flags().BoolVar(&o.AllowInsecure, "allow-insecure-registry", false,
-		"whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing")
 }

--- a/cmd/cosign/cli/options/load.go
+++ b/cmd/cosign/cli/options/load.go
@@ -21,7 +21,8 @@ import (
 
 // LoadOptions is the top level wrapper for the load command.
 type LoadOptions struct {
-	Directory string
+	Directory     string
+	AllowInsecure bool
 }
 
 var _ Interface = (*LoadOptions)(nil)
@@ -32,4 +33,7 @@ func (o *LoadOptions) AddFlags(cmd *cobra.Command) {
 		"path to directory where the signed image is stored on disk")
 	_ = cmd.Flags().SetAnnotation("dir", cobra.BashCompSubdirsInDir, []string{})
 	_ = cmd.MarkFlagRequired("dir")
+
+	cmd.Flags().BoolVar(&o.AllowInsecure, "allow-insecure-registry", false,
+		"whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing")
 }

--- a/doc/cosign_load.md
+++ b/doc/cosign_load.md
@@ -19,9 +19,12 @@ cosign load [flags]
 ### Options
 
 ```
-      --allow-insecure-registry   whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
-      --dir string                path to directory where the signed image is stored on disk
-  -h, --help                      help for load
+      --allow-http-registry                                                                      whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
+      --allow-insecure-registry                                                                  whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
+      --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --dir string                                                                               path to directory where the signed image is stored on disk
+  -h, --help                                                                                     help for load
+      --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_load.md
+++ b/doc/cosign_load.md
@@ -19,8 +19,9 @@ cosign load [flags]
 ### Options
 
 ```
-      --dir string   path to directory where the signed image is stored on disk
-  -h, --help         help for load
+      --allow-insecure-registry   whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
+      --dir string                path to directory where the signed image is stored on disk
+  -h, --help                      help for load
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
According to the issue #2986, we need in certain cases like that of "Tactical edge deployments for the Government",  to 'load' an image to a registry that is had either NO tls cert, for the ability to tell cosign to ignore the cert, or use http instead. 
This PR fixes #2986 
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note

`cosign load` was added with `--allow-insecure-registry` to disable TLS verification when interacting with insecure (e.g. self-signed) container registries

<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
Yes, added it in the github docs
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
