### PR TITLE
fix: update error in `SignedEntity` to be more descriptive

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -179,7 +179,7 @@ func SignCmd(ro *options.RootOptions, ko options.KeyOpts, signOpts options.SignO
 
 		if digest, ok := ref.(name.Digest); ok && !signOpts.Recursive {
 			se, err := ociremote.SignedEntity(ref, opts...)
-			if err == ociremote.ErrEntityNotFound {
+			if ociremote.IsEntityNotFoundError(err) {
 				se = ociremote.SignedUnknown(digest)
 			} else if err != nil {
 				return fmt.Errorf("accessing image: %w", err)

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -179,7 +179,7 @@ func SignCmd(ro *options.RootOptions, ko options.KeyOpts, signOpts options.SignO
 
 		if digest, ok := ref.(name.Digest); ok && !signOpts.Recursive {
 			se, err := ociremote.SignedEntity(ref, opts...)
-			if ociremote.IsEntityNotFoundError(err) {
+			if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
 				se = ociremote.SignedUnknown(digest)
 			} else if err != nil {
 				return fmt.Errorf("accessing image: %w", err)

--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -37,18 +36,22 @@ var (
 	remoteIndex = remote.Index
 	remoteGet   = remote.Get
 	remoteWrite = remote.Write
-
-	// ErrEntityNotFound is the error that SignedEntity returns when the
-	// provided ref does not exist.
-	ErrEntityNotFound = "cosign remoteGet: entity not found in registry"
 )
 
-func NewEntityNotFoundError(err error) error {
-	return fmt.Errorf("%s error: %w", ErrEntityNotFound, err)
+// EntityNotFoundError is the error that SignedEntity returns when the
+// provided ref does not exist.
+type EntityNotFoundError struct {
+	baseErr error
 }
 
-func IsEntityNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), ErrEntityNotFound)
+func (e *EntityNotFoundError) Error() string {
+	return fmt.Sprintf("entity not found in registry, error: %v", e.baseErr)
+}
+
+func NewEntityNotFoundError(err error) error {
+	return &EntityNotFoundError{
+		baseErr: err,
+	}
 }
 
 // SignedEntity provides access to a remote reference, and its signatures.

--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -40,7 +40,7 @@ var (
 
 	// ErrEntityNotFound is the error that SignedEntity returns when the
 	// provided ref does not exist.
-	ErrEntityNotFound = "entity not found in registry"
+	ErrEntityNotFound = "cosign remoteGet: entity not found in registry"
 )
 
 func NewEntityNotFoundError(err error) error {

--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -44,7 +44,7 @@ var (
 )
 
 func NewEntityNotFoundError(err error) error {
-	return fmt.Errorf("%s error: %v", ErrEntityNotFound, err)
+	return fmt.Errorf("%s error: %w", ErrEntityNotFound, err)
 }
 
 func IsEntityNotFoundError(err error) bool {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Closes #2930 

The exact error described in the issue cannot happen anymore as [that behavior was changed in v2.1.0](https://github.com/sigstore/cosign/pull/2959/files#diff-72911b6572099462e5f2e8ff920f4f9228587ab100820a26d3e90377c36bd73fR182-R184). 

PR https://github.com/sigstore/cosign/pull/2959 updated the old behaviour and added an if case where the [error message is used in an if statement](https://github.com/sigstore/cosign/pull/2959/files#diff-72911b6572099462e5f2e8ff920f4f9228587ab100820a26d3e90377c36bd73fR182-R183). The issue with this is that the error value is lost when `ErrEntityNotFound` error is created. This creates a problem where the error in `SignedEntity` are not descriptive enough when `remoteGet` function fails. 

This PR will:
- Add a function called `NewEntityNotFoundError` which uses the error received by `remoteGet` to create a new error.
- Add a function called `IsEntityNotFoundError` which is used in the if statement that checks if the error message contains an `ErrEntityNotFound` string.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.
-->

Updated error in `SignedEntity` to be more descriptive

cc @znewman01 
