### PR TITLE
fix: allow cosign download sbom when image is absent

### DIFF
--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -47,7 +47,15 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
 	if err != nil {
-		return err
+		if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
+			if digest, ok := ref.(name.Digest); ok {
+				se = ociremote.SignedUnknown(digest)
+			} else {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
 
 	se, err = platform.SignedEntityForPlatform(se, attOptions.Platform)

--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -51,6 +51,7 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 	if err != nil {
 		if errors.As(err, &entityNotFoundError) {
 			if digest, ok := ref.(name.Digest); ok {
+				// We don't need to access the original image to download the attached attestation
 				se = ociremote.SignedUnknown(digest)
 			} else {
 				return err

--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -46,16 +46,14 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 	}
 
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
-	if err != nil {
-		if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
-			if digest, ok := ref.(name.Digest); ok {
-				se = ociremote.SignedUnknown(digest)
-			} else {
-				return err
-			}
+	if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
+		if digest, ok := ref.(name.Digest); ok {
+			se = ociremote.SignedUnknown(digest)
 		} else {
 			return err
 		}
+	} else if err != nil {
+		return err
 	}
 
 	se, err = platform.SignedEntityForPlatform(se, attOptions.Platform)

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -45,7 +45,15 @@ func SBOMCmd(
 
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
 	if err != nil {
-		return nil, err
+		if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
+			if digest, ok := ref.(name.Digest); ok {
+				se = ociremote.SignedUnknown(digest)
+			} else {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
 	}
 
 	se, err = platform.SignedEntityForPlatform(se, dnOpts.Platform)

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -47,6 +47,7 @@ func SBOMCmd(
 	var entityNotFoundError *ociremote.EntityNotFoundError
 	if err != nil {
 		if errors.As(err, &entityNotFoundError) {
+			// We don't need to access the original image to download the attached sbom
 			if digest, ok := ref.(name.Digest); ok {
 				se = ociremote.SignedUnknown(digest)
 			} else {

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -44,14 +44,17 @@ func SBOMCmd(
 	}
 
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
-	if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
-		if digest, ok := ref.(name.Digest); ok {
-			se = ociremote.SignedUnknown(digest)
+	var entityNotFoundError *ociremote.EntityNotFoundError
+	if err != nil {
+		if errors.As(err, &entityNotFoundError) {
+			if digest, ok := ref.(name.Digest); ok {
+				se = ociremote.SignedUnknown(digest)
+			} else {
+				return nil, err
+			}
 		} else {
 			return nil, err
 		}
-	} else if err != nil {
-		return nil, err
 	}
 
 	se, err = platform.SignedEntityForPlatform(se, dnOpts.Platform)

--- a/cmd/cosign/cli/download/sbom.go
+++ b/cmd/cosign/cli/download/sbom.go
@@ -44,16 +44,14 @@ func SBOMCmd(
 	}
 
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
-	if err != nil {
-		if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
-			if digest, ok := ref.(name.Digest); ok {
-				se = ociremote.SignedUnknown(digest)
-			} else {
-				return nil, err
-			}
+	if _, isEntityNotFoundErr := err.(*ociremote.EntityNotFoundError); isEntityNotFoundErr {
+		if digest, ok := ref.(name.Digest); ok {
+			se = ociremote.SignedUnknown(digest)
 		} else {
 			return nil, err
 		}
+	} else if err != nil {
+		return nil, err
 	}
 
 	se, err = platform.SignedEntityForPlatform(se, dnOpts.Platform)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Closes: https://github.com/sigstore/cosign/issues/2603
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Cosign will not fail to download sbom when image is absent.

This PR build on top of changes made in: https://github.com/sigstore/cosign/pull/2959

**Proof:**
```bash
$ DIGEST=$(crane digest cgr.dev/chainguard/static)

$ crane copy cgr.dev/chainguard/static@$DIGEST ttl.sh/sbom-no-img:1h
2023/09/16 21:37:03 Copying from cgr.dev/chainguard/static@sha256:a432665213f109d5e48111316030eecc5191654cf02a5b66ac6c5d6b310a5511 to ttl.sh/sbom-no-img:1h
...
sha256:a432665213f109d5e48111316030eecc5191654cf02a5b66ac6c5d6b310a5511 size: 1835

$ go run ./cmd/cosign sign ttl.sh/sbom-no-img:1h 
Generating ephemeral keys...
Retrieving signed certificate...
...
Pushing signature to: ttl.sh/sbom-no-img

$ go run ./cmd/cosign attach sbom ttl.sh/sbom-no-img@$DIGEST  --sbom <(echo "{}")
WARNING: Attaching SBOMs this way does not sign them. If you want to sign them, use 'cosign attest --predicate /dev/fd/11 --key <key path>' or 'cosign sign --key <key path> --attachment sbom <image uri>'.
Uploading SBOM file for [ttl.sh/sbom-no-img@sha256:a432665213f109d5e48111316030eecc5191654cf02a5b66ac6c5d6b310a5511] to [ttl.sh/sbom-no-img:sha256-a432665213f109d5e48111316030eecc5191654cf02a5b66ac6c5d6b310a5511.sbom] with mediaType [text/spdx].

$ go run ./cmd/cosign download sbom ttl.sh/sbom-no-img@$DIGEST 

WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>' or verify its signature using 'cosign verify --key <key path> --attachment sbom <image uri>'.
Found SBOM of media type: text/spdx
{}

$ crane delete ttl.sh/sbom-no-img@$DIGEST 

$ crane delete ttl.sh/sbom-no-img@$DIGEST # delete confirmation
Error: DELETE https://ttl.sh/v2/sbom-no-img/manifests/sha256:a432665213f109d5e48111316030eecc5191654cf02a5b66ac6c5d6b310a5511: MANIFEST_UNKNOWN: manifest unknown

$ go run ./cmd/cosign download sbom ttl.sh/sbom-no-img@$DIGEST
WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>' or verify its signature using 'cosign verify --key <key path> --attachment sbom <image uri>'.
Found SBOM of media type: text/spdx
{}
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Added support for `cosign download sbom` when image is absent
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
