### PR TITLE
Set `bundleVerified` to true after Rekor verification (Resolves #3740) 

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -710,6 +710,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 			}
 			t := time.Unix(*e.IntegratedTime, 0)
 			acceptableRekorBundleTime = &t
+			bundleVerified = true
 		}
 	}
 

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -38,6 +39,7 @@ import (
 
 	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -51,12 +53,15 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/types"
 	"github.com/sigstore/cosign/v2/test"
 	"github.com/sigstore/rekor/pkg/generated/client"
+	"github.com/sigstore/rekor/pkg/generated/client/entries"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	rtypes "github.com/sigstore/rekor/pkg/types"
+	hashedrekord_v001 "github.com/sigstore/rekor/pkg/types/hashedrekord/v0.0.1"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/sigstore/sigstore/pkg/tuf"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/transparency-dev/merkle/rfc6962"
 )
@@ -524,41 +529,131 @@ func uuid(e models.LogEntryAnon) string {
 	return hex.EncodeToString(rfc6962.DefaultHasher.HashLeaf(entryBytes))
 }
 
-// This test ensures that image signature validation fails properly if we are
-// using a SigVerifier with Rekor.
-// In other words, we require checking against RekorPubKeys when verifying
-// image signature.
-// This could be made more robust with supplying a mismatched trusted RekorPubKeys
-// rather than none.
-// See https://github.com/sigstore/cosign/v2/issues/1816 for more details.
-func TestVerifyImageSignatureWithSigVerifierAndRekor(t *testing.T) {
-	sv, privKey, err := signature.NewDefaultECDSASignerVerifier()
-	if err != nil {
-		t.Fatalf("error generating verifier: %v", err)
+func TestImageSignatureVerificationWithRekor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Generate signer and public key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "error generating private key")
+
+	signer, err := signature.LoadECDSASignerVerifier(privateKey, crypto.SHA256)
+	require.NoError(t, err, "error loading signer")
+
+	publicKey, err := signer.PublicKey()
+	require.NoError(t, err, "error getting public key")
+	publicKeyPEM, err := cryptoutils.MarshalPublicKeyToPEM(publicKey)
+	require.NoError(t, err, "error marshalling public key to PEM")
+
+	blob := []byte("foo")
+	blobSignature, err := signer.SignMessage(bytes.NewReader(blob))
+	require.NoError(t, err, "error signing blob")
+	blobSignatureBase64 := base64.StdEncoding.EncodeToString(blobSignature)
+
+	ociSignature, err := static.NewSignature(blob, blobSignatureBase64)
+	require.NoError(t, err, "error creating OCI signature")
+
+	// Mock Rekor entry setup
+	rekorPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "error generating Rekor private key")
+
+	rekorSigner, err := signature.LoadECDSASignerVerifier(rekorPrivateKey, crypto.SHA256)
+	require.NoError(t, err, "error loading Rekor signer")
+
+	rekorPublicKey := rekorPrivateKey.Public().(*ecdsa.PublicKey)
+	logID, err := calculateLogID(rekorPublicKey)
+	require.NoError(t, err, "error calculating Rekor log ID")
+
+	rekorEntry := createRekorEntry(t, ctx, logID, rekorSigner, blob, blobSignature, publicKeyPEM)
+
+	mockClient := &client.Rekor{
+		Entries: &mockEntriesClient{
+			searchLogQueryFunc: func(params *entries.SearchLogQueryParams, opts ...entries.ClientOption) (*entries.SearchLogQueryOK, error) {
+				return &entries.SearchLogQueryOK{
+					Payload: []models.LogEntry{*rekorEntry},
+				}, nil
+			},
+		},
 	}
 
