### PR TITLE
Put secrets on github organizations

### DIFF
--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -73,11 +73,12 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 	var owner, repo string
 	split := strings.Split(ref, "/")
 
-	if len(split) == 2 {
+	switch len(split) {
+	case 2:
 		owner, repo = split[0], split[1]
-	} else if len(split) == 1 {
+	case 1:
 		owner = split[0]
-	} else {
+	default:
 		return errors.New("could not parse scheme, use github://<owner> or github://<owner>/<repo> format")
 	}
 

--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -153,15 +153,17 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 func (g *Gh) getPublicKey(client *github.Client, ctx context.Context, owner string, repo string) (*github.PublicKey, *github.Response, error) {
 	if len(repo) > 0 {
 		return client.Actions.GetRepoPublicKey(ctx, owner, repo)
+	} else {
+		return client.Actions.GetOrgPublicKey(ctx, owner)
 	}
-	return client.Actions.GetOrgPublicKey(ctx, owner)
 }
 
 func (g *Gh) createOrUpdateOrgSecret(client *github.Client, ctx context.Context, owner string, repo string, encryptedCosignPasswd *github.EncryptedSecret) (*github.Response, error) {
 	if len(repo) > 0 {
 		return client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, encryptedCosignPasswd)
+	} else {
+		return client.Actions.CreateOrUpdateOrgSecret(ctx, owner, encryptedCosignPasswd)
 	}
-	return client.Actions.CreateOrUpdateOrgSecret(ctx, owner, encryptedCosignPasswd)
 }
 
 // NOTE: GetSecret is not implemented for GitHub

--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -153,17 +153,15 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 func (g *Gh) getPublicKey(ctx context.Context, client *github.Client, owner string, repo string) (*github.PublicKey, *github.Response, error) {
 	if len(repo) > 0 {
 		return client.Actions.GetRepoPublicKey(ctx, owner, repo)
-	} else {
-		return client.Actions.GetOrgPublicKey(ctx, owner)
 	}
+	return client.Actions.GetOrgPublicKey(ctx, owner)
 }
 
 func (g *Gh) createOrUpdateOrgSecret(ctx context.Context, client *github.Client, owner string, repo string, encryptedCosignPasswd *github.EncryptedSecret) (*github.Response, error) {
 	if len(repo) > 0 {
 		return client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, encryptedCosignPasswd)
-	} else {
-		return client.Actions.CreateOrUpdateOrgSecret(ctx, owner, encryptedCosignPasswd)
 	}
+	return client.Actions.CreateOrUpdateOrgSecret(ctx, owner, encryptedCosignPasswd)
 }
 
 // NOTE: GetSecret is not implemented for GitHub

--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -81,7 +81,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return errors.New("could not parse scheme, use github://<owner> or github://<owner>/<repo> format")
 	}
 
-	key, getPubKeyResp, err := g.getPublicKey(client, ctx, owner, repo)
+	key, getPubKeyResp, err := g.getPublicKey(ctx, client, owner, repo)
 	if err != nil {
 		return fmt.Errorf("could not get repository public key: %w", err)
 	}
@@ -96,7 +96,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("could not encrypt the secret: %w", err)
 	}
 
-	passwordSecretEnvResp, err := g.createOrUpdateOrgSecret(client, ctx, owner, repo, encryptedCosignPasswd)
+	passwordSecretEnvResp, err := g.createOrUpdateOrgSecret(ctx, client, owner, repo, encryptedCosignPasswd)
 	if err != nil {
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" github actions secret: %w", err)
 	}
@@ -113,7 +113,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("could not encrypt the secret: %w", err)
 	}
 
-	privateKeySecretEnvResp, err := g.createOrUpdateOrgSecret(client, ctx, owner, repo, encryptedCosignPrivKey)
+	privateKeySecretEnvResp, err := g.createOrUpdateOrgSecret(ctx, client, owner, repo, encryptedCosignPrivKey)
 	if err != nil {
 		return fmt.Errorf("could not create \"COSIGN_PRIVATE_KEY\" github actions secret: %w", err)
 	}
@@ -130,7 +130,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("could not encrypt the secret: %w", err)
 	}
 
-	publicKeySecretEnvResp, err := g.createOrUpdateOrgSecret(client, ctx, owner, repo, encryptedCosignPubKey)
+	publicKeySecretEnvResp, err := g.createOrUpdateOrgSecret(ctx, client, owner, repo, encryptedCosignPubKey)
 	if err != nil {
 		return fmt.Errorf("could not create \"COSIGN_PUBLIC_KEY\" github actions secret: %w", err)
 	}
@@ -150,7 +150,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 	return nil
 }
 
-func (g *Gh) getPublicKey(client *github.Client, ctx context.Context, owner string, repo string) (*github.PublicKey, *github.Response, error) {
+func (g *Gh) getPublicKey(ctx context.Context, client *github.Client, owner string, repo string) (*github.PublicKey, *github.Response, error) {
 	if len(repo) > 0 {
 		return client.Actions.GetRepoPublicKey(ctx, owner, repo)
 	} else {
@@ -158,7 +158,7 @@ func (g *Gh) getPublicKey(client *github.Client, ctx context.Context, owner stri
 	}
 }
 
-func (g *Gh) createOrUpdateOrgSecret(client *github.Client, ctx context.Context, owner string, repo string, encryptedCosignPasswd *github.EncryptedSecret) (*github.Response, error) {
+func (g *Gh) createOrUpdateOrgSecret(ctx context.Context, client *github.Client, owner string, repo string, encryptedCosignPasswd *github.EncryptedSecret) (*github.Response, error) {
 	if len(repo) > 0 {
 		return client.Actions.CreateOrUpdateRepoSecret(ctx, owner, repo, encryptedCosignPasswd)
 	} else {


### PR DESCRIPTION
closes #3566

#### Summary
Currently is only possible to set secrets on a repo, adding the possibility to set it in an organization is pretty useful, since it allows to control secrets per organization instead of adding multiple secrets to individual repos.

#### Release Note
Allows secret creation on github organizations

