### PR TITLE
support --platform for verify-attestation

### DIFF
--- a/cmd/cosign/cli/download.go
+++ b/cmd/cosign/cli/download.go
@@ -61,7 +61,6 @@ func downloadSignature() *cobra.Command {
 
 func downloadSBOM() *cobra.Command {
 	o := &options.RegistryOptions{}
-	do := &options.SBOMDownloadOptions{}
 
 	cmd := &cobra.Command{
 		Use:              "sbom",
@@ -71,12 +70,11 @@ func downloadSBOM() *cobra.Command {
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Fprintln(os.Stderr, "WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>' or verify its signature using 'cosign verify --key <key path> --attachment sbom <image uri>'.")
-			_, err := download.SBOMCmd(cmd.Context(), *o, *do, args[0], cmd.OutOrStdout())
+			_, err := download.SBOMCmd(cmd.Context(), *o, args[0], cmd.OutOrStdout())
 			return err
 		},
 	}
 
-	do.AddFlags(cmd)
 	o.AddFlags(cmd)
 
 	return cmd

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -45,7 +45,7 @@ func (pl *platformList) String() string {
 
 func SBOMCmd(
 	ctx context.Context, regOpts options.RegistryOptions,
-	dnOpts options.SBOMDownloadOptions, imageRef string, out io.Writer,
+	imageRef string, out io.Writer,
 ) ([]string, error) {
 	ref, err := name.ParseReference(imageRef, regOpts.NameOptions()...)
 	if err != nil {
@@ -65,12 +65,12 @@ func SBOMCmd(
 	idx, isIndex := se.(oci.SignedImageIndex)
 
 	// We only allow --platform on multiarch indexes
-	if dnOpts.Platform != "" && !isIndex {
+	if regOpts.Platform != "" && !isIndex {
 		return nil, fmt.Errorf("specified reference is not a multiarch image")
 	}
 
-	if dnOpts.Platform != "" && isIndex {
-		targetPlatform, err := v1.ParsePlatform(dnOpts.Platform)
+	if regOpts.Platform != "" && isIndex {
+		targetPlatform, err := v1.ParsePlatform(regOpts.Platform)
 		if err != nil {
 			return nil, fmt.Errorf("parsing platform: %w", err)
 		}

--- a/cmd/cosign/cli/options/download.go
+++ b/cmd/cosign/cli/options/download.go
@@ -17,30 +17,15 @@ package options
 
 import "github.com/spf13/cobra"
 
-// DownloadOptions is the struct for control
-type SBOMDownloadOptions struct {
-	Platform string // Platform to download sboms
-}
-
 type AttestationDownloadOptions struct {
 	PredicateType string // Predicate type of attestation to retrieve
 	Platform      string // Platform to download attestations
 }
 
-var _ Interface = (*SBOMDownloadOptions)(nil)
-
 var _ Interface = (*AttestationDownloadOptions)(nil)
-
-// AddFlags implements Interface
-func (o *SBOMDownloadOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.Platform, "platform", "",
-		"download SBOM for a specific platform image")
-}
 
 // AddFlags implements Interface
 func (o *AttestationDownloadOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.PredicateType, "predicate-type", "",
 		"download attestation with matching predicateType")
-	cmd.Flags().StringVar(&o.Platform, "platform", "",
-		"download attestation for a specific platform image")
 }

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -68,6 +68,7 @@ type VerifyAttestationCommand struct {
 	TSACertChainPath             string
 	IgnoreTlog                   bool
 	MaxWorkers                   int
+	Platform                     string
 }
 
 // Exec runs the verification command


### PR DESCRIPTION
#### Summary

Support `cosign verify-attestation <img> --platform=linux/arm64 ...`

This flag was added to `cosign download attestation` in https://github.com/sigstore/cosign/pull/2980, but this promotes the flag to a general-purpose registry option, which means it can be reused by `cosign download <sbom|attestation>` and `verify-attestation`, and others.

#### Release Note

- Added broader support for `--platform`

#### Documentation

Generated docs are probably sufficient.