### PR TITLE
fix latest tag not being created and add latest to the dev image as well and go updates

### DIFF
--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.21.8-0@sha256:9c86fc6c6763cd5cd9a07f25083fc5a87f3525b5f8d7ff886822e2153f0c8405 \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.21.9-0@sha256:3ea5f8dc2ea7508df43516966c9d498e830b1f0739a58de81ca7e28211822de6 \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.8-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.9-0"
         env:
           TUF_ROOT: /tmp
 
@@ -43,7 +43,7 @@ jobs:
       - check-signature
 
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.21.8-0@sha256:9c86fc6c6763cd5cd9a07f25083fc5a87f3525b5f8d7ff886822e2153f0c8405
+      image: ghcr.io/gythialy/golang-cross:v1.21.9-0@sha256:3ea5f8dc2ea7508df43516966c9d498e830b1f0739a58de81ca7e28211822de6
 
     permissions: {}
 

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -26,7 +26,7 @@ jobs:
   check-signature:
     runs-on: ubuntu-latest
     container:
-      image: gcr.io/projectsigstore/cosign:v2.2.3-dev@sha256:0d795fa145b03026b7bc2a35e33068cdb75e1c1f974e604c17408bf7bd174967
+      image: gcr.io/projectsigstore/cosign:v2.2.4-dev@sha256:13efd4c62710d75f07d12d8aad36a8657eeffd4f5f3a40bcbc207d8aafa67d41
 
     steps:
       - name: Check Signature

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,6 @@ env:
   - CGO_ENABLED=1
   - DOCKER_CLI_EXPERIMENTAL=enabled
   - COSIGN_YES=true
-  - LATEST_TAG=,latest
 
 # Prevents parallel builds from stepping on each others toes downloading modules
 before:

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ ko-cosign-dev:
 	$(create_kocache_path)
 	LDFLAGS="$(LDFLAGS)" GIT_HASH=$(GIT_HASH) GIT_VERSION=$(GIT_VERSION) \
 	KOCACHE=$(KOCACHE_PATH) KO_DEFAULTBASEIMAGE=gcr.io/distroless/static-debian12:debug-nonroot ko build --base-import-paths \
-		--platform=all --tags $(GIT_VERSION)-dev --tags $(GIT_HASH)-dev \
+		--platform=all --tags $(GIT_VERSION)-dev --tags $(GIT_HASH)-dev$(LATEST_TAG)-dev \
 		$(ARTIFACT_HUB_LABELS) --image-refs cosignDevImagerefs \
 		github.com/sigstore/cosign/v2/cmd/cosign
 

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -38,14 +38,14 @@ steps:
       - TUF_ROOT=/tmp
     args:
       - 'verify'
-      - 'ghcr.io/gythialy/golang-cross:v1.21.8-0@sha256:9c86fc6c6763cd5cd9a07f25083fc5a87f3525b5f8d7ff886822e2153f0c8405'
+      - 'ghcr.io/gythialy/golang-cross:v1.21.9-0@sha256:3ea5f8dc2ea7508df43516966c9d498e830b1f0739a58de81ca7e28211822de6'
       - '--certificate-oidc-issuer'
       - "https://token.actions.githubusercontent.com"
       - '--certificate-identity'
-      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.8-0"
+      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.21.9-0"
 
   # maybe we can build our own image and use that to be more in a safe side
-  - name: ghcr.io/gythialy/golang-cross:v1.21.8-0@sha256:9c86fc6c6763cd5cd9a07f25083fc5a87f3525b5f8d7ff886822e2153f0c8405
+  - name: ghcr.io/gythialy/golang-cross:v1.21.9-0@sha256:3ea5f8dc2ea7508df43516966c9d498e830b1f0739a58de81ca7e28211822de6
     entrypoint: /bin/sh
     dir: "go/src/sigstore/cosign"
     env:
@@ -68,7 +68,7 @@ steps:
         gcloud auth configure-docker \
         && make release
 
-  - name: ghcr.io/gythialy/golang-cross:v1.21.8-0@sha256:9c86fc6c6763cd5cd9a07f25083fc5a87f3525b5f8d7ff886822e2153f0c8405
+  - name: ghcr.io/gythialy/golang-cross:v1.21.9-0@sha256:3ea5f8dc2ea7508df43516966c9d498e830b1f0739a58de81ca7e28211822de6
     entrypoint: 'bash'
     dir: "go/src/sigstore/cosign"
     env:

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -84,6 +84,7 @@ steps:
       - COSIGN_YES=true
       - GOOGLE_SERVICE_ACCOUNT_NAME=keyless@${PROJECT_ID}.iam.gserviceaccount.com
       - GITHUB_USER=${_GITHUB_USER}
+      - LATEST_TAG=",latest"
     secretEnv:
       - GITHUB_TOKEN
     args:

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -32,7 +32,7 @@ steps:
         echo "Checking out ${_GIT_TAG}"
         git checkout ${_GIT_TAG}
 
-  - name: 'gcr.io/projectsigstore/cosign:v2.2.3-dev@sha256:0d795fa145b03026b7bc2a35e33068cdb75e1c1f974e604c17408bf7bd174967'
+  - name: 'gcr.io/projectsigstore/cosign:v2.2.4-dev@sha256:13efd4c62710d75f07d12d8aad36a8657eeffd4f5f3a40bcbc207d8aafa67d41'
     dir: "go/src/sigstore/cosign"
     env:
       - TUF_ROOT=/tmp


### PR DESCRIPTION

#### Summary

- fix latest tag not being created and add latest to the dev image as well
- update cosign to 2.2.4
- update go for the builder image to use 1.21.9


Fixes: https://github.com/sigstore/cosign/issues/3621