### PR TITLE
fix 'go vet -tags e2e ./...'

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -2883,7 +2883,7 @@ func setLocalEnv(t *testing.T, dir string) error {
 	// fulcio repo is downloaded to the user's home directory by e2e_test.sh
 	home, err := os.UserHomeDir()
 	if err != nil {
-		fmt.Errorf("error getting home directory: %w", err)
+		return fmt.Errorf("error getting home directory: %w", err)
 	}
 	t.Setenv(env.VariableSigstoreCTLogPublicKeyFile.String(), path.Join(home, "fulcio/config/ctfe/pubkey.pem"))
 	err = downloadAndSetEnv(t, fulcioURL+"/api/v1/rootCert", env.VariableSigstoreRootFile.String(), dir)

--- a/test/testdata/README.md
+++ b/test/testdata/README.md
@@ -77,7 +77,7 @@ $ openssl req -new -key leafCA.key -out leafCA.csr
 $ openssl x509 -req -in leafCA.csr -CA intermediateCA.crt -CAkey intermediateCA.key  -CAcreateserial -CAserial leafca.srl -out leafCA.crt -days 1825 -sha256 -extfile leafConfigFile
 ```
 
-11. Generate Certificate chain by concatinating Intermediate certificate and Root certificate
+11. Generate Certificate chain by concatenating Intermediate certificate and Root certificate
 
 ```shell
 $ cat intermediateCA.crt rootCA.crt > certChain.crt
@@ -172,7 +172,7 @@ $ openssl req -new -key secondleafCA.key -out secondleafCA.csr
 $ openssl x509 -req -in secondleafCA.csr -CA secondintermediateCA.crt -CAkey secondintermediateCA.key  -CAcreateserial -CAserial secondleafca.srl -out secondleafCA.crt -days 1825 -sha256 -extfile leafConfigFile
 ```
 
-26. Generate Certificate chain by concatinating second Intermediate certificate and second Root certificate
+26. Generate Certificate chain by concatenating second Intermediate certificate and second Root certificate
 
 ```shell
 $ cat secondintermediateCA.crt secondrootCA.crt > secondcertChain.crt


### PR DESCRIPTION

#### Summary
fix an error  - the return value of `fmt.Errorf` unused - flagged by
```bash
$ go vet -tags e2e ./...
# github.com/sigstore/cosign/v2/test
# [github.com/sigstore/cosign/v2/test]
./e2e_test.go:2886:13: result of fmt.Errorf call not used
```

#### Release Note
NONE

#### Documentation
n/a

### Miscellaneous
Question - should we add a check with `go vet -tags e2e ./...` to be able to discover such errors in the future?