### PR TITLE
wait for the workers become available again to continue the execution

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -629,9 +629,8 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 			t.Done(nil)
 		}(sig, i)
 
-		if t.Throttle() > 0 {
-			break
-		}
+		// wait till workers are available
+		t.Throttle()
 	}
 
 	for _, s := range signatures {
@@ -996,9 +995,8 @@ func verifyImageAttestations(ctx context.Context, atts oci.Signatures, h v1.Hash
 			t.Done(nil)
 		}(att, i)
 
-		if t.Throttle() > 0 {
-			break
-		}
+		// wait till workers are available
+		t.Throttle()
 	}
 
 	for _, a := range attestations {


### PR DESCRIPTION
#### Summary
- wait for the workers become available again to continue the execution

if you run in the container we saw some run that the verification failed

```
$ docker run gcr.io/projectsigstore/cosign:v2.1.0 verify --certificate-oidc-issuer=https://accounts.google.com --certificate-identity=keyless@distroless.iam.gserviceaccount.com gcr.io/distroless/static-debian11                                                                                                                                                                                                                                                                                           WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested                                                                                                                                                                                                                                                                                                                                                   Error: no matching signatures: nil certificate provided
main.go:69: error during command execution: no matching signatures: nil certificate provided
```
and eventually, that works if you increase the `workers` to let's say 50 that worked. this is because we were aborting the full execution of the signatures if the request jobs were bigger than the workers, now we wait for the workers be available to continue the process.
