### PR TITLE
Allow `cosign save` to reuse save directory to help dedupe shared layers.

### DIFF
--- a/cmd/cosign/cli/load.go
+++ b/cmd/cosign/cli/load.go
@@ -39,6 +39,9 @@ func Load() *cobra.Command {
 		//Args:             cobra.ExactArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if o.Registry.Name != "" && len(args) != 0 {
+				return fmt.Errorf("both --registry and image argument provided, only one should be used")
+			}
 			if o.Registry.Name != "" && len(args) == 0 {
 				return LoadCmd(cmd.Context(), *o, "")
 			}
@@ -54,10 +57,6 @@ func Load() *cobra.Command {
 }
 
 func LoadCmd(ctx context.Context, opts options.LoadOptions, imageRef string) error {
-	if opts.Registry.Name != "" && imageRef != "" {
-		return fmt.Errorf("both --registry and image argument provided, only one should be used")
-	}
-
 	var ref name.Reference
 	var err error
 	if opts.Registry.Name == "" {

--- a/cmd/cosign/cli/load.go
+++ b/cmd/cosign/cli/load.go
@@ -54,7 +54,6 @@ func Load() *cobra.Command {
 }
 
 func LoadCmd(ctx context.Context, opts options.LoadOptions, imageRef string) error {
-
 	if opts.Registry.Name != "" && imageRef != "" {
 		return fmt.Errorf("both --registry and image argument provided, only one should be used")
 	}
@@ -82,7 +81,6 @@ func LoadCmd(ctx context.Context, opts options.LoadOptions, imageRef string) err
 
 	if opts.Registry.Name == "" {
 		return remote.WriteSignedImageIndexImages(ref, sii, ociremoteOpts...)
-	} else {
-		return remote.WriteSignedImageIndexImagesBulk(opts.Registry.Name, sii, ociremoteOpts...)
 	}
+	return remote.WriteSignedImageIndexImagesBulk(opts.Registry.Name, sii, ociremoteOpts...)
 }

--- a/cmd/cosign/cli/options/load.go
+++ b/cmd/cosign/cli/options/load.go
@@ -34,4 +34,8 @@ func (o *LoadOptions) AddFlags(cmd *cobra.Command) {
 		"path to directory where the signed image is stored on disk")
 	_ = cmd.Flags().SetAnnotation("dir", cobra.BashCompSubdirsInDir, []string{})
 	_ = cmd.MarkFlagRequired("dir")
+
+	cmd.Flags().StringVar(&o.Registry.Name, "registry", "",
+		"registry to use for bulk load")
+	_ = cmd.Flags().SetAnnotation("registry", cobra.BashCompSubdirsInDir, []string{})
 }

--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -42,7 +42,7 @@ type RegistryOptions struct {
 	AllowInsecure      bool
 	AllowHTTPRegistry  bool
 	KubernetesKeychain bool
-	Name		       string
+	Name               string
 	RefOpts            ReferenceOptions
 	Keychain           Keychain
 

--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -42,6 +42,7 @@ type RegistryOptions struct {
 	AllowInsecure      bool
 	AllowHTTPRegistry  bool
 	KubernetesKeychain bool
+	Name		       string
 	RefOpts            ReferenceOptions
 	Keychain           Keychain
 

--- a/cmd/cosign/cli/save.go
+++ b/cmd/cosign/cli/save.go
@@ -63,7 +63,7 @@ func SaveCmd(_ context.Context, opts options.SaveOptions, imageRef string) error
 		if err != nil {
 			return fmt.Errorf("getting signed image: %w", err)
 		}
-		return layout.WriteSignedImage(opts.Directory, si)
+		return layout.WriteSignedImage(opts.Directory, si, ref)
 	}
 
 	if _, ok := se.(oci.SignedImageIndex); ok {
@@ -71,7 +71,7 @@ func SaveCmd(_ context.Context, opts options.SaveOptions, imageRef string) error
 		if err != nil {
 			return fmt.Errorf("getting signed image index: %w", err)
 		}
-		return layout.WriteSignedImageIndex(opts.Directory, sii)
+		return layout.WriteSignedImageIndex(opts.Directory, sii, ref)
 	}
 	return errors.New("unknown signed entity")
 }

--- a/doc/cosign_load.md
+++ b/doc/cosign_load.md
@@ -13,7 +13,7 @@ cosign load [flags]
 ### Examples
 
 ```
-  cosign load --dir <path to directory> <IMAGE>
+  cosign load --dir <path to directory> <IMAGE> OR cosign load --dir <path to directory> --registry <REGISTRY>
 ```
 
 ### Options
@@ -25,6 +25,7 @@ cosign load [flags]
       --dir string                                                                               path to directory where the signed image is stored on disk
   -h, --help                                                                                     help for load
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry string                                                                          registry to use for bulk load
 ```
 
 ### Options inherited from parent commands

--- a/pkg/oci/layout/index.go
+++ b/pkg/oci/layout/index.go
@@ -27,7 +27,7 @@ import (
 const (
 	KindAnnotation       = "kind"
 	ImageAnnotation      = "dev.cosignproject.cosign/image"
-	ImageRefAnnotation = "org.opencontainers.image.ref.name"
+	ImageRefAnnotation   = "org.opencontainers.image.ref.name"
 	ImageIndexAnnotation = "dev.cosignproject.cosign/imageIndex"
 	SigsAnnotation       = "dev.cosignproject.cosign/sigs"
 	AttsAnnotation       = "dev.cosignproject.cosign/atts"

--- a/pkg/oci/layout/index.go
+++ b/pkg/oci/layout/index.go
@@ -25,11 +25,12 @@ import (
 )
 
 const (
-	kindAnnotation       = "kind"
-	imageAnnotation      = "dev.cosignproject.cosign/image"
-	imageIndexAnnotation = "dev.cosignproject.cosign/imageIndex"
-	sigsAnnotation       = "dev.cosignproject.cosign/sigs"
-	attsAnnotation       = "dev.cosignproject.cosign/atts"
+	KindAnnotation       = "kind"
+	ImageAnnotation      = "dev.cosignproject.cosign/image"
+	ImageTitleAnnotation = "org.opencontainers.image.title"
+	ImageIndexAnnotation = "dev.cosignproject.cosign/imageIndex"
+	SigsAnnotation       = "dev.cosignproject.cosign/sigs"
+	AttsAnnotation       = "dev.cosignproject.cosign/atts"
 )
 
 // SignedImageIndex provides access to a local index reference, and its signatures.
@@ -59,7 +60,7 @@ var _ oci.SignedImageIndex = (*index)(nil)
 
 // Signatures implements oci.SignedImageIndex
 func (i *index) Signatures() (oci.Signatures, error) {
-	img, err := i.imageByAnnotation(sigsAnnotation)
+	img, err := i.imageByAnnotation(SigsAnnotation)
 	if err != nil {
 		return nil, err
 	}
@@ -71,7 +72,7 @@ func (i *index) Signatures() (oci.Signatures, error) {
 
 // Attestations implements oci.SignedImageIndex
 func (i *index) Attestations() (oci.Signatures, error) {
-	img, err := i.imageByAnnotation(attsAnnotation)
+	img, err := i.imageByAnnotation(AttsAnnotation)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +93,7 @@ func (i *index) SignedImage(h v1.Hash) (oci.SignedImage, error) {
 	var img v1.Image
 	var err error
 	if h.String() == ":" {
-		img, err = i.imageByAnnotation(imageAnnotation)
+		img, err = i.imageByAnnotation(ImageAnnotation)
 	} else {
 		img, err = i.Image(h)
 	}
@@ -113,7 +114,7 @@ func (i *index) imageByAnnotation(annotation string) (v1.Image, error) {
 		return nil, err
 	}
 	for _, m := range manifest.Manifests {
-		if val, ok := m.Annotations[kindAnnotation]; ok && val == annotation {
+		if val, ok := m.Annotations[KindAnnotation]; ok && val == annotation {
 			return i.Image(m.Digest)
 		}
 	}
@@ -126,7 +127,7 @@ func (i *index) imageIndexByAnnotation(annotation string) (v1.ImageIndex, error)
 		return nil, err
 	}
 	for _, m := range manifest.Manifests {
-		if val, ok := m.Annotations[kindAnnotation]; ok && val == annotation {
+		if val, ok := m.Annotations[KindAnnotation]; ok && val == annotation {
 			return i.ImageIndex(m.Digest)
 		}
 	}
@@ -138,7 +139,7 @@ func (i *index) SignedImageIndex(h v1.Hash) (oci.SignedImageIndex, error) {
 	var ii v1.ImageIndex
 	var err error
 	if h.String() == ":" {
-		ii, err = i.imageIndexByAnnotation(imageIndexAnnotation)
+		ii, err = i.imageIndexByAnnotation(ImageIndexAnnotation)
 	} else {
 		ii, err = i.ImageIndex(h)
 	}

--- a/pkg/oci/layout/index.go
+++ b/pkg/oci/layout/index.go
@@ -27,7 +27,7 @@ import (
 const (
 	KindAnnotation       = "kind"
 	ImageAnnotation      = "dev.cosignproject.cosign/image"
-	ImageTitleAnnotation = "org.opencontainers.image.title"
+	ImageRefAnnotation = "org.opencontainers.image.ref.name"
 	ImageIndexAnnotation = "dev.cosignproject.cosign/imageIndex"
 	SigsAnnotation       = "dev.cosignproject.cosign/sigs"
 	AttsAnnotation       = "dev.cosignproject.cosign/atts"

--- a/pkg/oci/layout/write.go
+++ b/pkg/oci/layout/write.go
@@ -16,10 +16,10 @@
 package layout
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
-	"errors"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -31,14 +31,14 @@ import (
 // WriteSignedImage writes the image and all related signatures, attestations and attachments
 func WriteSignedImage(path string, si oci.SignedImage, ref name.Reference) error {
 	layoutPath, err := layout.FromPath(path)
-    if os.IsNotExist(err) {
-        // If the layout doesn't exist, create a new one
-        layoutPath, err = layout.Write(path, empty.Index)
-    }
-    if err != nil {
-        return err
-    }
-	
+	if os.IsNotExist(err) {
+		// If the layout doesn't exist, create a new one
+		layoutPath, err = layout.Write(path, empty.Index)
+	}
+	if err != nil {
+		return err
+	}
+
 	// write the image
 	if err := appendImage(layoutPath, si, ref, ImageAnnotation); err != nil {
 		return fmt.Errorf("appending signed image: %w", err)
@@ -49,26 +49,26 @@ func WriteSignedImage(path string, si oci.SignedImage, ref name.Reference) error
 // WriteSignedImageIndex writes the image index and all related signatures, attestations and attachments
 func WriteSignedImageIndex(path string, si oci.SignedImageIndex, ref name.Reference) error {
 	layoutPath, err := layout.FromPath(path)
-    if os.IsNotExist(err) {
-        // If the layout doesn't exist, create a new one
-        layoutPath, err = layout.Write(path, empty.Index)
-    }
-    if err != nil {
-        return err
-    }
+	if os.IsNotExist(err) {
+		// If the layout doesn't exist, create a new one
+		layoutPath, err = layout.Write(path, empty.Index)
+	}
+	if err != nil {
+		return err
+	}
 
-    // Append the image index
-    imageRef, err := getImageRef(ref)
-    if err != nil {
-        return err // Return the error from getImageRef immediately.
-    }
-    if err := layoutPath.AppendIndex(si, layout.WithAnnotations(
-        map[string]string{KindAnnotation: ImageIndexAnnotation, ImageTitleAnnotation: imageRef},
-    )); err != nil {
-        return fmt.Errorf("appending signed image index: %w", err)
-    }
+	// Append the image index
+	imageRef, err := getImageRef(ref)
+	if err != nil {
+		return err // Return the error from getImageRef immediately.
+	}
+	if err := layoutPath.AppendIndex(si, layout.WithAnnotations(
+		map[string]string{KindAnnotation: ImageIndexAnnotation, ImageRefAnnotation: imageRef},
+	)); err != nil {
+		return fmt.Errorf("appending signed image index: %w", err)
+	}
 
-    return writeSignedEntity(layoutPath, si, ref)
+	return writeSignedEntity(layoutPath, si, ref)
 }
 
 func writeSignedEntity(path layout.Path, se oci.SignedEntity, ref name.Reference) error {
@@ -105,12 +105,12 @@ func isEmpty(s oci.Signatures) bool {
 
 func appendImage(path layout.Path, img v1.Image, ref name.Reference, annotation string) error {
 	imageRef, err := getImageRef(ref)
-    if err != nil {
-        return err // Return the error from getImageRef immediately.
-    }
+	if err != nil {
+		return err // Return the error from getImageRef immediately.
+	}
 	return path.AppendImage(img, layout.WithAnnotations(
-        map[string]string{KindAnnotation: annotation, ImageTitleAnnotation: imageRef},
-    ))
+		map[string]string{KindAnnotation: annotation, ImageRefAnnotation: imageRef},
+	))
 }
 
 func getImageRef(ref name.Reference) (string, error) {

--- a/pkg/oci/layout/write.go
+++ b/pkg/oci/layout/write.go
@@ -30,16 +30,13 @@ import (
 // WriteSignedImage writes the image and all related signatures, attestations and attachments
 func WriteSignedImage(path string, si oci.SignedImage, ref name.Reference) error {
 	layoutPath, err := layout.FromPath(path)
+    if os.IsNotExist(err) {
+        // If the layout doesn't exist, create a new one
+        layoutPath, err = layout.Write(path, empty.Index)
+    }
     if err != nil {
-        if os.IsNotExist(err) {
-            // If the layout doesn't exist, create a new one
-            layoutPath, err = layout.Write(path, empty.Index)
-            if err != nil {
-                return err
-            }
-        } else {
-            return err
-        }
+        return err
+    }
     }
 	
 	// write the image

--- a/pkg/oci/layout/write.go
+++ b/pkg/oci/layout/write.go
@@ -118,9 +118,6 @@ func getImageRef(ref name.Reference) (string, error) {
 		return "", errors.New("reference is nil")
 	}
 	registry := ref.Context().RegistryStr() + "/"
-	imageRef := ref.Name()
-	if strings.HasPrefix(imageRef, registry) {
-		imageRef = imageRef[len(registry):]
-	}
+	imageRef := strings.TrimPrefix(ref.Name(), registry)
 	return imageRef, nil
 }

--- a/pkg/oci/layout/write.go
+++ b/pkg/oci/layout/write.go
@@ -49,16 +49,12 @@ func WriteSignedImage(path string, si oci.SignedImage, ref name.Reference) error
 // WriteSignedImageIndex writes the image index and all related signatures, attestations and attachments
 func WriteSignedImageIndex(path string, si oci.SignedImageIndex, ref name.Reference) error {
 	layoutPath, err := layout.FromPath(path)
+    if os.IsNotExist(err) {
+        // If the layout doesn't exist, create a new one
+        layoutPath, err = layout.Write(path, empty.Index)
+    }
     if err != nil {
-        if os.IsNotExist(err) {
-            // If the layout doesn't exist, create a new one
-            layoutPath, err = layout.Write(path, empty.Index)
-            if err != nil {
-                return err
-            }
-        } else {
-            return err
-        }
+        return err
     }
 
     // Append the image index

--- a/pkg/oci/layout/write_test.go
+++ b/pkg/oci/layout/write_test.go
@@ -21,13 +21,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
-	"github.com/google/go-containerregistry/pkg/name"
 )
 
 func TestReadWrite(t *testing.T) {

--- a/pkg/oci/layout/write_test.go
+++ b/pkg/oci/layout/write_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
+	"github.com/google/go-containerregistry/pkg/name"
 )
 
 func TestReadWrite(t *testing.T) {
@@ -36,7 +37,8 @@ func TestReadWrite(t *testing.T) {
 	// write random signed image to disk
 	si := randomSignedImage(t)
 	tmp := t.TempDir()
-	if err := WriteSignedImage(tmp, si); err != nil {
+	ref, err := name.ParseReference("test.com/test")
+	if err := WriteSignedImage(tmp, si, ref); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/oci/layout/write_test.go
+++ b/pkg/oci/layout/write_test.go
@@ -38,6 +38,9 @@ func TestReadWrite(t *testing.T) {
 	si := randomSignedImage(t)
 	tmp := t.TempDir()
 	ref, err := name.ParseReference("test.com/test")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := WriteSignedImage(tmp, si, ref); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -28,8 +28,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	ociexperimental "github.com/sigstore/cosign/v2/internal/pkg/oci/remote"
 	"github.com/sigstore/cosign/v2/pkg/oci"
-	ctypes "github.com/sigstore/cosign/v2/pkg/types"
 	"github.com/sigstore/cosign/v2/pkg/oci/layout"
+	ctypes "github.com/sigstore/cosign/v2/pkg/types"
 )
 
 // WriteSignedImageIndexImages writes the images within the image index
@@ -103,10 +103,10 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 		return err
 	}
 	for _, m := range manifest.Manifests {
-		
+
 		// write image index if exists
 		if val, ok := m.Annotations[layout.KindAnnotation]; ok && val == layout.ImageIndexAnnotation {
-			imgTitle := m.Annotations[layout.ImageTitleAnnotation]
+			imgTitle := m.Annotations[layout.ImageRefAnnotation]
 			fmt.Println(imgTitle)
 			si, err := sii.SignedImageIndex(m.Digest)
 			if err != nil {
@@ -127,7 +127,7 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 
 		// write any images
 		if val, ok := m.Annotations[layout.KindAnnotation]; ok && val == layout.ImageAnnotation {
-			imgTitle := m.Annotations[layout.ImageTitleAnnotation]
+			imgTitle := m.Annotations[layout.ImageRefAnnotation]
 			fmt.Println(imgTitle)
 			si, err := sii.SignedImage(m.Digest)
 			if err != nil {
@@ -148,7 +148,7 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 
 		// write the signatures
 		if val, ok := m.Annotations[layout.KindAnnotation]; ok && val == layout.SigsAnnotation {
-			imgTitle := m.Annotations[layout.ImageTitleAnnotation]
+			imgTitle := m.Annotations[layout.ImageRefAnnotation]
 			sigs, err := sii.SignedImage(m.Digest)
 			if err != nil {
 				return err
@@ -169,7 +169,7 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 
 		// write the attestations
 		if val, ok := m.Annotations[layout.KindAnnotation]; ok && val == layout.AttsAnnotation {
-			imgTitle := m.Annotations[layout.ImageTitleAnnotation]
+			imgTitle := m.Annotations[layout.ImageRefAnnotation]
 			atts, err := sii.SignedImage(m.Digest)
 			if err != nil {
 				return err

--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -105,7 +105,6 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 		// write image index if exists
 		if val, ok := m.Annotations[layout.KindAnnotation]; ok && val == layout.ImageIndexAnnotation {
 			imgTitle := m.Annotations[layout.ImageRefAnnotation]
-			fmt.Println(imgTitle)
 			si, err := sii.SignedImageIndex(m.Digest)
 			if err != nil {
 				return fmt.Errorf("signed image index: %w", err)
@@ -126,7 +125,6 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 		// write any images
 		if val, ok := m.Annotations[layout.KindAnnotation]; ok && val == layout.ImageAnnotation {
 			imgTitle := m.Annotations[layout.ImageRefAnnotation]
-			fmt.Println(imgTitle)
 			si, err := sii.SignedImage(m.Digest)
 			if err != nil {
 				return fmt.Errorf("signed image: %w", err)

--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -153,6 +153,9 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 			}
 			if sigs != nil { // will be nil if there are no associated signatures
 				ref, err := name.ParseReference(targetRegistry + "/" + imgTitle)
+				if err != nil {
+					return fmt.Errorf("creating new reference: %w", err)
+				}
 				sigsTag, err := SignatureTag(ref, opts...)
 				if err != nil {
 					return fmt.Errorf("sigs tag: %w", err)
@@ -174,6 +177,9 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 			}
 			if atts != nil { // will be nil if there are no associated attestations
 				ref, err := name.ParseReference(targetRegistry + "/" + imgTitle)
+				if err != nil {
+					return fmt.Errorf("creating new reference: %w", err)
+				}
 				attsTag, err := AttestationTag(ref, opts...)
 				if err != nil {
 					return fmt.Errorf("sigs tag: %w", err)

--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -96,14 +96,12 @@ func WriteSignedImageIndexImages(ref name.Reference, sii oci.SignedImageIndex, o
 // Bulk version.  Uses targetRegistry for multiple images/sigs/atts.
 // This includes the signed image and associated signatures in the image index
 func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageIndex, opts ...Option) error {
-
 	// loop through all of the items in the manifest
 	manifest, err := sii.IndexManifest()
 	if err != nil {
 		return err
 	}
 	for _, m := range manifest.Manifests {
-
 		// write image index if exists
 		if val, ok := m.Annotations[layout.KindAnnotation]; ok && val == layout.ImageIndexAnnotation {
 			imgTitle := m.Annotations[layout.ImageRefAnnotation]
@@ -187,7 +185,6 @@ func WriteSignedImageIndexImagesBulk(targetRegistry string, sii oci.SignedImageI
 				}
 			}
 		}
-
 	}
 	return nil
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1738,10 +1738,10 @@ func TestSaveLoadBulk(t *testing.T) {
                 must(cli.SaveCmd(ctx, options.SaveOptions{Directory: imageDir}, imgName), t)
 
                 // Verify the local image using a local key
-                must(verifyLocal(pubKeyPath, imageDir, true, nil, ""), t)                
+                must(verifyLocal(pubKeyPath, imageDir, true, nil, ""), t)
             }
-			// Load the images from the temp dir into a registry 
-			must(cli.LoadCmd(ctx, options.LoadOptions{Directory: imageDir, Registry: regName), t)
+			// Load the images from the temp dir into a registry
+			must(cli.LoadCmd(ctx, options.LoadOptions{Directory: imageDir, Registry: regName}), t)
 
 			// verify the new images
 			must(verify(pubKeyPath, path.Join(regName, imageName[0]), true, nil, ""), t)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
When using `cosign save` with dozens, or in my case, hundreds of images, the storage consumption can really add up with each image requiring their own directory.  There's potentially a case where images can share layers so this change allows for the `cosign save` function to be able to reuse a directory from a previous save and just build on the `index.json` along with an additional annotation for each entry to aide with the corresponding `cosign load`.

From there, I've modified `cosign load` to have a new optional flag `--registry` where you can specify a registry to load all of the images to from a single directory.  In cases where you are only dealing with a single image, the load command would function exactly how it does today where you just provide the remote reference via the cli.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.
-->
* Updated `cosign save` to append the index.json if pointed at a `--dir` used in a previous save.
* Added the `org.opencontainers.image.ref.name` annotation to the index.json for clarity and to help with `cosign load` in cases where the directory is reused.
* Updated `cosign load` to have an optional flag called `--registry` that can be used in cases where the index.json from a save contains multiple images.  This handles being able to control where the images get loaded to in the case where providing a single ref via the CLI no longer makes sense.  If you don't provide the `--registry` flag, the `cosign load` command will continue to function as it does today.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Example usage:
`cosign save image1:v1.0 --dir ~/saves`
`cosign save image2:v1.0 --dir ~/saves`

`cat ~/saves/index.json`

```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1581,
         "digest": "sha256:c5b6da2ffbc9f63e8d250d5985f722830dfb5cc8958e8f64f7e14edc18b584fa",
         "annotations": {
            "kind": "dev.cosignproject.cosign/image",
            "org.opencontainers.image.ref.name": "image1:v1.0"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 558,
         "digest": "sha256:077bc8e8cfe1577f89959c749da1fbe941bde8b35b7ccdfe4f5832fb5ade2ec1",
         "annotations": {
            "kind": "dev.cosignproject.cosign/sigs",
            "org.opencontainers.image.ref.name": "image1:v1.0"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 468,
         "digest": "sha256:7e6fb78b8f35c859c9200567229a4350c17e057d4d13c80121a3f603748a1cb0",
         "annotations": {
            "kind": "dev.cosignproject.cosign/atts",
            "org.opencontainers.image.ref.name": "image1:v1.0"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
         "size": 967,
         "digest": "sha256:7e42b1a631859c6740835659a022ed96097955dde2707f32e7a089f5b5f64c06",
         "annotations": {
            "kind": "dev.cosignproject.cosign/imageIndex",
            "org.opencontainers.image.ref.name": "image2:v1.0"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 558,
         "digest": "sha256:88145843e5dcd7a0d515cf874997b1d4eaa742a1594dc75c6bd111f109cf4455",
         "annotations": {
            "kind": "dev.cosignproject.cosign/sigs",
            "org.opencontainers.image.ref.name": "image2:v1.0"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 469,
         "digest": "sha256:6fa5a413e06af7babaeae39bb06c92b563463080fd46003b078050787c3ef6f0",
         "annotations": {
            "kind": "dev.cosignproject.cosign/atts",
            "org.opencontainers.image.ref.name": "image2:v1.0"
         }
      }
   ]
}
```

`cosign load  --dir ~/saves --registry your.registry.com`