### PR TITLE
Use local rekor and fulcio instances in e2e tests

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -77,8 +77,8 @@ import (
 
 const (
 	serverEnv = "REKOR_SERVER"
-	rekorURL  = "https://rekor.sigstore.dev"
-	fulcioURL = "https://fulcio.sigstore.dev"
+	rekorURL  = "http://127.0.0.1:3000"
+	fulcioURL = "http://127.0.0.1:5555"
 )
 
 var keyPass = []byte("hello")

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1324,6 +1324,11 @@ func TestGenerateKeyPairK8s(t *testing.T) {
 	if v, ok := s.Data["cosign.password"]; !ok || string(v) != password {
 		t.Fatalf("password is incorrect, got %v expected %v", v, "foo")
 	}
+	// Clean up the secret (so tests can be re-run locally)
+	err = client.CoreV1().Secrets(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestMultipleSignatures(t *testing.T) {

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -29,6 +29,13 @@ cd rekor
 
 echo "starting services"
 docker-compose up -d
+cleanup_services() {
+    echo "cleaning up"
+    pushd $HOME/rekor
+    docker-compose down
+    popd
+}
+trap cleanup_services EXIT
 
 count=0
 
@@ -50,7 +57,7 @@ echo "running tests"
 
 popd
 go build -o cosign ./cmd/cosign
-go test -tags=e2e -race $(go list ./... | grep -v third_party/)
+go test -tags=e2e -v -race ./test/...
 
 # Test on a private registry
 echo "testing sign/verify/clean on private registry"
@@ -80,7 +87,3 @@ if (./cosign manifest verify ./test/testdata/unsigned_manifest.yaml --certificat
 make ko-local
 img="ko.local/cosign:$(git rev-parse HEAD)"
 docker run $img version
-
-echo "cleanup"
-cd $HOME/rekor
-docker-compose down


### PR DESCRIPTION
In 70683571 the e2e tests moved from running on the locally-spun-up
rekor instance to the public instance. This means test signatures are
piling up in the public instance, and the tests may be taking longer
than they need to since they are using an external service.

This change moves back to using the local rekor instance, which the e2e
has still been spinning up even though it has been going unused. Also
now do the same for fulcio.

This PR also includes minor cleanups in the e2e tests and test script.

Depends on https://github.com/sigstore/fulcio/pull/1518
Relates to https://github.com/sigstore/sigstore-probers/issues/105
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
Test changes only.