### PR TITLE
Support Gitpod workspaces

### DIFF
--- a/pkg/cosign/env/env.go
+++ b/pkg/cosign/env/env.go
@@ -63,6 +63,7 @@ const (
 	VariableGitHubToken               Variable = "GITHUB_TOKEN" //nolint:gosec
 	VariableGitHubRequestToken        Variable = "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
 	VariableGitHubRequestURL          Variable = "ACTIONS_ID_TOKEN_REQUEST_URL"
+	VariableGitpodWorkspaceId         Variable = "GITPOD_WORKSPACE_ID"
 	VariableSPIFFEEndpointSocket      Variable = "SPIFFE_ENDPOINT_SOCKET"
 	VariableGoogleServiceAccountName  Variable = "GOOGLE_SERVICE_ACCOUNT_NAME"
 	VariableGitLabHost                Variable = "GITLAB_HOST"
@@ -154,6 +155,12 @@ var (
 		VariableGitHubRequestURL: {
 			Description: "is the URL for GitHub's OIDC provider",
 			Expects:     "string with the URL for the OIDC provider",
+			Sensitive:   false,
+			External:    true,
+		},
+		VariableGitpodWorkspaceId: {
+			Description: "is the ID of the workspace in Gitpod",
+			Expects:     "string with the ID of the Gitpod workspace",
 			Sensitive:   false,
 			External:    true,
 		},

--- a/pkg/providers/gitpod/doc.go
+++ b/pkg/providers/gitpod/doc.go
@@ -1,0 +1,18 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gitpod defines an implementation of the providers.Interface
+// that reads identity tokens from the gitpod API within a workspace.
+package gitpod

--- a/pkg/providers/gitpod/gitpod.go
+++ b/pkg/providers/gitpod/gitpod.go
@@ -1,0 +1,46 @@
+//
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitpod
+
+import (
+	"context"
+	"os/exec"
+
+	"github.com/sigstore/cosign/v2/pkg/cosign/env"
+	"github.com/sigstore/cosign/v2/pkg/providers"
+)
+
+func init() {
+	providers.Register("filesystem", &gitpod{})
+}
+
+type gitpod struct{}
+
+var _ providers.Interface = (*gitpod)(nil)
+
+// Enabled implements providers.Interface
+func (ga *gitpod) Enabled(_ context.Context) bool {
+	return env.Getenv(env.VariableGitpodWorkspaceId) != ""
+}
+
+// Provide implements providers.Interface
+func (ga *gitpod) Provide(ctx context.Context, audience string) (string, error) {
+	token, err := exec.Command("gp idp token --audience " + audience).Output()
+	if err != nil {
+		return "", err
+	}
+	return string(token), nil
+}


### PR DESCRIPTION
Closes https://github.com/sigstore/cosign/issues/2997

Summary
This PR adds a provider that, when run from within a Gitpod workspace, retrieves a token automatically from the command line, which means users do not have to do any additional auth checks or config.

This PR was previously open as https://github.com/sigstore/cosign/pull/2998 however work on Gitpod's end stalled and it took some time before changes were implemented that made this viable. These updates mean some, though not all, tokens can now be used with Sigstore, and Gitpod are correctly populating the `email_verified` field as required by Fulcio. Part of the logic of this PR has been changed to make sure we only send through tokens if they have this field and will be valid.

Release Note
Documentation