### PR TITLE
Add PayloadProvider interface to decouple AttestationToPayloadJSON from oci.Signature interface

### DIFF
--- a/pkg/policy/attestation.go
+++ b/pkg/policy/attestation.go
@@ -29,6 +29,17 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/cosign/attestation"
 )
 
+// PayloadProvider is a subset of oci.Signature that only provides the
+// Payload() method.
+type PayloadProvider interface {
+	// Payload fetches the opaque data that is being signed.
+	// This will always return data when there is no error.
+	Payload() ([]byte, error)
+}
+
+// Assert that oci.Signature implements PayloadProvider
+var _ PayloadProvider = (oci.Signature)(nil)
+
 // AttestationToPayloadJSON takes in a verified Attestation (oci.Signature) and
 // marshals it into a JSON depending on the payload that's then consumable
 // by policy engine like cue, rego, etc.
@@ -45,7 +56,7 @@ import (
 // or the predicateType is not the one they are looking for. Without returning
 // this, it's hard for users to know which attestations/predicateTypes were
 // inspected.
-func AttestationToPayloadJSON(_ context.Context, predicateType string, verifiedAttestation oci.Signature) ([]byte, string, error) {
+func AttestationToPayloadJSON(_ context.Context, predicateType string, verifiedAttestation PayloadProvider) ([]byte, string, error) {
 	if predicateType == "" {
 		return nil, "", errors.New("missing predicate type")
 	}


### PR DESCRIPTION
I'm working on Policy Controller and need to use `AttestationToPayloadJSON` without having an entire `oci.Signature`. Since this func only needs the `Payload`, I added a small `PayloadProvider` interface containing only the `Payload` func, which preserves backwards compatibility while decoupling the `oci.Signature` interface.

Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
