### PR TITLE
Handle HTTP_1_1_REQUIRED errors in github provider

### DIFF
--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sigstore/cosign/v2/pkg/cosign/env"
@@ -54,22 +55,38 @@ func (ga *githubActions) Enabled(_ context.Context) bool {
 }
 
 // Provide implements providers.Interface
-func (ga *githubActions) Provide(_ context.Context, audience string) (string, error) {
+func (ga *githubActions) Provide(ctx context.Context, audience string) (string, error) {
 	url := env.Getenv(env.VariableGitHubRequestURL) + "&audience=" + audience
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return "", err
 	}
 
+	// May be replaced by a different client if we hit HTTP_1_1_REQUIRED.
+	client := http.DefaultClient
+
 	// Retry up to 3 times.
 	for i := 0; ; i++ {
 		req.Header.Add("Authorization", "bearer "+env.Getenv(env.VariableGitHubRequestToken))
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := client.Do(req)
 		if err != nil {
 			if i == 2 {
 				return "", err
 			}
+
+			// This error isn't exposed by net/http, and retrying this with the
+			// DefaultClient will fail because it will just use HTTP2 again.
+			// I don't know why go doesn't do this for us.
+			if strings.Contains(err.Error(), "HTTP_1_1_REQUIRED") {
+				http1transport := http.DefaultTransport.(*http.Transport).Clone()
+				http1transport.ForceAttemptHTTP2 = false
+
+				client = &http.Client{
+					Transport: http1transport,
+				}
+			}
+
 			fmt.Fprintf(os.Stderr, "error fetching GitHub OIDC token (will retry): %v\n", err)
 			time.Sleep(time.Second)
 			continue


### PR DESCRIPTION
I've been seeing this quite a bit recently. I'm not sure why it happens, but hopefully this helps.

Also, plumb context into the right place.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

I frequently see a pattern of `dial tcp 13.107.42.16:443: i/o timeout`, followed by two failed requests.

First:

```
stream error: stream ID 1; HTTP_1_1_REQUIRED; received from peer
```

Then

```
stream error: stream ID 3; HTTP_1_1_REQUIRED; received from peer
```

Then we fail outright because we only do 3 requests in the github provider.

I have no way to easily test this because it relies on triggering Microsoft's bad networking running on GitHub Actions, so I apologize for this being a little janky.

One thing that's very frustrating about this error is that there is not a nicely typed way to check this because (for some reason) none of the http2 error codes are exposed: https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/http/h2_bundle.go;l=1172-1187;drc=d4f0d896a6856e3d6fc64d0e0714645844c59aa0

It's possible to get at this with using [`errors.As`](https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/http/h2_error.go;drc=4d13aabdf62a15d19a6f41a781aa7e85f02f3f26) that relies on reflection to compare a different error type and... eh... just checking the string seems better. 

#### Release Note

NONE