### PR TITLE
adds tsa cert chain check for env var or tuf targets.

### DIFF
--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -30,6 +30,7 @@ type CommonVerifyOptions struct {
 	// it for other verify options.
 	ExperimentalOCI11     bool
 	PrivateInfrastructure bool
+	UseSignedTimestamps   bool
 }
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
@@ -39,6 +40,9 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-certificate-chain", "",
 		"path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. "+
 			"Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp")
+
+	cmd.Flags().BoolVar(&o.UseSignedTimestamps, "use-signed-timestamps", false,
+		"use signed timestamps if available")
 
 	cmd.Flags().BoolVar(&o.IgnoreTlog, "insecure-ignore-tlog", false,
 		"ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts "+

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -28,7 +28,6 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/rekor"
-	"github.com/sigstore/cosign/v2/internal/pkg/cosign/tsa"
 	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/cosign/cue"
@@ -118,30 +117,15 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		}
 	}
 
-	if c.TSACertChainPath != "" {
-		_, err := os.Stat(c.TSACertChainPath)
-		if err != nil {
-			return fmt.Errorf("unable to open timestamp certificate chain file '%s: %w", c.TSACertChainPath, err)
-		}
-		// TODO: Add support for TUF certificates.
-		pemBytes, err := os.ReadFile(filepath.Clean(c.TSACertChainPath))
-		if err != nil {
-			return fmt.Errorf("error reading certification chain path file: %w", err)
-		}
-
-		leaves, intermediates, roots, err := tsa.SplitPEMCertificateChain(pemBytes)
-		if err != nil {
-			return fmt.Errorf("error splitting certificates: %w", err)
-		}
-		if len(leaves) > 1 {
-			return fmt.Errorf("certificate chain must contain at most one TSA certificate")
-		}
-		if len(leaves) == 1 {
-			co.TSACertificate = leaves[0]
-		}
-		co.TSAIntermediateCertificates = intermediates
-		co.TSARootCertificates = roots
+	tsaCertificates, err := cosign.GetTSACerts(ctx, c.TSACertChainPath, cosign.GetTufTargets)
+	if err != nil {
+		ui.Warnf(ctx, fmt.Sprintf("unable to load or get TSA certificates: %s", err.Error()))
+	} else {
+		co.TSACertificate = tsaCertificates.LeafCert
+		co.TSARootCertificates = tsaCertificates.RootCert
+		co.TSAIntermediateCertificates = tsaCertificates.IntermediateCerts
 	}
+
 	if !c.IgnoreTlog {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
@@ -157,6 +141,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			return fmt.Errorf("getting Rekor public keys: %w", err)
 		}
 	}
+
 	if keylessVerification(c.KeyRef, c.Sk) {
 		// This performs an online fetch of the Fulcio roots. This is needed
 		// for verifying keyless certificates (both online and offline).
@@ -169,6 +154,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
 	}
+
 	keyRef := c.KeyRef
 
 	// Keys are optional!

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/rekor"
-	"github.com/sigstore/cosign/v2/internal/pkg/cosign/tsa"
 	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/blob"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
