### PR TITLE
group dependabot dependencies updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,18 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    gomod:
+      actions:
+        update-types:
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
#### Summary

group dependabot updates in one PR to reduce the number of PRs,

for go mod updates it will group for patch updates and for actions minor and patches