### PR TITLE
add --private-infrastructure flag

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -28,7 +28,8 @@ type CommonVerifyOptions struct {
 	MaxWorkers       int
 	// This is added to CommonVerifyOptions to provide a path to support
 	// it for other verify options.
-	ExperimentalOCI11 bool
+	ExperimentalOCI11     bool
+	PrivateInfrastructure bool
 }
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
@@ -42,6 +43,9 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.IgnoreTlog, "insecure-ignore-tlog", false,
 		"ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts "+
 			"cannot be publicly verified when not included in a log")
+
+	cmd.Flags().BoolVar(&o.PrivateInfrastructure, "private-infrastructure", false,
+		"skip transparency log verification when verifying artifacts in a privately deployed infrastructure")
 
 	cmd.Flags().BoolVar(&o.ExperimentalOCI11, "experimental-oci11", false,
 		"set to true to enable experimental OCI 1.1 behaviour")

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -89,6 +89,10 @@ against the transparency log.`,
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if o.CommonVerifyOptions.PrivateInfrastructure {
+				o.CommonVerifyOptions.IgnoreTlog = true
+			}
+
 			annotations, err := o.AnnotationsMap()
 			if err != nil {
 				return err
@@ -140,7 +144,7 @@ against the transparency log.`,
 
 			ctx := cmd.Context()
 
-			if o.CommonVerifyOptions.IgnoreTlog {
+			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "signature"))
 			}
 
@@ -201,6 +205,10 @@ against the transparency log.`,
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if o.CommonVerifyOptions.PrivateInfrastructure {
+				o.CommonVerifyOptions.IgnoreTlog = true
+			}
+
 			v := &verify.VerifyAttestationCommand{
 				RegistryOptions:              o.Registry,
 				CheckClaims:                  o.CheckClaims,
@@ -235,7 +243,7 @@ against the transparency log.`,
 
 			ctx := cmd.Context()
 
-			if o.CommonVerifyOptions.IgnoreTlog {
+			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "attestation"))
 			}
 
@@ -298,6 +306,10 @@ The blob may be specified as a path to a file or - for stdin.`,
 		Args:             cobra.ExactArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if o.CommonVerifyOptions.PrivateInfrastructure {
+				o.CommonVerifyOptions.IgnoreTlog = true
+			}
+
 			ko := options.KeyOpts{
 				KeyRef:               o.Key,
 				Sk:                   o.SecurityKey.Use,
@@ -326,7 +338,7 @@ The blob may be specified as a path to a file or - for stdin.`,
 
 			ctx := cmd.Context()
 
-			if o.CommonVerifyOptions.IgnoreTlog {
+			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "blob"))
 			}
 
@@ -359,6 +371,10 @@ The blob may be specified as a path to a file.`,
 		Args:             cobra.MaximumNArgs(1),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if o.CommonVerifyOptions.PrivateInfrastructure {
+				o.CommonVerifyOptions.IgnoreTlog = true
+			}
+
 			ko := options.KeyOpts{
 				KeyRef:               o.Key,
 				Sk:                   o.SecurityKey.Use,
@@ -397,7 +413,7 @@ The blob may be specified as a path to a file.`,
 
 			ctx := cmd.Context()
 
-			if o.CommonVerifyOptions.IgnoreTlog {
+			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "blob attestation"))
 			}
 

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -78,6 +78,7 @@ cosign dockerfile verify [flags]
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
+      --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -72,6 +72,7 @@ cosign manifest verify [flags]
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
+      --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -82,6 +82,7 @@ cosign verify-attestation [flags]
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --policy strings                                                                           specify CUE or Rego files will be using for validation
+      --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -48,6 +48,7 @@ cosign verify-blob-attestation [flags]
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --max-workers int                                 the amount of maximum workers for parallel executions (default 10)
       --offline                                         only allow offline verification
+      --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")
       --rfc3161-timestamp string                        path to RFC3161 timestamp FILE
       --sct string                                      path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -77,6 +77,7 @@ cosign verify-blob [flags]
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --max-workers int                                 the amount of maximum workers for parallel executions (default 10)
       --offline                                         only allow offline verification
+      --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")
       --rfc3161-timestamp string                        path to RFC3161 timestamp FILE
       --sct string                                      path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -95,6 +95,7 @@ cosign verify [flags]
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
+      --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username

--- a/test/e2e_signblob_tsa_mtls.sh
+++ b/test/e2e_signblob_tsa_mtls.sh
@@ -86,6 +86,11 @@ $COSIGN_CLI verify-blob --bundle cosign.bundle \
     --rfc3161-timestamp=timestamp.txt --timestamp-certificate-chain=$TIMESTAMP_CHAIN_FILE \
     --insecure-ignore-tlog=true --key import-cosign.pub $BLOB
 
+$COSIGN_CLI verify-blob --bundle cosign.bundle \
+    --certificate-identity-regexp '.*' --certificate-oidc-issuer-regexp '.*' \
+    --rfc3161-timestamp=timestamp.txt --timestamp-certificate-chain=$TIMESTAMP_CHAIN_FILE \
+    --private-infrastructure --key import-cosign.pub $BLOB
+
 # cleanup
 rm -fr blob.sig ca-key.pem cacert.pem cert.pem cosign.bundle import-cosign.key \
     import-cosign.pub key.pem timestamp.txt timestamp-chain.pem \

--- a/test/e2e_test_secrets.sh
+++ b/test/e2e_test_secrets.sh
@@ -165,6 +165,7 @@ cat /dev/urandom | head -n 10 | base64 > randomblob
 dgst=$(./cosign upload blob -f randomblob ${blobimg})
 ./cosign sign --key ${signing_key} --tlog-upload=false ${dgst}
 ./cosign verify --key ${verification_key} --insecure-ignore-tlog=true ${dgst} # For sanity
+./cosign verify --key ${verification_key} --private-infrastructure ${dgst}
 
 # clean up a bit
 crane delete $blobimg || true


### PR DESCRIPTION
Partially fixes #2736

#### Summary
This commit adds the `--private-infrastructure` command line flag for verification commands. This flag is an alias for `--insecure-ignore-tlog` with the exception that it also silences the warning message the later flag prints. This flag is intended for users who do not rely on a public transparency log and have their own private infrastructure dedicated to verification.

I decided to make the `--private-infrastructure` flag automatically set the corresponding `--insecure-ignore-tlog` option in order to preserve the warning that is printed only when the later flag is used, but I am open to other approaches if desired!

I added a couple of calls using this flag instead of the `--insecure-ignore-tlog` flag to the e2e tests for `verify` and `verify-blob` commands. This change also affects the `verify-attestation` and `verify-blob-attestation` commands but I couldn't find e2e tests for these, so I left them untested. 

#### Release Note
* Added the `--private-infrastructure` flag for verification commands as an alias for `--insecure-ignore-tlog`

#### Documentation
I will open a PR in the Sigstore docs repo once someone has had a chance to give the initial OK on this change!
