### PR TITLE
add missing groups key for dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,8 +20,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    gomod:
-      actions:
+    groups:
+      gomod:
         update-types:
           - "patch"
 


### PR DESCRIPTION

#### Summary
- add missing groups key for dependabot config