### PR TITLE
Allow to fetch signatures by signed entity.

### DIFF
--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -65,12 +65,15 @@ const (
 )
 
 func FetchSignaturesForReference(_ context.Context, ref name.Reference, opts ...ociremote.Option) ([]SignedPayload, error) {
-	simg, err := ociremote.SignedEntity(ref, opts...)
+	se, err := ociremote.SignedEntity(ref, opts...)
 	if err != nil {
 		return nil, err
 	}
+	return FetchSignatures(se)
+}
 
-	sigs, err := simg.Signatures()
+func FetchSignatures(se oci.SignedEntity) ([]SignedPayload, error) {
+	sigs, err := se.Signatures()
 	if err != nil {
 		return nil, fmt.Errorf("remote image: %w", err)
 	}
@@ -79,7 +82,7 @@ func FetchSignaturesForReference(_ context.Context, ref name.Reference, opts ...
 		return nil, fmt.Errorf("fetching signatures: %w", err)
 	}
 	if len(l) == 0 {
-		return nil, fmt.Errorf("no signatures associated with %s", ref)
+		return nil, fmt.Errorf("no signatures found")
 	}
 
 	signatures := make([]SignedPayload, len(l))


### PR DESCRIPTION
#### Summary

When using cosign as a dependency and attempting to fetch signatures for a specific signed entity, the signed entity is always fetched from the registry.

In case the signed entity has been fetched previously, it'd be nice to introduce a function similar to the `FetchAttestations` that allows to fetch signatures from the signed entity directly, without reaching out to the registry to fetch the signed entity beforehand.

With the current changes in the PR, the error will now not include the reference anymore. However, the changes were also made to `FetchAttestations` in the same way.
If we want to include this information, we may wrap the returned error from `FetchAttestations/FetchSignatures` with  the reference, so the content of the error will stay the same.

#### Release Note

NONE

