### PR TITLE
Add deprecation notice for any usage of SBOM attachments

### DIFF
--- a/cmd/cosign/cli/attach.go
+++ b/cmd/cosign/cli/attach.go
@@ -63,16 +63,18 @@ func attachSBOM() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:              "sbom",
-		Short:            "Attach sbom to the supplied container image",
+		Short:            "DEPRECATED: Attach sbom to the supplied container image",
+		Long:             "Attach sbom to the supplied container image\n\n" + options.SBOMAttachmentDeprecation,
 		Example:          "  cosign attach sbom <image uri>",
 		Args:             cobra.ExactArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintln(os.Stderr, options.SBOMAttachmentDeprecation)
 			mediaType, err := o.MediaType()
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(os.Stderr, "WARNING: Attaching SBOMs this way does not sign them. If you want to sign them, use 'cosign attest --predicate %s --key <key path>' or 'cosign sign --key <key path> --attachment sbom <image uri>'.\n", o.SBOM)
+			fmt.Fprintf(os.Stderr, "WARNING: Attaching SBOMs this way does not sign them. To sign them, use 'cosign attest --predicate %s --key <key path>'.\n", o.SBOM)
 			return attach.SBOMCmd(cmd.Context(), o.Registry, o.RegistryExperimental, o.SBOM, mediaType, args[0])
 		},
 	}

--- a/cmd/cosign/cli/download.go
+++ b/cmd/cosign/cli/download.go
@@ -65,12 +65,14 @@ func downloadSBOM() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:              "sbom",
-		Short:            "Download SBOMs from the supplied container image",
+		Short:            "DEPRECATED: Download SBOMs from the supplied container image",
+		Long:             "Download SBOMs from the supplied container image\n\n" + options.SBOMAttachmentDeprecation,
 		Example:          "  cosign download sbom <image uri>",
 		Args:             cobra.ExactArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintln(os.Stderr, "WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>' or verify its signature using 'cosign verify --key <key path> --attachment sbom <image uri>'.")
+			fmt.Fprintln(os.Stderr, options.SBOMAttachmentDeprecation)
+			fmt.Fprintln(os.Stderr, "WARNING: Downloading SBOMs this way does not ensure its authenticity. If you want to ensure a tamper-proof SBOM, download it using 'cosign download attestation <image uri>'.")
 			_, err := download.SBOMCmd(cmd.Context(), *o, *do, args[0], cmd.OutOrStdout())
 			return err
 		},

--- a/cmd/cosign/cli/options/clean.go
+++ b/cmd/cosign/cli/options/clean.go
@@ -65,7 +65,7 @@ var _ Interface = (*CleanOptions)(nil)
 func (c *CleanOptions) AddFlags(cmd *cobra.Command) {
 	c.Registry.AddFlags(cmd)
 	c.CleanType = defaultCleanType()
-	cmd.Flags().Var(&c.CleanType, "type", "a type of clean: <signature|attestation|sbom|all>")
+	cmd.Flags().Var(&c.CleanType, "type", "a type of clean: <signature|attestation|sbom|all> (sbom is deprecated)")
 	// TODO(#2044): Rename to --skip-confirmation for consistency?
 	cmd.Flags().BoolVarP(&c.Force, "force", "f", false, "do not prompt for confirmation")
 }

--- a/cmd/cosign/cli/options/deprecate.go
+++ b/cmd/cosign/cli/options/deprecate.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 The Sigstore Authors.
+// Copyright 2023 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,22 +15,7 @@
 
 package options
 
