### PR TITLE
Fix idempotency error with signing

### DIFF
--- a/pkg/cosign/tlog_test.go
+++ b/pkg/cosign/tlog_test.go
@@ -67,14 +67,12 @@ func TestExpectedRekorResponse(t *testing.T) {
 		name         string
 		requestUUID  string
 		responseUUID string
-		treeID       string
 		wantErr      bool
 	}{
 		{
 			name:         "valid match with request & response entry UUID",
 			requestUUID:  validTreeID + validUUID,
 			responseUUID: validTreeID + validUUID,
-			treeID:       validTreeID,
 			wantErr:      false,
 		},
 		// The following is the current typical Rekor behavior.
@@ -82,63 +80,54 @@ func TestExpectedRekorResponse(t *testing.T) {
 			name:         "valid match with request entry UUID",
 			requestUUID:  validTreeID + validUUID,
 			responseUUID: validUUID,
-			treeID:       validTreeID,
 			wantErr:      false,
 		},
 		{
 			name:         "valid match with request UUID",
 			requestUUID:  validUUID,
 			responseUUID: validUUID,
-			treeID:       validTreeID,
 			wantErr:      false,
 		},
 		{
 			name:         "valid match with response entry UUID",
 			requestUUID:  validUUID,
 			responseUUID: validTreeID + validUUID,
-			treeID:       validTreeID,
 			wantErr:      false,
 		},
 		{
 			name:         "mismatch uuid with response tree id",
 			requestUUID:  validUUID,
 			responseUUID: validTreeID + validUUID1,
-			treeID:       validTreeID,
 			wantErr:      true,
 		},
 		{
 			name:         "mismatch uuid with request tree id",
 			requestUUID:  validTreeID + validUUID1,
 			responseUUID: validUUID,
-			treeID:       validTreeID,
 			wantErr:      true,
 		},
 		{
 			name:         "mismatch tree id",
 			requestUUID:  validTreeID + validUUID,
-			responseUUID: validUUID,
-			treeID:       validTreeID1,
+			responseUUID: validTreeID1 + validUUID,
 			wantErr:      true,
 		},
 		{
 			name:         "invalid response tree id",
 			requestUUID:  validTreeID + validUUID,
 			responseUUID: invalidTreeID + validUUID,
-			treeID:       invalidTreeID,
 			wantErr:      true,
 		},
 		{
 			name:         "invalid request tree id",
 			requestUUID:  invalidTreeID + validUUID,
 			responseUUID: validUUID,
-			treeID:       invalidTreeID,
 			wantErr:      true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isExpectedResponseUUID(tt.requestUUID,
-				tt.responseUUID, tt.treeID); (got != nil) != tt.wantErr {
+			if got := isExpectedResponseUUID(tt.requestUUID, tt.responseUUID); (got != nil) != tt.wantErr {
 				t.Errorf("isExpectedResponseUUID() = %v, want %v", got, tt.wantErr)
 			}
 		})


### PR DESCRIPTION
The expected behavior is to fetch an existing entry from the log when signing generates the same signature and that entry is uploaded to the log, so that signing is idempotent.

The bug was that the prepended shard ID was compared to the log ID. The log ID is a sha256 hash of the log's public key, which is not the same as the shard ID. Now we compare the prepended shard IDs from both the request and response entry UUID when present.

This was not caught in tests since we used a valid shard ID as input rather than the log ID.

Verified by generating an RSA key (which will generate the same signature given the same input) and signing a container.

Fixes https://github.com/sigstore/cosign/issues/3356

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
