### PR TITLE
Add support for OpenVEX predicate type

### DIFF
--- a/cmd/cosign/cli/options/predicate.go
+++ b/cmd/cosign/cli/options/predicate.go
@@ -38,6 +38,7 @@ const (
 	PredicateCycloneDX = "cyclonedx"
 	PredicateLink      = "link"
 	PredicateVuln      = "vuln"
+	PredicateOpenVEX   = "openvex"
 )
 
 // PredicateTypeMap is the mapping between the predicate `type` option to predicate URI.
@@ -51,6 +52,7 @@ var PredicateTypeMap = map[string]string{
 	PredicateCycloneDX: in_toto.PredicateCycloneDX,
 	PredicateLink:      in_toto.PredicateLinkV1,
 	PredicateVuln:      attestation.CosignVulnProvenanceV01,
+	PredicateOpenVEX:   attestation.OpenVexNamespace,
 }
 
 // PredicateOptions is the wrapper for predicate related options.
@@ -63,7 +65,7 @@ var _ Interface = (*PredicateOptions)(nil)
 // AddFlags implements Interface
 func (o *PredicateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Type, "type", "custom",
-		"specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI")
+		"specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI")
 }
 
 // ParsePredicateType parses the predicate `type` flag passed into a predicate URI, or validates `type` is a valid URI.

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -58,7 +58,7 @@ cosign attest-blob [flags]
       --slot string                       security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-server-url string       url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr
       --tlog-upload                       whether or not to upload to the tlog (default true)
-      --type string                       specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+      --type string                       specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
   -y, --yes                               skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -71,7 +71,7 @@ cosign attest [flags]
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-server-url string                                                              url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr
       --tlog-upload                                                                              whether or not to upload to the tlog (default true)
-      --type string                                                                              specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+      --type string                                                                              specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
   -y, --yes                                                                                      skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -91,7 +91,7 @@ cosign verify-attestation [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string                                                       path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
-      --type string                                                                              specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+      --type string                                                                              specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -56,7 +56,7 @@ cosign verify-blob-attestation [flags]
       --sk                                              whether to use a hardware security key
       --slot string                                     security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string              path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
-      --type string                                     specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|custom) or an URI (default "custom")
+      --type string                                     specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -35,6 +35,12 @@ const (
 
 	// CosignVulnProvenanceV01 specifies the type of VulnerabilityScan Predicate
 	CosignVulnProvenanceV01 = "https://cosign.sigstore.dev/attestation/vuln/v1"
+
+	// OpenVexNamespace holds the URI of the OpenVEX context to identify its
+	// predicate type. More info about the specification can be found at
+	// https://github.com/openvex/spec and the attestation spec is found here:
+	// https://github.com/openvex/spec/blob/main/ATTESTING.md
+	OpenVexNamespace = "https://openvex.dev/ns"
 )
 
 // CosignPredicate specifies the format of the Custom Predicate.
@@ -124,6 +130,8 @@ func GenerateStatement(opts GenerateOpts) (interface{}, error) {
 		return generateLinkStatement(predicate, opts.Digest, opts.Repo)
 	case "vuln":
 		return generateVulnStatement(predicate, opts.Digest, opts.Repo)
+	case "openvex":
+		return generateOpenVexStatement(predicate, opts.Digest, opts.Repo)
 	default:
 		stamp := timestamp(opts)
 		predicateType := customType(opts)
@@ -248,6 +256,17 @@ func generateLinkStatement(rawPayload []byte, digest string, repo string) (inter
 	return in_toto.LinkStatement{
 		StatementHeader: generateStatementHeader(digest, repo, in_toto.PredicateLinkV1),
 		Predicate:       link,
+	}, nil
+}
+
+func generateOpenVexStatement(rawPayload []byte, digest string, repo string) (interface{}, error) {
+	var data interface{}
+	if err := json.Unmarshal(rawPayload, &data); err != nil {
+		return nil, err
+	}
+	return in_toto.Statement{
+		StatementHeader: generateStatementHeader(digest, repo, OpenVexNamespace),
+		Predicate:       data,
 	}, nil
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR adds support for OpenVEX as a known predicate type to the `cosign attest` and   `cosign download attestation` and `cosign attest-blob` commands.

Instead of linking the openvex go-modules, I've hardcoded the value or the predicate URI in a const to avoid growing the dependency tree.

Resolves #3404

#### Release Note

* OpenVEX is now one of the recognized predicate types using the identifier string `openvex` as the type.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
TBD



Signed-off-by: Adolfo García Veytia (Puerco) <puerco@chainguard.dev>