### PR TITLE
feat: add support outputting rekor response on signing

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -620,7 +620,7 @@ func (c *SignerVerifier) Bytes(ctx context.Context) ([]byte, error) {
 }
 
 func fetchLocalSignedPayload(sig oci.Signature) (*cosign.LocalSignedPayload, error) {
-	var signedPayload *cosign.LocalSignedPayload
+	signedPayload := &cosign.LocalSignedPayload{}
 	var err error
 	signedPayload.Base64Signature, err = sig.Base64Signature()
 	if err != nil {
@@ -630,9 +630,11 @@ func fetchLocalSignedPayload(sig oci.Signature) (*cosign.LocalSignedPayload, err
 	if err != nil {
 		return nil, err
 	}
-	signedPayload.Cert = base64.StdEncoding.EncodeToString(sigCert.Raw)
-	if err != nil {
-		return nil, err
+	if sigCert != nil {
+		signedPayload.Cert = base64.StdEncoding.EncodeToString(sigCert.Raw)
+		if err != nil {
+			return nil, err
+		}
 	}
 	signedPayload.Bundle, err = sig.Bundle()
 	if err != nil {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -960,7 +960,7 @@ func TestRekorOutput(t *testing.T) {
 	td := t.TempDir()
 
 	imgName := path.Join(repo, "cosign-e2e")
-	bundlePath := filepath.Join(td1, "bundle.sig")
+	bundlePath := filepath.Join(td, "bundle.sig")
 
 	_, _, cleanup := mkimage(t, imgName)
 	defer cleanup()
@@ -986,7 +986,7 @@ func TestRekorOutput(t *testing.T) {
 		t.Fatal(err)
 	} else {
 		var localCosignPayload cosign.LocalSignedPayload
-		if err := json.Unmarshal(rekorBundleByte, &localCosignPayload); err != nil {
+		if err := json.Unmarshal(file, &localCosignPayload); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -952,9 +952,6 @@ func TestRekorBundle(t *testing.T) {
 }
 
 func TestRekorOutput(t *testing.T) {
-	// turn on the tlog
-	defer setenv(t, env.VariableExperimental.String(), "1")()
-
 	repo, stop := reg(t)
 	defer stop()
 	td := t.TempDir()


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes: #3110

Previously, there's no support for outputting a bundle with `cosign sign` ([code](https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/sign/sign.go#L266-L298)), only `sign-blob` ([code](https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/sign/sign_blob.go#L135-L152)). This PR adds support for outputting rekor response on signing. This supports use-cases where a signer does not want to attach metadata immediately to the container.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Added support outputting rekor response on signing with `cosign sign`
#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
