### PR TITLE
Honor creation timestamp for signatures again

### DIFF
--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -41,6 +41,7 @@ type SignOptions struct {
 	TSAServerURL          string
 	IssueCertificate      bool
 	SignContainerIdentity string
+	HonorCreateTimestamp  bool
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -130,4 +131,6 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.SignContainerIdentity, "sign-container-identity", "",
 		"manually set the .critical.docker-reference field for the signed identity, which is useful when image proxies are being used where the pull reference should match the signature")
+
+	cmd.Flags().BoolVar(&o.HonorCreateTimestamp, "honor-create-timestamp", false, "honor the create timestamp in the signature artefact to be pushed to the OCI registry")
 }

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -21,27 +21,27 @@ import (
 
 // SignOptions is the top level wrapper for the sign command.
 type SignOptions struct {
-	Key                   string
-	Cert                  string
-	CertChain             string
-	Upload                bool
-	Output                string // deprecated: TODO remove when the output flag is fully deprecated
-	OutputSignature       string // TODO: this should be the root output file arg.
-	OutputPayload         string
-	OutputCertificate     string
-	PayloadPath           string
-	Recursive             bool
-	Attachment            string
-	SkipConfirmation      bool
-	TlogUpload            bool
-	TSAClientCACert       string
-	TSAClientCert         string
-	TSAClientKey          string
-	TSAServerName         string
-	TSAServerURL          string
-	IssueCertificate      bool
-	SignContainerIdentity string
-	HonorCreateTimestamp  bool
+	Key                     string
+	Cert                    string
+	CertChain               string
+	Upload                  bool
+	Output                  string // deprecated: TODO remove when the output flag is fully deprecated
+	OutputSignature         string // TODO: this should be the root output file arg.
+	OutputPayload           string
+	OutputCertificate       string
+	PayloadPath             string
+	Recursive               bool
+	Attachment              string
+	SkipConfirmation        bool
+	TlogUpload              bool
+	TSAClientCACert         string
+	TSAClientCert           string
+	TSAClientKey            string
+	TSAServerName           string
+	TSAServerURL            string
+	IssueCertificate        bool
+	SignContainerIdentity   string
+	RecordCreationTimestamp bool
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -132,5 +132,5 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.SignContainerIdentity, "sign-container-identity", "",
 		"manually set the .critical.docker-reference field for the signed identity, which is useful when image proxies are being used where the pull reference should match the signature")
 
-	cmd.Flags().BoolVar(&o.HonorCreateTimestamp, "honor-create-timestamp", false, "honor the create timestamp in the signature artefact to be pushed to the OCI registry")
+	cmd.Flags().BoolVar(&o.RecordCreationTimestamp, "record-creation-timestamp", false, "set the createdAt timestamp in the signature artifact to the time it was created; by default, cosign sets this to the zero value")
 }

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -86,7 +86,7 @@ race conditions or (worse) malicious tampering.
   cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>
 
   # sign a container image and honor the creation timestamp of the signature
-  cosign sign --key cosign.key --honor-create-timestamp <IMAGE DIGEST>`,
+  cosign sign --key cosign.key --record-creation-timestamp <IMAGE DIGEST>`,
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -83,7 +83,10 @@ race conditions or (worse) malicious tampering.
   cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
 
   # sign a container image by manually setting the container image identity
-  cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>`,
+  cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>
+
+  # sign a container image and honor the creation timestamp of the signature
+  cosign sign --key cosign.key --honor-create-timestamp <IMAGE DIGEST>`,
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -329,7 +329,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	}
 
 	// Attach the signature to the entity.
-	newSE, err := mutate.AttachSignatureToEntity(se, ociSig, mutate.WithDupeDetector(dd), mutate.WithHonorCreationTimestamp(signOpts.RecordCreationTimestamp))
+	newSE, err := mutate.AttachSignatureToEntity(se, ociSig, mutate.WithDupeDetector(dd), mutate.WithRecordCreationTimestamp(signOpts.RecordCreationTimestamp))
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -329,7 +329,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	}
 
 	// Attach the signature to the entity.
