### PR TITLE
fix help text when in a container

### DIFF
--- a/cmd/cosign/cli/templates/term/term_writer.go
+++ b/cmd/cosign/cli/templates/term/term_writer.go
@@ -98,7 +98,7 @@ func GetWordWrapperLimit() (uint, error) {
 	stdout := os.Stdout
 	fd := stdout.Fd()
 	if !term.IsTerminal(fd) {
-		return 0, errors.New("file descriptor is not a terminal")
+		return 0, nil
 	}
 	terminalSize := GetSize(fd)
 	if terminalSize == nil {


### PR DESCRIPTION
#### Summary
- fix help text when in a container

Fixes: https://github.com/sigstore/cosign/issues/3081

```
$ docker run ko.local/cosign:8196968a32e1ca34eb1f27614e54d8668c0564595e8f19d88f86948eb78a0fad help
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
A tool for Container Signing, Verification and Storage in an OCI registry.

Usage:
cosign [command]

Available Commands:
attach                  Provides utilities for attaching artifacts to other artifacts in a registry
attest                  Attest the supplied container image.
attest-blob             Attest the supplied blob.
clean                   Remove all signatures from an image.
completion              Generate completion script
copy                    Copy the supplied container image and signatures.
dockerfile              Provides utilities for discovering images in and performing operations on Dockerfiles
download                Provides utilities for downloading artifacts and attached artifacts in a registry
env                     Prints Cosign environment variables
generate                Generates (unsigned) signature payloads from the supplied container image.
generate-key-pair       Generates a key-pair.
help                    Help about any command
import-key-pair         Imports a PEM-encoded RSA or EC private key.
initialize              Initializes SigStore root to retrieve trusted certificate and key targets for verification.
load                    Load a signed image on disk to a remote registry
login                   Log in to a registry
manifest                Provides utilities for discovering images in and performing operations on Kubernetes manifests
public-key              Gets a public key from the key-pair.
save                    Save the container image and associated signatures to disk at the specified directory.
sign                    Sign the supplied container image.
sign-blob               Sign the supplied blob, outputting the base64-encoded signature to stdout.
tree                    Display supply chain security related artifacts for an image such as signatures, SBOMs and attestations
triangulate             Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
upload                  Provides utilities for uploading artifacts to a registry
verify                  Verify a signature on the supplied container image
verify-attestation      Verify an attestation on the supplied container image
verify-blob             Verify a signature on the supplied blob
verify-blob-attestation Verify an attestation on the supplied blob
version                 Prints the version

Flags:
    -h, --help=false:
        help for cosign

    --output-file='':
        log output to a file

    -t, --timeout=3m0s:
        timeout for commands

    -d, --verbose=false:
        log debug output

Additional help topics:
cosign piv-tool                This cosign was not built with piv-tool support!
cosign pkcs11-tool             This cosign was not built with pkcs11-tool support!

Use "cosign [command] --help" for more information about a command.
```

