### PR TITLE
Allow overriding remote options

### DIFF
--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -44,6 +44,9 @@ type RegistryOptions struct {
 	KubernetesKeychain bool
 	RefOpts            ReferenceOptions
 	Keychain           Keychain
+
+	// RegistryClientOpts allows overriding the result of GetRegistryClientOpts.
+	RegistryClientOpts []remote.Option
 }
 
 var _ Interface = (*RegistryOptions)(nil)
@@ -86,6 +89,12 @@ func (o *RegistryOptions) NameOptions() []name.Option {
 }
 
 func (o *RegistryOptions) GetRegistryClientOpts(ctx context.Context) []remote.Option {
+	if o.RegistryClientOpts != nil {
+		ropts := o.RegistryClientOpts
+		ropts = append(ropts, remote.WithContext(ctx))
+		return ropts
+	}
+
 	opts := []remote.Option{
 		remote.WithContext(ctx),
 		remote.WithUserAgent(UserAgent()),


### PR DESCRIPTION
RegistryOptions.GetRegistryClientOpts is used in a bunch of places, and it always instantiates a new set of options. This is ~fine for callers that only use the options once (e.g. the cosign CLI), but is unfortunate for callers that would like to reuse those options.

It's useful to reuse these options because they represent a shared context that eliminates a lot of duplicate work across calls (e.g. authenticating with the registry and doing existence checks).