### PR TITLE
parse the rekor bundle correctly

### DIFF
--- a/cmd/cosign/cli/attach.go
+++ b/cmd/cosign/cli/attach.go
@@ -66,7 +66,7 @@ func attachSignature() *cobra.Command {
 		PersistentPreRun: options.BindViper,
 		Args:             cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return attach.SignatureCmd(cmd.Context(), o.Registry, o.Signature, o.Payload, o.Cert, o.CertChain, o.TimeStampedSig, o.RekorBundle, args[0])
+			return attach.SignatureCmd(cmd.Context(), o.Registry, o.Signature, o.Payload, o.Cert, o.CertChain, o.TimeStampedSig, o.RekorResponse, args[0])
 		},
 	}
 

--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -107,7 +107,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 		var rekorResponse cosign.RekorResponse
 		err = json.Unmarshal(rekorResponseByte, &rekorResponse)
 		if err != nil {
-			return fmt.Errorf("unmarshal rekorResponse error: %v", err)
+			return fmt.Errorf("unmarshal rekorResponse error: %w", err)
 		}
 
 		if rekorResponse == nil {

--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -76,8 +76,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 	var cert []byte
 	var certChain []byte
 	var timeStampedSig []byte
-	var rekorBundle *bundle.RekorBundle
-
+	rekorBundle := &bundle.RekorBundle{}
 	if certRef != "" {
 		cert, err = os.ReadFile(filepath.Clean(certRef))
 		if err != nil {
@@ -108,22 +107,19 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 		var rekorResponse cosign.RekorResponse
 		err = json.Unmarshal(rekorResponseByte, &rekorResponse)
 		if err != nil {
-			return fmt.Errorf("Unmarshal rekorResponse error: ", err)
+			return fmt.Errorf("unmarshal rekorResponse error: %v", err)
 		}
 
 		if rekorResponse == nil {
 			return fmt.Errorf("unable to parse rekor-response to attach to image")
 		}
+
 		for _, v := range rekorResponse {
 			rekorBundle.SignedEntryTimestamp = v.Verification.SignedEntryTimestamp
 			rekorBundle.Payload.Body = v.Body
 			rekorBundle.Payload.IntegratedTime = *v.IntegratedTime
 			rekorBundle.Payload.LogIndex = *v.LogIndex
 			rekorBundle.Payload.LogID = *v.LogID
-		}
-
-		if rekorBundle == nil {
-			return fmt.Errorf("unable to parse Rekor response to attach to image")
 		}
 	}
 

--- a/cmd/cosign/cli/options/attach.go
+++ b/cmd/cosign/cli/options/attach.go
@@ -32,7 +32,7 @@ type AttachSignatureOptions struct {
 	Cert           string
 	CertChain      string
 	TimeStampedSig string
-	RekorBundle    string
+	RekorResponse  string
 	Registry       RegistryOptions
 }
 
@@ -58,8 +58,10 @@ func (o *AttachSignatureOptions) AddFlags(cmd *cobra.Command) {
 			"signing certificate and end with the root certificate. Included in the OCI Signature")
 	cmd.Flags().StringVar(&o.TimeStampedSig, "tsr", "",
 		"path to the Time Stamped Signature Response from RFC3161 compliant TSA")
-	cmd.Flags().StringVar(&o.RekorBundle, "rekor-response", "",
-		"path to the rekor bundle")
+	cmd.Flags().StringVar(&o.RekorResponse, "rekor-response", "",
+		"NOTE: the path can be either bundle, i.e. `bundle.json` which can be retrieve as o/p of command "+
+			"`cosign sign --bundle < bundle.json >` or "+
+			"rekor bundle formatted from rekor-response.")
 }
 
 // AttachSBOMOptions is the top level wrapper for the attach sbom command.

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -43,7 +43,7 @@ cosign attach signature [flags]
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
-      --rekor-response string                                                                    path to the rekor bundle
+      --rekor-response bundle.json                                                               NOTE: the path can be either bundle, i.e. bundle.json which can be retrieve as o/p of command `cosign sign --bundle < bundle.json >` or rekor bundle formatted from rekor-response.
       --signature string                                                                         path to the signature, or {-} for stdin
       --tsr string                                                                               path to the Time Stamped Signature Response from RFC3161 compliant TSA
 ```

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	"github.com/sigstore/rekor/pkg/generated/models"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -50,6 +51,8 @@ type LocalSignedPayload struct {
 	Cert            string              `json:"cert,omitempty"`
 	Bundle          *bundle.RekorBundle `json:"rekorBundle,omitempty"`
 }
+
+type RekorResponse map[string]models.LogEntryAnon
 
 type Signatures struct {
 	KeyID string `json:"keyid"`

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -930,7 +930,7 @@ func TestAttachWithRFC3161Timestamp(t *testing.T) {
 	must(verifyKeylessTSA(imgName, file.Name(), true, true), t)
 }
 
-func TestAttachWithRekorBundle(t *testing.T) {
+func TestAttachWithRekorResponse(t *testing.T) {
 	ctx := context.Background()
 
 	repo, stop := reg(t)
@@ -968,30 +968,14 @@ func TestAttachWithRekorBundle(t *testing.T) {
 
 	certchainRef := mkfile(string(append(pemSub[:], pemRoot[:]...)), td, t)
 
-	localRekorBundle := &bundle.RekorBundle{
-		SignedEntryTimestamp: strfmt.Base64("MEUCIEDcarEwRYkrxE9ne+kzEVvUhnWaauYzxhUyXOLy1hwAAiEA4VdVCvNRs+D/5o33C2KBy+q2YX3lP4Y7nqRFU+K3hi0="),
-		Payload: bundle.RekorPayload{
-			Body:           "REMOVED",
-			IntegratedTime: 1631646761,
-			LogIndex:       693591,
-			LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
-		},
-	}
-
-	localPayload := cosign.LocalSignedPayload{
-		Base64Signature: b64signature,
-		Cert:            string(pemLeaf),
-		Bundle:          localRekorBundle,
-	}
-
 	rekorResponse := make(cosign.RekorResponse)
-	logIndexValue := int64(63771522)
-	rootHash := "5bbff4e9f8034a33b102996271c0e01b87caa83c44c46e893b47b81467fd808c"
-	treeSize := int64(64319120)
-	checkPoint := "rekor.sigstore.dev - 2605736670972794746\n64319120\nW7/06fgDSjOxApliccDgG4fKqDxExG6JO0e4FGf9gIw=\nTimestamp: 1706845443714164712\n\n— rekor.sigstore.dev wNI9ajBFAiEAnduIhP1Jjz8E0ZAP8e1x0aKqzJCtmWZyV1mRJB/PlOoCIBoeHdjeONYmxlD2Za7sU0NeK/60skNnwoelsa3m2M8z\n"
 	integratedTime := int64(1706680021)
 	logID := "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"
 	logIndex := int64(67934953)
+	checkPoint := "rekor.sigstore.dev - 2605736670972794746\n64319120\nW7/06fgDSjOxApliccDgG4fKqDxExG6JO0e4FGf9gIw=\nTimestamp: 1706845443714164712\n\n— rekor.sigstore.dev wNI9ajBFAiEAnduIhP1Jjz8E0ZAP8e1x0aKqzJCtmWZyV1mRJB/PlOoCIBoeHdjeONYmxlD2Za7sU0NeK/60skNnwoelsa3m2M8z\n"
+	logIndexValue := int64(63771522)
+	rootHash := "5bbff4e9f8034a33b102996271c0e01b87caa83c44c46e893b47b81467fd808c"
+	treeSize := int64(64319120)
 
 	logEntry := models.LogEntryAnon{
 		Body:           "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiaGFzaGVkcmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI3YTIxODlmNzNlYTVkYmVlMmQ1NjgxMGU4NjBjZDgxNjdlYTFiMGYzMTdkZGRjMmU0YzE2NmU3ZDY4NzUzOGYwIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6Ik1FUUNJQlZtMVc1YlNSOXBTYVFyRWRVL2dOeEZuaVQzMCs4RGp5SG9naERwWHM3b0FpQXMyby82c3l2bzRaTDd3YVUrMXBNeVIvR1dNWlZTaUdzRm5hSm04ZDZZZ0E9PSIsInB1YmxpY0tleSI6eyJjb250ZW50IjoiTFMwdExTMUNSVWRKVGlCUVZVSk1TVU1nUzBWWkxTMHRMUzBLVFVacmQwVjNXVWhMYjFwSmVtb3dRMEZSV1VsTGIxcEplbW93UkVGUlkwUlJaMEZGUldGSWNHUmhZVE13ZEVOaVMxbG5lalpyUlhsQmNqTXJORmh5TWdwb1pWUjNaM2hQVVVrM2QwcDRiVWhIWW5OU1dYcEJWbFJyUVN0RGIzVjZUblZrTUc5eGRuUTRXVXB0Tm5CQlFUZG5SbUZFUkZGU05EUlJQVDBLTFMwdExTMUZUa1FnVUZWQ1RFbERJRXRGV1MwdExTMHRDZz09In19fX0=",
@@ -1011,26 +995,8 @@ func TestAttachWithRekorBundle(t *testing.T) {
 
 	rekorResponse["24296fb24b8ad77a8ada322cbba201d23b88acd2f68b29e358668e3aef36306ddb2c253ca0dc9ede"] = logEntry
 
-	jsonBundle, err := json.Marshal(localPayload)
-	if err != nil {
-		t.Fatal(err)
-	}
-	jsonRekorBundle, err := json.Marshal(localRekorBundle)
-	if err != nil {
-		t.Fatal(err)
-	}
 	jsonRekorResponsePath, err := json.Marshal(rekorResponse)
 	if err != nil {
-		t.Fatal(err)
-	}
-
-	bundlePath := filepath.Join(td, "bundle.json")
-	if err := os.WriteFile(bundlePath, jsonBundle, 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	rekorBundlePath := filepath.Join(td, "bundle2.json")
-	if err := os.WriteFile(rekorBundlePath, jsonRekorBundle, 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1040,14 +1006,6 @@ func TestAttachWithRekorBundle(t *testing.T) {
 	}
 
 	// Upload it!
-	err = attach.SignatureCmd(ctx, options.RegistryOptions{}, sigRef, payloadref, pemleafRef, certchainRef, "", bundlePath, imgName)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = attach.SignatureCmd(ctx, options.RegistryOptions{}, sigRef, payloadref, pemleafRef, certchainRef, "", rekorBundlePath, imgName)
-	if err != nil {
-		t.Fatal(err)
-	}
 	err = attach.SignatureCmd(ctx, options.RegistryOptions{}, sigRef, payloadref, pemleafRef, certchainRef, "", rekorResponsePath, imgName)
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -236,7 +236,6 @@ func TestSignVerifyClean(t *testing.T) {
 }
 
 func TestImportSignVerifyClean(t *testing.T) {
-
 	repo, stop := reg(t)
 	defer stop()
 	td := t.TempDir()
@@ -968,31 +967,47 @@ func TestAttachWithRekorBundle(t *testing.T) {
 
 	certchainRef := mkfile(string(append(pemSub[:], pemRoot[:]...)), td, t)
 
+	localRekorBundle := &bundle.RekorBundle{
+		SignedEntryTimestamp: strfmt.Base64("MEUCIEDcarEwRYkrxE9ne+kzEVvUhnWaauYzxhUyXOLy1hwAAiEA4VdVCvNRs+D/5o33C2KBy+q2YX3lP4Y7nqRFU+K3hi0="),
+		Payload: bundle.RekorPayload{
+			Body:           "REMOVED",
+			IntegratedTime: 1631646761,
+			LogIndex:       693591,
+			LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
+		},
+	}
+
 	localPayload := cosign.LocalSignedPayload{
 		Base64Signature: b64signature,
 		Cert:            string(pemLeaf),
-		Bundle: &bundle.RekorBundle{
-			SignedEntryTimestamp: strfmt.Base64("MEUCIEDcarEwRYkrxE9ne+kzEVvUhnWaauYzxhUyXOLy1hwAAiEA4VdVCvNRs+D/5o33C2KBy+q2YX3lP4Y7nqRFU+K3hi0="),
-			Payload: bundle.RekorPayload{
-				Body:           "REMOVED",
-				IntegratedTime: 1631646761,
-				LogIndex:       693591,
-				LogID:          "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d",
-			},
-		},
+		Bundle:          localRekorBundle,
 	}
 
 	jsonBundle, err := json.Marshal(localPayload)
 	if err != nil {
 		t.Fatal(err)
 	}
+	jsonRekorBundle, err := json.Marshal(localRekorBundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	bundlePath := filepath.Join(td, "bundle.json")
 	if err := os.WriteFile(bundlePath, jsonBundle, 0644); err != nil {
 		t.Fatal(err)
 	}
 
+	rekorBundlePath := filepath.Join(td, "bundle2.json")
+	if err := os.WriteFile(rekorBundlePath, jsonRekorBundle, 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	// Upload it!
 	err = attach.SignatureCmd(ctx, options.RegistryOptions{}, sigRef, payloadref, pemleafRef, certchainRef, "", bundlePath, imgName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = attach.SignatureCmd(ctx, options.RegistryOptions{}, sigRef, payloadref, pemleafRef, certchainRef, "", rekorBundlePath, imgName)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1615,7 +1630,6 @@ func keypair(t *testing.T, td string) (*cosign.KeysBytes, string, string) {
 }
 
 func importKeyPair(t *testing.T, td string) (*cosign.KeysBytes, string, string) {
-
 	const validrsa1 = `-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEAx5piWVlE62NnZ0UzJ8Z6oKiKOC4dbOZ1HsNhIRtqkM+Oq4G+
 25yq6P+0JU/Qvr9veOGEb3R/J9u8JBo+hv2i5X8OtgvP2V2pi6f1s6vK7L0+6uRb
@@ -1675,7 +1689,6 @@ qGzRVIDGbNkrVHM0IsAtHRpC0rYrtZY+9OwiraGcsqUMLwwQdCA=
 		t.Fatal(err)
 	}
 	return keys, privKeyPath, pubKeyPath
