### PR TITLE
Fail timestamp verification if no root is provided

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1101,11 +1101,12 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 // no root is provided with a timestamp.
 func VerifyRFC3161Timestamp(sig oci.Signature, co *CheckOpts) (*timestamp.Timestamp, error) {
 	ts, err := sig.RFC3161Timestamp()
-	if err != nil {
+	switch {
+	case err != nil:
 		return nil, err
-	} else if ts == nil {
+	case ts == nil:
 		return nil, nil
-	} else if co.TSARootCertificates == nil {
+	case co.TSARootCertificates == nil:
 		return nil, errors.New("no TSA root certificate(s) provided to verify timestamp")
 	}
 

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -648,14 +648,12 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 	bundleVerified bool, err error) {
 	var acceptableRFC3161Time, acceptableRekorBundleTime *time.Time // Timestamps for the signature we accept, or nil if not applicable.
 
-	if co.TSARootCertificates != nil {
-		acceptableRFC3161Timestamp, err := VerifyRFC3161Timestamp(sig, co)
-		if err != nil {
-			return false, fmt.Errorf("unable to verify RFC3161 timestamp bundle: %w", err)
-		}
-		if acceptableRFC3161Timestamp != nil {
-			acceptableRFC3161Time = &acceptableRFC3161Timestamp.Time
-		}
+	acceptableRFC3161Timestamp, err := VerifyRFC3161Timestamp(sig, co)
+	if err != nil {
+		return false, fmt.Errorf("unable to verify RFC3161 timestamp bundle: %w", err)
+	}
+	if acceptableRFC3161Timestamp != nil {
+		acceptableRFC3161Time = &acceptableRFC3161Timestamp.Time
 	}
 
 	if !co.IgnoreTlog {
@@ -1099,13 +1097,16 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 
 // VerifyRFC3161Timestamp verifies that the timestamp in sig is correctly signed, and if so,
 // returns the timestamp value.
-// It returns (nil, nil) if there is no timestamp, or (nil, err) if there is an invalid timestamp.
+// It returns (nil, nil) if there is no timestamp, or (nil, err) if there is an invalid timestamp or if
+// no root is provided with a timestamp.
 func VerifyRFC3161Timestamp(sig oci.Signature, co *CheckOpts) (*timestamp.Timestamp, error) {
 	ts, err := sig.RFC3161Timestamp()
 	if err != nil {
 		return nil, err
 	} else if ts == nil {
 		return nil, nil
+	} else if co.TSARootCertificates == nil {
+		return nil, errors.New("no TSA root certificate(s) provided to verify timestamp")
 	}
 
 	b64Sig, err := sig.Base64Signature()

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1420,4 +1420,13 @@ func TestVerifyRFC3161Timestamp(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "hashed messages don't match") {
 		t.Fatalf("expected error verifying mismatched signatures, got: %v", err)
 	}
+
+	// failure without root certificate
+	_, err = VerifyRFC3161Timestamp(ociSig, &CheckOpts{
+		TSACertificate:              leaves[0],
+		TSAIntermediateCertificates: intermediates,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no TSA root certificate(s) provided to verify timestamp") {
+		t.Fatalf("expected error verifying without a root certificate, got: %v", err)
+	}
 }

--- a/test/e2e_tsa_mtls.sh
+++ b/test/e2e_tsa_mtls.sh
@@ -31,6 +31,7 @@ TIMESTAMP_SERVER_CERT=$CERT_BASE/tsa-mtls-server.crt
 TIMESTAMP_SERVER_KEY=$CERT_BASE/tsa-mtls-server.key
 TIMESTAMP_SERVER_NAME="server.example.com"
 TIMESTAMP_SERVER_URL=https://localhost:3000/api/v1/timestamp
+TIMESTAMP_CHAIN_FILE="timestamp-chain.pem"
 
 set +e
 COSIGN_CLI=./cosign
@@ -50,6 +51,12 @@ timestamp-server serve --disable-ntp-monitoring --tls-host 0.0.0.0 --tls-port 30
 		--scheme https --tls-ca $TIMESTAMP_CACERT --tls-key $TIMESTAMP_SERVER_KEY \
 		--tls-certificate $TIMESTAMP_SERVER_CERT &
 
+sleep 1
+curl -k -s --key test/testdata/tsa-mtls-client.key \
+    --cert test/testdata/tsa-mtls-client.crt \
+    --cacert test/testdata/tsa-mtls-ca.crt https://localhost:3000/api/v1/timestamp/certchain \
+    > $TIMESTAMP_CHAIN_FILE
+echo "DONE: $(ls -l $TIMESTAMP_CHAIN_FILE)"
 
 IMG=${IMAGE_URI_DIGEST:-}
 if [[ "$#" -ge 1 ]]; then
@@ -85,8 +92,8 @@ rm -f key.pem import-cosign.*
 echo "cosign verify:"
 $COSIGN_CLI verify --insecure-ignore-tlog --insecure-ignore-sct --check-claims=true \
 	--certificate-identity-regexp 'xyz@nosuchprovider.com' --certificate-oidc-issuer-regexp '.*' \
-	--certificate-chain cacert.pem $IMG
+	--certificate-chain cacert.pem --timestamp-certificate-chain $TIMESTAMP_CHAIN_FILE $IMG
 
 # cleanup
-rm -fr ca-key.pem cacert.pem cert.pem /tmp/timestamp-authority
+rm -fr ca-key.pem cacert.pem cert.pem timestamp-chain.pem /tmp/timestamp-authority
 pkill -f 'timestamp-server'

--- a/test/e2e_tsa_mtls.sh
+++ b/test/e2e_tsa_mtls.sh
@@ -31,7 +31,7 @@ TIMESTAMP_SERVER_CERT=$CERT_BASE/tsa-mtls-server.crt
 TIMESTAMP_SERVER_KEY=$CERT_BASE/tsa-mtls-server.key
 TIMESTAMP_SERVER_NAME="server.example.com"
 TIMESTAMP_SERVER_URL=https://localhost:3000/api/v1/timestamp
-TIMESTAMP_CHAIN_FILE="timestamp-chain.pem"
+TIMESTAMP_CHAIN_FILE="timestamp-chain"
 
 set +e
 COSIGN_CLI=./cosign
@@ -95,5 +95,5 @@ $COSIGN_CLI verify --insecure-ignore-tlog --insecure-ignore-sct --check-claims=t
 	--certificate-chain cacert.pem --timestamp-certificate-chain $TIMESTAMP_CHAIN_FILE $IMG
 
 # cleanup
-rm -fr ca-key.pem cacert.pem cert.pem timestamp-chain.pem /tmp/timestamp-authority
+rm -fr ca-key.pem cacert.pem cert.pem timestamp-chain /tmp/timestamp-authority
 pkill -f 'timestamp-server'

--- a/test/e2e_tsa_mtls.sh
+++ b/test/e2e_tsa_mtls.sh
@@ -74,7 +74,6 @@ echo "IMG (IMAGE_URI_DIGEST): $IMG, TIMESTAMP_SERVER_URL: $TIMESTAMP_SERVER_URL"
 
 rm -f *.pem import-cosign.* key.pem
 
-
 # use gencert to generate CA, keys and certificates
 echo "generate keys and certificates with gencert"
 


### PR DESCRIPTION
The bug was that we would conditionally check a timestamp if a root was provided. If no root was provided even if a timestamp was provided, then signature verification would succeed.

The good news is this will not show a successful signature if the transparency log does not contain the entry too, for timestamp verification.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