-import (
-	"github.com/spf13/cobra"
-)
-
-// TriangulateOptions is the top level wrapper for the triangulate command.
-type TriangulateOptions struct {
-	Type     string
-	Registry RegistryOptions
-}
-
-var _ Interface = (*TriangulateOptions)(nil)
-
-// AddFlags implements Interface
-func (o *TriangulateOptions) AddFlags(cmd *cobra.Command) {
-	o.Registry.AddFlags(cmd)
-
-	cmd.Flags().StringVar(&o.Type, "type", "signature",
-		"related attachment to triangulate (attestation|sbom|signature), default signature (sbom is deprecated)")
-}
+const SBOMAttachmentDeprecation = "WARNING: SBOM attachments are deprecated " +
+	"and support will be removed in a Cosign release soon after 2024-02-22 " +
+	"(see https://github.com/sigstore/cosign/issues/2755). " +
+	"Instead, please use SBOM attestations."

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -100,7 +100,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 		"if a multi-arch image is specified, additionally sign each discrete image")
 
 	cmd.Flags().StringVar(&o.Attachment, "attachment", "",
-		"related image attachment to sign (sbom), default none")
+		"DEPRECATED, related image attachment to sign (sbom), default none")
 
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
 		"skip confirmation prompts for non-destructive operations")

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -84,7 +84,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 		"whether to check the claims found")
 
 	cmd.Flags().StringVar(&o.Attachment, "attachment", "",
-		"related image attachment to verify (sbom), default none")
+		"DEPRECATED, related image attachment to verify (sbom), default none")
 
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "json",
 		"output format for the signing image information (json|text)")

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -17,6 +17,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -88,7 +89,9 @@ race conditions or (worse) malicious tampering.
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch o.Attachment {
-			case "sbom", "":
+			case "sbom":
+				fmt.Fprintln(os.Stderr, options.SBOMAttachmentDeprecation)
+			case "":
 				break
 			default:
 				return fmt.Errorf("specified image attachment %s not specified. Can be 'sbom'", o.Attachment)

--- a/cmd/cosign/cli/triangulate/triangulate.go
+++ b/cmd/cosign/cli/triangulate/triangulate.go
@@ -18,6 +18,7 @@ package triangulate
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
@@ -41,6 +42,7 @@ func MungeCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef str
 	case cosign.Signature:
 		dstRef, err = ociremote.SignatureTag(ref, ociremoteOpts...)
 	case cosign.SBOM:
+		fmt.Fprintln(os.Stderr, options.SBOMAttachmentDeprecation)
 		dstRef, err = ociremote.SBOMTag(ref, ociremoteOpts...)
 	case cosign.Attestation:
 		dstRef, err = ociremote.AttestationTag(ref, ociremoteOpts...)

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -88,7 +88,9 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	}
 
 	switch c.Attachment {
-	case "sbom", "":
+	case "sbom":
+		fmt.Fprintln(os.Stderr, options.SBOMAttachmentDeprecation)
+	case "":
 		break
 	default:
 		return flag.ErrHelp

--- a/doc/cosign_attach.md
+++ b/doc/cosign_attach.md
@@ -20,6 +20,6 @@ Provides utilities for attaching artifacts to other artifacts in a registry
 
 * [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign attach attestation](cosign_attach_attestation.md)	 - Attach attestation to the supplied container image
-* [cosign attach sbom](cosign_attach_sbom.md)	 - Attach sbom to the supplied container image
+* [cosign attach sbom](cosign_attach_sbom.md)	 - DEPRECATED: Attach sbom to the supplied container image
 * [cosign attach signature](cosign_attach_signature.md)	 - Attach signatures to the supplied container image
 

--- a/doc/cosign_attach_sbom.md
+++ b/doc/cosign_attach_sbom.md
@@ -1,6 +1,12 @@
 ## cosign attach sbom
 
+DEPRECATED: Attach sbom to the supplied container image
+
+### Synopsis
+
 Attach sbom to the supplied container image
+
+WARNING: SBOM attachments are deprecated and support will be removed in a Cosign release soon after 2024-02-22 (see https://github.com/sigstore/cosign/issues/2755). Instead, please use SBOM attestations.
 
 ```
 cosign attach sbom [flags]

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -21,7 +21,7 @@ cosign clean [flags]
   -f, --force                                                                                    do not prompt for confirmation
   -h, --help                                                                                     help for clean
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
-      --type CLEAN_TYPE                                                                          a type of clean: <signature|attestation|sbom|all> (default all)
+      --type CLEAN_TYPE                                                                          a type of clean: <signature|attestation|sbom|all> (sbom is deprecated) (default all)
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -52,7 +52,7 @@ cosign dockerfile verify [flags]
       --allow-http-registry                                                                      whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
   -a, --annotations strings                                                                      extra key=value pairs to sign
-      --attachment string                                                                        related image attachment to verify (sbom), default none
+      --attachment string                                                                        DEPRECATED, related image attachment to verify (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --base-image-only                                                                          only verify the base image (the last FROM image in the Dockerfile)
       --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.

--- a/doc/cosign_download.md
+++ b/doc/cosign_download.md
@@ -20,6 +20,6 @@ Provides utilities for downloading artifacts and attached artifacts in a registr
 
 * [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign download attestation](cosign_download_attestation.md)	 - Download in-toto attestations from the supplied container image
-* [cosign download sbom](cosign_download_sbom.md)	 - Download SBOMs from the supplied container image
+* [cosign download sbom](cosign_download_sbom.md)	 - DEPRECATED: Download SBOMs from the supplied container image
 * [cosign download signature](cosign_download_signature.md)	 - Download signatures from the supplied container image
 

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -1,6 +1,12 @@
 ## cosign download sbom
 
+DEPRECATED: Download SBOMs from the supplied container image
+
+### Synopsis
+
 Download SBOMs from the supplied container image
+
+WARNING: SBOM attachments are deprecated and support will be removed in a Cosign release soon after 2024-02-22 (see https://github.com/sigstore/cosign/issues/2755). Instead, please use SBOM attestations.
 
 ```
 cosign download sbom [flags]

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -47,7 +47,7 @@ cosign manifest verify [flags]
       --allow-http-registry                                                                      whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
   -a, --annotations strings                                                                      extra key=value pairs to sign
-      --attachment string                                                                        related image attachment to verify (sbom), default none
+      --attachment string                                                                        DEPRECATED, related image attachment to verify (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -72,7 +72,7 @@ cosign sign [flags]
       --allow-http-registry                                                                      whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
   -a, --annotations strings                                                                      extra key=value pairs to sign
-      --attachment string                                                                        related image attachment to sign (sbom), default none
+      --attachment string                                                                        DEPRECATED, related image attachment to sign (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --certificate string                                                                       path to the X.509 certificate in PEM format to include in the OCI Signature
       --certificate-chain string                                                                 path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Included in the OCI Signature

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -20,7 +20,7 @@ cosign triangulate [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for triangulate
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
-      --type string                                                                              related attachment to triangulate (attestation|sbom|signature), default signature (default "signature")
+      --type string                                                                              related attachment to triangulate (attestation|sbom|signature), default signature (sbom is deprecated) (default "signature")
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -70,7 +70,7 @@ cosign verify [flags]
       --allow-http-registry                                                                      whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
   -a, --annotations strings                                                                      extra key=value pairs to sign
-      --attachment string                                                                        related image attachment to verify (sbom), default none
+      --attachment string                                                                        DEPRECATED, related image attachment to verify (sbom), default none
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
       --certificate string                                                                       path to the public certificate. The certificate will be verified against the Fulcio roots if the --certificate-chain option is not passed.
       --certificate-chain string                                                                 path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate

--- a/specs/SBOM_SPEC.md
+++ b/specs/SBOM_SPEC.md
@@ -1,5 +1,9 @@
 # Cosign SBOM Specifications
 
+**WARNING**: SBOM attachments are deprecated and support will be removed in a Cosign release soon
+after 2024-02-22 (see [sigstore/cosign#2755](https://github.com/sigstore/cosign/issues/2755)).
+Instead, please use SBOM [attestations](./specs/ATTESTATION_SPEC.md).
+
 This document aims to describe how `cosign` attaches SBOM (Software Bill of Materials) documents to containers.
 
 The goal is to specify the behavior well enough to promote other implementations and enable interoperability.


### PR DESCRIPTION
#### Summary

This change marks any usage of SBOM attachments as deprecated. Instead, users are recommended to use SBOM attestations due to its increased security.

Resolves #2755

#### Release Note

* Add deprecation notice for any usage of SBOM attachments

#### Documentation

Updated the SBOM_SPEC.md to indicate SBOM attachments are deprecated.