### PR TITLE
bump scaffolding to newest v0.6.7 release

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -40,7 +40,7 @@ jobs:
 
     env:
       KO_DOCKER_REPO: "registry.local:5000/policy-controller"
-      SCAFFOLDING_RELEASE_VERSION: "v0.6.6"
+      SCAFFOLDING_RELEASE_VERSION: "v0.6.7"
       GO111MODULE: on
       GOFLAGS: -ldflags=-s -ldflags=-w
       KOCACHE: ~/ko


### PR DESCRIPTION
this tests against rekor v1.3.0 and fulcio v1.4.0