### PR TITLE
feat: add `--only` flag in `cosign copy` to copy sign, att & sbom

### DIFF
--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -34,7 +34,10 @@ func Copy() *cobra.Command {
   cosign copy example.com/src:latest example.com/dest:latest
 
   # copy the signatures only
-  cosign copy --sig-only example.com/src example.com/dest
+  cosign copy --only=sign example.com/src example.com/dest
+
+  # copy the signatures, attestations, sbom only
+  cosign copy --only=sign,att,sbom example.com/src example.com/dest
 
   # overwrite destination image and signatures
   cosign copy -f example.com/src example.com/dest
@@ -45,7 +48,7 @@ func Copy() *cobra.Command {
 		Args:             cobra.ExactArgs(2),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return copy.CopyCmd(cmd.Context(), o.Registry, args[0], args[1], o.SignatureOnly, o.Force, o.Platform)
+			return copy.CopyCmd(cmd.Context(), o.Registry, args[0], args[1], o.SignatureOnly, o.Force, o.CopyOnly, o.Platform)
 		},
 	}
 

--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -32,11 +33,12 @@ import (
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/cosign/v2/pkg/oci/walk"
 	"golang.org/x/sync/errgroup"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // CopyCmd implements the logic to copy the supplied container image and signatures.
 // nolint
-func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstImg string, sigOnly, force bool, platform string) error {
+func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstImg string, sigOnly, force bool, copyOnly, platform string) error {
 	no := regOpts.NameOptions()
 	srcRef, err := name.ParseReference(srcImg, no...)
 	if err != nil {
@@ -99,15 +101,9 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 			return nil
 		}
 
-		if err := copyTag(ociremote.SignatureTag); err != nil {
-			return err
-		}
+		tags := parseOnlyFlag(copyOnly)
 
-		if sigOnly {
-			return nil
-		}
-
-		for _, tm := range []tagMap{ociremote.AttestationTag, ociremote.SBOMTag} {
+		for _, tm := range tags {
 			if err := copyTag(tm); err != nil {
 				return err
 			}
@@ -130,8 +126,8 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 		return err
 	}
 
-	// If we're only copying sigs, we have nothing left to do.
-	if sigOnly {
+	// If we're only copying sig/att/sbom, we have nothing left to do.
+	if len(parseOnlyFlag(copyOnly)) > 0 {
 		return nil
 	}
 
@@ -177,4 +173,20 @@ func remoteCopy(ctx context.Context, pusher *remote.Pusher, src, dest name.Refer
 
 	fmt.Fprintf(os.Stderr, "Copying %s to %s...\n", src, dest)
 	return pusher.Push(ctx, dest, got)
+}
+
+func parseOnlyFlag(str string) []tagMap {
+	var tags []tagMap
+	items := strings.Split(str, ",")
+	tagSet := sets.New(items...)
+	if tagSet.Has("sign") {
+		tags = append(tags, ociremote.SignatureTag)
+	}
+	if tagSet.Has("sbom") {
+		tags = append(tags, ociremote.SBOMTag)
+	}
+	if tagSet.Has("att") {
+		tags = append(tags, ociremote.AttestationTag)
+	}
+	return tags
 }

--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -79,6 +79,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 		return err
 	}
 
+	tags := parseeOnlyOpt(copyOnly, sigOnly)
 	if err := walk.SignedEntity(gctx, root, func(ctx context.Context, se oci.SignedEntity) error {
 		// Both of the SignedEntity types implement Digest()
 		h, err := se.Digest()
@@ -100,8 +101,6 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 
 			return nil
 		}
-
-		tags := parseOnlyFlag(copyOnly, sigOnly)
 
 		for _, tm := range tags {
 			if err := copyTag(tm); err != nil {
@@ -127,7 +126,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 	}
 
 	// If we're only copying sig/att/sbom, we have nothing left to do.
-	if len(parseOnlyFlag(copyOnly, sigOnly)) > 0 {
+	if len(tags) > 0 {
 		return nil
 	}
 
@@ -175,12 +174,13 @@ func remoteCopy(ctx context.Context, pusher *remote.Pusher, src, dest name.Refer
 	return pusher.Push(ctx, dest, got)
 }
 
-func parseOnlyFlag(str string, sigOnly bool) []tagMap {
+func parseeOnlyOpt(str string, sigOnly bool) []tagMap {
 	var tags []tagMap
 	items := strings.Split(str, ",")
 	tagSet := sets.New(items...)
 
 	if sigOnly {
+		fmt.Fprintf(os.Stderr, "--sig-only is deprecated, use --only=sign instead")
 		tagSet.Insert("sign")
 	}
 

--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -79,7 +79,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 		return err
 	}
 
-	tags := parseeOnlyOpt(copyOnly, sigOnly)
+	tags := parseOnlyOpt(copyOnly, sigOnly)
 	if err := walk.SignedEntity(gctx, root, func(ctx context.Context, se oci.SignedEntity) error {
 		// Both of the SignedEntity types implement Digest()
 		h, err := se.Digest()
@@ -174,7 +174,7 @@ func remoteCopy(ctx context.Context, pusher *remote.Pusher, src, dest name.Refer
 	return pusher.Push(ctx, dest, got)
 }
 
-func parseeOnlyOpt(str string, sigOnly bool) []tagMap {
+func parseOnlyOpt(str string, sigOnly bool) []tagMap {
 	var tags []tagMap
 	items := strings.Split(str, ",")
 	tagSet := sets.New(items...)

--- a/cmd/cosign/cli/copy/copy.go
+++ b/cmd/cosign/cli/copy/copy.go
@@ -101,7 +101,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 			return nil
 		}
 
-		tags := parseOnlyFlag(copyOnly)
+		tags := parseOnlyFlag(copyOnly, sigOnly)
 
 		for _, tm := range tags {
 			if err := copyTag(tm); err != nil {
@@ -127,7 +127,7 @@ func CopyCmd(ctx context.Context, regOpts options.RegistryOptions, srcImg, dstIm
 	}
 
 	// If we're only copying sig/att/sbom, we have nothing left to do.
-	if len(parseOnlyFlag(copyOnly)) > 0 {
+	if len(parseOnlyFlag(copyOnly, sigOnly)) > 0 {
 		return nil
 	}
 
@@ -175,10 +175,15 @@ func remoteCopy(ctx context.Context, pusher *remote.Pusher, src, dest name.Refer
 	return pusher.Push(ctx, dest, got)
 }
 
-func parseOnlyFlag(str string) []tagMap {
+func parseOnlyFlag(str string, sigOnly bool) []tagMap {
 	var tags []tagMap
 	items := strings.Split(str, ",")
 	tagSet := sets.New(items...)
+
+	if sigOnly {
+		tagSet.Insert("sign")
+	}
+
 	if tagSet.Has("sign") {
 		tags = append(tags, ociremote.SignatureTag)
 	}

--- a/cmd/cosign/cli/copy/copy_test.go
+++ b/cmd/cosign/cli/copy/copy_test.go
@@ -33,7 +33,7 @@ func TestCopyAttachmentTagPrefix(t *testing.T) {
 
 	err := CopyCmd(ctx, options.RegistryOptions{
 		RefOpts: refOpts,
-	}, srcImg, destImg, false, true, "")
+	}, srcImg, destImg, false, true, "", "")
 	if err == nil {
 		t.Fatal("failed to copy with attachment-tag-prefix")
 	}
@@ -45,7 +45,7 @@ func TestCopyPlatformOpt(t *testing.T) {
 	srcImg := "alpine"
 	destImg := "test-alpine"
 
-	err := CopyCmd(ctx, options.RegistryOptions{}, srcImg, destImg, false, true, "linux/amd64")
+	err := CopyCmd(ctx, options.RegistryOptions{}, srcImg, destImg, false, true, "", "linux/amd64")
 	if err == nil {
 		t.Fatal("failed to copy with platform")
 	}

--- a/cmd/cosign/cli/options/copy.go
+++ b/cmd/cosign/cli/options/copy.go
@@ -21,6 +21,7 @@ import (
 
 // CopyOptions is the top level wrapper for the copy command.
 type CopyOptions struct {
+	CopyOnly      string
 	SignatureOnly bool
 	Force         bool
 	Platform      string
@@ -33,8 +34,11 @@ var _ Interface = (*CopyOptions)(nil)
 func (o *CopyOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 
+	cmd.Flags().StringVar(&o.CopyOnly, "only", "",
+		"custom string array to only copy specific items. ex: --only=sbom,sign,att")
+
 	cmd.Flags().BoolVar(&o.SignatureOnly, "sig-only", false,
-		"only copy the image signature")
+		"[DEPRECATED] only copy the image signature")
 
 	cmd.Flags().BoolVarP(&o.Force, "force", "f", false,
 		"overwrite destination image(s), if necessary")

--- a/cmd/cosign/cli/options/copy.go
+++ b/cmd/cosign/cli/options/copy.go
@@ -35,7 +35,7 @@ func (o *CopyOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.CopyOnly, "only", "",
-		"custom string array to only copy specific items. ex: --only=sbom,sign,att")
+		"custom string array to only copy specific items, this flag is comma delimited. ex: --only=sbom,sign,att")
 
 	cmd.Flags().BoolVar(&o.SignatureOnly, "sig-only", false,
 		"[DEPRECATED] only copy the image signature")

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -36,7 +36,7 @@ cosign copy [flags]
   -f, --force                                                                                    overwrite destination image(s), if necessary
   -h, --help                                                                                     help for copy
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
-      --only string                                                                              custom string array to only copy specific items. ex: --only=sbom,sign,att
+      --only string                                                                              custom string array to only copy specific items, this flag is comma delimited. ex: --only=sbom,sign,att
       --platform string                                                                          only copy container image and its signatures for a specific platform image
       --sig-only                                                                                 [DEPRECATED] only copy the image signature
 ```

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -15,7 +15,10 @@ cosign copy [flags]
   cosign copy example.com/src:latest example.com/dest:latest
 
   # copy the signatures only
-  cosign copy --sig-only example.com/src example.com/dest
+  cosign copy --only=sign example.com/src example.com/dest
+
+  # copy the signatures, attestations, sbom only
+  cosign copy --only=sign,att,sbom example.com/src example.com/dest
 
   # overwrite destination image and signatures
   cosign copy -f example.com/src example.com/dest
@@ -33,8 +36,9 @@ cosign copy [flags]
   -f, --force                                                                                    overwrite destination image(s), if necessary
   -h, --help                                                                                     help for copy
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --only string                                                                              custom string array to only copy specific items. ex: --only=sbom,sign,att
       --platform string                                                                          only copy container image and its signatures for a specific platform image
-      --sig-only                                                                                 only copy the image signature
+      --sig-only                                                                                 [DEPRECATED] only copy the image signature
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Closes: #2002

This PR will add a new `--only` flag that accept custom string array to download sboms, signatures and attestations
```bash
$ cosign copy --only=sbom,sign,att <SRC> <DST>
```
#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Added `--only` flag in `cosign copy` to copy sign, att & sbom
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Ran `make docgen` to generate required docs