-	payload := []byte{1, 2, 3, 4}
-	h := sha256.Sum256(payload)
-	sig, _ := privKey.Sign(rand.Reader, h[:], crypto.SHA256)
-	ociSig, _ := static.NewSignature(payload, base64.StdEncoding.EncodeToString(sig))
-
-	// Add a fake rekor client - this makes it look like there's a matching
-	// tlog entry for the signature during validation (even though it does not
-	// match the underlying data / key)
-	mClient := new(client.Rekor)
-	mClient.Entries = &mock.EntriesClient{
-		Entries: []*models.LogEntry{&data},
+	// Mock Rekor public key
+	trustedRekorPubKeys := &TrustedTransparencyLogPubKeys{
+		Keys: map[string]TransparencyLogPubKey{
+			logID: {
+				PubKey: rekorPublicKey,
+				Status: tuf.Active,
+			},
+		},
 	}
 
-	if _, err := VerifyImageSignature(context.TODO(), ociSig, v1.Hash{}, &CheckOpts{
-		SigVerifier: sv,
-		RekorClient: mClient,
-		Identities:  []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
-	}); err == nil || !strings.Contains(err.Error(), "no valid tlog entries found no trusted rekor public keys provided") {
-		// This is failing to validate the Rekor public key itself.
-		// At the very least this ensures
-		// that we're hitting tlog validation during signature checking.
-		t.Fatalf("expected error while verifying signature, got %s", err)
+	// Non-matching Rekor public key
+	nonMatchingPrivateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err, "error generating invalid private key")
+	nonMatchingPublicKey := nonMatchingPrivateKey.Public().(*ecdsa.PublicKey)
+
+	nonMatchingRekorPubKeys := &TrustedTransparencyLogPubKeys{
+		Keys: map[string]TransparencyLogPubKey{
+			logID: {
+				PubKey: nonMatchingPublicKey,
+				Status: tuf.Active,
+			},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		checkOpts   CheckOpts
+		rekorClient *client.Rekor
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name: "Verification succeeds with valid Rekor public keys",
+			checkOpts: CheckOpts{
+				SigVerifier:  signer,
+				RekorClient:  mockClient,
+				RekorPubKeys: trustedRekorPubKeys,
+				Identities:   []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
+			},
+			rekorClient: mockClient,
+			expectError: false,
+		},
+		{
+			name: "Verification fails with no Rekor public keys",
+			checkOpts: CheckOpts{
+				SigVerifier: signer,
+				RekorClient: mockClient,
+				Identities:  []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
+			},
+			rekorClient: mockClient,
+			expectError: true,
+			errorMsg:    "no valid tlog entries found no trusted rekor public keys provided",
+		},
+		{
+			name: "Verification fails with non-matching Rekor public keys",
+			checkOpts: CheckOpts{
+				SigVerifier:  signer,
+				RekorClient:  mockClient,
+				RekorPubKeys: nonMatchingRekorPubKeys,
+				Identities:   []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
+			},
+			rekorClient: mockClient,
+			expectError: true,
+			errorMsg:    "verifying signedEntryTimestamp: unable to verify SET",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bundleVerified, err := VerifyImageSignature(ctx, ociSignature, v1.Hash{}, &tt.checkOpts)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.True(t, bundleVerified, "bundle verification failed")
+			}
+		})
 	}
 }
 
@@ -1498,4 +1593,82 @@ func TestVerifyRFC3161Timestamp(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "no TSA root certificate(s) provided to verify timestamp") {
 		t.Fatalf("expected error verifying without a root certificate, got: %v", err)
 	}
