### PR TITLE
fix(clean): Fix clean cmd for private registries

### DIFF
--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -133,6 +133,20 @@ func DigestTag(ref name.Reference, opts ...Option) (name.Tag, error) {
 	return suffixTag(ref, "", ":", o)
 }
 
+// DockerContentDigest fetches the Docker-Content-Digest header for the referenced tag,
+// which is required to delete the object in registry API v2.3 and greater.
+// See https://github.com/distribution/distribution/blob/main/docs/content/spec/api.md#deleting-an-image
+// and https://github.com/distribution/distribution/issues/1579
+func DockerContentDigest(ref name.Tag, opts ...Option) (name.Tag, error) {
+	o := makeOptions(ref.Context(), opts...)
+	desc, err := remoteGet(ref, o.ROpt...)
+	if err != nil {
+		return name.Tag{}, err
+	}
+	h := desc.Digest
+	return o.TargetRepository.Tag(normalizeWithSeparator(h, o.TagPrefix, "", ":")), nil
+}
+
 func suffixTag(ref name.Reference, suffix string, algorithmSeparator string, o *options) (name.Tag, error) {
 	var h v1.Hash
 	if digest, ok := ref.(name.Digest); ok {


### PR DESCRIPTION
Without this patch, running `cosign clean` on an image in a private registry uses the wrong object reference and fails to delete artifacts for the image.

On Dockerhub, it is sufficient to call DELETE directly on an object name:

```
DELETE /v2/namespace/repo/manifests/sha256-deadbeef.sig
```

On registry version v2.3 and greater, this does not work. Instead, we need to perform a GET to retrieve the object digest, and call DELETE on that:

```
GET /v2/namespace/repo/manifests/sha256-deadbeef.sig
=> ... Docker-Content-Digest: sha256:cafeb0ba
DELETE /v2/namespace/repo/manifests/sha256:cafeb0ba
```

Since we can't know what type of registry we're dealing with, we try the original version first, and the new version as a fallback.

See the GitHub issue[1] which explains the issue, and the API documentation[2].

This also fixes a minor formatting issue in the error message.

[1] https://github.com/distribution/distribution/issues/1579
[2] https://github.com/distribution/distribution/blob/main/docs/content/spec/api.md#deleting-an-image

Fixes #2265

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
See above

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
Fixed the "clean" command for private registries.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
n/a