-	newSE, err := mutate.AttachSignatureToEntity(se, ociSig, mutate.WithDupeDetector(dd), mutate.WithHonorCreationTimestamp(signOpts.HonorCreateTimestamp))
+	newSE, err := mutate.AttachSignatureToEntity(se, ociSig, mutate.WithDupeDetector(dd), mutate.WithHonorCreationTimestamp(signOpts.RecordCreationTimestamp))
 	if err != nil {
 		return err
 	}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -329,7 +329,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	}
 
 	// Attach the signature to the entity.
-	newSE, err := mutate.AttachSignatureToEntity(se, ociSig, mutate.WithDupeDetector(dd))
+	newSE, err := mutate.AttachSignatureToEntity(se, ociSig, mutate.WithDupeDetector(dd), mutate.WithHonorCreationTimestamp(signOpts.HonorCreateTimestamp))
 	if err != nil {
 		return err
 	}

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -64,6 +64,9 @@ cosign sign [flags]
 
   # sign a container image by manually setting the container image identity
   cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>
+
+  # sign a container image and honor the creation timestamp of the signature
+  cosign sign --key cosign.key --honor-create-timestamp <IMAGE DIGEST>
 ```
 
 ### Options
@@ -78,6 +81,7 @@ cosign sign [flags]
       --certificate-chain string                                                                 path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Included in the OCI Signature
       --fulcio-url string                                                                        address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
+      --honor-create-timestamp                                                                   honor the create timestamp in the signature artefact to be pushed to the OCI registry
       --identity-token string                                                                    identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
       --issue-certificate                                                                        issue a code signing certificate from Fulcio, even if a key is provided

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -81,7 +81,6 @@ cosign sign [flags]
       --certificate-chain string                                                                 path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Included in the OCI Signature
       --fulcio-url string                                                                        address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
-      --honor-create-timestamp                                                                   honor the create timestamp in the signature artefact to be pushed to the OCI registry
       --identity-token string                                                                    identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
       --issue-certificate                                                                        issue a code signing certificate from Fulcio, even if a key is provided
@@ -97,6 +96,7 @@ cosign sign [flags]
       --output-payload string                                                                    write the signed payload to FILE
       --output-signature string                                                                  write the signature to FILE
       --payload string                                                                           path to a payload file to use rather than generating one
+      --record-creation-timestamp                                                                set the createdAt timestamp in the signature artifact to the time it was created; by default, cosign sets this to the zero value
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
       --registry-password string                                                                 registry basic auth password
       --registry-referrers-mode registryReferrersMode                                            mode for fetching references from the registry. allowed: legacy, oci-1-1

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -66,7 +66,7 @@ cosign sign [flags]
   cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>
 
   # sign a container image and honor the creation timestamp of the signature
-  cosign sign --key cosign.key --honor-create-timestamp <IMAGE DIGEST>
+  cosign sign --key cosign.key --record-creation-timestamp <IMAGE DIGEST>
 ```
 
 ### Options

--- a/pkg/oci/mutate/mutate.go
+++ b/pkg/oci/mutate/mutate.go
@@ -377,5 +377,5 @@ func (so *signOpts) dedupeAndReplace(sig oci.Signature, basefn func() (oci.Signa
 		}
 		return ReplaceSignatures(replace)
 	}
-	return AppendSignatures(base, sig)
+	return AppendSignatures(base, so.hct, sig)
 }

--- a/pkg/oci/mutate/mutate.go
+++ b/pkg/oci/mutate/mutate.go
@@ -377,5 +377,5 @@ func (so *signOpts) dedupeAndReplace(sig oci.Signature, basefn func() (oci.Signa
 		}
 		return ReplaceSignatures(replace)
 	}
-	return AppendSignatures(base, so.hct, sig)
+	return AppendSignatures(base, so.rct, sig)
 }

--- a/pkg/oci/mutate/options.go
+++ b/pkg/oci/mutate/options.go
@@ -60,7 +60,7 @@ func WithReplaceOp(ro ReplaceOp) SignOption {
 	}
 }
 
