### PR TITLE
improve error messages around bundle != payload hash

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1105,11 +1105,16 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 	}
 
 	alg, bundlehash, err := bundleHash(bundle.Payload.Body.(string), signature)
+	if err != nil {
+		return false, fmt.Errorf("computing bundle hash: %w", err)
+	}
 	h := sha256.Sum256(payload)
 	payloadHash := hex.EncodeToString(h[:])
 
-	if alg != "sha256" || bundlehash != payloadHash {
-		return false, fmt.Errorf("matching bundle to payload: %w", err)
+	if alg != "sha256" {
+		return false, fmt.Errorf("unexpected algorithm: %q", alg)
+	} else if bundlehash != payloadHash {
+		return false, fmt.Errorf("matching bundle to payload: bundle=%q, payload=%q", bundlehash, payloadHash)
 	}
 	return true, nil
 }


### PR DESCRIPTION
Before this change, when the bundle hash doesn't match the payload hash, the error message is `error verifying bundle: matching bundle to payload: %!w(<nil>)` which isn't terribly helpful.

This hopes to improve the error experience in this area, by:

- clearly failing ASAP when bundle hash computation fails
- clearly failing separately if the bundle algorithm is somehow not sha256
- clearly failing with both hashes when they don't match, hopefully making debugging easier