@@ -116,28 +115,14 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		return fmt.Errorf("timestamp-certificate-chain is required to validate a RFC3161 timestamp")
 	}
 	if c.KeyOpts.TSACertChainPath != "" {
-		_, err := os.Stat(c.KeyOpts.TSACertChainPath)
+		tsaCertificates, err := cosign.GetTSACerts(ctx, c.TSACertChainPath, cosign.GetTufTargets)
 		if err != nil {
-			return fmt.Errorf("unable to open timestamp certificate chain file '%s: %w", c.KeyOpts.TSACertChainPath, err)
+			ui.Warnf(ctx, fmt.Sprintf("unable to load or get TSA certificates: %s", err.Error()))
+		} else {
+			co.TSACertificate = tsaCertificates.LeafCert
+			co.TSARootCertificates = tsaCertificates.RootCert
+			co.TSAIntermediateCertificates = tsaCertificates.IntermediateCerts
 		}
-		// TODO: Add support for TUF certificates.
-		pemBytes, err := os.ReadFile(filepath.Clean(c.KeyOpts.TSACertChainPath))
-		if err != nil {
-			return fmt.Errorf("error reading certification chain path file: %w", err)
-		}
-
-		leaves, intermediates, roots, err := tsa.SplitPEMCertificateChain(pemBytes)
-		if err != nil {
-			return fmt.Errorf("error splitting certificates: %w", err)
-		}
-		if len(leaves) > 1 {
-			return fmt.Errorf("certificate chain must contain at most one TSA certificate")
-		}
-		if len(leaves) == 1 {
-			co.TSACertificate = leaves[0]
-		}
-		co.TSAIntermediateCertificates = intermediates
-		co.TSARootCertificates = roots
 	}
 
 	if !c.IgnoreTlog {

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -35,7 +35,6 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/rekor"
 	internal "github.com/sigstore/cosign/v2/internal/pkg/cosign"
 	payloadsize "github.com/sigstore/cosign/v2/internal/pkg/cosign/payload/size"
-	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/blob"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/cosign/bundle"
@@ -71,7 +70,8 @@ type VerifyBlobAttestationCommand struct {
 	PredicateType string
 	// TODO: Add policies
 
-	SignaturePath string // Path to the signature
+	SignaturePath       string // Path to the signature
+	UseSignedTimestamps bool
 }
 
 // Exec runs the verification command
@@ -140,14 +140,15 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	}
 
 	// Set up TSA, Fulcio roots and tlog public keys and clients.
