### PR TITLE
Bump builder image to use go1.21.4 and add new cosign image tags with shell 

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -26,14 +26,14 @@ jobs:
   check-signature:
     runs-on: ubuntu-latest
     container:
-      image: gcr.io/projectsigstore/cosign:v2.2.1@sha256:88498ed17e61605cd68a5fc9d1fcd756ae0ef2d5515417881d739654accf818f
+      image: gcr.io/projectsigstore/cosign:v2.2.0@sha256:280b47054876d415f66a279e666e35157cae6881f3538599710290c70bb75369
 
     steps:
       - name: Check Signature
         run: |
           cosign verify ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366 \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.3-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.4-0"
         env:
           TUF_ROOT: /tmp
 

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -26,12 +26,12 @@ jobs:
   check-signature:
     runs-on: ubuntu-latest
     container:
-      image: gcr.io/projectsigstore/cosign:v2.2.0@sha256:280b47054876d415f66a279e666e35157cae6881f3538599710290c70bb75369
+      image: gcr.io/projectsigstore/cosign:v2.2.1@sha256:88498ed17e61605cd68a5fc9d1fcd756ae0ef2d5515417881d739654accf818f
 
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632 \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366 \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
           --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.3-0"
         env:
@@ -43,7 +43,7 @@ jobs:
       - check-signature
 
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632
+      image: ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366
 
     permissions: {}
 
@@ -117,7 +117,7 @@ jobs:
         run: make snapshot
         env:
           PROJECT_ID: honk-fake-project
-          RUNTIME_IMAGE: gcr.io/distroless/static:debug-nonroot
+          RUNTIME_IMAGE: gcr.io/distroless/static-debian12:nonroot
 
       - name: check binaries
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,10 +12,6 @@ before:
   hooks:
     - go mod tidy
     - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
-  # if running a release we will generate the images in this step
-  # if running in the CI the CI env va is set and we dont run the ko steps
-  # this is needed because we are generating files that goreleaser was not aware to push to GH project release
-    - /bin/bash -c 'if [ -z "$CI" ]; then make sign-release-images; fi'
 
 gomod:
   proxy: true

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
         echo "Checking out ${_GIT_TAG}"
         git checkout ${_GIT_TAG}
 
-  - name: 'gcr.io/projectsigstore/cosign:v2.2.1@sha256:88498ed17e61605cd68a5fc9d1fcd756ae0ef2d5515417881d739654accf818f'
+  - name: 'gcr.io/projectsigstore/cosign:v2.2.0@sha256:280b47054876d415f66a279e666e35157cae6881f3538599710290c70bb75369'
     dir: "go/src/sigstore/cosign"
     env:
       - TUF_ROOT=/tmp

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,20 +32,20 @@ steps:
         echo "Checking out ${_GIT_TAG}"
         git checkout ${_GIT_TAG}
 
-  - name: 'gcr.io/projectsigstore/cosign:v2.2.0@sha256:280b47054876d415f66a279e666e35157cae6881f3538599710290c70bb75369'
+  - name: 'gcr.io/projectsigstore/cosign:v2.2.1@sha256:88498ed17e61605cd68a5fc9d1fcd756ae0ef2d5515417881d739654accf818f'
     dir: "go/src/sigstore/cosign"
     env:
       - TUF_ROOT=/tmp
     args:
       - 'verify'
-      - 'ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632'
+      - 'ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366'
       - '--certificate-oidc-issuer'
       - "https://token.actions.githubusercontent.com"
       - '--certificate-identity'
-      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.3-0"
+      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.4-0"
 
   # maybe we can build our own image and use that to be more in a safe side
-  - name: ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632
+  - name: ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366
     entrypoint: /bin/sh
     dir: "go/src/sigstore/cosign"
     env:
@@ -68,7 +68,7 @@ steps:
         gcloud auth configure-docker \
         && make release
 
-  - name: ghcr.io/gythialy/golang-cross:v1.21.3-0@sha256:6e2c885532ad276195d3e3f269055fb2742c8963b231d097c467758dd425a632
+  - name: ghcr.io/gythialy/golang-cross:v1.21.4-0@sha256:d18679c199db258cac9876a80abf9aff69485cf8a324bf547521f3de4cf3a366
     entrypoint: 'bash'
     dir: "go/src/sigstore/cosign"
     env:

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -90,7 +90,7 @@ steps:
       - '-c'
       - |
         echo $$GITHUB_TOKEN | docker login ghcr.io -u $$GITHUB_USER --password-stdin \
-        && make copy-signed-release-to-ghcr || true
+        && make sign-release-images && make copy-signed-release-to-ghcr || true
 
 availableSecrets:
   secretManager:

--- a/release/ko-sign-release-images.sh
+++ b/release/ko-sign-release-images.sh
@@ -32,8 +32,19 @@ if [[ ! -f cosignImagerefs ]]; then
     exit 1
 fi
 
+if [[ ! -f cosignDevImagerefs ]]; then
+    echo "cosignDevImagerefs not found"
+    exit 1
+fi
+
 echo "Signing cosign images with GCP KMS Key..."
 cosign sign --yes --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat cosignImagerefs)
 
 echo "Signing images with Keyless..."
 cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat cosignImagerefs)
+
+echo "Signing cosign images with GCP KMS Key..."
+cosign sign --yes --key "gcpkms://projects/$PROJECT_ID/locations/$KEY_LOCATION/keyRings/$KEY_RING/cryptoKeys/$KEY_NAME/versions/$KEY_VERSION" -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat cosignDevImagerefs)
+
+echo "Signing images with Keyless..."
+cosign sign --yes -a GIT_HASH="$GIT_HASH" -a GIT_VERSION="$GIT_VERSION" $(cat cosignDevImagerefs)

--- a/release/release.mk
+++ b/release/release.mk
@@ -18,7 +18,7 @@ sign-release-images: ko
 # used when need to validate the goreleaser
 .PHONY: snapshot
 snapshot:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --clean --timeout 120m --parallelism 1
+	LDFLAGS="$(LDFLAGS)" goreleaser release --skip=sign,publish --snapshot --clean --timeout 120m --parallelism 1
 
 ####################
 # copy image to GHCR
@@ -27,3 +27,4 @@ snapshot:
 .PHONY: copy-signed-release-to-ghcr
 copy-signed-release-to-ghcr:
 	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:$(GIT_VERSION)
+	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev


### PR DESCRIPTION
#### Summary
- bump builder image to use go1.21.4
- build -dev tag images that have a shell

also building the image only if the binaries and GitHub release is successfully released 

Now, when we release, we will generate the following images:

- `gcr.io/projectsigstore/cosign:vx.y.z` no shell
- `gcr.io/projectsigstore/cosign:vx.y.z-dev` with shell

Fixes: https://github.com/sigstore/cosign/issues/3361