### PR TITLE
Update the script for working with blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,12 @@ You can publish an artifact with `cosign upload blob`:
 
 ```shell
 $ echo "my first artifact" > artifact
-$ BLOB_SUM=$(shasum -a 256 artifact | cut -d' ' -f 1)
-c69d72c98b55258f9026f984e4656f0e9fd3ef024ea3fac1d7e5c7e6249f1626  artifact
-BLOB_NAME=my-artifact-(uuidgen | head -c 8 | tr 'A-Z' 'a-z')
+$ BLOB_SUM=$(shasum -a 256 artifact | cut -d' ' -f 1) && echo "$BLOB_SUM"
+c69d72c98b55258f9026f984e4656f0e9fd3ef024ea3fac1d7e5c7e6249f1626
+$ BLOB_NAME=my-artifact-$(uuidgen | head -c 8 | tr 'A-Z' 'a-z')
 $ BLOB_URI=ttl.sh/$BLOB_NAME:1h
-$ BLOB_URI_DIGEST=$(cosign upload blob -f artifact $BLOB_URI)
+
+$ BLOB_URI_DIGEST=$(cosign upload blob -f artifact $BLOB_URI) && echo "$BLOB_URI_DIGEST"
 Uploading file from [artifact] to [ttl.sh/my-artifact-f42c22e0:5m] with media type [text/plain]
 File [artifact] is available directly at [ttl.sh/v2/my-artifact-f42c22e0/blobs/sha256:c69d72c98b55258f9026f984e4656f0e9fd3ef024ea3fac1d7e5c7e6249f1626]
 Uploaded image to:


### PR DESCRIPTION
#### Summary
The demo script for working with blobs was inaccurate in its current representation. I updated the commands such that they can be easily copied and pasted to get the shown output.

Resolves: sigstore/cosign#3609

#### Release Note
None

#### Documentation
None
