### PR TITLE
Fix copy without any flag set

### DIFF
--- a/cmd/cosign/cli/copy.go
+++ b/cmd/cosign/cli/copy.go
@@ -34,10 +34,10 @@ func Copy() *cobra.Command {
   cosign copy example.com/src:latest example.com/dest:latest
 
   # copy the signatures only
-  cosign copy --only=sign example.com/src example.com/dest
+  cosign copy --only=sig example.com/src example.com/dest
 
   # copy the signatures, attestations, sbom only
-  cosign copy --only=sign,att,sbom example.com/src example.com/dest
+  cosign copy --only=sig,att,sbom example.com/src example.com/dest
 
   # overwrite destination image and signatures
   cosign copy -f example.com/src example.com/dest

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -15,10 +15,10 @@ cosign copy [flags]
   cosign copy example.com/src:latest example.com/dest:latest
 
   # copy the signatures only
-  cosign copy --only=sign example.com/src example.com/dest
+  cosign copy --only=sig example.com/src example.com/dest
 
   # copy the signatures, attestations, sbom only
-  cosign copy --only=sign,att,sbom example.com/src example.com/dest
+  cosign copy --only=sig,att,sbom example.com/src example.com/dest
 
   # overwrite destination image and signatures
   cosign copy -f example.com/src example.com/dest


### PR DESCRIPTION
PR #3247 added an --only flag which when set copies only a subset of metadata. By default the flag is set to an empty string, meaning that by default copy would copy nothing. This PR fixes this bug so that if only is unset, copy defaults to the same behavior as before copying everything.

Also update the tag name to be sig rather than sign for the flag.

Fixes https://github.com/sigstore/cosign/issues/3379

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
