### PR TITLE
added ability to get image digest back via triangulate

### DIFF
--- a/cmd/cosign/cli/options/triangulate.go
+++ b/cmd/cosign/cli/options/triangulate.go
@@ -32,5 +32,5 @@ func (o *TriangulateOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Type, "type", "signature",
-		"related attachment to triangulate (attestation|sbom|signature), default signature (sbom is deprecated)")
+		"related attachment to triangulate (attestation|sbom|signature|digest), default signature (sbom is deprecated)")
 }

--- a/cmd/cosign/cli/triangulate/triangulate.go
+++ b/cmd/cosign/cli/triangulate/triangulate.go
@@ -38,14 +38,22 @@ func MungeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef str
 	}
 
 	var dstRef name.Tag
+	var dstRefName string
+
 	switch attachmentType {
 	case cosign.Signature:
 		dstRef, err = ociremote.SignatureTag(ref, ociremoteOpts...)
+		dstRefName = dstRef.Name()
 	case cosign.SBOM:
 		fmt.Fprintln(os.Stderr, options.SBOMAttachmentDeprecation)
 		dstRef, err = ociremote.SBOMTag(ref, ociremoteOpts...)
+		dstRefName = dstRef.Name()
 	case cosign.Attestation:
 		dstRef, err = ociremote.AttestationTag(ref, ociremoteOpts...)
+		dstRefName = dstRef.Name()
+	case cosign.Digest:
+		dstRef, err = ociremote.DigestTag(ref, ociremoteOpts...)
+		dstRefName = fmt.Sprint(dstRef.Repository.Name(), "@", dstRef.TagStr())
 	default:
 		err = fmt.Errorf("unknown attachment type %s", attachmentType)
 	}
@@ -53,6 +61,6 @@ func MungeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef str
 		return err
 	}
 
-	fmt.Println(dstRef.Name())
+	fmt.Println(dstRefName)
 	return nil
 }

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -20,7 +20,7 @@ cosign triangulate [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for triangulate
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
-      --type string                                                                              related attachment to triangulate (attestation|sbom|signature), default signature (sbom is deprecated) (default "signature")
+      --type string                                                                              related attachment to triangulate (attestation|sbom|signature|digest), default signature (sbom is deprecated) (default "signature")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -64,6 +64,7 @@ const (
 	Signature   = "signature"
 	SBOM        = "sbom"
 	Attestation = "attestation"
+	Digest      = "digest"
 )
 
 func FetchSignaturesForReference(_ context.Context, ref name.Reference, opts ...ociremote.Option) ([]SignedPayload, error) {

--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -97,31 +97,43 @@ func SignedEntity(ref name.Reference, options ...Option) (oci.SignedEntity, erro
 // normalize turns image digests into tags with optional prefix & suffix:
 // sha256:d34db33f -> [prefix]sha256-d34db33f[.suffix]
 func normalize(h v1.Hash, prefix string, suffix string) string {
+	return normalizeWithSeparator(h, prefix, suffix, "-")
+}
+
+// normalizeWithSeparator turns image digests into tags with optional prefix & suffix:
+// sha256:d34db33f -> [prefix]sha256[algorithmSeparator]d34db33f[.suffix]
+func normalizeWithSeparator(h v1.Hash, prefix string, suffix string, algorithmSeparator string) string {
 	if suffix == "" {
-		return fmt.Sprint(prefix, h.Algorithm, "-", h.Hex)
+		return fmt.Sprint(prefix, h.Algorithm, algorithmSeparator, h.Hex)
 	}
-	return fmt.Sprint(prefix, h.Algorithm, "-", h.Hex, ".", suffix)
+	return fmt.Sprint(prefix, h.Algorithm, algorithmSeparator, h.Hex, ".", suffix)
 }
 
 // SignatureTag returns the name.Tag that associated signatures with a particular digest.
 func SignatureTag(ref name.Reference, opts ...Option) (name.Tag, error) {
 	o := makeOptions(ref.Context(), opts...)
-	return suffixTag(ref, o.SignatureSuffix, o)
+	return suffixTag(ref, o.SignatureSuffix, "-", o)
 }
 
 // AttestationTag returns the name.Tag that associated attestations with a particular digest.
 func AttestationTag(ref name.Reference, opts ...Option) (name.Tag, error) {
 	o := makeOptions(ref.Context(), opts...)
-	return suffixTag(ref, o.AttestationSuffix, o)
+	return suffixTag(ref, o.AttestationSuffix, "-", o)
 }
 
 // SBOMTag returns the name.Tag that associated SBOMs with a particular digest.
 func SBOMTag(ref name.Reference, opts ...Option) (name.Tag, error) {
 	o := makeOptions(ref.Context(), opts...)
-	return suffixTag(ref, o.SBOMSuffix, o)
+	return suffixTag(ref, o.SBOMSuffix, "-", o)
 }
 
-func suffixTag(ref name.Reference, suffix string, o *options) (name.Tag, error) {
+// DigestTag returns the name.Tag that associated SBOMs with a particular digest.
+func DigestTag(ref name.Reference, opts ...Option) (name.Tag, error) {
+	o := makeOptions(ref.Context(), opts...)
+	return suffixTag(ref, "", ":", o)
+}
+
+func suffixTag(ref name.Reference, suffix string, algorithmSeparator string, o *options) (name.Tag, error) {
 	var h v1.Hash
 	if digest, ok := ref.(name.Digest); ok {
 		var err error
@@ -136,7 +148,7 @@ func suffixTag(ref name.Reference, suffix string, o *options) (name.Tag, error) 
 		}
 		h = desc.Digest
 	}
-	return o.TargetRepository.Tag(normalize(h, o.TagPrefix, suffix)), nil
+	return o.TargetRepository.Tag(normalizeWithSeparator(h, o.TagPrefix, suffix, algorithmSeparator)), nil
 }
 
 // signatures is a shared implementation of the oci.Signed* Signatures method.


### PR DESCRIPTION
#### Summary
Provides the ability to resolve digest for image without the need to use another tool, such as crane/skopeo
- https://github.com/sigstore/cosign/issues/3251

Fixes https://github.com/sigstore/cosign/issues/3034

#### Documentation
CLI provides self-documentation via extra option on flag.
