### PR TITLE
Fix --sig-only in cosign copy

### DIFF
--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -96,6 +96,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 		if err := copyTag(ociremote.SignatureTag); err != nil {
 			return err
 		}
+
 		if sigOnly {
 			return nil
 		}
@@ -117,13 +118,15 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 	}); err != nil {
 		return err
 	}
-	if sigOnly {
-		return nil
-	}
 
 	// Wait for everything to be copied over.
 	if err := g.Wait(); err != nil {
 		return err
+	}
+
+	// If we're only copying sigs, we have nothing left to do.
+	if sigOnly {
+		return nil
 	}
 
 	// Now that everything has been copied over, update the tag.


### PR DESCRIPTION
This sigOnly early return needs to come after we Wait() for the signature to finish copying.