+}
+
+// Mock Rekor client
+type mockEntriesClient struct {
+	entries.ClientService
+	searchLogQueryFunc func(params *entries.SearchLogQueryParams, opts ...entries.ClientOption) (*entries.SearchLogQueryOK, error)
+}
+
+func (m *mockEntriesClient) SearchLogQuery(params *entries.SearchLogQueryParams, opts ...entries.ClientOption) (*entries.SearchLogQueryOK, error) {
+	if m.searchLogQueryFunc != nil {
+		return m.searchLogQueryFunc(params, opts...)
+	}
+	return nil, nil
+}
+
+func createRekorEntry(t *testing.T, ctx context.Context, logID string, rekorSigner signature.SignerVerifier, payload, signature, publicKeyPEM []byte) *models.LogEntry {
+	hashedRekorEntry := &hashedrekord_v001.V001Entry{}
+	payloadHash := sha256.Sum256(payload)
+
+	artifactProperties := rtypes.ArtifactProperties{
+		ArtifactHash:   hex.EncodeToString(payloadHash[:]),
+		SignatureBytes: signature,
+		PublicKeyBytes: [][]byte{publicKeyPEM},
+		PKIFormat:      "x509",
+	}
+
+	entryProps, err := hashedRekorEntry.CreateFromArtifactProperties(ctx, artifactProperties)
+	require.NoError(t, err)
+
+	rekorEntry, err := rtypes.UnmarshalEntry(entryProps)
+	require.NoError(t, err)
+
+	canonicalEntry, err := rekorEntry.Canonicalize(ctx)
+	require.NoError(t, err)
+
+	integratedTime := time.Now()
+	certificates, _ := cryptoutils.UnmarshalCertificatesFromPEM(publicKeyPEM)
+	if len(certificates) > 0 {
+		integratedTime = certificates[0].NotAfter.Add(-1 * time.Second)
+	}
+
+	logEntry := models.LogEntryAnon{
+		Body:           base64.StdEncoding.EncodeToString(canonicalEntry),
+		IntegratedTime: swag.Int64(integratedTime.Unix()),
+		LogIndex:       swag.Int64(0),
+		LogID:          swag.String(logID),
+	}
+
+	jsonLogEntry, err := json.Marshal(logEntry)
+	require.NoError(t, err)
+
+	canonicalPayload, err := jsoncanonicalizer.Transform(jsonLogEntry)
+	require.NoError(t, err)
+
+	signedEntryTimestamp, err := rekorSigner.SignMessage(bytes.NewReader(canonicalPayload))
+	require.NoError(t, err)
+
+	entryUUID, _ := ComputeLeafHash(&logEntry)
+
+	logEntry.Verification = &models.LogEntryAnonVerification{
+		SignedEntryTimestamp: signedEntryTimestamp,
+		InclusionProof: &models.InclusionProof{
+			LogIndex: swag.Int64(0),
+			TreeSize: swag.Int64(1),
+			RootHash: swag.String(hex.EncodeToString(entryUUID)),
+			Hashes:   []string{},
+		},
+	}
+	return &models.LogEntry{hex.EncodeToString(entryUUID): logEntry}
+}
+
+func calculateLogID(pub crypto.PublicKey) (string, error) {
+	pubBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(pubBytes)
+	return hex.EncodeToString(digest[:]), nil
 }

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -564,11 +564,11 @@ func TestImageSignatureVerificationWithRekor(t *testing.T) {
 	logID, err := calculateLogID(rekorPublicKey)
 	require.NoError(t, err, "error calculating Rekor log ID")
 
-	rekorEntry := createRekorEntry(t, ctx, logID, rekorSigner, blob, blobSignature, publicKeyPEM)
+	rekorEntry := createRekorEntry(ctx, t, logID, rekorSigner, blob, blobSignature, publicKeyPEM)
 
 	mockClient := &client.Rekor{
 		Entries: &mockEntriesClient{
-			searchLogQueryFunc: func(params *entries.SearchLogQueryParams, opts ...entries.ClientOption) (*entries.SearchLogQueryOK, error) {
+			searchLogQueryFunc: func(_ *entries.SearchLogQueryParams, _ ...entries.ClientOption) (*entries.SearchLogQueryOK, error) {
 				return &entries.SearchLogQueryOK{
 					Payload: []models.LogEntry{*rekorEntry},
 				}, nil
@@ -1608,7 +1608,7 @@ func (m *mockEntriesClient) SearchLogQuery(params *entries.SearchLogQueryParams,
 	return nil, nil
 }
 
-func createRekorEntry(t *testing.T, ctx context.Context, logID string, rekorSigner signature.SignerVerifier, payload, signature, publicKeyPEM []byte) *models.LogEntry {
+func createRekorEntry(ctx context.Context, t *testing.T, logID string, rekorSigner signature.SignerVerifier, payload, signature, publicKeyPEM []byte) *models.LogEntry {
 	hashedRekorEntry := &hashedrekord_v001.V001Entry{}
 	payloadHash := sha256.Sum256(payload)
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR addresses an issue where the `bundleVerified` flag was not set to true after a successful online Rekor verification. The change ensures that `bundleVerified` accurately reflects the verification status when Rekor lookup is used.

Resolves #3740 

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
