### PR TITLE
feat: add platform flag to cosign copy command

### DIFF
--- a/cmd/cosign/cli/common/platform.go
+++ b/cmd/cosign/cli/common/platform.go
@@ -1,0 +1,76 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sigstore/cosign/v2/pkg/oci"
+)
+
+type platformList []struct {
+	Hash     v1.Hash
+	Platform *v1.Platform
+}
+
+func (pl *platformList) String() string {
+	r := []string{}
+	for _, p := range *pl {
+		r = append(r, p.Platform.String())
+	}
+	return strings.Join(r, ", ")
+}
+
+func GetIndexPlatforms(idx oci.SignedImageIndex) (platformList, error) {
+	im, err := idx.IndexManifest()
+	if err != nil {
+		return nil, fmt.Errorf("fetching index manifest: %w", err)
+	}
+
+	platforms := platformList{}
+	for _, m := range im.Manifests {
+		if m.Platform == nil {
+			continue
+		}
+		platforms = append(platforms, struct {
+			Hash     v1.Hash
+			Platform *v1.Platform
+		}{m.Digest, m.Platform})
+	}
+	return platforms, nil
+}
+
+// matchPlatform filters a list of platforms returning only those matching
+// a base. "Based" on ko's internal equivalent while it moves to GGCR.
+// https://github.com/google/ko/blob/e6a7a37e26d82a8b2bb6df991c5a6cf6b2728794/pkg/build/gobuild.go#L1020
+func MatchPlatform(base *v1.Platform, list platformList) platformList {
+	ret := platformList{}
+	for _, p := range list {
+		if base.OS != "" && base.OS != p.Platform.OS {
+			continue
+		}
+		if base.Architecture != "" && base.Architecture != p.Platform.Architecture {
+			continue
+		}
+		if base.Variant != "" && base.Variant != p.Platform.Variant {
+			continue
+		}
+
+		if base.OSVersion != "" && p.Platform.OSVersion != base.OSVersion {
+			if base.OS != "windows" {
+				continue
+			} else { //nolint: revive
+				if pcount, bcount := strings.Count(base.OSVersion, "."), strings.Count(p.Platform.OSVersion, "."); pcount == 2 && bcount == 3 {
+					if base.OSVersion != p.Platform.OSVersion[:strings.LastIndex(p.Platform.OSVersion, ".")] {
+						continue
+					}
+				} else {
+					continue
+				}
+			}
+		}
+		ret = append(ret, p)
+	}
+
+	return ret
+}

--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -37,7 +37,10 @@ func Copy() *cobra.Command {
   cosign copy --sig-only example.com/src example.com/dest
 
   # overwrite destination image and signatures
-  cosign copy -f example.com/src example.com/dest`,
+  cosign copy -f example.com/src example.com/dest
+
+	# copy a container image and its signatures for a specific platform
+  cosign copy --platform=linux/amd64 example.com/src:latest example.com/dest:latest`,
 
 		Args:             cobra.ExactArgs(2),
 		PersistentPreRun: options.BindViper,

--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -45,7 +45,7 @@ func Copy() *cobra.Command {
 		Args:             cobra.ExactArgs(2),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return copy.CopyCmd(cmd.Context(), o.Registry, args[0], args[1], o.SignatureOnly, o.Force)
+			return copy.CopyCmd(cmd.Context(), o.Registry, args[0], args[1], o.SignatureOnly, o.Force, o.Platform)
 		},
 	}
 

