### PR TITLE
Enhancement to PR 3643

### DIFF
--- a/pkg/oci/internal/signature/layer.go
+++ b/pkg/oci/internal/signature/layer.go
@@ -63,11 +63,11 @@ func (s *sigLayer) Payload() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 	payload, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
-	defer r.Close()
 	return payload, nil
 }
 

--- a/pkg/oci/signature/layer.go
+++ b/pkg/oci/signature/layer.go
@@ -63,6 +63,7 @@ func (s *sigLayer) Payload() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 	payload, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR enhanced the changes done in PR #3643 to fix issue #3642

#### Summary
The enhancement done is 
1. In file https://github.com/sigstore/cosign/blob/7001e8203fea32c59a1bc30d9650cb8d73dd0587/pkg/oci/internal/signature/layer.go#L60 
   Moved the call of Defer clause above io.ReadAll() so that in case of failure in io.ReadAll() we still close the file stream.
2. Added the same code in file
https://github.com/sigstore/cosign/blob/7001e8203fea32c59a1bc30d9650cb8d73dd0587/pkg/oci/signature/layer.go#L60

#### Release Note
NONE

#### Documentation
NONE