-func WithHonorCreationTimestamp(rct bool) SignOption {
+func WithRecordCreationTimestamp(rct bool) SignOption {
 	return func(so *signOpts) {
 		so.rct = rct
 	}

--- a/pkg/oci/mutate/options.go
+++ b/pkg/oci/mutate/options.go
@@ -35,7 +35,7 @@ type SignOption func(*signOpts)
 type signOpts struct {
 	dd  DupeDetector
 	ro  ReplaceOp
-	hct bool
+	rct bool
 }
 
 func makeSignOpts(opts ...SignOption) *signOpts {
@@ -60,9 +60,9 @@ func WithReplaceOp(ro ReplaceOp) SignOption {
 	}
 }
 
-func WithHonorCreationTimestamp(hct bool) SignOption {
+func WithHonorCreationTimestamp(rct bool) SignOption {
 	return func(so *signOpts) {
-		so.hct = hct
+		so.rct = rct
 	}
 }
 

--- a/pkg/oci/mutate/options.go
+++ b/pkg/oci/mutate/options.go
@@ -33,8 +33,9 @@ type ReplaceOp interface {
 type SignOption func(*signOpts)
 
 type signOpts struct {
-	dd DupeDetector
-	ro ReplaceOp
+	dd  DupeDetector
+	ro  ReplaceOp
+	hct bool
 }
 
 func makeSignOpts(opts ...SignOption) *signOpts {
@@ -56,6 +57,12 @@ func WithDupeDetector(dd DupeDetector) SignOption {
 func WithReplaceOp(ro ReplaceOp) SignOption {
 	return func(so *signOpts) {
 		so.ro = ro
+	}
+}
+
+func WithHonorCreationTimestamp(hct bool) SignOption {
+	return func(so *signOpts) {
+		so.hct = hct
 	}
 }
 

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -25,7 +25,7 @@ import (
 
 // AppendSignatures produces a new oci.Signatures with the provided signatures
 // appended to the provided base signatures.
-func AppendSignatures(base oci.Signatures, honorTimestamp bool, sigs ...oci.Signature) (oci.Signatures, error) {
+func AppendSignatures(base oci.Signatures, recordCreationTimestamp bool, sigs ...oci.Signature) (oci.Signatures, error) {
 	adds := make([]mutate.Addendum, 0, len(sigs))
 	for _, sig := range sigs {
 		ann, err := sig.Annotations()
@@ -43,7 +43,7 @@ func AppendSignatures(base oci.Signatures, honorTimestamp bool, sigs ...oci.Sign
 		return nil, err
 	}
 
-	if honorTimestamp {
+	if recordCreationTimestamp {
 		t, err := now.Now()
 		if err != nil {
 			return nil, err

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -25,7 +25,7 @@ import (
 
 // AppendSignatures produces a new oci.Signatures with the provided signatures
 // appended to the provided base signatures.
-func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signatures, error) {
+func AppendSignatures(base oci.Signatures, honorTimestamp bool, sigs ...oci.Signature) (oci.Signatures, error) {
 	adds := make([]mutate.Addendum, 0, len(sigs))
 	for _, sig := range sigs {
 		ann, err := sig.Annotations()
@@ -43,15 +43,17 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 		return nil, err
 	}
 
-	t, err := now.Now()
-	if err != nil {
-		return nil, err
-	}
+	if honorTimestamp {
+		t, err := now.Now()
+		if err != nil {
+			return nil, err
+		}
 
-	// Set the Created date to time of execution
-	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
-	if err != nil {
-		return nil, err
+		// Set the Created date to time of execution
+		img, err = mutate.CreatedAt(img, v1.Time{Time: t})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &sigAppender{

--- a/pkg/oci/mutate/signatures.go
+++ b/pkg/oci/mutate/signatures.go
@@ -19,6 +19,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/sigstore/cosign/v2/internal/pkg/now"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 )
 
@@ -38,6 +39,17 @@ func AppendSignatures(base oci.Signatures, sigs ...oci.Signature) (oci.Signature
 	}
 
 	img, err := mutate.Append(base, adds...)
+	if err != nil {
+		return nil, err
+	}
+
+	t, err := now.Now()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the Created date to time of execution
+	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/mutate/signatures_test.go
+++ b/pkg/oci/mutate/signatures_test.go
@@ -73,7 +73,7 @@ func TestAppendSignatures(t *testing.T) {
 
 	if testCfg, err := threeSig.ConfigFile(); err != nil {
 		t.Fatalf("ConfigFile() = %v", err)
-	} else if !testCfg.Created.Time.IsZero() {
-		t.Errorf("Date of Signature was not Zero")
+	} else if testCfg.Created.Time.IsZero() {
+		t.Errorf("Date of Signature was Zero")
 	}
 }

--- a/pkg/oci/mutate/signatures_test.go
+++ b/pkg/oci/mutate/signatures_test.go
@@ -38,17 +38,17 @@ func TestAppendSignatures(t *testing.T) {
 		t.Fatalf("NewSignature() = %v", err)
 	}
 
-	oneSig, err := AppendSignatures(base, s1)
+	oneSig, err := AppendSignatures(base, false, s1)
 	if err != nil {
 		t.Fatalf("AppendSignatures() = %v", err)
 	}
 
-	twoSig, err := AppendSignatures(oneSig, s2)
+	twoSig, err := AppendSignatures(oneSig, false, s2)
 	if err != nil {
 		t.Fatalf("AppendSignatures() = %v", err)
 	}
 
-	threeSig, err := AppendSignatures(oneSig, s2, s3)
+	threeSig, err := AppendSignatures(oneSig, true, s2, s3)
 	if err != nil {
 		t.Fatalf("AppendSignatures() = %v", err)
 	}
@@ -74,6 +74,12 @@ func TestAppendSignatures(t *testing.T) {
 	if testCfg, err := threeSig.ConfigFile(); err != nil {
 		t.Fatalf("ConfigFile() = %v", err)
 	} else if testCfg.Created.Time.IsZero() {
+		t.Errorf("Date of Signature was Zero")
+	}
+
+	if testDefaultCfg, err := twoSig.ConfigFile(); err != nil {
+		t.Fatalf("ConfigFile() = %v", err)
+	} else if !testDefaultCfg.Created.Time.IsZero() {
 		t.Errorf("Date of Signature was Zero")
 	}
 }

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -49,7 +49,7 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 	// Add annotations from options
 	img = mutate.Annotations(img, o.Annotations).(v1.Image)
 
-	if o.HonorCreateTimestamp {
+	if o.RecordCreationTimestamp {
 		t, err := now.Now()
 		if err != nil {
 			return nil, err

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -49,16 +49,19 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 	// Add annotations from options
 	img = mutate.Annotations(img, o.Annotations).(v1.Image)
 
-	t, err := now.Now()
-	if err != nil {
-		return nil, err
+	if o.HonorCreateTimestamp {
+		t, err := now.Now()
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the Created date to time of execution
+		img, err = mutate.CreatedAt(img, v1.Time{Time: t})
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	// Set the Created date to time of execution
-	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
-	if err != nil {
-		return nil, err
-	}
 	return &file{
 		SignedImage: signed.Image(img),
 		layer:       layer,

--- a/pkg/oci/static/file.go
+++ b/pkg/oci/static/file.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/v2/internal/pkg/now"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 )
@@ -48,6 +49,16 @@ func NewFile(payload []byte, opts ...Option) (oci.File, error) {
 	// Add annotations from options
 	img = mutate.Annotations(img, o.Annotations).(v1.Image)
 
+	t, err := now.Now()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the Created date to time of execution
+	img, err = mutate.CreatedAt(img, v1.Time{Time: t})
+	if err != nil {
+		return nil, err
+	}
 	return &file{
 		SignedImage: signed.Image(img),
 		layer:       layer,

--- a/pkg/oci/static/file_test.go
+++ b/pkg/oci/static/file_test.go
@@ -126,8 +126,8 @@ func TestNewFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ConfigFile() = %v", err)
 		}
-		if !fileCfg.Created.Time.IsZero() {
-			t.Errorf("Date of Signature was not Zero")
+		if fileCfg.Created.Time.IsZero() {
+			t.Errorf("Date of Signature was Zero")
 		}
 	})
 

--- a/pkg/oci/static/file_test.go
+++ b/pkg/oci/static/file_test.go
@@ -32,7 +32,7 @@ func TestNewFile(t *testing.T) {
 		t.Fatalf("NewFile() = %v", err)
 	}
 
-	timestampedFile, err := NewFile([]byte(payload), WithLayerMediaType("foo"), WithAnnotations(map[string]string{"foo": "bar"}), WithHonorCreationTimestamp(true))
+	timestampedFile, err := NewFile([]byte(payload), WithLayerMediaType("foo"), WithAnnotations(map[string]string{"foo": "bar"}), WithRecordCreationTimestamp(true))
 
 	if err != nil {
 		t.Fatalf("NewFile() = %v", err)

--- a/pkg/oci/static/file_test.go
+++ b/pkg/oci/static/file_test.go
@@ -32,6 +32,12 @@ func TestNewFile(t *testing.T) {
 		t.Fatalf("NewFile() = %v", err)
 	}
 
+	timestampedFile, err := NewFile([]byte(payload), WithLayerMediaType("foo"), WithAnnotations(map[string]string{"foo": "bar"}), WithHonorCreationTimestamp(true))
+
+	if err != nil {
+		t.Fatalf("NewFile() = %v", err)
+	}
+
 	layers, err := file.Layers()
 	if err != nil {
 		t.Fatalf("Layers() = %v", err)
@@ -126,7 +132,14 @@ func TestNewFile(t *testing.T) {
 		if err != nil {
 			t.Fatalf("ConfigFile() = %v", err)
 		}
-		if fileCfg.Created.Time.IsZero() {
+		if !fileCfg.Created.Time.IsZero() {
+			t.Errorf("Date of Signature was not Zero")
+		}
+		tsCfg, err := timestampedFile.ConfigFile()
+		if err != nil {
+			t.Fatalf("ConfigFile() = %v", err)
+		}
+		if tsCfg.Created.Time.IsZero() {
 			t.Errorf("Date of Signature was Zero")
 		}
 	})

--- a/pkg/oci/static/options.go
+++ b/pkg/oci/static/options.go
@@ -27,13 +27,14 @@ import (
 type Option func(*options)
 
 type options struct {
-	LayerMediaType   types.MediaType
-	ConfigMediaType  types.MediaType
-	Bundle           *bundle.RekorBundle
-	RFC3161Timestamp *bundle.RFC3161Timestamp
-	Cert             []byte
-	Chain            []byte
-	Annotations      map[string]string
+	LayerMediaType       types.MediaType
+	ConfigMediaType      types.MediaType
+	Bundle               *bundle.RekorBundle
+	RFC3161Timestamp     *bundle.RFC3161Timestamp
+	Cert                 []byte
+	Chain                []byte
+	Annotations          map[string]string
+	HonorCreateTimestamp bool
 }
 
 func makeOptions(opts ...Option) (*options, error) {
@@ -110,5 +111,12 @@ func WithCertChain(cert, chain []byte) Option {
 	return func(o *options) {
 		o.Cert = cert
 		o.Chain = chain
+	}
+}
+
+// WithHonorCreationTimestamp sets the feature flag to honor the creation timestamp to time of running
+func WithHonorCreationTimestamp(hct bool) Option {
+	return func(o *options) {
+		o.HonorCreateTimestamp = hct
 	}
 }

--- a/pkg/oci/static/options.go
+++ b/pkg/oci/static/options.go
@@ -27,14 +27,14 @@ import (
 type Option func(*options)
 
 type options struct {
-	LayerMediaType       types.MediaType
-	ConfigMediaType      types.MediaType
-	Bundle               *bundle.RekorBundle
-	RFC3161Timestamp     *bundle.RFC3161Timestamp
-	Cert                 []byte
-	Chain                []byte
-	Annotations          map[string]string
-	HonorCreateTimestamp bool
+	LayerMediaType          types.MediaType
+	ConfigMediaType         types.MediaType
+	Bundle                  *bundle.RekorBundle
+	RFC3161Timestamp        *bundle.RFC3161Timestamp
+	Cert                    []byte
+	Chain                   []byte
+	Annotations             map[string]string
+	RecordCreationTimestamp bool
 }
 
 func makeOptions(opts ...Option) (*options, error) {
@@ -114,9 +114,9 @@ func WithCertChain(cert, chain []byte) Option {
 	}
 }
 
-// WithHonorCreationTimestamp sets the feature flag to honor the creation timestamp to time of running
-func WithHonorCreationTimestamp(hct bool) Option {
+// WithRecordCreationTimestamp sets the feature flag to honor the creation timestamp to time of running
+func WithRecordCreationTimestamp(rct bool) Option {
 	return func(o *options) {
-		o.HonorCreateTimestamp = hct
+		o.RecordCreationTimestamp = rct
 	}
 }


### PR DESCRIPTION
closes #3298

#### Summary

As the timestamp is part of the OCI spec it makes no sense to omit it. signatures that are pushed to an OCI registry are not immutable by default and honoring the creation timestamp will enable people to use time based cleanup policies in their registries again (as in GCP, GitLab etc.).

#### Release Note

Fixes null timestamp in signatures and honor creation timestamp again
