### PR TITLE
fixing issue 3426

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -502,7 +502,7 @@ func keylessVerification(keyRef string, sk bool) bool {
 	return true
 }
 
-func keylessVerificationWithSCTEnabled(IgnoreSCT bool, keyRef string, sk bool, CertChain string) bool {
+func keylessVerificationWithSCTEnabled(ignoreSCT bool, keyRef string, sk bool, certChain string) bool {
 	rootEnv := env.Getenv(env.VariableSigstoreRootFile)
 	if keyRef != "" {
 		return false
@@ -510,10 +510,10 @@ func keylessVerificationWithSCTEnabled(IgnoreSCT bool, keyRef string, sk bool, C
 	if sk {
 		return false
 	}
-	if IgnoreSCT && (CertChain != "" || rootEnv != "") {
+	if ignoreSCT && (certChain != "" || rootEnv != "") {
 		return false
 	}
-	if IgnoreSCT {
+	if ignoreSCT {
 		return false
 	}
 	return true

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -111,7 +111,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 	}
 	// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
-	if !c.IgnoreSCT || keylessVerification(c.KeyRef, c.Sk) {
+	if keylessVerificationWithSCTEnabled(c.IgnoreSCT, c.KeyRef, c.Sk, c.CertChain) {
 		co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
 		if err != nil {
 			return fmt.Errorf("getting ctlog public keys: %w", err)

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -111,7 +111,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 	}
 	// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
-	if keylessVerificationWithSCTEnabled(c.IgnoreSCT, c.KeyRef, c.Sk, c.CertChain) {
+	if shouldVerifySCT(c.IgnoreSCT, c.KeyRef, c.Sk) {
 		co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
 		if err != nil {
 			return fmt.Errorf("getting ctlog public keys: %w", err)

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -286,7 +286,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	}
 
 	// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
-	if keylessVerificationWithSCTEnabled(c.IgnoreSCT, c.KeyRef, c.Sk, c.CertChain) {
+	if shouldVerifySCT(c.IgnoreSCT, c.KeyRef, c.Sk) {
 		co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
 		if err != nil {
 			return fmt.Errorf("getting ctlog public keys: %w", err)

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -286,7 +286,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	}
 
 	// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
-	if !c.IgnoreSCT || keylessVerification(c.KeyRef, c.Sk) {
+	if keylessVerificationWithSCTEnabled(c.IgnoreSCT, c.KeyRef, c.Sk, c.CertChain) {
 		co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
 		if err != nil {
 			return fmt.Errorf("getting ctlog public keys: %w", err)

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -190,7 +190,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		}
 	}
 	// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
-	if keylessVerificationWithSCTEnabled(c.IgnoreSCT, c.KeyRef, c.Sk, c.CertChain) {
+	if shouldVerifySCT(c.IgnoreSCT, c.KeyRef, c.Sk) {
 		co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
 		if err != nil {
 			return fmt.Errorf("getting ctlog public keys: %w", err)

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -190,7 +190,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		}
 	}
 	// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
-	if !c.IgnoreSCT || keylessVerification(c.KeyRef, c.Sk) {
+	if keylessVerificationWithSCTEnabled(c.IgnoreSCT, c.KeyRef, c.Sk, c.CertChain) {
 		co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
 		if err != nil {
 			return fmt.Errorf("getting ctlog public keys: %w", err)


### PR DESCRIPTION
Closes #3426 

#### Summary
The PR fixes the issue mentioned in issue #3426 
The code changes done in this PR allow user to do cosign verification for a BYO PKI use case. 
The use case is that it is a restricted environment, i.e. no access to TUF root CDN.
Signer has a BYO PKI which generates signatures, and attach those to registry.
Verifier uses Trusted root certificate shared by signer to to verification in a Air gap environment with no access to TUF root CDN. 
The user passes the flags
cosign verify harbor.demo-ncd.services.te0014-demo-ncd.dyn.nesc.net/ncd-orb/orbs/ncd-ncd_fp6_generic-799@sha256:c08f847db8877aeefa3852ae9ee471fa7c421be4089b855fd0e545d521e2d87c --certificate-identity-regexp='.*' --certificate-oidc-issuer-regexp='.*' --insecure-ignore-sct=true --insecure-ignore-tlog=true --cert-chain=rootCA.crt --verbose=true

so user has provided --insecure-ignore-sct=true but still cosign verification was failing. due to code changes done in PR
https://github.com/sigstore/cosign/pull/3415

which has introduced the code change
https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/verify/verify.go (209):
// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
     if !c.IgnoreSCT || keylessVerification(c.KeyRef, c.Sk) {
           co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
           if err != nil {
                return fmt.Errorf("getting ctlog public keys: %w", err)
           }
     }

With this code change the passing of flag IgnoreSCT  was not of much use in keylessverification as it was still going to get CTLogPub key from CND TUF, so this impact the BYO PKI use case where we are using keyless verification by passing Trusted Root certificate via --cert-chain argument or using SIGSTORE_ROOT_FILE env variable.
The code changes done in this PR introduces following logic
1. if user provide key we dont need to pass --insecure-ignore-sct=true 
2. If user is using keyless verification using cert-chain or SIGSTORE_ROOT_FILE option and passing --insecure-ignore-sct=true than cosign will not go to get CTLog Public key.

#### Release Note
Fixes Issue #3426 
File changed:
/cosign/cmd/cosign/cli/verify/verify.go
/cosign/cmd/cosign/cli/verify/verify_attestation.go
/cosign/cmd/cosign/cli/verify/verify_blob.go
/cosign/cmd/cosign/cli/verify/verify_blob_attestation.go

Introduced a new function to check if it is keylessverification using SCT option.
func keylessVerificationWithSCTEnabled(IgnoreSCT bool, keyRef string, sk bool, CertChain string) bool {
        rootEnv := env.Getenv(env.VariableSigstoreRootFile)
        if keyRef != "" {
                return false
        }
        if sk {
                return false
        }
        if IgnoreSCT && (CertChain != "" || rootEnv != "") {
                return false
        }
        if IgnoreSCT {
                return false
        }
        return true
}

and used this function to check if we need to get CTLogs Public key or not during Verify signature procedure.

#### Documentation
No change is needed in Documentation
