### PR TITLE
feat: add OVHcloud MPR registry tested with cosign

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Today, `cosign` has been tested and works against the following registries:
 * IBM Cloud Container Registry
 * Cloudsmith Container Registry
 * The CNCF zot Registry
+* OVHcloud Managed Private Registry
 
 We aim for wide registry support. To `sign` images in registries which do not yet fully support [OCI media types](https://github.com/sigstore/cosign/blob/main/specs/SIGNATURE_SPEC.md), one may need to use `COSIGN_DOCKER_MEDIA_TYPES` to fall back to legacy equivalents. For example:
 


### PR DESCRIPTION
Closes #3638 

This PR just improve the README file to add the useful information that cosign have been tested and it is recommended in the OVHcloud Managed Private Registry service.

#### Summary

The OVHcloud Managed Private Registry service have been tested successfuly with cosign and the usage of cosign is recommended also with this registry:
https://help.ovhcloud.com/csm/en-gb-public-cloud-private-registry-sign-artifacts-with-cosign?id=kb_article_view&sysparm_article=KB0059141

#### Documentation

README file have been improved.