### PR TITLE
Verify sigs and attestations in parallel

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -597,24 +598,37 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 		}
 	}
 
-	validationErrs := []string{}
+	validationErrs := make([]string, len(sl))
+	signatures := make([]oci.Signature, len(sl))
 
-	for _, sig := range sl {
-		sig, err := static.Copy(sig)
-		if err != nil {
-			validationErrs = append(validationErrs, err.Error())
-			continue
-		}
-		verified, err := VerifyImageSignature(ctx, sig, h, co)
-		bundleVerified = bundleVerified || verified
-		if err != nil {
-			validationErrs = append(validationErrs, err.Error())
-			continue
-		}
+	var wg sync.WaitGroup
 
-		// Phew, we made it.
-		checkedSignatures = append(checkedSignatures, sig)
+	for i, sig := range sl {
+		wg.Add(1)
+		go func(sig oci.Signature, index int) {
+			defer wg.Done()
+			sig, err := static.Copy(sig)
+			if err != nil {
+				validationErrs[index] = err.Error()
+				return
+			}
+			verified, err := VerifyImageSignature(ctx, sig, h, co)
+			bundleVerified = bundleVerified || verified
+			if err != nil {
+				validationErrs[index] = err.Error()
+				return
+			}
+			signatures[index] = sig
+		}(sig, i)
 	}
+	wg.Wait()
+
+	for _, s := range signatures {
+		if s != nil {
+			checkedSignatures = append(checkedSignatures, s)
+		}
+	}
+
 	if len(checkedSignatures) == 0 {
 		// TODO: ErrNoMatchingSignatures.Unwrap should return []error,
 		// or we should replace "...%s" strings.Join with "...%w", errors.Join.
@@ -934,25 +948,39 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 		return nil, false, err
 	}
 
-	validationErrs := []string{}
-	for _, att := range sl {
-		att, err := static.Copy(att)
-		if err != nil {
-			validationErrs = append(validationErrs, err.Error())
-			continue
-		}
-		if err := func(att oci.Signature) error {
-			verified, err := verifyInternal(ctx, att, h, verifyOCIAttestation, co)
-			bundleVerified = bundleVerified || verified
-			return err
-		}(att); err != nil {
-			validationErrs = append(validationErrs, err.Error())
-			continue
-		}
+	validationErrs := make([]string, len(sl))
+	attestations := make([]oci.Signature, len(sl))
 
-		// Phew, we made it.
-		checkedAttestations = append(checkedAttestations, att)
+	var wg sync.WaitGroup
+
+	for i, att := range sl {
+		wg.Add(1)
+		go func(att oci.Signature, index int) {
+			defer wg.Done()
+			att, err := static.Copy(att)
+			if err != nil {
+				validationErrs[index] = err.Error()
+				return
+			}
+			if err := func(att oci.Signature) error {
+				verified, err := verifyInternal(ctx, att, h, verifyOCIAttestation, co)
+				bundleVerified = bundleVerified || verified
+				return err
+			}(att); err != nil {
+				validationErrs[index] = err.Error()
+				return
+			}
+			attestations[index] = att
+		}(att, i)
 	}
+	wg.Wait()
+
+	for _, a := range attestations {
+		if a != nil {
+			checkedAttestations = append(checkedAttestations, a)
+		}
+	}
+
 	if len(checkedAttestations) == 0 {
 		return nil, false, &ErrNoMatchingAttestations{
 			fmt.Errorf("no matching attestations: %s", strings.Join(validationErrs, "\n ")),

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -600,6 +600,7 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 
 	validationErrs := make([]string, len(sl))
 	signatures := make([]oci.Signature, len(sl))
+	bundlesVerified := make([]bool, len(sl))
 
 	var wg sync.WaitGroup
 
@@ -613,7 +614,7 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 				return
 			}
 			verified, err := VerifyImageSignature(ctx, sig, h, co)
-			bundleVerified = bundleVerified || verified
+			bundlesVerified[index] = verified
 			if err != nil {
 				validationErrs[index] = err.Error()
 				return
@@ -627,6 +628,10 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 		if s != nil {
 			checkedSignatures = append(checkedSignatures, s)
 		}
+	}
+
+	for _, verified := range bundlesVerified {
+		bundleVerified = bundleVerified || verified
 	}
 
 	if len(checkedSignatures) == 0 {
@@ -950,6 +955,7 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 
 	validationErrs := make([]string, len(sl))
 	attestations := make([]oci.Signature, len(sl))
+	bundlesVerified := make([]bool, len(sl))
 
 	var wg sync.WaitGroup
 
@@ -964,7 +970,7 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 			}
 			if err := func(att oci.Signature) error {
 				verified, err := verifyInternal(ctx, att, h, verifyOCIAttestation, co)
-				bundleVerified = bundleVerified || verified
+				bundlesVerified[index] = verified
 				return err
 			}(att); err != nil {
 				validationErrs[index] = err.Error()
@@ -979,6 +985,10 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 		if a != nil {
 			checkedAttestations = append(checkedAttestations, a)
 		}
+	}
+
+	for _, verified := range bundlesVerified {
+		bundleVerified = bundleVerified || verified
 	}
 
 	if len(checkedAttestations) == 0 {


### PR DESCRIPTION
This should significantly speed up verification time for images that have a lot of signature or attestations.

