### PR TITLE
Fixing issue 3642

### DIFF
--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -67,6 +67,7 @@ func (s *sigLayer) Payload() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 	return payload, nil
 }
 


### PR DESCRIPTION

This PR Closes #3642 
The issue fixed is related to Memory leak happening in 
File: https://github.com/sigstore/cosign/blob/6206f5af392ccefcc6a6cbb167bbccc833b46ed4/pkg/oci/internal/signature/layer.go#L60
Function: func (s *sigLayer) Payload() ([]byte, error) 

#### Summary
The cause of the problem as identified is missing Defer call in function
func (s *sigLayer) Payload() ([]byte, error) {
	// Compressed is a misnomer here, we just want the raw bytes from the registry.
	r, err := s.Layer.Compressed()
	if err != nil {
		return nil, err
	}
	payload, err := io.ReadAll(r)
	if err != nil {
		return nil, err
	}
	return payload, nil
}
so the code changes done is to introduce Defer clause before returning from function to close the file stream.
func (s *sigLayer) Payload() ([]byte, error) {
	// Compressed is a misnomer here, we just want the raw bytes from the registry.
	r, err := s.Layer.Compressed()
	if err != nil {
		return nil, err
	}
	payload, err := io.ReadAll(r)
	if err != nil {
		return nil, err
	}
        defer r.Close()
	return payload, nil
}

#### Release Note
Bug fix for Issue #3642 
#### Documentation
No change in Documentation