### PR TITLE
Updates ci tests

### DIFF
--- a/.github/workflows/e2e-tests-kms.yml
+++ b/.github/workflows/e2e-tests-kms.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: cpanato/vault-installer@4246c92b8f047fdb824eb7387d86b3c7806e2bf3 # v0.0.2
         with:
-          vault-release: '1.12.2'
+          vault-release: '1.14.1'
 
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -46,8 +46,8 @@ jobs:
           check-latest: true
 
       - uses: imjasonh/setup-crane@00c9e93efa4e1138c9a7a5c594acd6c75a2fbf0c # v0.3
-      
-      - name: Run e2e_test_attach.sh 
+
+      - name: Run e2e_test_attach.sh
         shell: bash
         run: ./test/e2e_test_attach.sh
 

--- a/.github/workflows/kind-e2e-insecure-registry.yaml
+++ b/.github/workflows/kind-e2e-insecure-registry.yaml
@@ -29,10 +29,10 @@ jobs:
       fail-fast: false # Keep running if one leg fails.
       matrix:
         k8s-version:
-        - v1.22.x
-        - v1.23.x
         - v1.24.x
         - v1.25.x
+        - v1.26.x
+        - v1.27.x
 
     env:
       # https://github.com/google/go-containerregistry/pull/125 allows insecure registry for

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         k8s-version:
-        - v1.24.x
+        - v1.25.x
         tuf-root:
         - remote
         - air-gap


### PR DESCRIPTION
#### Summary
- bump hashicorp vault
- sunset k8s 1.22 and 1.23 and add 1.26 asnd 1.27 releases
