### PR TITLE
update builder to use go1.21.1 and bump cosign image

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -26,14 +26,14 @@ jobs:
   check-signature:
     runs-on: ubuntu-latest
     container:
-      image: gcr.io/projectsigstore/cosign:v2.1.1@sha256:411ace177097a33cb2ee74028a87ffdcb70965003cd1378c1ec7bf9f9dec9359
+      image: gcr.io/projectsigstore/cosign:v2.2.0@sha256:280b47054876d415f66a279e666e35157cae6881f3538599710290c70bb75369
 
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.21.0-0@sha256:383b0f45ed1d469a904230d75e2bf74dd3af7b9675872379d7748703c2cc7f26 \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.21.1-0@sha256:7864d898e45db9d749f14180051edb46ff61bf42914e3b8ecddec5a36813aa6c \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.0-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.1-0"
         env:
           TUF_ROOT: /tmp
 
@@ -43,7 +43,7 @@ jobs:
       - check-signature
 
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.21.0-0@sha256:383b0f45ed1d469a904230d75e2bf74dd3af7b9675872379d7748703c2cc7f26
+      image: ghcr.io/gythialy/golang-cross:v1.21.1-0@sha256:7864d898e45db9d749f14180051edb46ff61bf42914e3b8ecddec5a36813aa6c
 
     permissions: {}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -119,8 +119,8 @@ builds:
     binary: cosign-darwin-arm64
     no_unique_dist_dir: true
     env:
-      - CC=aarch64-apple-darwin21.4-clang
-      - CXX=aarch64-apple-darwin21.4-clang++
+      - CC=aarch64-apple-darwin22-clang
+      - CXX=aarch64-apple-darwin22-clang++
     main: ./cmd/cosign
     flags:
       - -trimpath

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,20 +32,20 @@ steps:
         echo "Checking out ${_GIT_TAG}"
         git checkout ${_GIT_TAG}
 
-  - name: 'gcr.io/projectsigstore/cosign:v2.1.1@sha256:411ace177097a33cb2ee74028a87ffdcb70965003cd1378c1ec7bf9f9dec9359'
+  - name: 'gcr.io/projectsigstore/cosign:v2.2.0@sha256:280b47054876d415f66a279e666e35157cae6881f3538599710290c70bb75369'
     dir: "go/src/sigstore/cosign"
     env:
       - TUF_ROOT=/tmp
     args:
       - 'verify'
-      - 'ghcr.io/gythialy/golang-cross:v1.21.0-0@sha256:383b0f45ed1d469a904230d75e2bf74dd3af7b9675872379d7748703c2cc7f26'
+      - 'ghcr.io/gythialy/golang-cross:v1.21.1-0@sha256:7864d898e45db9d749f14180051edb46ff61bf42914e3b8ecddec5a36813aa6c'
       - '--certificate-oidc-issuer'
       - "https://token.actions.githubusercontent.com"
       - '--certificate-identity'
-      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.0-0"
+      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.1-0"
 
   # maybe we can build our own image and use that to be more in a safe side
-  - name: ghcr.io/gythialy/golang-cross:v1.21.0-0@sha256:383b0f45ed1d469a904230d75e2bf74dd3af7b9675872379d7748703c2cc7f26
+  - name: ghcr.io/gythialy/golang-cross:v1.21.1-0@sha256:7864d898e45db9d749f14180051edb46ff61bf42914e3b8ecddec5a36813aa6c
     entrypoint: /bin/sh
     dir: "go/src/sigstore/cosign"
     env:
@@ -68,7 +68,7 @@ steps:
         gcloud auth configure-docker \
         && make release
 
-  - name: ghcr.io/gythialy/golang-cross:v1.21.0-0@sha256:383b0f45ed1d469a904230d75e2bf74dd3af7b9675872379d7748703c2cc7f26
+  - name: ghcr.io/gythialy/golang-cross:v1.21.1-0@sha256:7864d898e45db9d749f14180051edb46ff61bf42914e3b8ecddec5a36813aa6c
     entrypoint: 'bash'
     dir: "go/src/sigstore/cosign"
     env:


### PR DESCRIPTION
#### Summary
- update builder to use go1.21.1 and bump cosign image