### PR TITLE
Beautify help flags

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -26,6 +26,7 @@ import (
 
 	cranecmd "github.com/google/go-containerregistry/cmd/crane/cmd"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/templates"
 	cobracompletefig "github.com/withfig/autocomplete-tools/integrations/cobra"
 )
 
@@ -87,6 +88,8 @@ func New() *cobra.Command {
 		},
 	}
 	ro.AddFlags(cmd)
+
+	templates.SetCustomUsage(cmd)
 
 	// Add sub-commands.
 	cmd.AddCommand(Attach())

--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -89,7 +89,7 @@ func New() *cobra.Command {
 	}
 	ro.AddFlags(cmd)
 
-	templates.SetCustomUsage(cmd)
+	templates.SetCustomUsageFunc(cmd)
 
 	// Add sub-commands.
 	cmd.AddCommand(Attach())

--- a/cmd/cosign/cli/templates/help_flags_printer.go
+++ b/cmd/cosign/cli/templates/help_flags_printer.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package templates
 
 import (

--- a/cmd/cosign/cli/templates/help_flags_printer.go
+++ b/cmd/cosign/cli/templates/help_flags_printer.go
@@ -1,0 +1,77 @@
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/mitchellh/go-wordwrap"
+	flag "github.com/spf13/pflag"
+)
+
+const offset = 10
+
+// HelpFlagPrinter is a printer that
+// processes the help flag and print
+// it to i/o writer
+type HelpFlagPrinter struct {
+	wrapLimit uint
+	out       io.Writer
+}
+
+// NewHelpFlagPrinter will initialize a HelpFlagPrinter given the
+// i/o writer
+func NewHelpFlagPrinter(out io.Writer, wrapLimit uint) *HelpFlagPrinter {
+	return &HelpFlagPrinter{
+		wrapLimit: wrapLimit,
+		out:       out,
+	}
+}
+
+// PrintHelpFlag will beautify the help flags and print it out to p.out
+func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
+	formatBuf := new(bytes.Buffer)
+	writeFlag(formatBuf, flag)
+
+	wrappedStr := formatBuf.String()
+	flagAndUsage := strings.Split(formatBuf.String(), "\n")
+	flagStr := flagAndUsage[0]
+
+	// if the flag usage is longer than one line, wrap it again
+	if len(flagAndUsage) > 1 {
+		nextLines := strings.Join(flagAndUsage[1:], " ")
+		wrappedUsages := wordwrap.WrapString(nextLines, p.wrapLimit-offset)
+		wrappedStr = flagStr + "\n" + wrappedUsages
+	}
+	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")
+
+	fmt.Fprintf(p.out, appendTabStr+"\n\n")
+}
+
+// writeFlag will output the help flag based
+// on the format provided by getFlagFormat to i/o writer
+func writeFlag(out io.Writer, f *flag.Flag) {
+	deprecated := ""
+	if f.Deprecated != "" {
+		deprecated = fmt.Sprintf(" (DEPRECATED: %s)", f.Deprecated)
+	}
+	fmt.Fprintf(out, getFlagFormat(f), f.Shorthand, f.Name, f.DefValue, f.Usage, deprecated)
+}
+
+// getFlagFormat will output the flag format
+func getFlagFormat(f *flag.Flag) string {
+	var format string
+	format = "--%s=%s:\n%s%s"
+	if f.Value.Type() == "string" {
+		format = "--%s='%s':\n%s%s"
+	}
+
+	if len(f.Shorthand) > 0 {
+		format = "    -%s, " + format
+	} else {
+		format = "    %s" + format
+	}
+
+	return format
+}

--- a/cmd/cosign/cli/templates/templater.go
+++ b/cmd/cosign/cli/templates/templater.go
@@ -3,8 +3,8 @@ package templates
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"strings"
+	"text/template"
 	"unicode"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/templates/term"
