### PR TITLE
Stop using deprecated in_toto.ProvenanceStatement

### DIFF
--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -213,7 +213,7 @@ func generateSLSAProvenanceStatementSLSA02(rawPayload []byte, digest string, rep
 	if err != nil {
 		return "", fmt.Errorf("unmarshal Provenance predicate: %w", err)
 	}
-	return in_toto.ProvenanceStatement{
+	return in_toto.ProvenanceStatementSLSA02{
 		StatementHeader: generateStatementHeader(digest, repo, slsa02.PredicateSLSAProvenance),
 		Predicate:       predicate,
 	}, nil

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -105,7 +105,7 @@ func appendSlices(slices [][]byte) []byte {
 }
 
 func Test_verifyOCIAttestation(t *testing.T) {
-	stmt, err := json.Marshal(in_toto.ProvenanceStatement{})
+	stmt, err := json.Marshal(in_toto.ProvenanceStatementSLSA02{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/policy/attestation.go
+++ b/pkg/policy/attestation.go
@@ -106,13 +106,13 @@ func AttestationToPayloadJSON(_ context.Context, predicateType string, verifiedA
 			return nil, statement.PredicateType, fmt.Errorf("marshaling LinkStatement: %w", err)
 		}
 	case options.PredicateSLSA:
-		var slsaProvenanceStatement in_toto.ProvenanceStatement
+		var slsaProvenanceStatement in_toto.ProvenanceStatementSLSA02
 		if err := json.Unmarshal(decodedPayload, &slsaProvenanceStatement); err != nil {
-			return nil, statement.PredicateType, fmt.Errorf("unmarshaling ProvenanceStatement): %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("unmarshaling ProvenanceStatementSLSA02): %w", err)
 		}
 		payload, err = json.Marshal(slsaProvenanceStatement)
 		if err != nil {
-			return nil, statement.PredicateType, fmt.Errorf("marshaling ProvenanceStatement: %w", err)
+			return nil, statement.PredicateType, fmt.Errorf("marshaling ProvenanceStatementSLSA02: %w", err)
 		}
 	case options.PredicateSPDX, options.PredicateSPDXJSON:
 		var spdxStatement in_toto.SPDXStatement


### PR DESCRIPTION

#### Summary
The struct `in_toto.ProvenanceStatement` is marked as deprecated. Instead, it is recommened to use a version-specific struct. The `in_toto.ProvenanceStatementSLSA02` is the equivalent.

#### Release Note
* When generating a SLSA v0.2 statement, `attestation.GenerateStatement` now returns an object of type `in_toto.ProvenanceStatementSLSA02` instead of the deprecated `in_toto.ProvenanceStatement`.

#### Documentation

NONE