### PR TITLE
 Add `--yes` flag `cosign import-key-pair` to skip the overwrite confirmation.

### DIFF
--- a/cmd/cosign/cli/import_key_pair.go
+++ b/cmd/cosign/cli/import_key_pair.go
@@ -42,7 +42,7 @@ CAVEATS:
   the COSIGN_PASSWORD environment variable to provide one.`,
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return importkeypair.ImportKeyPairCmd(cmd.Context(), o.Key, o.OutputKeyPrefix, args)
+			return importkeypair.ImportKeyPairCmd(cmd.Context(), *o, args)
 		},
 	}
 

--- a/cmd/cosign/cli/importkeypair/import_key_pair.go
+++ b/cmd/cosign/cli/importkeypair/import_key_pair.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	icos "github.com/sigstore/cosign/v2/internal/pkg/cosign"
 	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
@@ -33,14 +34,14 @@ var (
 )
 
 // nolint
-func ImportKeyPairCmd(ctx context.Context, keyVal string, outputKeyPrefixVal string, args []string) error {
-	keys, err := cosign.ImportKeyPair(keyVal, GetPass)
+func ImportKeyPairCmd(ctx context.Context, o options.ImportKeyPairOptions, args []string) error {
+	keys, err := cosign.ImportKeyPair(o.Key, GetPass)
 	if err != nil {
 		return err
 	}
 
-	privateKeyFileName := outputKeyPrefixVal + ".key"
-	publicKeyFileName := outputKeyPrefixVal + ".pub"
+	privateKeyFileName := o.OutputKeyPrefix + ".key"
+	publicKeyFileName := o.OutputKeyPrefix + ".pub"
 
 	fileExists, err := icos.FileExists(privateKeyFileName)
 	if err != nil {
@@ -49,8 +50,10 @@ func ImportKeyPairCmd(ctx context.Context, keyVal string, outputKeyPrefixVal str
 
 	if fileExists {
 		ui.Warnf(ctx, "File %s already exists. Overwrite?", privateKeyFileName)
-		if err := ui.ConfirmContinue(ctx); err != nil {
-			return err
+		if !o.SkipConfirmation {
+			if err := ui.ConfirmContinue(ctx); err != nil {
+				return err
+			}
 		}
 	}
 	// TODO: make sure the perms are locked down first.

--- a/cmd/cosign/cli/importkeypair/import_key_pair_test.go
+++ b/cmd/cosign/cli/importkeypair/import_key_pair_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	icos "github.com/sigstore/cosign/v2/internal/pkg/cosign"
 )
 
@@ -62,7 +63,11 @@ func TestImportOfKeys(t *testing.T) {
 	// framework if there is no value set by the user when running the
 	// command.
 	outputtedKeyPairFileName := "my-test"
-	ImportKeyPairCmd(context.Background(), privateKeyFileName, outputtedKeyPairFileName, nil)
+	ImportKeyPairCmd(context.Background(), options.ImportKeyPairOptions{
+		Key:              privateKeyFileName,
+		OutputKeyPrefix:  outputtedKeyPairFileName,
+		SkipConfirmation: false,
+	}, nil)
 
 	// removes temporary RSA private key used for test
 	checkIfFileExistsThenDelete(privateKeyFileName, t)

--- a/cmd/cosign/cli/options/import_key_pair.go
+++ b/cmd/cosign/cli/options/import_key_pair.go
@@ -43,5 +43,5 @@ func (o *ImportKeyPairOptions) AddFlags(cmd *cobra.Command) {
 	_ = cmd.Flags().SetAnnotation("output-key-prefix", cobra.BashCompFilenameExt, []string{})
 
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
-		"skip confirmation prompts for non-destructive operations")
+		"skip confirmation prompts for overwriting existing key")
 }

--- a/cmd/cosign/cli/options/import_key_pair.go
+++ b/cmd/cosign/cli/options/import_key_pair.go
@@ -26,6 +26,8 @@ type ImportKeyPairOptions struct {
 
 	// Filename used for outputted keys
 	OutputKeyPrefix string
+
+	SkipConfirmation bool
 }
 
 var _ Interface = (*ImportKeyPairOptions)(nil)
@@ -39,4 +41,7 @@ func (o *ImportKeyPairOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&o.OutputKeyPrefix, "output-key-prefix", "o", "import-cosign",
 		"name used for outputted key pairs")
 	_ = cmd.Flags().SetAnnotation("output-key-prefix", cobra.BashCompFilenameExt, []string{})
+
+	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
+		"skip confirmation prompts for non-destructive operations")
 }

--- a/doc/cosign_import-key-pair.md
+++ b/doc/cosign_import-key-pair.md
@@ -32,6 +32,7 @@ CAVEATS:
   -h, --help                       help for import-key-pair
   -k, --key string                 import key pair to use for signing
   -o, --output-key-prefix string   name used for outputted key pairs (default "import-cosign")
+  -y, --yes                        skip confirmation prompts for non-destructive operations
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_import-key-pair.md
+++ b/doc/cosign_import-key-pair.md
@@ -32,7 +32,7 @@ CAVEATS:
   -h, --help                       help for import-key-pair
   -k, --key string                 import key pair to use for signing
   -o, --output-key-prefix string   name used for outputted key pairs (default "import-cosign")
-  -y, --yes                        skip confirmation prompts for non-destructive operations
+  -y, --yes                        skip confirmation prompts for overwriting existing key
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

This PR closes https://github.com/sigstore/cosign/issues/3382.

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Users may call `cosign import-key-pair` and then `cosign sign` multiple times to sign multiple images in CI/CD pipelines. And cannot confirm overwrite:
```
WARNING: File imported.key already exists. Overwrite?
22:27:00 Are you sure you would like to continue? [y/N] 2023/11/20 22:27:00 unable to import key pair: user declined the prompt
22:27:00 ERROR: exit status 1
```

It is better to add a `--yes` flag to skip the overwrite confirmation.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Added `--yes` flag in `cosign import-key-pair` to skip the overwrite confirmation.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Already updated doc/cosign_import-key-pair.md.