-
 }
 
 func TestUploadDownload(t *testing.T) {


### PR DESCRIPTION

#### Summary
This PR fixes the bugs while attaching the `rekor-bundle` into an image.
Closes #3458

#### Release Note
Bug fixes and fixes of previous known issues

#### Documentation
- Use `OpenSSL` tool to generate key pair.
- **private key**:  `openssl genrsa -out privkey.pem 4096`
- **public key**: `openssl rsa -in privkey.pem -outform PEM -pubout -out pubkey.pem`
- `IMAGE_DIGEST=ghcr.io/viveksahu26/hi-cosign:main`
- Generate Payload of an Image
	- `cosign generate $IMAGE_DIGEST > payload.json`
- Now sign the payload, using private key:
	- `openssl dgst -sha256 -sign privkey.pem -out payload.json.sig  payload.json`
- Convert the signature into `base64`
	- `cat payload.json.sig | base64 > payload.json.base64.sig`
- Let's check the manifest of image:
	- `NEW_IMAGE=$(cosign triangulate ${IMAGE_DIGEST})`
	- `crane manifest ${NEW_IMAGE}`
- Now, let's upload `payload`, `signature`, and `public key` to rekor instance.
	- `rekor-cli upload --artifact payload.json --signature payload.json.sig --public-key pubkey.pem --pki-format x509`
	- You will get o/p as `logIndex` or `uuid` of the record.
- Finally, `rekor-bundle` is added. Now check the `rekor-bundle`:
	- check whether record is uploaded or not: `rekor-cli get --log-index 60606559`
- Now, let's attach this `rekor-bundle` to an Image, for that first you need to create a `rekor-bundle` by yourself. 
        - `curl https://rekor.sigstore.dev/api/v1/log/entries\?logIndex\=60606559 | jq`
	- Now construct the rekor-bundle:
		 ```json
		cat rekor_bundle.json | jq
		{
		  "SignedEntryTimestamp": "MEYCIQDCBEsMQKGMopTKw9/NNnxUNqEPcmJotc7VuRlkcSaS2gIhAIoHOgkFXIOy2rI843w79yLVYc6/M/QMUApLvbFcF7Qj",
		  "Payload": {
			"body": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoicmVrb3JkIiwic3BlYyI6eyJkYXRhIjp7Imhhc2giOnsiYWxnb3JpdGhtIjoic2hhMjU2IiwidmFsdWUiOiI0ODEwZmQ5YjEzODdlNDZhZWMyM2NmNTYwNjU3OTcxOTllZmU3NzM3YmQ0NmNiMTViYzI0Y2VkMjY5MGNhYzUyIn19LCJzaWduYXR1cmUiOnsiY29udGVudCI6IkdPOUlIcCsyemkvNUI4SEZWWkVYQStIN0JIVGxBZm1OQ2FMbGNxeFhLaENMQmdmazZjNFo4UkFGUnFodGVOWGMxNzlIaXkweSsvbjR5d0tyc2Q4UFh2Y3VObmlLM2tneXhXYzJHNWowTjJBRE85QStZY2U2NkUrcTN4MkQyU0FveWVMcnpkby9Qa2lmVDR1dnVZK0o1NVlMUW9XRG5nMExid1NVVGVGOGpHRXdMN3pKUTRzZzhOSnhvMFMyVStWdlZLSVNoRzFFQWlBOUMxZ2M1NWhHT29yTmFhZjhEL3JTM0V5THFIS3EzL1N1REhseHAzUVk2clU4QlZJTlVWZ2lUbWJ6WHY2eW83NnJVMmsyampwOWFaWlRiK1F2UWdWbGV6WGwrVld5U0thb0pxQ3RRNy9mMk5FdFplZ1VUSnJRQTdnMERrbXoyMUFDMzk4YlZpMHRmUDF2aXZEelh4TkMxNXBtL2tYdWk2ejcxOUtHazhxN3NRMDVyY3ZaZm9pMERmRmNZbDB0aFA4K1dsRU5kdU5zRnJtK1ZQditaYjBCbnFHM0twTkZ0Ymdtc092WXFvNHAyZjFlb1IwTFNEMlp3cEFRNERUd3dRRGh5UEk3MzdWT2ZJc1hObHg2T0srVml5Vmg4cGhRZHJrK2doRXJJVEM0WFllYVlRaUNvWTgySWNDcEh3Mmw3QS9SeDdiNXdVMDhnVkg2S1JjWmJFNm9mVStmSFFTcTQ4OHhvNnQrUHdLWHVDN1RtUFhJLzB4Uys4aDJ4bXRqOCtXOHRRQzFZRHcwU3JGZzIyelBFMkRjR3Z5KytIQXNpazd6VmEzNlovN2VzcndSOWpxdE8vd1M3UnAwQVMvenNjZVdiWTFoVEhVcXNsbE9FYU9DYThoN2NnUCtQTWdSV0dZPSIsImZvcm1hdCI6Ing1MDkiLCJwdWJsaWNLZXkiOnsiY29udGVudCI6IkxTMHRMUzFDUlVkSlRpQlFWVUpNU1VNZ1MwVlpMUzB0TFMwS1RVbEpRMGxxUVU1Q1oydHhhR3RwUnpsM01FSkJVVVZHUVVGUFEwRm5PRUZOU1VsRFEyZExRMEZuUlVGdFRsVk9SRWxVZHpKcVUzWmpZbEVyYjBwMU5ncGlaMWN2Tm5ZNFdHTk9WRmRoTHpKdWRUbFVVbVJTYldONmJtVnZWMVE1VGtKclZWcEZPV2hZYVU1U0t5OUNOVTVyTlZwa2RtSjJWVEUwYmtFNVJqSmtDalZJVURKS1UxUkNTVVZ5Y0hSblNVVnpTMHRaYkhKblJrRjVUSEYxWWtGbllYSXJZWEJLY0U5QmFHOXZXa1pIV1ZOTlRDOXZVWGxXTVdoUlYwdEdiRkFLTUd4aldFazNPRFJNU0dwemNubE9iM2xCUmxoR1JuazBhR1pCUXpaVE4zTTVVRTFQUjFWU1RVNXdibU5YYkZseFpqaFFUMVJCUlZSaVRETjRVa0lyUkFwU1QxQk1Za3ROVjNoNVVIbFRTR0ZuVW5JMlJHUktOVUZyYW5oMVUwWldUelFyZG1Kb2ExaFlURTUxTkZKcWFFVlVibE5LVDNJMVYzWjZiREF5T0ZjekNqVk1haTkyV0ZWNFoyMUNjV1F2Y0dKS01EQklNVko0Ym14V0wwOHlOV3B2Tm1aNVRXUmlPVzFxTjNKUlpHUnVWMUpqVVhGU0szQTJjVWR2Ukd4NU5UY0tSRFIzVm1SaWJGVk9WbWRyTUd4T1NrOWplbkl2WTB3dmNHSllTa28yYW5kMEt6UkNhbGxYVjA1VmVIUTNNM2hDTkhSTE4yZE9aVWN3ZUZReWNGSklNQW81U2pGWVZrWTViblJtUjNWcVJuTm1VeXRVTUhCemFYbHpNRFJ2V2twWE0xRlBUbE15UkRFek9IWTFRVWhaVDJsVGJXMUNSakJtUVdOUE5qUm9iMDA1Q2pJNVJFdE9URTlEUldsbWIydFBkMjlyVkROQmVrMHZaREl4WlZBd2MxbHZOV05ZT1hKR1NGSmxhVGdyZEVGWWF6aGpVMnBZWjI5eE1rRXdabEZNVFdJS2RFWjZWVXA1YkU5elltSjJTV3N6VUV0S2VXeFpSMDVDZG5rek56SkdkRlV3ZWtaTVVWQlRiMW93TWxaSFVTODBWbXR0YVZScU5GcFRkakZaYlV4UVNRcFhiVE01ZUVkd2FEaFpVbVpGUVhKR1JWRlNOeTlLV2tad2JVc3pPV1ZwTkZsWmVsRndjRXhqVW1sRVdHUjBia0pEV1VSTE0ydHVSekZzWnpKWVIyRnpDazF0V0VsdFFYQlFTMWcwTDA5a1RVdzVaVXMwY0dZd1EwRjNSVUZCVVQwOUNpMHRMUzB0UlU1RUlGQlZRa3hKUXlCTFJWa3RMUzB0TFFvPSJ9fX19",
			"integratedTime": "1704106175",
			"logIndex": "60606559",
			"logID": "c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d"
		  }
		}

		```
**NOTE**: currently there is no such commands which automates the process of constructing a rekor bundle for us. Like `cosign generate` command create the payload on providing the image.
	- Now upload this `rekor-bundle`, `signature` and `payload` to an Image.
		- `cosign attach signature --payload payload.json --signature payload.json.base64.sig --rekor-response rekor_bundle.json  $IMAGE_DIGEST`
		
- Check the manifest of image, whether the rekor-bundle is added to the image or not.
	- `NEW_IMAGE=$(cosign triangulate ${IMAGE_DIGEST})`
	- `crane manifest ${NEW_IMAGE}`
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
