### PR TITLE
use go1.21.7 as go-version in actions/setup-go

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: '1.21' 
           check-latest: true
 
       - name: Run pkcs11 end-to-end tests

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,9 +31,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-env:
-  GO_VERSION: '1.21'
-
 jobs:
   e2e-secrets:
     strategy:


### PR DESCRIPTION
#### Summary
Change the `go_version` to `1.21.7` consistently throughout the file.  Currently some settings have a hardwired `1.21` while one other uses `${{ env.GO_VERSION }}` which causes a warning and uses go1.20.x leading to an error on the missing `slices` package - https://github.com/sigstore/cosign/actions/runs/7885778751/job/21517629805?pr=3539:
```sh
Run actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
Setup go version spec 
Warning: go-version input was not specified. The action will try to use pre-installed version.
/usr/bin/go env GOMODCACHE
/usr/bin/go env GOCACHE
/home/runner/go/pkg/mod
/home/runner/.cache/go-build
Cache is not found
go version go1.20.14 linux/amd64
```

#### Release Note
NONE

#### Documentation
n/a
