### PR TITLE
feat: adds no cert found on sig exit code

### DIFF
--- a/cmd/cosign/errors/exit_code_lookup.go
+++ b/cmd/cosign/errors/exit_code_lookup.go
@@ -34,6 +34,10 @@ func LookupExitCodeForError(err interface{ error }) int {
 		return ImageWithoutSignature
 	}
 
+	if noCertificateFoundOnSignature(err) {
+		return NoCertificateFoundOnSignature
+	}
+
 	// we want to return exit code = `1` at this point because there is
 	// no valid exit code found for the error type passed, so we default to 1.
 	return 1
@@ -52,4 +56,9 @@ func imageTagNotFoundError(err interface{ error }) bool {
 func noSignaturesFoundError(err interface{ error }) bool {
 	var errNoSignaturesFound *cosignError.ErrNoSignaturesFound
 	return errors.As(err, &errNoSignaturesFound)
+}
+
+func noCertificateFoundOnSignature(err interface{ error }) bool {
+	var errNoCertificateFoundOnSignature *cosignError.ErrNoCertificateFoundOnSignature
+	return errors.As(err, &errNoCertificateFoundOnSignature)
 }

--- a/cmd/cosign/errors/exit_codes.go
+++ b/cmd/cosign/errors/exit_codes.go
@@ -33,3 +33,6 @@ const NonExistentTag = 11
 
 // Error verifying image due to no matching signature
 const NoMatchingSignature = 12
+
+// Error verifying image due to no certificate found on signature
+const NoCertificateFoundOnSignature = 13

--- a/doc/cosign_exit_codes.md
+++ b/doc/cosign_exit_codes.md
@@ -7,3 +7,4 @@
 | 10 | Error verifying image due to no signature|
 | 11 | Error verifying image due to non-existent tag|
 | 12 | Error verifying image due to no matching signature|
+| 13 | Error verifying image due to no certificate found on signature|

--- a/pkg/cosign/errors.go
+++ b/pkg/cosign/errors.go
@@ -67,3 +67,11 @@ type ErrNoMatchingAttestations struct {
 func (e *ErrNoMatchingAttestations) Error() string {
 	return e.err.Error()
 }
+
+type ErrNoCertificateFoundOnSignature struct {
+	err error
+}
+
+func (e *ErrNoCertificateFoundOnSignature) Error() string {
+	return e.err.Error()
+}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -689,8 +689,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 			return false, err
 		}
 		if cert == nil {
-			// TODO: add error type instead of blank string
-			return false, ThrowError(&VerificationFailure{
+			return false, ThrowError(&ErrNoCertificateFoundOnSignature{
 				fmt.Errorf("no certificate found on signature"),
 			})
 		}


### PR DESCRIPTION
Adds the exit code and error type for when no certificate is found on a signature is thrown during verification.

Signed-off-by: ChrisJBurns <29541485+ChrisJBurns@users.noreply.github.com>