--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -26,6 +26,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/common"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
@@ -35,7 +36,7 @@ import (
 
 // CopyCmd implements the logic to copy the supplied container image and signatures.
 // nolint
-func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstImg string, sigOnly, force bool) error {
+func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstImg string, sigOnly, force bool, platform string) error {
 	no := regOpts.NameOptions()
 	srcRef, err := name.ParseReference(srcImg, no...)
 	if err != nil {
@@ -69,6 +70,43 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 	root, err := ociremote.SignedEntity(srcRef, ociRemoteOpts...)
 	if err != nil {
 		return err
+	}
+
+	idx, isIndex := root.(oci.SignedImageIndex)
+
+	if platform != "" && !isIndex {
+		return fmt.Errorf("specified reference is not a multiarch image")
+	}
+
+	if platform != "" && isIndex {
+		targetPlatform, err := v1.ParsePlatform(platform)
+		if err != nil {
+			return fmt.Errorf("parsing platform: %w", err)
+		}
+		platforms, err := common.GetIndexPlatforms(idx)
+		if err != nil {
+			return fmt.Errorf("getting available platforms: %w", err)
+		}
+
+		platforms = common.MatchPlatform(targetPlatform, platforms)
+		if len(platforms) == 0 {
+			return fmt.Errorf("unable to find an SBOM for %s", targetPlatform.String())
+		}
+		if len(platforms) > 1 {
+			return fmt.Errorf(
+				"platform spec matches more than one image architecture: %s",
+				platforms.String(),
+			)
+		}
+
+		nroot, err := idx.SignedImage(platforms[0].Hash)
+		if err != nil {
+			return fmt.Errorf("searching for %s image: %w", platforms[0].Hash.String(), err)
+		}
+		if nroot == nil {
+			return fmt.Errorf("unable to find image %s", platforms[0].Hash.String())
+		}
+		root = nroot
 	}
 
 	if err := walk.SignedEntity(gctx, root, func(ctx context.Context, se oci.SignedEntity) error {

--- a/cmd/cosign/cli/copy/copy_test.go
+++ b/cmd/cosign/cli/copy/copy_test.go
@@ -38,3 +38,15 @@ func TestCopyAttachmentTagPrefix(t *testing.T) {
 		t.Fatal("failed to copy with attachment-tag-prefix")
 	}
 }
+
+func TestCopyPlatformOpt(t *testing.T) {
+	ctx := context.Background()
+
+	srcImg := "alpine"
+	destImg := "test-alpine"
+
+	err := CopyCmd(ctx, options.RegistryOptions{}, srcImg, destImg, false, true, "linux/amd64")
+	if err == nil {
+		t.Fatal("failed to copy with platform")
+	}
+}

--- a/cmd/cosign/cli/copy/copy_test.go
+++ b/cmd/cosign/cli/copy/copy_test.go
@@ -33,7 +33,7 @@ func TestCopyAttachmentTagPrefix(t *testing.T) {
 
 	err := CopyCmd(ctx, options.RegistryOptions{
 		RefOpts: refOpts,
-	}, srcImg, destImg, false, true)
+	}, srcImg, destImg, false, true, "")
 	if err == nil {
 		t.Fatal("failed to copy with attachment-tag-prefix")
 	}

--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/sigstore/cosign/v2/cmd/cosign/cli/common"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
-	"github.com/sigstore/cosign/v2/pkg/oci"
+	"github.com/sigstore/cosign/v2/pkg/oci/platform"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 )
 
@@ -52,42 +50,9 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 		return err
 	}
 
-	idx, isIndex := se.(oci.SignedImageIndex)
-
-	// We only allow --platform on multiarch indexes
-	if attOptions.Platform != "" && !isIndex {
-		return fmt.Errorf("specified reference is not a multiarch image")
-	}
-
-	if attOptions.Platform != "" && isIndex {
-		targetPlatform, err := v1.ParsePlatform(attOptions.Platform)
-		if err != nil {
-			return fmt.Errorf("parsing platform: %w", err)
-		}
-		platforms, err := common.GetIndexPlatforms(idx)
-		if err != nil {
-			return fmt.Errorf("getting available platforms: %w", err)
-		}
-
-		platforms = common.MatchPlatform(targetPlatform, platforms)
-		if len(platforms) == 0 {
-			return fmt.Errorf("unable to find an attestation for %s", targetPlatform.String())
-		}
-		if len(platforms) > 1 {
-			return fmt.Errorf(
-				"platform spec matches more than one image architecture: %s",
-				platforms.String(),
-			)
-		}
-
-		nse, err := idx.SignedImage(platforms[0].Hash)
-		if err != nil {
-			return fmt.Errorf("searching for %s image: %w", platforms[0].Hash.String(), err)
-		}
-		if nse == nil {
-			return fmt.Errorf("unable to find image %s", platforms[0].Hash.String())
-		}
-		se = nse
+	se, err = platform.SignedEntityForPlatform(se, attOptions.Platform)
+	if err != nil {
+		return err
 	}
 
 	attestations, err := cosign.FetchAttestations(se, predicateType)

--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/common"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci"
@@ -63,12 +64,12 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 		if err != nil {
 			return fmt.Errorf("parsing platform: %w", err)
 		}
-		platforms, err := getIndexPlatforms(idx)
+		platforms, err := common.GetIndexPlatforms(idx)
 		if err != nil {
 			return fmt.Errorf("getting available platforms: %w", err)
 		}
 
-		platforms = matchPlatform(targetPlatform, platforms)
+		platforms = common.MatchPlatform(targetPlatform, platforms)
 		if len(platforms) == 0 {
 			return fmt.Errorf("unable to find an attestation for %s", targetPlatform.String())
 		}
@@ -79,12 +80,12 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 			)
 		}
 