-	if c.RFC3161TimestampPath != "" && c.KeyOpts.TSACertChainPath == "" {
-		return fmt.Errorf("timestamp-cert-chain is required to validate a rfc3161 timestamp bundle")
+	if c.RFC3161TimestampPath != "" && !(c.TSACertChainPath != "" || c.UseSignedTimestamps) {
+		return fmt.Errorf("either TSA certificate chain path must be provided or use-signed-timestamps must be set when using RFC3161 timestamp path")
 	}
 
-	tsaCertificates, err := cosign.GetTSACerts(ctx, c.TSACertChainPath, cosign.GetTufTargets)
-	if err != nil {
-		ui.Warnf(ctx, fmt.Sprintf("unable to load or get TSA certificates: %s", err.Error()))
-	} else {
+	if c.TSACertChainPath != "" || c.UseSignedTimestamps {
+		tsaCertificates, err := cosign.GetTSACerts(ctx, c.TSACertChainPath, cosign.GetTufTargets)
+		if err != nil {
+			return fmt.Errorf("unable to load or get TSA certificates: %w", err)
+		}
 		co.TSACertificate = tsaCertificates.LeafCert
 		co.TSARootCertificates = tsaCertificates.RootCert
 		co.TSAIntermediateCertificates = tsaCertificates.IntermediateCerts

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -89,6 +89,7 @@ cosign dockerfile verify [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string                                                       path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
+      --use-signed-timestamps                                                                    use signed timestamps if available
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -83,6 +83,7 @@ cosign manifest verify [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string                                                       path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
+      --use-signed-timestamps                                                                    use signed timestamps if available
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -92,6 +92,7 @@ cosign verify-attestation [flags]
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string                                                       path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
       --type string                                                                              specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
+      --use-signed-timestamps                                                                    use signed timestamps if available
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -57,6 +57,7 @@ cosign verify-blob-attestation [flags]
       --slot string                                     security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string              path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
       --type string                                     specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
+      --use-signed-timestamps                           use signed timestamps if available
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -85,6 +85,7 @@ cosign verify-blob [flags]
       --sk                                              whether to use a hardware security key
       --slot string                                     security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string              path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
+      --use-signed-timestamps                           use signed timestamps if available
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -106,6 +106,7 @@ cosign verify [flags]
       --sk                                                                                       whether to use a hardware security key
       --slot string                                                                              security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-certificate-chain string                                                       path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates, and may contain the leaf TSA certificate if not present in the timestamp
+      --use-signed-timestamps                                                                    use signed timestamps if available
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cosign/env/env.go
+++ b/pkg/cosign/env/env.go
@@ -58,6 +58,7 @@ const (
 	VariableSigstoreRootFile           Variable = "SIGSTORE_ROOT_FILE"
 	VariableSigstoreRekorPublicKey     Variable = "SIGSTORE_REKOR_PUBLIC_KEY"
 	VariableSigstoreIDToken            Variable = "SIGSTORE_ID_TOKEN" //nolint:gosec
+	VariableSigstoreTSACertificateFile Variable = "SIGSTORE_TSA_CERTIFICATE_FILE"
 
 	// Other external environment variables
 	VariableGitHubHost                Variable = "GITHUB_HOST"
@@ -138,7 +139,12 @@ var (
 			Sensitive:   false,
 			External:    true,
 		},
-
+		VariableSigstoreTSACertificateFile: {
+			Description: "path to the concatenated PEM-encoded TSA certificate file (leaf, intermediate(s), root) used by Sigstore",
+			Expects:     "path to the TSA certificate file",
+			Sensitive:   false,
+			External:    true,
+		},
 		VariableGitHubHost: {
 			Description: "is URL of the GitHub Enterprise instance",
 			Expects:     "string with the URL of GitHub Enterprise instance",

--- a/pkg/cosign/tsa.go
+++ b/pkg/cosign/tsa.go
@@ -1,0 +1,139 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"fmt"
+	"os"
+
+	"github.com/sigstore/cosign/v2/pkg/cosign/env"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/tuf"
+)
+
+const (
+	tsaLeafCertStr                = `tsa_leaf.crt.pem`
+	tsaRootCertStr                = `tsa_root.crt.pem`
+	tsaIntermediateCertStrPattern = `tsa_intermediate_%d.crt.pem`
+)
+
+type TSACertificates struct {
+	LeafCert          *x509.Certificate
+	IntermediateCerts []*x509.Certificate
+	RootCert          []*x509.Certificate
+}
+
+type GetTargetStub func(ctx context.Context, usage tuf.UsageKind, names []string) ([]byte, error)
+
+func GetTufTargets(ctx context.Context, usage tuf.UsageKind, names []string) ([]byte, error) {
+	tufClient, err := tuf.NewFromEnv(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error creating TUF client: %w", err)
+	}
+	targets, err := tufClient.GetTargetsByMeta(usage, names)
+	if err != nil {
+		return nil, fmt.Errorf("error fetching targets by metadata with usage %v: %w", usage, err)
+	}
+
+	var buffer bytes.Buffer
+	for _, target := range targets {
+		buffer.Write(target.Target)
+		buffer.WriteByte('\n')
+	}
+	return buffer.Bytes(), nil
+}
+
+// GetTSACerts retrieves trusted TSA certificates from the embedded or cached
+// TUF root. If expired, makes a network call to retrieve the updated targets.
+// By default, the certificates come from TUF, but you can override this for test
+// purposes by using an env variable `SIGSTORE_TSA_CERTIFICATE_FILE` or a file path
+// specified in `TSACertChainPath`. If using an alternate, the file should be in PEM format.
+func GetTSACerts(ctx context.Context, certChainPath string, fn GetTargetStub) (*TSACertificates, error) {
+	altTSACert := env.Getenv(env.VariableSigstoreTSACertificateFile)
+
+	var raw []byte
+	var err error
+
+	switch {
+	case altTSACert != "":
+		raw, err = os.ReadFile(altTSACert)
+	case certChainPath != "":
+		raw, err = os.ReadFile(certChainPath)
+	default:
+		certNames := []string{tsaLeafCertStr, tsaRootCertStr}
+		for i := 0; ; i++ {
+			intermediateCertStr := fmt.Sprintf(tsaIntermediateCertStrPattern, i)
+			_, err := fn(ctx, tuf.TSA, []string{intermediateCertStr})
+			if err != nil {
+				break
+			}
+			certNames = append(certNames, intermediateCertStr)
+		}
+		raw, err = fn(ctx, tuf.TSA, certNames)
+		if err != nil {
+			return nil, fmt.Errorf("error fetching TSA certificates: %w", err)
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("error reading TSA certificate file: %w", err)
+	}
+
+	leaves, intermediates, roots, err := splitPEMCertificateChain(raw)
+	if err != nil {
+		return nil, fmt.Errorf("error splitting TSA certificates: %w", err)
+	}
+
+	if len(leaves) > 1 {
+		return nil, fmt.Errorf("TSA certificate chain must contain at most one leaf certificate")
+	}
+
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("TSA certificate chain must contain at least one root certificate")
+	}
+
+	return &TSACertificates{
+		LeafCert:          leaves[0],
+		IntermediateCerts: intermediates,
+		RootCert:          roots,
+	}, nil
+}
+
+// splitPEMCertificateChain returns a list of leaf (non-CA) certificates, a certificate pool for
+// intermediate CA certificates, and a certificate pool for root CA certificates
+func splitPEMCertificateChain(pem []byte) (leaves, intermediates, roots []*x509.Certificate, err error) {
+	certs, err := cryptoutils.UnmarshalCertificatesFromPEM(pem)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	for _, cert := range certs {
+		if !cert.IsCA {
+			leaves = append(leaves, cert)
+		} else {
+			// root certificates are self-signed
+			if bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+				roots = append(roots, cert)
+			} else {
+				intermediates = append(intermediates, cert)
+			}
+		}
+	}
+
+	return leaves, intermediates, roots, nil
+}

--- a/pkg/cosign/tsa_test.go
+++ b/pkg/cosign/tsa_test.go
@@ -1,0 +1,119 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testLeafCert = `-----BEGIN CERTIFICATE-----
+MIIBjzCCATSgAwIBAgIRAOoa5khdNMW26Nz0VCvjbBAwCgYIKoZIzj0EAwIwGzEZ
+MBcGA1UEAxMQaHR0cHM6Ly9ibGFoLmNvbTAgFw0yNDA2MDMyMDE2MDFaGA8yMTI0
+MDUxMDIwMTYwMFowGzEZMBcGA1UEAxMQaHR0cHM6Ly9ibGFoLmNvbTBZMBMGByqG
+SM49AgEGCCqGSM49AwEHA0IABL7w/TW5lOU9KwnGQRIyZp/ReNQF1eA2rKC582Jo
+nMomwCk2bA8c5dHrvvHe+mI8JeMNEg3lkIsVQp46dKGlgYujVzBVMA4GA1UdDwEB
+/wQEAwIBBjAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBSA7lVsQm5OUzvYi+o8PuBs
+CrAnljAWBgNVHSUBAf8EDDAKBggrBgEFBQcDCDAKBggqhkjOPQQDAgNJADBGAiEA
+oJSZgJPX2tqXhfvLm+5UR399+E6+rgUnSRUf4+p+K5gCIQCmtfuv8IkUIYE5ybtx
++bn5E95xINfDMSPBa+0PEbB5RA==
+-----END CERTIFICATE-----`
+	testRootCert = `-----BEGIN CERTIFICATE-----
+MIIBezCCASKgAwIBAgIRAMvdlXw/uuYvsJaCTa02uW4wCgYIKoZIzj0EAwIwGzEZ
+MBcGA1UEAxMQaHR0cHM6Ly9ibGFoLmNvbTAgFw0yNDA2MDMyMDE1NTFaGA8yMTI0
+MDUxMDIwMTU1MFowGzEZMBcGA1UEAxMQaHR0cHM6Ly9ibGFoLmNvbTBZMBMGByqG
+SM49AgEGCCqGSM49AwEHA0IABLziRBPdWUTx9x3Z7zIMyo/C9cqsLK+hqnWDQS7K
+TA38mZhMHnJ0vSaEA4g9J2ccI1x4G/HegCi9LkJG/EZLBjyjRTBDMA4GA1UdDwEB
+/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgEBMB0GA1UdDgQWBBQuDQqo97s/5Lc5
+IxmFcVg3arCV2DAKBggqhkjOPQQDAgNHADBEAiAJOr0GnYaqVxShSEgVJKi/hYXf
+PH5bKk0M9ceasS7VwQIgMkxzlWr+m10OELtAbOlI8faN/5WFKm8m8rrwnhmHzjw=
+-----END CERTIFICATE-----`
+)
+
+func MockGetTufTargets(name string) ([]byte, error) {
+	if name == `tsa_leaf.crt.pem` {
+		return []byte(testLeafCert), nil
+	} else if name == `tsa_root.crt.pem` {
+		return []byte(testRootCert), nil
+	}
+
+	return nil, errors.New("no intermediates")
+}
+
+func TestGetTSACertsFromEnv(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "tsa_cert_chain.pem")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.Write([]byte(testLeafCert + "\n" + testRootCert))
+	require.NoError(t, err)
+
+	os.Setenv("SIGSTORE_TSA_CERTIFICATE_FILE", tempFile.Name())
+	defer os.Unsetenv("SIGSTORE_TSA_CERTIFICATE_FILE")
+
+	tsaCerts, err := GetTSACerts(context.Background(), tempFile.Name(), GetTufTargets)
+	if err != nil {
+		t.Fatalf("Failed to get TSA certs from env: %v", err)
+	}
+	require.NotNil(t, tsaCerts)
+	require.NotNil(t, tsaCerts.LeafCert)
+	require.NotNil(t, tsaCerts.RootCert)
+	require.Len(t, tsaCerts.RootCert, 1)
+}
+
+func TestGetTSACertsFromPath(t *testing.T) {
+	tempFile, err := os.CreateTemp("", "tsa_cert_chain_path.pem")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.Write([]byte(testLeafCert + "\n" + testRootCert))
+	require.NoError(t, err)
+
+	tsaCerts, err := GetTSACerts(context.Background(), tempFile.Name(), GetTufTargets)
+	if err != nil {
+		t.Fatalf("Failed to get TSA certs from path: %v", err)
+	}
+	require.NotNil(t, tsaCerts)
+	require.NotNil(t, tsaCerts.LeafCert)
+	require.NotNil(t, tsaCerts.RootCert)
+	require.Len(t, tsaCerts.RootCert, 1)
+}
+
+func TestGetTSACertsFromTUF(t *testing.T) {
+	originalValue := os.Getenv("SIGSTORE_TSA_CERTIFICATE_FILE")
+	os.Unsetenv("SIGSTORE_TSA_CERTIFICATE_FILE")
+	defer os.Setenv("SIGSTORE_TSA_CERTIFICATE_FILE", originalValue)
+
+	tempFile, err := os.CreateTemp("", "tsa_cert_chain.pem")
+	require.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.Write([]byte(testLeafCert + "\n" + testRootCert))
+	require.NoError(t, err)
+
+	tsaCerts, err := GetTSACerts(context.Background(), tempFile.Name(), GetTufTargets)
+	if err != nil {
+		t.Fatalf("Failed to get TSA certs from TUF: %v", err)
+	}
+	require.NotNil(t, tsaCerts)
+	require.NotNil(t, tsaCerts.LeafCert)
+	require.NotNil(t, tsaCerts.RootCert)
+	require.Len(t, tsaCerts.RootCert, 1)
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->
closes #3563
#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Creates parity between Cosign / TSA (e.g. TSA values are handled similarly to ctlog, fulcio, and rekor creds now) since sigstore/sigstore TUF client was recently updated to support the ["TSA" usage type](https://github.com/sigstore/sigstore/blob/364b1acc28de3ea95178e82d0b365036d60c6eb1/pkg/tuf/usage_type.go#L29).

Currently, the TSA cert chain is required via Cosign's cli [flag](https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/verify/verify_blob.go#L118-L141), though, as per https://github.com/sigstore/cosign/issues/3563, Cosign can support reading the cert chain from either an environment variable or the TUF targets, similar to Fulcio certs, Rekor keys or the CTLog public key that can be provided on verification. I looked at [RekorPubKeys](https://github.com/sigstore/cosign/blob/main/pkg/cosign/tlog.go#L122) and [GetCTLogPubs](https://github.com/sigstore/cosign/blob/main/pkg/cosign/ctlog.go#L35) as an example.

huge thanks to @aalsabag for helping w/ unit tests.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Checks for TSA cert-chain in environment variable, `SIGSTORE_TSA_CERTIFICATE_FILE`, and TUF targets
