### PR TITLE
Remove slow e2e tests

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -661,88 +661,6 @@ func TestAttestationReplaceCreate(t *testing.T) {
 	}
 }
 
-func TestExcessiveAttestations(t *testing.T) {
-	repo, stop := reg(t)
-	defer stop()
-	td := t.TempDir()
-
-	imgName := path.Join(repo, "cosign-attest-download-e2e")
-
-	_, _, cleanup := mkimage(t, imgName)
-	defer cleanup()
-
-	_, privKeyPath, _ := keypair(t, td)
-	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-
-	ctx := context.Background()
-
-	slsaAttestation := `{ "buildType": "x", "builder": { "id": "2" }, "recipe": {} }`
-	slsaAttestationPath := filepath.Join(td, "attestation.slsa.json")
-	if err := os.WriteFile(slsaAttestationPath, []byte(slsaAttestation), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	vulnAttestation := `
-	{
-    "invocation": {
-      "parameters": null,
-      "uri": "invocation.example.com/cosign-testing",
-      "event_id": "",
-      "builder.id": ""
-    },
-    "scanner": {
-      "uri": "fakescanner.example.com/cosign-testing",
-      "version": "",
-      "db": {
-        "uri": "",
-        "version": ""
-      },
-      "result": null
-    },
-    "metadata": {
-      "scanStartedOn": "2022-04-12T00:00:00Z",
-      "scanFinishedOn": "2022-04-12T00:10:00Z"
-    }
-}
-`
-	ref, err := name.ParseReference(imgName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	regOpts := options.RegistryOptions{}
-	ociremoteOpts, err := regOpts.ClientOpts(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < 102; i++ {
-		vulnAttestationPath := filepath.Join(td, fmt.Sprintf("attestation-%d.vuln.json", i))
-		if err := os.WriteFile(vulnAttestationPath, []byte(vulnAttestation), 0600); err != nil {
-			t.Fatal(err)
-		}
-
-		// Attest to create a vuln attestation
-		attestCommand := attest.AttestCommand{
-			KeyOpts:       ko,
-			PredicatePath: vulnAttestationPath,
-			PredicateType: "vuln",
-			Timeout:       30 * time.Second,
-			Replace:       false,
-		}
-		must(attestCommand.Exec(ctx, imgName), t)
-	}
-
-	attOpts := options.AttestationDownloadOptions{}
-	_, err = cosign.FetchAttestationsForReference(ctx, ref, attOpts.PredicateType, ociremoteOpts...)
-	if err == nil {
-		t.Fatalf("Expected an error, but 'err' was 'nil'")
-	}
-	expectedError := "maximum number of attestations on an image is 100, found 102"
-	if err.Error() != expectedError {
-		t.Errorf("Exted the error to be: '%s' but it was '%s'", expectedError, err.Error())
-	}
-}
-
 func TestAttestationReplace(t *testing.T) {
 	repo, stop := reg(t)
 	defer stop()
@@ -1333,38 +1251,6 @@ func TestDuplicateSign(t *testing.T) {
 
 	if len(signatures) > 1 {
 		t.Errorf("expected there to only be one signature, got %v", signatures)
-	}
-}
-
-func TestExcessiveSignatures(t *testing.T) {
-	repo, stop := reg(t)
-	defer stop()
-	td := t.TempDir()
-
-	imgName := path.Join(repo, "cosign-e2e")
-
-	_, _, cleanup := mkimage(t, imgName)
-	defer cleanup()
-
-	ctx := context.Background()
-
-	for i := 0; i < 102; i++ {
-		_, privKeyPath, _ := keypair(t, td)
-
-		// Sign the image
-		ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
-		so := options.SignOptions{
-			Upload: true,
-		}
-		must(sign.SignCmd(ro, ko, so, []string{imgName}), t)
-	}
-	err := download.SignatureCmd(ctx, options.RegistryOptions{}, imgName)
-	if err == nil {
-		t.Fatal("Expected an error, but 'err' was 'nil'")
-	}
-	expectedErr := "maximum number of signatures on an image is 100, found 102"
-	if err.Error() != expectedErr {
-		t.Fatalf("Expected the error '%s', but got the error '%s'", expectedErr, err.Error())
 	}
 }
 

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -50,7 +50,7 @@ echo "running tests"
 
 popd
 go build -o cosign ./cmd/cosign
-go test -timeout 15m -tags=e2e -race $(go list ./... | grep -v third_party/)
+go test -tags=e2e -race $(go list ./... | grep -v third_party/)
 
 # Test `cosign dockerfile verify`
 ./cosign dockerfile verify ./test/testdata/single_stage.Dockerfile --certificate-identity https://github.com/distroless/alpine-base/.github/workflows/release.yaml@refs/heads/main --certificate-oidc-issuer https://token.actions.githubusercontent.com


### PR DESCRIPTION
Splitting these tests into their own package still shows them taking
\>5m. Long-term fix would be supporting a way to attach multiple
signatures at once to avoid roundtrips to the registry.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