-		nse, err := idx.SignedImage(platforms[0].hash)
+		nse, err := idx.SignedImage(platforms[0].Hash)
 		if err != nil {
-			return fmt.Errorf("searching for %s image: %w", platforms[0].hash.String(), err)
+			return fmt.Errorf("searching for %s image: %w", platforms[0].Hash.String(), err)
 		}
 		if nse == nil {
-			return fmt.Errorf("unable to find image %s", platforms[0].hash.String())
+			return fmt.Errorf("unable to find image %s", platforms[0].Hash.String())
 		}
 		se = nse
 	}

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -21,27 +21,14 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/common"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 )
-
-type platformList []struct {
-	hash     v1.Hash
-	platform *v1.Platform
-}
-
-func (pl *platformList) String() string {
-	r := []string{}
-	for _, p := range *pl {
-		r = append(r, p.platform.String())
-	}
-	return strings.Join(r, ", ")
-}
 
 func SBOMCmd(
 	ctx context.Context, regOpts options.RegistryOptions,
@@ -74,12 +61,12 @@ func SBOMCmd(
 		if err != nil {
 			return nil, fmt.Errorf("parsing platform: %w", err)
 		}
-		platforms, err := getIndexPlatforms(idx)
+		platforms, err := common.GetIndexPlatforms(idx)
 		if err != nil {
 			return nil, fmt.Errorf("getting available platforms: %w", err)
 		}
 
-		platforms = matchPlatform(targetPlatform, platforms)
+		platforms = common.MatchPlatform(targetPlatform, platforms)
 		if len(platforms) == 0 {
 			return nil, fmt.Errorf("unable to find an SBOM for %s", targetPlatform.String())
 		}
@@ -90,12 +77,12 @@ func SBOMCmd(
 			)
 		}
 
-		nse, err := idx.SignedImage(platforms[0].hash)
+		nse, err := idx.SignedImage(platforms[0].Hash)
 		if err != nil {
-			return nil, fmt.Errorf("searching for %s image: %w", platforms[0].hash.String(), err)
+			return nil, fmt.Errorf("searching for %s image: %w", platforms[0].Hash.String(), err)
 		}
 		if nse == nil {
-			return nil, fmt.Errorf("unable to find image %s", platforms[0].hash.String())
+			return nil, fmt.Errorf("unable to find image %s", platforms[0].Hash.String())
 		}
 		se = nse
 	}
@@ -106,7 +93,7 @@ func SBOMCmd(
 			return nil, errors.New("no sbom attached to reference")
 		}
 		// Help the user with the available architectures
