### PR TITLE
Remove CertSubject function

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -345,7 +345,11 @@ func PrintVerification(ctx context.Context, verified []oci.Signature, output str
 		for _, sig := range verified {
 			if cert, err := sig.Cert(); err == nil && cert != nil {
 				ce := cosign.CertExtensions{Cert: cert}
-				ui.Infof(ctx, "Certificate subject: %s", sigs.CertSubject(cert))
+				sub := ""
+				if sans := cryptoutils.GetSubjectAlternateNames(cert); len(sans) > 0 {
+					sub = sans[0]
+				}
+				ui.Infof(ctx, "Certificate subject: %s", sub)
 				if issuerURL := ce.GetIssuer(); issuerURL != "" {
 					ui.Infof(ctx, "Certificate issuer URL: %s", issuerURL)
 				}
@@ -398,7 +402,11 @@ func PrintVerification(ctx context.Context, verified []oci.Signature, output str
 				if ss.Optional == nil {
 					ss.Optional = make(map[string]interface{})
 				}
-				ss.Optional["Subject"] = sigs.CertSubject(cert)
+				sub := ""
+				if sans := cryptoutils.GetSubjectAlternateNames(cert); len(sans) > 0 {
+					sub = sans[0]
+				}
+				ss.Optional["Subject"] = sub
 				if issuerURL := ce.GetIssuer(); issuerURL != "" {
 					ss.Optional["Issuer"] = issuerURL
 					ss.Optional[cosign.CertExtensionOIDCIssuer] = issuerURL

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -17,7 +17,6 @@ package signature
 import (
 	"context"
 	"crypto"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"strings"
@@ -233,19 +232,4 @@ func PublicKeyPem(key signature.PublicKeyProvider, pkOpts ...signature.PublicKey
 		return nil, err
 	}
 	return cryptoutils.MarshalPublicKeyToPEM(pub)
-}
-
-func CertSubject(c *x509.Certificate) string {
-	switch {
-	case c.EmailAddresses != nil:
-		return c.EmailAddresses[0]
-	case c.URIs != nil:
-		return c.URIs[0].String()
-	}
-	// ignore error if there's no OtherName SAN
-	otherName, _ := cryptoutils.UnmarshalOtherNameSAN(c.Extensions)
-	if len(otherName) > 0 {
-		return otherName
-	}
-	return ""
 }

--- a/pkg/signature/keys_test.go
+++ b/pkg/signature/keys_test.go
@@ -17,17 +17,12 @@ package signature
 import (
 	"context"
 	"crypto"
-	"crypto/x509/pkix"
 	"errors"
-	"net"
-	"net/url"
 	"os"
 	"testing"
 
 	"github.com/sigstore/cosign/v2/pkg/blob"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
-	"github.com/sigstore/cosign/v2/test"
-	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsignature "github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/kms"
 )
@@ -170,34 +165,5 @@ func TestVerifierForKeyRefError(t *testing.T) {
 func pass(s string) cosign.PassFunc {
 	return func(_ bool) ([]byte, error) {
 		return []byte(s), nil
-	}
-}
-
-func TestCertSubject(t *testing.T) {
-	rootCert, rootKey, _ := test.GenerateRootCa()
-	subCert, subKey, _ := test.GenerateSubordinateCa(rootCert, rootKey)
-
-	// generate with OtherName, which will override other SANs
-	ext, err := cryptoutils.MarshalOtherNameSAN("subject-othername", true)
-	if err != nil {
-		t.Fatalf("error marshalling SANs: %v", err)
-	}
-	exts := []pkix.Extension{*ext}
-	leafCert, _, _ := test.GenerateLeafCert("unused", "oidc-issuer", subCert, subKey, exts...)
-	if otherName := CertSubject(leafCert); otherName != "subject-othername" {
-		t.Fatalf("unexpected otherName, got %s", otherName)
-	}
-
-	// generate with email
-	leafCert, _, _ = test.GenerateLeafCert("subject-email", "oidc-issuer", subCert, subKey)
-	if email := CertSubject(leafCert); email != "subject-email" {
-		t.Fatalf("unexpected email address, got %s", email)
-	}
-
-	// generate with URI
-	uri, _ := url.Parse("spiffe://domain/user")
-	leafCert, _, _ = test.GenerateLeafCertWithSubjectAlternateNames([]string{}, []string{}, []net.IP{}, []*url.URL{uri}, "oidc-issuer", subCert, subKey)
-	if uri := CertSubject(leafCert); uri != "spiffe://domain/user" {
-		t.Fatalf("unexpected URI, got %s", uri)
 	}
 }


### PR DESCRIPTION
There is an existing function that handles more certificate subject types.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
