### PR TITLE
feat: improve dockerfile verify subcommand

### DIFF
--- a/cmd/cosign/cli/dockerfile/verify.go
+++ b/cmd/cosign/cli/dockerfile/verify.go
@@ -47,7 +47,8 @@ func (c *VerifyDockerfileCommand) Exec(ctx context.Context, args []string) error
 	}
 	defer dockerfile.Close()
 
-	images, err := getImagesFromDockerfile(ctx, dockerfile)
+	fc := newFinderCache()
+	images, err := fc.getImagesFromDockerfile(ctx, dockerfile)
 	if err != nil {
 		return fmt.Errorf("failed extracting images from Dockerfile: %w", err)
 	}
@@ -62,18 +63,48 @@ func (c *VerifyDockerfileCommand) Exec(ctx context.Context, args []string) error
 	return c.VerifyCommand.Exec(ctx, images)
 }
 
-func getImagesFromDockerfile(ctx context.Context, dockerfile io.Reader) ([]string, error) {
+type finderCache struct {
+	Env    map[string]string
+	Stages []string
+}
+
+func newFinderCache() *finderCache {
+	return &finderCache{
+		Env:    map[string]string{},
+		Stages: []string{},
+	}
+}
+
+func (fc *finderCache) isStage(input string) (found bool) {
+	for _, s := range fc.Stages {
+		if s == input {
+			found = true
+			break
+		}
+	}
+	return found
+}
+
+func (fc *finderCache) getImagesFromDockerfile(ctx context.Context, dockerfile io.Reader) ([]string, error) {
 	var images []string
 	fileScanner := bufio.NewScanner(dockerfile)
 	for fileScanner.Scan() {
 		line := strings.TrimSpace(fileScanner.Text())
-		if strings.HasPrefix(strings.ToUpper(line), "FROM") {
-			switch image := getImageFromLine(line); image {
+		lineUpper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(lineUpper, "FROM"):
+			switch image := fc.getImageFromLine(line); image {
 			case "scratch":
 				ui.Infof(ctx, "- scratch image ignored")
 			default:
 				images = append(images, image)
 			}
+		case strings.HasPrefix(lineUpper, "COPY"):
+			if image := fc.getImageFromCopyLine(line); image != "" {
+				images = append(images, image)
+			}
+		case strings.HasPrefix(lineUpper, "ENV") || strings.HasPrefix(lineUpper, "ARG"):
+			fc.getEnvAndArgs(line)
 		}
 	}
 	if err := fileScanner.Err(); err != nil {
@@ -82,16 +113,85 @@ func getImagesFromDockerfile(ctx context.Context, dockerfile io.Reader) ([]strin
 	return images, nil
 }
 
-func getImageFromLine(line string) string {
-	line = strings.TrimPrefix(line, "FROM") // Remove "FROM" prefix
-	line = os.ExpandEnv(line)               // Substitute templated vars
+func (fc *finderCache) getImageFromLine(line string) string {
+	line = strings.TrimPrefix(line, "FROM")          // Remove "FROM" prefix
+	line = os.Expand(line, func(key string) string { // Substitute templated vars
+		if val, ok := fc.Env[key]; ok {
+			return val
+		}
+		// NOTE not using pkg/cosign/env due to env not relating to cosign
+		//nolint:forbidigo
+		if val, ok := os.LookupEnv(key); ok {
+			return val
+		}
+		return ""
+	})
 	fields := strings.Fields(line)
 	for i := len(fields) - 1; i > 0; i-- {
 		// Remove the "AS" portion of line
 		if strings.EqualFold(fields[i], "AS") {
+			fc.Stages = append(fc.Stages, fields[i+1])
 			fields = fields[:i]
 			break
 		}
 	}
 	return fields[len(fields)-1] // The image should be the last portion of the line that remains
+}
+
+func (fc *finderCache) getImageFromCopyLine(line string) string {
+	line = strings.TrimPrefix(line, "COPY")          // Remove "COPY" prefix
+	line = os.Expand(line, func(key string) string { // Substitute templated vars
+		if val, ok := fc.Env[key]; ok {
+			return val
+		}
+		// NOTE not using pkg/cosign/env due to env not relating to cosign
+		//nolint:forbidigo
+		if val, ok := os.LookupEnv(key); ok {
+			return val
+		}
+		return ""
+	})
+	var image string
+	fields := strings.Fields(line)
+	for _, f := range fields {
+		if !strings.Contains(f, "--from=") {
+			continue
+		}
+		split := strings.Split(f, "=")
+		if len(split) < 2 {
+			continue
+		}
+		if fc.isStage(split[1]) {
+			continue
+		}
+		image = split[1]
+		break
+	}
+	return image
+}
+
+func (fc *finderCache) getEnvAndArgs(line string) {
+	line = strings.TrimPrefix(line, "ENV")           // Remove "ENV" prefix
+	line = strings.TrimPrefix(line, "ARG")           // Remove "ARG" prefix
+	line = os.Expand(line, func(key string) string { // Substitute templated vars
+		if val, ok := fc.Env[key]; ok {
+			return val
+		}
+		// NOTE not using pkg/cosign/env due to env not relating to cosign
+		//nolint:forbidigo
+		if val, ok := os.LookupEnv(key); ok {
+			return val
+		}
+		return ""
+	})
+	fields := strings.Fields(line)
+	for _, f := range fields {
+		keyvalue := strings.Split(f, "=")
+		if len(keyvalue) < 2 {
+			continue
+		}
+		key := strings.Trim(keyvalue[0], " ")
+		value := strings.Trim(keyvalue[1], " ")
+		fc.Env[key] = value
+	}
 }


### PR DESCRIPTION
support images resolved from ENV, ARG and COPY --from

resolves: #3260

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

`cosign dockerfile verify` does not interpolate variables in `FROM` statements, instead just panics.
Adds the ability to load key-value pairs from `ENV` and `ARG` to interpolate in `FROM` and `COPY --from` statements.

#### Release Note

Improved discoverability for images in Dockerfiles