### PR TITLE
fix: prefer GitHub OIDC provider if enabled

### DIFF
--- a/pkg/providers/all/all.go
+++ b/pkg/providers/all/all.go
@@ -19,10 +19,15 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/providers"
 
 	// Link in all of the providers.
+	// Link the GitHub one first, since we might be running in a GitHub self-hosted
+	// runner running in one of the other environments, and we should prefer GitHub
+	// credentials if we can find them.
+	_ "github.com/sigstore/cosign/v2/pkg/providers/github"
+
+	// Link in the rest of the providers.
 	_ "github.com/sigstore/cosign/v2/pkg/providers/buildkite"
 	_ "github.com/sigstore/cosign/v2/pkg/providers/envvar"
 	_ "github.com/sigstore/cosign/v2/pkg/providers/filesystem"
-	_ "github.com/sigstore/cosign/v2/pkg/providers/github"
 	_ "github.com/sigstore/cosign/v2/pkg/providers/google"
 	_ "github.com/sigstore/cosign/v2/pkg/providers/spiffe"
 )


### PR DESCRIPTION
We've had reports of unusual behavior in cosign and other tools that use this idiom, when it's used in a GitHub self-hosted runner with `id-token: write` and when the environment it's hosted in _also_ provides ambient OIDC credentials (e.g., GKE).

The issue is that _both_ GitHub's ID token is available, _and_ the GKE environment's credentials are as well. The way this code worked before, and due to Go's map iteration randomization, this code would randomly choose between GitHub and Google credentials, producing ...confusing behavior.

This PR addresses this issue by iterating through providers in the order they were underscore-imported, rather than randomly as the map is iterated. This also changes `pkg/providers/all`* to explicitly order the imports so that `github` comes first, so those credentials are consistently used before any others.

*This is gross. `pkg/providers/all` is gross. It's a dependency bomb, and it should not exist. I'd like to refactor this in a future set of changes to deprecate `all`, and encourage consumers to explicitly import only the providers they want, then do something like https://github.com/sigstore/sigstore/pull/1115 where these providers are split into separate Go modules, so consumers of `cosign` as a library don't have to import all these heavy dependencies. That's a battle for another day though.

Demo that explicit import order changes the order of `init` execution: https://go.dev/play/p/TFqq6BRmLDz

@haydentherapper 