### PR TITLE
Correct help text of triangulate cmd

### DIFF
--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -29,7 +29,7 @@ func Triangulate() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:              "triangulate",
-		Short:            "Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.",
+		Short:            "Outputs the located cosign image reference. This is the location where cosign stores the specified artifact type.",
 		Example:          "  cosign triangulate <IMAGE>",
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -36,7 +36,7 @@ A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign sign](cosign_sign.md)	 - Sign the supplied container image.
 * [cosign sign-blob](cosign_sign-blob.md)	 - Sign the supplied blob, outputting the base64-encoded signature to stdout.
 * [cosign tree](cosign_tree.md)	 - Display supply chain security related artifacts for an image such as signatures, SBOMs and attestations
-* [cosign triangulate](cosign_triangulate.md)	 - Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
+* [cosign triangulate](cosign_triangulate.md)	 - Outputs the located cosign image reference. This is the location where cosign stores the specified artifact type.
 * [cosign upload](cosign_upload.md)	 - Provides utilities for uploading artifacts to a registry
 * [cosign verify](cosign_verify.md)	 - Verify a signature on the supplied container image
 * [cosign verify-attestation](cosign_verify-attestation.md)	 - Verify an attestation on the supplied container image

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -1,6 +1,6 @@
 ## cosign triangulate
 
-Outputs the located cosign image reference. This is the location cosign stores the specified artifact type.
+Outputs the located cosign image reference. This is the location where cosign stores the specified artifact type.
 
 ```
 cosign triangulate [flags]


### PR DESCRIPTION
#### Summary

This PR adjust the wording of the description of the triangulate sub-command. The original did not sound like correct English.

#### Release Note

NONE

#### Documentation

No changes needed.
