### PR TITLE
Use the timeout flag value in verify* commands.

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -16,6 +16,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -142,7 +143,7 @@ against the transparency log.`,
 				v.NameOptions = append(v.NameOptions, name.Insecure)
 			}
 
-			ctx := cmd.Context()
+			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "signature"))
@@ -241,7 +242,7 @@ against the transparency log.`,
 				return fmt.Errorf("please set the --max-worker flag to a value that is greater than 0")
 			}
 
-			ctx := cmd.Context()
+			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "attestation"))
@@ -336,7 +337,7 @@ The blob may be specified as a path to a file or - for stdin.`,
 				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 			}
 
-			ctx := cmd.Context()
+			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "blob"))
@@ -411,7 +412,7 @@ The blob may be specified as a path to a file.`,
 				path = args[0]
 			}
 
-			ctx := cmd.Context()
+			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "blob attestation"))

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -143,7 +143,8 @@ against the transparency log.`,
 				v.NameOptions = append(v.NameOptions, name.Insecure)
 			}
 
-			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
+			defer cancel()
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "signature"))
@@ -242,7 +243,8 @@ against the transparency log.`,
 				return fmt.Errorf("please set the --max-worker flag to a value that is greater than 0")
 			}
 
-			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
+			defer cancel()
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "attestation"))
@@ -337,7 +339,8 @@ The blob may be specified as a path to a file or - for stdin.`,
 				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 			}
 
-			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
+			defer cancel()
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "blob"))
@@ -412,7 +415,8 @@ The blob may be specified as a path to a file.`,
 				path = args[0]
 			}
 
-			ctx, _ := context.WithTimeout(cmd.Context(), ro.Timeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
+			defer cancel()
 
 			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
 				ui.Warnf(ctx, fmt.Sprintf(ignoreTLogMessage, "blob attestation"))


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

This PR closes https://github.com/sigstore/cosign/issues/3390.

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

`--timeout` flag is not useful in verify* commands.

For example, when there is a network issue (not connecting to the company VPN but still try to access the internal service), even if I set `--timeout 5s`, the `cosign verify` will still hang for a long time (about one minute in my case) until erroring out.
```
$ ./cosign verify --timeout 5s internal.registry.com/image-name:tag
Error: Get "https://internal.registry.com/v2/": dial tcp <ip address>: i/o timeout
main.go:69: error during command execution: Get "https://internal.registry.com/v2/": dial tcp <ip address>: i/o timeout
```

After this pr, the command errors out when timeout.
```
$ ./cosign verify --timeout 5s internal.registry.com/image-name:tag
Error: Get "https://internal.registry.com/v2/": dial tcp <ip address>: context deadline exceeded
main.go:69: error during command execution: Get "https://internal.registry.com/v2/": context deadline exceeded
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Used the timeout flag value in verify* commands.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

No need to update documentation.
