### PR TITLE
Make config layers in ociremote mountable

### DIFF
--- a/pkg/oci/remote/image.go
+++ b/pkg/oci/remote/image.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 )
@@ -46,6 +47,12 @@ func SignedImage(ref name.Reference, options ...Option) (oci.SignedImage, error)
 type image struct {
 	v1.Image
 	opt *options
+}
+
+// The wrapped Image implements ConfigLayer, but the wrapping hides that from typechecks in pkg/v1/remote.
+// Make image explicitly implement ConfigLayer so that this returns a mountable config layer for pkg/v1/remote.
+func (i *image) ConfigLayer() (v1.Layer, error) {
+	return partial.ConfigLayer(i.Image)
 }
 
 var _ oci.SignedImage = (*image)(nil)

--- a/pkg/oci/remote/signatures.go
+++ b/pkg/oci/remote/signatures.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/sigstore/cosign/v2/pkg/oci"
 	"github.com/sigstore/cosign/v2/pkg/oci/empty"
@@ -50,6 +51,12 @@ func Signatures(ref name.Reference, opts ...Option) (oci.Signatures, error) {
 
 type sigs struct {
 	v1.Image
+}
+
+// The wrapped Image implements ConfigLayer, but the wrapping hides that from typechecks in pkg/v1/remote.
+// Make sigs explicitly implement ConfigLayer so that this returns a mountable config layer for pkg/v1/remote.
+func (s *sigs) ConfigLayer() (v1.Layer, error) {
+	return partial.ConfigLayer(s.Image)
 }
 
 var _ oci.Signatures = (*sigs)(nil)


### PR DESCRIPTION
The wrapping that oci.Signatures does hides the ConfigLayer() implementation in remote.Image that remote.Write relies on for determining if it can mount the config blob (vs having to re-upload it), so remote.Write is sending additional blob uploads, which incurs an additional roundtrip that we don't really need to do.

Explicitly implement ConfigLayer() in the wrappers by dispatching to the wrapped implementation fixes this.

Before this change, this check fails due to the wrapping:

https://github.com/google/go-containerregistry/blob/1b4e4078a545f2b6f96766a064b45ee77cdbefdd/pkg/v1/partial/with.go#L102-L104

Which means we get back this fallback implementation: https://github.com/google/go-containerregistry/blob/1b4e4078a545f2b6f96766a064b45ee77cdbefdd/pkg/v1/partial/with.go#L52-L88

Which means this check fails: https://github.com/google/go-containerregistry/blob/1b4e4078a545f2b6f96766a064b45ee77cdbefdd/pkg/v1/remote/write.go#L364

So we didn't attempt to mount.

https://go.dev/play/p/2kW3-XbdjmM