### PR TITLE
Update cosign generate cmd to not include newline

### DIFF
--- a/cmd/cosign/cli/generate/generate.go
+++ b/cmd/cosign/cli/generate/generate.go
@@ -49,6 +49,6 @@ func GenerateCmd(ctx context.Context, regOpts options.RegistryOptions, imageRef 
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(w, string(json))
+	fmt.Fprint(w, string(json))
 	return nil
 }


### PR DESCRIPTION
Fixes #3392 

#### Summary
Please see #3392 for a description of the problem.

Removing the newline will result in a payload and sha256sum that is equivalent to what you get with the `--output-payload` flag and inside the `hashedrekordobj.data.hash.value` field.

#### Release Note
I'm not sure if fixing this bug will be a breaking change for anyone relying on `cosign generate` to output with specific formatting.

#### Documentation
None
