### PR TITLE
Switch to cryptoutils function for SANS

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -296,7 +296,7 @@ func CheckCertificatePolicy(cert *x509.Certificate, co *CheckOpts) error {
 		return err
 	}
 	oidcIssuer := ce.GetIssuer()
-	sans := getSubjectAlternateNames(cert)
+	sans := cryptoutils.GetSubjectAlternateNames(cert)
 	// If there are identities given, go through them and if one of them
 	// matches, call that good, otherwise, return an error.
 	if len(co.Identities) > 0 {
@@ -397,29 +397,6 @@ func validateCertExtensions(ce CertExtensions, co *CheckOpts) error {
 		}
 	}
 	return nil
-}
-
-// getSubjectAlternateNames returns all of the following for a Certificate.
-// DNSNames
-// EmailAddresses
-// IPAddresses
-// URIs
-func getSubjectAlternateNames(cert *x509.Certificate) []string {
-	sans := []string{}
-	sans = append(sans, cert.DNSNames...)
-	sans = append(sans, cert.EmailAddresses...)
-	for _, ip := range cert.IPAddresses {
-		sans = append(sans, ip.String())
-	}
-	for _, uri := range cert.URIs {
-		sans = append(sans, uri.String())
-	}
-	// ignore error if there's no OtherName SAN
-	otherName, _ := cryptoutils.UnmarshalOtherNameSAN(cert.Extensions)
-	if len(otherName) > 0 {
-		sans = append(sans, otherName)
-	}
-	return sans
 }
 
 // ValidateAndUnpackCertWithChain creates a Verifier from a certificate. Verifies that the certificate

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1318,46 +1318,6 @@ func TestTrustedCertSuccessChainFromRoot(t *testing.T) {
 	}
 }
 
-func Test_getSubjectAltnernativeNames(t *testing.T) {
-	rootCert, rootKey, _ := test.GenerateRootCa()
-	subCert, subKey, _ := test.GenerateSubordinateCa(rootCert, rootKey)
-
-	// generate with OtherName, which will override other SANs
-	ext, err := cryptoutils.MarshalOtherNameSAN("subject-othername", true)
-	if err != nil {
-		t.Fatalf("error marshalling SANs: %v", err)
-	}
-	exts := []pkix.Extension{*ext}
-	leafCert, _, _ := test.GenerateLeafCert("unused@mail.com", "oidc-issuer", subCert, subKey, exts...)
-
-	sans := getSubjectAlternateNames(leafCert)
-	if len(sans) != 1 {
-		t.Fatalf("expected 1 SAN field, got %d", len(sans))
-	}
-	if sans[0] != "subject-othername" {
-		t.Fatalf("unexpected OtherName SAN value")
-	}
-
-	// generate with all other SANs
-	leafCert, _, _ = test.GenerateLeafCertWithSubjectAlternateNames([]string{"subject-dns"}, []string{"subject-email"}, []net.IP{{1, 2, 3, 4}}, []*url.URL{{Path: "testURL"}}, "oidc-issuer", subCert, subKey)
-	sans = getSubjectAlternateNames(leafCert)
-	if len(sans) != 4 {
-		t.Fatalf("expected 1 SAN field, got %d", len(sans))
-	}
-	if sans[0] != "subject-dns" {
-		t.Fatalf("unexpected DNS SAN value")
-	}
-	if sans[1] != "subject-email" {
-		t.Fatalf("unexpected email SAN value")
-	}
-	if sans[2] != "1.2.3.4" {
-		t.Fatalf("unexpected IP SAN value")
-	}
-	if sans[3] != "testURL" {
-		t.Fatalf("unexpected URL SAN value")
-	}
-}
-
 func TestVerifyRFC3161Timestamp(t *testing.T) {
 	// generate signed artifact
 	rootCert, rootKey, _ := test.GenerateRootCa()


### PR DESCRIPTION
It was moved to s/s awhile ago.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
