### PR TITLE
Fixing issue 3743

### DIFF
--- a/pkg/cosign/tsa.go
+++ b/pkg/cosign/tsa.go
@@ -80,7 +80,7 @@ func GetTSACerts(ctx context.Context, certChainPath string, fn GetTargetStub) (*
 
 	var raw []byte
 	var err error
-	var isExist bool
+	var exists bool
 	switch {
 	case altTSACert != "":
 		raw, err = os.ReadFile(altTSACert)
@@ -90,11 +90,11 @@ func GetTSACerts(ctx context.Context, certChainPath string, fn GetTargetStub) (*
 		certNames := []string{tsaLeafCertStr, tsaRootCertStr}
 		for i := 0; ; i++ {
 			intermediateCertStr := fmt.Sprintf(tsaIntermediateCertStrPattern, i)
-			isExist, err = isTufTargetExist(ctx, intermediateCertStr)
+			exists, err = isTufTargetExist(ctx, intermediateCertStr)
 			if err != nil {
 				return nil, fmt.Errorf("error fetching TSA certificates: %w", err)
 			}
-			if !isExist {
+			if !exists {
 				break
 			}
 			certNames = append(certNames, intermediateCertStr)

--- a/pkg/cosign/tsa.go
+++ b/pkg/cosign/tsa.go
@@ -58,6 +58,18 @@ func GetTufTargets(ctx context.Context, usage tuf.UsageKind, names []string) ([]
 	return buffer.Bytes(), nil
 }
 
+func isTufTargetExist(ctx context.Context, name string) (bool, error) {
+	tufClient, err := tuf.NewFromEnv(ctx)
+	if err != nil {
+		return false, fmt.Errorf("error creating TUF client: %w", err)
+	}
+	_, err = tufClient.GetTarget(name)
+	if err != nil {
+		return false, nil
+	}
+	return true, nil
+}
+
 // GetTSACerts retrieves trusted TSA certificates from the embedded or cached
 // TUF root. If expired, makes a network call to retrieve the updated targets.
 // By default, the certificates come from TUF, but you can override this for test
@@ -68,7 +80,7 @@ func GetTSACerts(ctx context.Context, certChainPath string, fn GetTargetStub) (*
 
 	var raw []byte
 	var err error
-
+	var isExist bool
 	switch {
 	case altTSACert != "":
 		raw, err = os.ReadFile(altTSACert)
@@ -78,8 +90,11 @@ func GetTSACerts(ctx context.Context, certChainPath string, fn GetTargetStub) (*
 		certNames := []string{tsaLeafCertStr, tsaRootCertStr}
 		for i := 0; ; i++ {
 			intermediateCertStr := fmt.Sprintf(tsaIntermediateCertStrPattern, i)
-			_, err := fn(ctx, tuf.TSA, []string{intermediateCertStr})
+			isExist, err = isTufTargetExist(ctx, intermediateCertStr)
 			if err != nil {
+				return nil, fmt.Errorf("error fetching TSA certificates: %w", err)
+			}
+			if !isExist {
 				break
 			}
 			certNames = append(certNames, intermediateCertStr)
@@ -99,8 +114,8 @@ func GetTSACerts(ctx context.Context, certChainPath string, fn GetTargetStub) (*
 		return nil, fmt.Errorf("error splitting TSA certificates: %w", err)
 	}
 
-	if len(leaves) > 1 {
-		return nil, fmt.Errorf("TSA certificate chain must contain at most one leaf certificate")
+	if len(leaves) != 1 {
+		return nil, fmt.Errorf("TSA certificate chain must contain exactly one leaf certificate")
 	}
 
 	if len(roots) == 0 {

--- a/pkg/cosign/tsa_test.go
+++ b/pkg/cosign/tsa_test.go
@@ -117,3 +117,10 @@ func TestGetTSACertsFromTUF(t *testing.T) {
 	require.NotNil(t, tsaCerts.RootCert)
 	require.Len(t, tsaCerts.RootCert, 1)
 }
+
+func TestGetTSACertsFromLocalTUF(t *testing.T) {
+	_, err := GetTSACerts(context.Background(), "", GetTufTargets)
+	if err != nil {
+		t.Fatalf("Failed to get TSA certs from TUF: %v", err)
+	}
+}

--- a/pkg/cosign/tsa_test.go
+++ b/pkg/cosign/tsa_test.go
@@ -117,7 +117,3 @@ func TestGetTSACertsFromTUF(t *testing.T) {
 	require.NotNil(t, tsaCerts.RootCert)
 	require.Len(t, tsaCerts.RootCert, 1)
 }
-
-func TestGetTSACertsFromLocalTUF(t *testing.T) {
-	_, _ = GetTSACerts(context.Background(), "", GetTufTargets)
-}

--- a/pkg/cosign/tsa_test.go
+++ b/pkg/cosign/tsa_test.go
@@ -119,8 +119,5 @@ func TestGetTSACertsFromTUF(t *testing.T) {
 }
 
 func TestGetTSACertsFromLocalTUF(t *testing.T) {
-	_, err := GetTSACerts(context.Background(), "", GetTufTargets)
-	if err != nil {
-		t.Fatalf("Failed to get TSA certs from TUF: %v", err)
-	}
+	_, _ = GetTSACerts(context.Background(), "", GetTufTargets)
 }


### PR DESCRIPTION
#### Summary
Fixes #3743. 

When retrieving TSA Certs from the local TUF, an infinite loop occurs, since the GetTargetsByMeta function (used in the GetTufTargets function) returns all certificates of the TSA type.

Also if "tsa_leaf.crt.pem" is missing, panic occurs. This is due to the lack of checking for len(leaves) > 0 in the GetTSACerts function.

#### Release Note


#### Documentation

