### PR TITLE
Fix pkg/cosign/errors

### DIFF
--- a/pkg/cosign/errors.go
+++ b/pkg/cosign/errors.go
@@ -14,26 +14,21 @@
 
 package cosign
 
+import "fmt"
+
 // VerificationFailure is the type of Go error that is used by cosign to surface
 // errors actually related to verification (vs. transient, misconfiguration,
 // transport, or authentication related issues).
-// It is now marked as deprecated and will be removed in favour of defined
-// error types with use of the ThrowError function.
 type VerificationFailure struct {
 	err error
 }
 
-// ThrowError returns the error type that is passed. It acts as a
-// single consistent way of throwing errors from the pkg level.
-// As long as the error type is defined before hand, this can be
-// used to throw errors up to the calling code without discrimination
-// around the error type.
-func ThrowError(err interface{ error }) error {
-	return err
-}
-
 func (e *VerificationFailure) Error() string {
 	return e.err.Error()
+}
+
+func (e *VerificationFailure) Unwrap() error {
+	return e.err
 }
 
 type ErrNoMatchingSignatures struct {
@@ -44,12 +39,20 @@ func (e *ErrNoMatchingSignatures) Error() string {
 	return e.err.Error()
 }
 
+func (e *ErrNoMatchingSignatures) Unwrap() error {
+	return e.err
+}
+
 type ErrImageTagNotFound struct {
 	err error
 }
 
 func (e *ErrImageTagNotFound) Error() string {
 	return e.err.Error()
+}
+
+func (e *ErrImageTagNotFound) Unwrap() error {
+	return e.err
 }
 
 type ErrNoSignaturesFound struct {
@@ -60,12 +63,20 @@ func (e *ErrNoSignaturesFound) Error() string {
 	return e.err.Error()
 }
 
+func (e *ErrNoSignaturesFound) Unwrap() error {
+	return e.err
+}
+
 type ErrNoMatchingAttestations struct {
 	err error
 }
 
 func (e *ErrNoMatchingAttestations) Error() string {
 	return e.err.Error()
+}
+
+func (e *ErrNoMatchingAttestations) Unwrap() error {
+	return e.err
 }
 
 type ErrNoCertificateFoundOnSignature struct {
@@ -75,3 +86,35 @@ type ErrNoCertificateFoundOnSignature struct {
 func (e *ErrNoCertificateFoundOnSignature) Error() string {
 	return e.err.Error()
 }
+
+func (e *ErrNoCertificateFoundOnSignature) Unwrap() error {
+	return e.err
+}
+
+// NewVerificationError exists for backwards compatibility.
+// Deprecated: see [VerificationFailure].
+func NewVerificationError(msg string, args ...interface{}) error {
+	return &VerificationError{
+		message: fmt.Sprintf(msg, args...),
+	}
+}
+
+// VerificationError exists for backwards compatibility.
+// Deprecated: see [VerificationFailure].
+type VerificationError struct {
+	message string
+}
+
+func (e *VerificationError) Error() string {
+	return e.message
+}
+
+var (
+	// ErrNoMatchingAttestationsMessage exists for backwards compatibility.
+	// Deprecated: see [ErrNoMatchingAttestations].
+	ErrNoMatchingAttestationsMessage = "no matching attestations"
+
+	// ErrNoMatchingAttestationsType exists for backwards compatibility.
+	// Deprecated: see [ErrNoMatchingAttestations].
+	ErrNoMatchingAttestationsType = "NoMatchingAttestations"
+)

--- a/pkg/cosign/errors_test.go
+++ b/pkg/cosign/errors_test.go
@@ -23,8 +23,8 @@ import (
 
 func TestErrors(t *testing.T) {
 	for _, want := range []error{
-		ThrowError(&VerificationFailure{errors.Errorf("not a constant %d", 3)}),
-		ThrowError(&VerificationFailure{errors.Errorf("not a string %s", "i am a string")}),
+		&VerificationFailure{errors.Errorf("not a constant %d", 3)},
+		&VerificationFailure{errors.Errorf("not a string %s", "i am a string")},
 	} {
 		t.Run(want.Error(), func(t *testing.T) {
 			verr := &VerificationFailure{}

--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -22,11 +22,6 @@ func (e *EvaluationFailure) Error() string {
 	return e.err.Error()
 }
 
-// ThrowError returns the error type that is passed. It acts as a
-// single consistent way of throwing errors from the pkg level.
-// As long as the error type is defined before hand, this can be
-// used to throw errors up to the calling code without discrimination
-// around the error type.
-func ThrowError(err interface{ error }) error {
-	return err
+func (e *EvaluationFailure) Unwrap() error {
+	return e.err
 }

--- a/pkg/policy/eval.go
+++ b/pkg/policy/eval.go
@@ -35,16 +35,16 @@ func EvaluatePolicyAgainstJSON(ctx context.Context, name, policyType string, pol
 	case "cue":
 		cueValidationErr := evaluateCue(ctx, jsonBytes, policyBody)
 		if cueValidationErr != nil {
-			return nil, ThrowError(&EvaluationFailure{
+			return nil, &EvaluationFailure{
 				fmt.Errorf("failed evaluating cue policy for %s: %w", name, cueValidationErr),
-			})
+			}
 		}
 	case "rego":
 		regoValidationWarn, regoValidationErr := evaluateRego(ctx, jsonBytes, policyBody)
 		if regoValidationErr != nil {
-			return regoValidationWarn, ThrowError(&EvaluationFailure{
+			return regoValidationWarn, &EvaluationFailure{
 				fmt.Errorf("failed evaluating rego policy for type %s: %w", name, regoValidationErr),
-			})
+			}
 		}
 		// It is possible to return warning messages when the policy is compliant
 		return regoValidationWarn, regoValidationErr


### PR DESCRIPTION
1. Remove ThrowError

This function is the identity function, so it doesn't appear to actually
do anything? Tests pass after deleting it.

2. Unwrap

Errors should implement Unwrap when they wrap another error so that
errors.Is/As will work with it.

3. Don't break policy-controller

This adds back some public symbols that were removed that prevent
policy-controller from bumping its cosign dependency. They are marked
deprecated.

https://github.com/sigstore/policy-controller/blob/b59a2bf7e4f95e2f9126ce8b4d9dd5bcfbd11c9f/pkg/webhook/validator.go#L518
https://github.com/sigstore/policy-controller/blob/b59a2bf7e4f95e2f9126ce8b4d9dd5bcfbd11c9f/pkg/webhook/validator.go#L836
https://github.com/sigstore/policy-controller/blob/b59a2bf7e4f95e2f9126ce8b4d9dd5bcfbd11c9f/pkg/webhook/validator.go#L912
