### PR TITLE
accepts `attachment-tag-prefix` for `cosign copy`

### DIFF
--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -109,6 +109,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 		// Copy the entity itself.
 		g.Go(func() error {
 			dst := dstRepoRef.Tag(srcDigest.Identifier())
+			dst = dst.Tag(normalize(h, regOpts.RefOpts.TagPrefix, ""))
 			return remoteCopy(ctx, pusher, srcDigest, dst, force, remoteOpts...)
 		})
 
@@ -167,4 +168,11 @@ func remoteCopy(ctx context.Context, pusher *remote.Pusher, src, dest name.Refer
 
 	fmt.Fprintf(os.Stderr, "Copying %s to %s...\n", src, dest)
 	return pusher.Push(ctx, dest, got)
+}
+
+func normalize(h v1.Hash, prefix string, suffix string) string {
+	if suffix == "" {
+		return fmt.Sprint(prefix, h.Algorithm, "-", h.Hex)
+	}
+	return fmt.Sprint(prefix, h.Algorithm, "-", h.Hex, ".", suffix)
 }

--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -109,7 +109,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 		// Copy the entity itself.
 		g.Go(func() error {
 			dst := dstRepoRef.Tag(srcDigest.Identifier())
-			dst = dst.Tag(normalize(h, regOpts.RefOpts.TagPrefix, ""))
+			dst = dst.Tag(fmt.Sprint(regOpts.RefOpts.TagPrefix, h.Algorithm, "-", h.Hex))
 			return remoteCopy(ctx, pusher, srcDigest, dst, force, remoteOpts...)
 		})
 
@@ -168,11 +168,4 @@ func remoteCopy(ctx context.Context, pusher *remote.Pusher, src, dest name.Refer
 
 	fmt.Fprintf(os.Stderr, "Copying %s to %s...\n", src, dest)
 	return pusher.Push(ctx, dest, got)
-}
-
-func normalize(h v1.Hash, prefix string, suffix string) string {
-	if suffix == "" {
-		return fmt.Sprint(prefix, h.Algorithm, "-", h.Hex)
-	}
-	return fmt.Sprint(prefix, h.Algorithm, "-", h.Hex, ".", suffix)
 }

--- a/cmd/cosign/cli/copy/copy_test.go
+++ b/cmd/cosign/cli/copy/copy_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 the Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package copy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
+)
+
+func TestCopyAttachmentTagPrefix(t *testing.T) {
+	ctx := context.Background()
+
+	refOpts := options.ReferenceOptions{
+		TagPrefix: "test-tag",
+	}
+
+	srcImg := "alpine"
+	destImg := "test-alpine"
+
+	err := CopyCmd(ctx, options.RegistryOptions{
+		RefOpts: refOpts,
+	}, srcImg, destImg, false, true)
+	if err == nil {
+		t.Fatal("failed to copy with attachment-tag-prefix")
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR was created in an attempt that closes #2962 where in the case of `cosign copy`,  `attachment-tag-prefix` was ignored. 
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note

Fixed `cosign copy` ignoring `attachment-tag-prefix` flag
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation

Nope, I guess.
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
