### PR TITLE
Fix nondeterminsitic timestamps

### DIFF
--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -19,7 +19,6 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/sigstore/cosign/v2/internal/pkg/now"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 )
 
@@ -39,17 +38,6 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 	}
 
 	img, err := mutate.Append(base, adds...)
-	if err != nil {
-		return nil, err
-	}
-
-	t, err := now.Now()
-	if err != nil {
-		return nil, err
-	}
-
-	// Set the Created date to time of execution
-	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/mutate/signatures_test.go
+++ b/pkg/oci/mutate/signatures_test.go
@@ -73,7 +73,7 @@ func TestAppendSignatures(t *testing.T) {
 
 	if testCfg, err := threeSig.ConfigFile(); err != nil {
 		t.Fatalf("ConfigFile() = %v", err)
-	} else if testCfg.Created.Time.IsZero() {
-		t.Errorf("Date of Signature was Zero")
+	} else if !testCfg.Created.Time.IsZero() {
+		t.Errorf("Date of Signature was not Zero")
 	}
 }

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/sigstore/cosign/v2/internal/pkg/now"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 )
@@ -49,16 +48,6 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 	// Add annotations from options
 	img = mutate.Annotations(img, o.Annotations).(v1.Image)
 
-	t, err := now.Now()
-	if err != nil {
-		return nil, err
-	}
-
-	// Set the Created date to time of execution
-	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
-	if err != nil {
-		return nil, err
-	}
 	return &file{
 		SignedImage: signed.Image(img),
 		layer:       layer,

--- a/pkg/oci/static/file_test.go
+++ b/pkg/oci/static/file_test.go
@@ -126,8 +126,8 @@ func TestNewFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ConfigFile() = %v", err)
 		}
-		if fileCfg.Created.Time.IsZero() {
-			t.Errorf("Date of Signature was Zero")
+		if !fileCfg.Created.Time.IsZero() {
+			t.Errorf("Date of Signature was not Zero")
 		}
 	})
 


### PR DESCRIPTION
We should not (by default) be making the artifacts we produce nondeterministic.

#### Summary

Fixes https://github.com/sigstore/cosign/issues/3120
