### PR TITLE
Deep inspect attestations when filtering download

### DIFF
--- a/cmd/cosign/cli/options/download.go
+++ b/cmd/cosign/cli/options/download.go
@@ -40,7 +40,7 @@ func (o *SBOMDownloadOptions) AddFlags(cmd *cobra.Command) {
 // AddFlags implements Interface
 func (o *AttestationDownloadOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.PredicateType, "predicate-type", "",
-		"download attestation with matching predicateType annotation")
+		"download attestation with matching predicateType")
 	cmd.Flags().StringVar(&o.Platform, "platform", "",
 		"download attestation for a specific platform image")
 }

--- a/doc/cosign_download_attestation.md
+++ b/doc/cosign_download_attestation.md
@@ -21,7 +21,7 @@ cosign download attestation [flags]
   -h, --help                                                                                     help for attestation
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --platform string                                                                          download attestation for a specific platform image
-      --predicate-type string                                                                    download attestation with matching predicateType annotation
+      --predicate-type string                                                                    download attestation with matching predicateType
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Resolves https://github.com/sigstore/cosign/issues/3030 by inspecting the attestation payload when filtering by predicate type. See additional context there.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

```
Fix predicate type filtering in `cosign download attestation` command.
```

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Updated the command docs to no longer mention the predicate type is fetched from annotations.