-		pl, err := getIndexPlatforms(idx)
+		pl, err := common.GetIndexPlatforms(idx)
 		if len(pl) > 0 && err == nil {
 			fmt.Fprintf(
 				os.Stderr,
@@ -138,58 +125,4 @@ func SBOMCmd(
 	fmt.Fprint(out, string(sbom))
 
 	return sboms, nil
-}
-
-func getIndexPlatforms(idx oci.SignedImageIndex) (platformList, error) {
-	im, err := idx.IndexManifest()
-	if err != nil {
-		return nil, fmt.Errorf("fetching index manifest: %w", err)
-	}
-
-	platforms := platformList{}
-	for _, m := range im.Manifests {
-		if m.Platform == nil {
-			continue
-		}
-		platforms = append(platforms, struct {
-			hash     v1.Hash
-			platform *v1.Platform
-		}{m.Digest, m.Platform})
-	}
-	return platforms, nil
-}
-
-// matchPlatform filters a list of platforms returning only those matching
-// a base. "Based" on ko's internal equivalent while it moves to GGCR.
-// https://github.com/google/ko/blob/e6a7a37e26d82a8b2bb6df991c5a6cf6b2728794/pkg/build/gobuild.go#L1020
-func matchPlatform(base *v1.Platform, list platformList) platformList {
-	ret := platformList{}
-	for _, p := range list {
-		if base.OS != "" && base.OS != p.platform.OS {
-			continue
-		}
-		if base.Architecture != "" && base.Architecture != p.platform.Architecture {
-			continue
-		}
-		if base.Variant != "" && base.Variant != p.platform.Variant {
-			continue
-		}
-
-		if base.OSVersion != "" && p.platform.OSVersion != base.OSVersion {
-			if base.OS != "windows" {
-				continue
-			} else { //nolint: revive
-				if pcount, bcount := strings.Count(base.OSVersion, "."), strings.Count(p.platform.OSVersion, "."); pcount == 2 && bcount == 3 {
-					if base.OSVersion != p.platform.OSVersion[:strings.LastIndex(p.platform.OSVersion, ".")] {
-						continue
-					}
-				} else {
-					continue
-				}
-			}
-		}
-		ret = append(ret, p)
-	}
-
-	return ret
 }

--- a/cmd/cosign/cli/options/copy.go
+++ b/cmd/cosign/cli/options/copy.go
@@ -23,6 +23,7 @@ import (
 type CopyOptions struct {
 	SignatureOnly bool
 	Force         bool
+	Platform      string
 	Registry      RegistryOptions
 }
 
@@ -37,4 +38,7 @@ func (o *CopyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVarP(&o.Force, "force", "f", false,
 		"overwrite destination image(s), if necessary")
+
+	cmd.Flags().StringVar(&o.Platform, "platform", "",
+		"only copy container image and its signatures for a specific platform image")
 }

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -19,6 +19,9 @@ cosign copy [flags]
 
   # overwrite destination image and signatures
   cosign copy -f example.com/src example.com/dest
+
+	# copy a container image and its signatures for a specific platform
+  cosign copy --platform=linux/amd64 example.com/src:latest example.com/dest:latest
 ```
 
 ### Options
@@ -30,6 +33,7 @@ cosign copy [flags]
   -f, --force                                                                                    overwrite destination image(s), if necessary
   -h, --help                                                                                     help for copy
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --platform string                                                                          only copy container image and its signatures for a specific platform image
       --sig-only                                                                                 only copy the image signature
 ```
 

--- a/pkg/oci/platform/platform.go
+++ b/pkg/oci/platform/platform.go
@@ -1,3 +1,17 @@
+// Copyright 2023 the Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package platform
 
 import (

--- a/pkg/oci/platform/platform.go
+++ b/pkg/oci/platform/platform.go
@@ -22,12 +22,12 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci"
 )
 
-type platformList []struct {
+type PlatformList []struct {
 	Hash     v1.Hash
 	Platform *v1.Platform
 }
 
-func (pl *platformList) String() string {
+func (pl *PlatformList) String() string {
 	r := []string{}
 	for _, p := range *pl {
 		r = append(r, p.Platform.String())
@@ -35,13 +35,13 @@ func (pl *platformList) String() string {
 	return strings.Join(r, ", ")
 }
 
-func GetIndexPlatforms(idx oci.SignedImageIndex) (platformList, error) {
+func GetIndexPlatforms(idx oci.SignedImageIndex) (PlatformList, error) {
 	im, err := idx.IndexManifest()
 	if err != nil {
 		return nil, fmt.Errorf("fetching index manifest: %w", err)
 	}
 
-	platforms := platformList{}
+	platforms := PlatformList{}
 	for _, m := range im.Manifests {
 		if m.Platform == nil {
 			continue
@@ -57,8 +57,8 @@ func GetIndexPlatforms(idx oci.SignedImageIndex) (platformList, error) {
 // matchPlatform filters a list of platforms returning only those matching
 // a base. "Based" on ko's internal equivalent while it moves to GGCR.
 // https://github.com/google/ko/blob/e6a7a37e26d82a8b2bb6df991c5a6cf6b2728794/pkg/build/gobuild.go#L1020
-func matchPlatform(base *v1.Platform, list platformList) platformList {
-	ret := platformList{}
+func matchPlatform(base *v1.Platform, list PlatformList) PlatformList {
+	ret := PlatformList{}
 	for _, p := range list {
 		if base.OS != "" && base.OS != p.Platform.OS {
 			continue

--- a/pkg/oci/platform/platform.go
+++ b/pkg/oci/platform/platform.go
@@ -22,12 +22,12 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci"
 )
 
-type PlatformList []struct {
+type List []struct {
 	Hash     v1.Hash
 	Platform *v1.Platform
 }
 
-func (pl *PlatformList) String() string {
+func (pl *List) String() string {
 	r := []string{}
 	for _, p := range *pl {
 		r = append(r, p.Platform.String())
@@ -35,13 +35,13 @@ func (pl *PlatformList) String() string {
 	return strings.Join(r, ", ")
 }
 
-func GetIndexPlatforms(idx oci.SignedImageIndex) (PlatformList, error) {
+func GetIndexPlatforms(idx oci.SignedImageIndex) (List, error) {
 	im, err := idx.IndexManifest()
 	if err != nil {
 		return nil, fmt.Errorf("fetching index manifest: %w", err)
 	}
 
-	platforms := PlatformList{}
+	platforms := List{}
 	for _, m := range im.Manifests {
 		if m.Platform == nil {
 			continue
@@ -57,8 +57,8 @@ func GetIndexPlatforms(idx oci.SignedImageIndex) (PlatformList, error) {
 // matchPlatform filters a list of platforms returning only those matching
 // a base. "Based" on ko's internal equivalent while it moves to GGCR.
 // https://github.com/google/ko/blob/e6a7a37e26d82a8b2bb6df991c5a6cf6b2728794/pkg/build/gobuild.go#L1020
-func matchPlatform(base *v1.Platform, list PlatformList) PlatformList {
-	ret := PlatformList{}
+func matchPlatform(base *v1.Platform, list List) List {
+	ret := List{}
 	for _, p := range list {
 		if base.OS != "" && base.OS != p.Platform.OS {
 			continue
@@ -130,5 +130,4 @@ func SignedEntityForPlatform(se oci.SignedEntity, platform string) (oci.SignedEn
 	}
 
 	return nse, nil
-
 }


### PR DESCRIPTION
Signed-off-by: Vishal Choudhary <sendtovishalchoudhary@gmail.com>
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Fixes: #2748

This PR adds a `--platform` flag to `cosign copy`. This allows copying images and signatures for specific platform/architecture.

/cc @imjasonh @znewman01 @cpanato

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Before:
```bash
cosign copy alpine ttl.sh/test-cosign-copy:5m
Copying index.docker.io/library/alpine@sha256:5febc00b4d2a84af2a077bc34ea90659b6570110a54253f19c5dca8164b1dbf6 to ttl.sh/test-cosign-copy:sha256:5febc00b4d2a84af2a077bc34ea90659b6570110a54253f19c5dca8164b1dbf6...
Copying index.docker.io/library/alpine@sha256:b312e4b0e2c665d634602411fcb7c2699ba748c36f59324457bc17de485f36f6 to ttl.sh/test-cosign-copy:sha256:b312e4b0e2c665d634602411fcb7c2699ba748c36f59324457bc17de485f36f6...
Copying index.docker.io/library/alpine@sha256:f748290eb66ad6f938e25dd348acfb3527a422e280b7547b1cdfaf38d4492c4b to ttl.sh/test-cosign-copy:sha256:f748290eb66ad6f938e25dd348acfb3527a422e280b7547b1cdfaf38d4492c4b...
Copying index.docker.io/library/alpine@sha256:16e86b2388774982fbdf230101a72201691b1f97cb0066c2099abf30dd7e6d59 to ttl.sh/test-cosign-copy:sha256:16e86b2388774982fbdf230101a72201691b1f97cb0066c2099abf30dd7e6d59...
Copying index.docker.io/library/alpine@sha256:c75ede79e457d6454bca6fc51967a247a4b9daff9f31197cfbef69b1a651cada to ttl.sh/test-cosign-copy:sha256:c75ede79e457d6454bca6fc51967a247a4b9daff9f31197cfbef69b1a651cada...
Copying index.docker.io/library/alpine@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a to ttl.sh/test-cosign-copy:sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a...
Copying index.docker.io/library/alpine@sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33 to ttl.sh/test-cosign-copy:sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33...
Copying index.docker.io/library/alpine@sha256:1fd62556954250bac80d601a196bb7fd480ceba7c10e94dd8fd4c6d1c08783d5 to ttl.sh/test-cosign-copy:sha256:1fd62556954250bac80d601a196bb7fd480ceba7c10e94dd8fd4c6d1c08783d5...
Copying index.docker.io/library/alpine@sha256:7144f7bab3d4c2648d7e59409f15ec52a18006a128c733fcff20d3a4a54ba44a to ttl.sh/test-cosign-copy:5m...
```

After:
```bash
go run ./cmd/cosign copy --platform=linux/amd64 alpine ttl.sh/test-cosign-copy-local:5m
Copying index.docker.io/library/alpine@sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33 to ttl.sh/test-cosign-copy-local:sha256-c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33...
Copying index.docker.io/library/alpine@sha256:c5c5fda71656f28e49ac9c5416b3643eaa6a108a8093151d6d1afc9463be8e33 to ttl.sh/test-cosign-copy-local:5m...
```
#### Release Note
Added `--platform` flag to `cosign copy` command
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
