### PR TITLE
Correct help text of verify-attestation sub-command policy argument

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -143,7 +143,7 @@ func (o *VerifyAttestationOptions) AddFlags(cmd *cobra.Command) {
 		"whether to check the claims found")
 
 	cmd.Flags().StringSliceVar(&o.Policies, "policy", nil,
-		"specify CUE or Rego files will be using for validation")
+		"specify CUE or Rego files with policies to be used for validation")
 
 	cmd.Flags().StringVarP(&o.Output, "output", "o", "json",
 		"output format for the signing image information (json|text)")

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -81,7 +81,7 @@ cosign verify-attestation [flags]
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
-      --policy strings                                                                           specify CUE or Rego files will be using for validation
+      --policy strings                                                                           specify CUE or Rego files with policies to be used for validation
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token


### PR DESCRIPTION
#### Summary

This PR adjust the wording of the `policy` argument for the `verify-attestation` sub-command. The original did not sound like correct English.

#### Release Note

NONE

#### Documentation

No changes needed.
