### PR TITLE
Make predicate a required flag in attest commands

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -55,7 +55,10 @@ func Attest() *cobra.Command {
   cosign attest --predicate <FILE> --type <TYPE> --key cosign.key --cert cosign.crt --cert-chain chain.crt <IMAGE>
 
   # attach an attestation to a container image which does not fully support OCI media types
-  COSIGN_DOCKER_MEDIA_TYPES=1 cosign attest --predicate <FILE> --type <TYPE> --key cosign.key legacy-registry.example.com/my/image`,
+  COSIGN_DOCKER_MEDIA_TYPES=1 cosign attest --predicate <FILE> --type <TYPE> --key cosign.key legacy-registry.example.com/my/image
+
+  # supply attestation via stdin
+  echo <PAYLOAD> | cosign attest --predicate - <IMAGE>`,
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -71,6 +71,10 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 		return &options.KeyParseError{}
 	}
 
+	if c.PredicatePath == "" {
+		return fmt.Errorf("predicate cannot be empty")
+	}
+
 	if c.Timeout != 0 {
 		var cancelFn context.CancelFunc
 		ctx, cancelFn = context.WithTimeout(ctx, c.Timeout)
@@ -107,10 +111,9 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 		hexDigest = c.ArtifactHash
 	}
 
-	fmt.Fprintln(os.Stderr, "Using predicate from:", c.PredicatePath)
-	predicate, err := os.Open(c.PredicatePath)
+	predicate, err := predicateReader(c.PredicatePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("getting predicate reader: %w", err)
 	}
 	defer predicate.Close()
 

--- a/cmd/cosign/cli/attest/common.go
+++ b/cmd/cosign/cli/attest/common.go
@@ -1,0 +1,35 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attest
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func predicateReader(predicatePath string) (io.ReadCloser, error) {
+	if predicatePath == "-" {
+		fmt.Fprintln(os.Stderr, "Using payload from: standard input")
+		return os.Stdin, nil
+	}
+
+	fmt.Fprintln(os.Stderr, "Using payload from:", predicatePath)
+	f, err := os.Open(predicatePath)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}

--- a/cmd/cosign/cli/attest/common_test.go
+++ b/cmd/cosign/cli/attest/common_test.go
@@ -57,6 +57,10 @@ func TestPredicateReader(t *testing.T) {
 			}
 
 			got, err := predicateReader(pf)
+			if err == nil {
+				defer got.Close()
+			}
+
 			if tc.wantErr {
 				require.Error(t, err)
 				return

--- a/cmd/cosign/cli/attest/common_test.go
+++ b/cmd/cosign/cli/attest/common_test.go
@@ -1,0 +1,74 @@
+// Copyright 2023 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attest
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPredicateReader(t *testing.T) {
+	cases := []struct {
+		name       string
+		path       string
+		wantErr    bool
+		wantStdin  bool
+		createFile bool
+	}{
+		{
+			name:      "standard input",
+			path:      "-",
+			wantStdin: true,
+		},
+		{
+			name:       "regular file",
+			path:       "payload.json",
+			createFile: true,
+		},
+		{
+			name:    "missing file",
+			path:    "payload.json",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pf := tc.path
+			if tc.createFile {
+				pf = path.Join(t.TempDir(), tc.path)
+				err := os.WriteFile(pf, []byte("payload"), 0644)
+				require.NoError(t, err)
+			}
+
+			got, err := predicateReader(pf)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tc.wantStdin {
+				require.Same(t, os.Stdin, got)
+			} else {
+				require.NotSame(t, os.Stdin, got)
+			}
+		})
+	}
+}

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -42,7 +42,10 @@ func AttestBlob() *cobra.Command {
   cosign attest-blob --predicate <FILE> --type <TYPE> --key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY]/versions/[VERSION] <BLOB>
 
   # attach an attestation to a blob with a key pair stored in Hashicorp Vault
-  cosign attest-blob --predicate <FILE> --type <TYPE> --key hashivault://[KEY] <BLOB>`,
+  cosign attest-blob --predicate <FILE> --type <TYPE> --key hashivault://[KEY] <BLOB>
+
+  # supply attestation via stdin
+  echo <PAYLOAD> | cosign attest-blob --predicate - --yes`,
 
 		Args:             cobra.ExactArgs(1),
 		PersistentPreRun: options.BindViper,

--- a/cmd/cosign/cli/options/predicate.go
+++ b/cmd/cosign/cli/options/predicate.go
@@ -87,6 +87,7 @@ func (o *PredicateLocalOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Path, "predicate", "",
 		"path to the predicate file.")
+	_ = cmd.MarkFlagRequired("predicate")
 }
 
 // PredicateRemoteOptions is the wrapper for remote predicate related options.

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -25,6 +25,9 @@ cosign attest-blob [flags]
 
   # attach an attestation to a blob with a key pair stored in Hashicorp Vault
   cosign attest-blob --predicate <FILE> --type <TYPE> --key hashivault://[KEY] <BLOB>
+
+  # supply attestation via stdin
+  echo <PAYLOAD> | cosign attest-blob --predicate - --yes
 ```
 
 ### Options

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -11,7 +11,6 @@ cosign attest [flags]
 ```
   cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <image uri>
 
-
   # attach an attestation to a container image Google sign-in
   cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>
 

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -11,6 +11,7 @@ cosign attest [flags]
 ```
   cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <image uri>
 
+
   # attach an attestation to a container image Google sign-in
   cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>
 
@@ -34,6 +35,9 @@ cosign attest [flags]
 
   # attach an attestation to a container image which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign attest --predicate <FILE> --type <TYPE> --key cosign.key legacy-registry.example.com/my/image
+
+  # supply attestation via stdin
+  echo <PAYLOAD> | cosign attest --predicate - <IMAGE>
 ```
 
 ### Options


### PR DESCRIPTION
#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

The default value for the `predicate` parameter for the `attest` and `attest-blob` commands is an empty string. However, an empty string is not a valid default value for this parameter resulting in an error.

In https://github.com/sigstore/cosign/issues/2937, it was suggested that the default value for this parameter should be `-` (read from stdin). But this results in somewhat odd behavior when stdin is not used.

This commit retains the default value of `""`, but adds the following guardrails:
1. Makes the `--predicate` parameter required.
2. Performs an early check for empty string, and reports an error accordingly.

I also ported the new behavior to the `attest-blob` command.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* `attest-blob` can now read predicate payload from standard input.


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Updated the CLI docs accordingly.