@@ -21,14 +21,15 @@ func SetCustomUsage(cmd *cobra.Command) {
 	if cmd == nil {
 		panic("nil root command")
 	}
-	templater := &templater{
+	t := &templater{
 		RootCmd:       cmd,
 		UsageTemplate: MainUsageTemplate(),
 	}
-	cmd.SetUsageFunc(templater.UsageFunc())
+
+	cmd.SetUsageFunc(t.UsageFunc())
 }
 
-func (templater *templater) UsageFunc(exposedFlags ...string) func(*cobra.Command) error {
+func (templater *templater) UsageFunc() func(*cobra.Command) error {
 	return func(c *cobra.Command) error {
 		t := template.New("usage")
 		t.Funcs(templater.templateFuncs())

--- a/cmd/cosign/cli/templates/templater.go
+++ b/cmd/cosign/cli/templates/templater.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package templates
 
 import (

--- a/cmd/cosign/cli/templates/templater.go
+++ b/cmd/cosign/cli/templates/templater.go
@@ -17,7 +17,7 @@ type templater struct {
 	RootCmd       *cobra.Command
 }
 
-func SetCustomUsage(cmd *cobra.Command) {
+func SetCustomUsageFunc(cmd *cobra.Command) {
 	if cmd == nil {
 		panic("nil root command")
 	}

--- a/cmd/cosign/cli/templates/templater.go
+++ b/cmd/cosign/cli/templates/templater.go
@@ -1,0 +1,89 @@
+package templates
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"strings"
+	"unicode"
+
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/templates/term"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+)
+
+type templater struct {
+	UsageTemplate string
+	RootCmd       *cobra.Command
+}
+
+func SetCustomUsage(cmd *cobra.Command) {
+	if cmd == nil {
+		panic("nil root command")
+	}
+	templater := &templater{
+		RootCmd:       cmd,
+		UsageTemplate: MainUsageTemplate(),
+	}
+	cmd.SetUsageFunc(templater.UsageFunc())
+}
+
+func (templater *templater) UsageFunc(exposedFlags ...string) func(*cobra.Command) error {
+	return func(c *cobra.Command) error {
+		t := template.New("usage")
+		t.Funcs(templater.templateFuncs())
+		template.Must(t.Parse(templater.UsageTemplate))
+		out := term.NewResponsiveWriter(c.OutOrStderr())
+		return t.Execute(out, c)
+	}
+}
+
+func (templater *templater) templateFuncs() template.FuncMap {
+	return template.FuncMap{
+		"trim":                    strings.TrimSpace,
+		"trimRightSpace":          trimRightSpace,
+		"trimTrailingWhitespaces": trimRightSpace,
+		"appendIfNotPresent":      appendIfNotPresent,
+		"rpad":                    rpad,
+		"gt":                      cobra.Gt,
+		"eq":                      cobra.Eq,
+		"flagsUsages":             flagsUsages,
+	}
+}
+
+func trimRightSpace(s string) string {
+	return strings.TrimRightFunc(s, unicode.IsSpace)
+}
+
+// appendIfNotPresent will append stringToAppend to the end of s, but only if it's not yet present in s.
+func appendIfNotPresent(s, stringToAppend string) string {
+	if strings.Contains(s, stringToAppend) {
+		return s
+	}
+	return s + " " + stringToAppend
+}
+
+// rpad adds padding to the right of a string.
+func rpad(s string, padding int) string {
+	template := fmt.Sprintf("%%-%ds", padding)
+	return fmt.Sprintf(template, s)
+}
+
+// flagsUsages will print out the kubectl help flags
+func flagsUsages(f *flag.FlagSet) (string, error) {
+	flagBuf := new(bytes.Buffer)
+	wrapLimit, err := term.GetWordWrapperLimit()
+	if err != nil {
+		return "", err
+	}
+	printer := NewHelpFlagPrinter(flagBuf, wrapLimit)
+
+	f.VisitAll(func(flag *flag.Flag) {
+		if flag.Hidden {
+			return
+		}
+		printer.PrintHelpFlag(flag)
+	})
+
+	return flagBuf.String(), nil
+}

--- a/cmd/cosign/cli/templates/templates.go
+++ b/cmd/cosign/cli/templates/templates.go
@@ -24,7 +24,7 @@ Flags:
 {{flagsUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
 Global Flags:
-{{flagsUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
 {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}

--- a/cmd/cosign/cli/templates/templates.go
+++ b/cmd/cosign/cli/templates/templates.go
@@ -1,0 +1,37 @@
+package templates
+
+// References: https://github.com/spf13/cobra/blob/4dd4b25de38418174a6e859e8a32eaccca32dccc/command.go#L539-L567
+const defaultUsageTemplate = `Usage:{{if .Runnable}}
+{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+{{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+{{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{flagsUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{flagsUsages .InheritedFlags | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
+
+func MainUsageTemplate() string {
+	return defaultUsageTemplate
+}

--- a/cmd/cosign/cli/templates/templates.go
+++ b/cmd/cosign/cli/templates/templates.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package templates
 
 // References: https://github.com/spf13/cobra/blob/4dd4b25de38418174a6e859e8a32eaccca32dccc/command.go#L539-L567

--- a/cmd/cosign/cli/templates/term/term_writer.go
+++ b/cmd/cosign/cli/templates/term/term_writer.go
@@ -1,3 +1,17 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package term
 
 import (

--- a/cmd/cosign/cli/templates/term/term_writer.go
+++ b/cmd/cosign/cli/templates/term/term_writer.go
@@ -1,0 +1,103 @@
+package term
+
+import (
+	"errors"
+	"io"
+	"os"
+
+	wordwrap "github.com/mitchellh/go-wordwrap"
+	"github.com/moby/term"
+)
+
+type wordWrapWriter struct {
+	limit  uint
+	writer io.Writer
+}
+
+type TerminalSize struct {
+	Width  uint16
+	Height uint16
+}
+
+// NewResponsiveWriter creates a Writer that detects the column width of the
+// terminal we are in, and adjusts every line width to fit and use recommended
+// terminal sizes for better readability. Does proper word wrapping automatically.
+//
+//	if terminal width >= 120 columns		use 120 columns
+//	if terminal width >= 100 columns		use 100 columns
+//	if terminal width >=  80 columns		use  80 columns
+//
+// In case we're not in a terminal or if it's smaller than 80 columns width,
+// doesn't do any wrapping.
+func NewResponsiveWriter(w io.Writer) io.Writer {
+	file, ok := w.(*os.File)
+	if !ok {
+		return w
+	}
+	fd := file.Fd()
+	if !term.IsTerminal(fd) {
+		return w
+	}
+
+	terminalSize := GetSize(fd)
+	if terminalSize == nil {
+		return w
+	}
+	limit := getTerminalLimitWidth(terminalSize)
+
+	return NewWordWrapWriter(w, limit)
+}
+
+// NewWordWrapWriter is a Writer that supports a limit of characters on every line
+// and does auto word wrapping that respects that limit.
+func NewWordWrapWriter(w io.Writer, limit uint) io.Writer {
+	return &wordWrapWriter{
+		limit:  limit,
+		writer: w,
+	}
+}
+
+func getTerminalLimitWidth(terminalSize *TerminalSize) uint {
+	var limit uint
+	switch {
+	case terminalSize.Width >= 120:
+		limit = 120
+	case terminalSize.Width >= 100:
+		limit = 100
+	case terminalSize.Width >= 80:
+		limit = 80
+	}
+	return limit
+}
+
+// GetSize returns the current size of the terminal associated with fd.
+func GetSize(fd uintptr) *TerminalSize {
+	winsize, err := term.GetWinsize(fd)
+	if err != nil {
+		return nil
+	}
+
+	return &TerminalSize{Width: winsize.Width, Height: winsize.Height}
+}
+
+func GetWordWrapperLimit() (uint, error) {
+	stdout := os.Stdout
+	fd := stdout.Fd()
+	if !term.IsTerminal(fd) {
+		return 0, errors.New("file descriptor is not a terminal")
+	}
+	terminalSize := GetSize(fd)
+	if terminalSize == nil {
+		return 0, errors.New("terminal size is nil")
+	}
+	return getTerminalLimitWidth(terminalSize), nil
+}
+
+func (w wordWrapWriter) Write(p []byte) (nn int, err error) {
+	if w.limit == 0 {
+		return w.writer.Write(p)
+	}
+	original := string(p)
+	wrapped := wordwrap.WrapString(original, w.limit)
+	return w.writer.Write([]byte(wrapped))
+}

--- a/cmd/help/main.go
+++ b/cmd/help/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/templates"
 	errors "github.com/sigstore/cosign/v2/cmd/cosign/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -41,6 +42,9 @@ func main() {
 		},
 	}
 	root.Flags().StringVarP(&dir, "dir", "d", "doc", "Path to directory in which to generate docs")
+
+	templates.SetCustomUsageFunc(root)
+
 	if err := root.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/miekg/pkcs11 v1.1.1
+	github.com/mitchellh/go-wordwrap v1.0.1
+	github.com/moby/term v0.5.0
 	github.com/mozillazg/docker-credential-acr-helper v0.3.0
 	github.com/open-policy-agent/opa v0.52.0
 	github.com/pkg/errors v0.9.1
@@ -70,6 +72,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.29 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.9.22 // indirect
@@ -191,7 +194,6 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/cyberphone/json-canonicalization v0.0.0-20220623050100-57a0ce2678a7 h1:vU+EP9ZuFUCYE0NYLwTSob+3LNEJATzNfP/DC7SWGWI=
 github.com/cyberphone/json-canonicalization v0.0.0-20220623050100-57a0ce2678a7/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
@@ -1159,11 +1160,8 @@ golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-<<<<<<< HEAD
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-=======
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
->>>>>>> Beautify help flags
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0 h1:m/sWOGCREuSBqg2
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0/go.mod h1:Pu5Zksi2KrU7LPbZbNINx6fuVrUp/ffvpxdDj+i8LeE=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 h1:FbH3BbSb4bvGluTesZZ+ttN/MDsnMmQP36OSnDuSXqw=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.6/go.mod h1:V6p3pKZx1KKkJubbxnDWrzNhEIfOy/pTGasLqzHIPHs=
@@ -690,6 +692,8 @@ github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
+github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1155,7 +1159,11 @@ golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+<<<<<<< HEAD
 golang.org/x/sys v0.0.0-20210616045830-e2b7044e8c71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+=======
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+>>>>>>> Beautify help flags
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
Closes https://github.com/sigstore/cosign/issues/2887

Before:
```bash
Attest the supplied blob.

Usage:
  cosign attest-blob [flags]

Examples:
  cosign attest-blob --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--f] [--r] <BLOB uri>

  # attach an attestation to a blob with a local key pair file and print the attestation
  cosign attest-blob --predicate <FILE> --type <TYPE> --key cosign.key --output-attestation <path> <BLOB>

  # attach an attestation to a blob with a key pair stored in Azure Key Vault
  cosign attest-blob --predicate <FILE> --type <TYPE> --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <BLOB>

  # attach an attestation to a blob with a key pair stored in AWS KMS
  cosign attest-blob --predicate <FILE> --type <TYPE> --key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <BLOB>

  # attach an attestation to a blob with a key pair stored in Google Cloud KMS
  cosign attest-blob --predicate <FILE> --type <TYPE> --key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]/versions/[VERSION] <BLOB>

  # attach an attestation to a blob with a key pair stored in Hashicorp Vault
  cosign attest-blob --predicate <FILE> --type <TYPE> --key hashivault://[KEY] <BLOB>

Flags:
      --bundle string                     write everything required to verify the blob to a FILE
      --certificate string                path to the X.509 certificate in PEM format to include in the OCI Signature
      --certificate-chain string          path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Included in the OCI Signature
      --fulcio-url string                 address of sigstore PKI server (default "https://fulcio.sigstore.dev")
      --hash string                       hash of blob in hexadecimal (base16). Used if you want to sign an artifact stored elsewhere and have the hash
  -h, --help                              help for attest-blob
      --identity-token string             identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
      --insecure-skip-verify              skip verifying fulcio published to the SCT (this should only be used for testing).
      --key string                        path to the private key file, KMS URI or Kubernetes Secret
      --oidc-client-id string             OIDC client ID for application (default "sigstore")
      --oidc-client-secret-file string    Path to file containing OIDC client secret for application
      --oidc-disable-ambient-providers    Disable ambient OIDC providers. When true, ambient credentials will not be read
      --oidc-issuer string                OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
      --oidc-provider string              Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github, filesystem, buildkite-agent]
      --oidc-redirect-url string          OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
      --output-attestation string         write the attestation to FILE
      --output-certificate string         write the certificate to FILE
      --output-signature string           write the signature to FILE
      --predicate string                  path to the predicate file.
      --rekor-url string                  address of rekor STL server (default "https://rekor.sigstore.dev")
      --rfc3161-timestamp-bundle string   path to an RFC 3161 timestamp bundle FILE
      --sk                                whether to use a hardware security key
      --slot string                       security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
      --timestamp-server-url string       url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr
      --tlog-upload                       whether or not to upload to the tlog (default true)
      --type string                       specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
  -y, --yes                               skip confirmation prompts for non-destructive operations

Global Flags:
      --output-file string   log output to a file
  -t, --timeout duration     timeout for commands (default 3m0s)
  -d, --verbose              log debug output
```

After 
```bash

 Attest the supplied blob.

Usage:
cosign attest-blob [flags]

Examples:
  cosign attest-blob --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--f] [--r] <BLOB uri>

  # attach an attestation to a blob with a local key pair file and print the attestation
  cosign attest-blob --predicate <FILE> --type <TYPE> --key cosign.key --output-attestation <path> <BLOB>

  # attach an attestation to a blob with a key pair stored in Azure Key Vault
  cosign attest-blob --predicate <FILE> --type <TYPE> --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <BLOB>

  # attach an attestation to a blob with a key pair stored in AWS KMS
  cosign attest-blob --predicate <FILE> --type <TYPE> --key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <BLOB>

  # attach an attestation to a blob with a key pair stored in Google Cloud KMS
  cosign attest-blob --predicate <FILE> --type <TYPE> --key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]/versions/[VERSION] <BLOB>

  # attach an attestation to a blob with a key pair stored in Hashicorp Vault
  cosign attest-blob --predicate <FILE> --type <TYPE> --key hashivault://[KEY] <BLOB>

Flags:
    --bundle='':
        write everything required to verify the blob to a FILE

    --certificate='':
        path to the X.509 certificate in PEM format to include in the OCI Signature

    --certificate-chain='':
        path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain
        for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate
        and end with the root certificate. Included in the OCI Signature

    --fulcio-url='https://fulcio.sigstore.dev':
        address of sigstore PKI server

    --hash='':
        hash of blob in hexadecimal (base16). Used if you want to sign an artifact stored elsewhere and have the hash

    -h, --help=false:
        help for attest-blob

    --identity-token='':
        identity token to use for certificate from fulcio. the token or a path to a file containing the token is
        accepted.

    --insecure-skip-verify=false:
        skip verifying fulcio published to the SCT (this should only be used for testing).

    --key='':
        path to the private key file, KMS URI or Kubernetes Secret

    --oidc-client-id='sigstore':
        OIDC client ID for application

    --oidc-client-secret-file='':
        Path to file containing OIDC client secret for application

    --oidc-disable-ambient-providers=false:
        Disable ambient OIDC providers. When true, ambient credentials will not be read

    --oidc-issuer='https://oauth2.sigstore.dev/auth':
        OIDC provider to be used to issue ID token

    --oidc-provider='':
        Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options
        include: [spiffe, google, github, filesystem, buildkite-agent]

    --oidc-redirect-url='':
        OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.

    --output-attestation='':
        write the attestation to FILE

    --output-certificate='':
        write the certificate to FILE

    --output-signature='':
        write the signature to FILE

    --predicate='':
        path to the predicate file.

    --rekor-url='https://rekor.sigstore.dev':
        address of rekor STL server

    --rfc3161-timestamp-bundle='':
        path to an RFC 3161 timestamp bundle FILE

    --sk=false:
        whether to use a hardware security key

    --slot='':
        security key slot to use for generated key (default: signature)
        (authentication|signature|card-authentication|key-management)

    --timestamp-server-url='':
        url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses,
        e.g. https://freetsa.org/tsr

    --tlog-upload=true:
        whether or not to upload to the tlog

    --type='custom':
        specify a predicate type (slsaprovenance|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI

    -y, --yes=false:
        skip confirmation prompts for non-destructive operations

Global Flags:
      --output-file string   log output to a file
  -t, --timeout duration     timeout for commands (default 3m0s)
  -d, --verbose              log debug output
```

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Beautify the help flags

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Beautify the help flags with custom printers
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
None