### PR TITLE
add handling of keyless verification for all verify commands

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -114,14 +114,14 @@ against the transparency log.`,
 				CheckClaims:                  o.CheckClaims,
 				KeyRef:                       o.Key,
 				CertRef:                      o.CertVerify.Cert,
+				CertChain:                    o.CertVerify.CertChain,
+				CAIntermediates:              o.CertVerify.CAIntermediates,
+				CARoots:                      o.CertVerify.CARoots,
 				CertGithubWorkflowTrigger:    o.CertVerify.CertGithubWorkflowTrigger,
 				CertGithubWorkflowSha:        o.CertVerify.CertGithubWorkflowSha,
 				CertGithubWorkflowName:       o.CertVerify.CertGithubWorkflowName,
 				CertGithubWorkflowRepository: o.CertVerify.CertGithubWorkflowRepository,
 				CertGithubWorkflowRef:        o.CertVerify.CertGithubWorkflowRef,
-				CAIntermediates:              o.CertVerify.CAIntermediates,
-				CARoots:                      o.CertVerify.CARoots,
-				CertChain:                    o.CertVerify.CertChain,
 				IgnoreSCT:                    o.CertVerify.IgnoreSCT,
 				SCTRef:                       o.CertVerify.SCT,
 				Sk:                           o.SecurityKey.Use,
@@ -223,6 +223,8 @@ against the transparency log.`,
 				CertVerifyOptions:            o.CertVerify,
 				CertRef:                      o.CertVerify.Cert,
 				CertChain:                    o.CertVerify.CertChain,
+				CAIntermediates:              o.CertVerify.CAIntermediates,
+				CARoots:                      o.CertVerify.CARoots,
 				CertGithubWorkflowTrigger:    o.CertVerify.CertGithubWorkflowTrigger,
 				CertGithubWorkflowSha:        o.CertVerify.CertGithubWorkflowSha,
 				CertGithubWorkflowName:       o.CertVerify.CertGithubWorkflowName,
@@ -281,6 +283,12 @@ The blob may be specified as a path to a file or - for stdin.`,
   # Verify a simple blob and message
   cosign verify-blob --key cosign.pub (--signature <sig path>|<sig url> msg)
 
+# Verify a signature with certificate and CA certificate chain
+  cosign verify-blob --certificate cert.pem --certificate-chain certchain.pem --signature $sig <blob>
+
+  # Verify a signature with CA roots and optional intermediate certificates
+  cosign verify-blob --certificate cert.pem --ca-roots caroots.pem [--ca-intermediates caintermediates.pem] --signature $sig <blob>
+
   # Verify a signature from an environment variable
   cosign verify-blob --key cosign.pub --signature $sig msg
 
@@ -333,6 +341,8 @@ The blob may be specified as a path to a file or - for stdin.`,
 				CertVerifyOptions:            o.CertVerify,
 				CertRef:                      o.CertVerify.Cert,
 				CertChain:                    o.CertVerify.CertChain,
+				CARoots:                      o.CertVerify.CARoots,
+				CAIntermediates:              o.CertVerify.CAIntermediates,
 				SigRef:                       o.Signature,
 				CertGithubWorkflowTrigger:    o.CertVerify.CertGithubWorkflowTrigger,
 				CertGithubWorkflowSHA:        o.CertVerify.CertGithubWorkflowSha,
@@ -402,6 +412,8 @@ The blob may be specified as a path to a file.`,
 				CertVerifyOptions:            o.CertVerify,
 				CertRef:                      o.CertVerify.Cert,
 				CertChain:                    o.CertVerify.CertChain,
+				CARoots:                      o.CertVerify.CARoots,
+				CAIntermediates:              o.CertVerify.CAIntermediates,
 				CertGithubWorkflowTrigger:    o.CertVerify.CertGithubWorkflowTrigger,
 				CertGithubWorkflowSHA:        o.CertVerify.CertGithubWorkflowSha,
 				CertGithubWorkflowName:       o.CertVerify.CertGithubWorkflowName,

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -179,6 +179,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			return err
 		}
 	}
+
 	keyRef := c.KeyRef
 	certRef := c.CertRef
 
@@ -511,15 +512,14 @@ func shouldVerifySCT(ignoreSCT bool, keyRef string, sk bool) bool {
 	return true
 }
 
-// loadCertsKeylessVerification loads certificates for the verification of keyless signatures
-// for the verify command.
+// loadCertsKeylessVerification loads certificates provided as a certificate chain or CA roots + CA intermediate
+// certificate files. If both certChain and caRootsFile are empty strings, the Fulcio roots are loaded.
 //
 // TODO - mention additionally verify-attestation, verify-blob, verify-blob-attestation
 // commands when they are extended to call this function.
 //
 // The co *cosign.CheckOpts is both input and output parameter - it gets updated
 // with the root and intermediate certificates needed for verification.
-// If both certChain and caRootsFile are empty strings, the Fulcio roots are loaded.
 func loadCertsKeylessVerification(certChainFile string,
 	caRootsFile string,
 	caIntermediatesFile string,
@@ -574,5 +574,6 @@ func loadCertsKeylessVerification(certChainFile string,
 			return fmt.Errorf("getting Fulcio intermediates: %w", err)
 		}
 	}
+
 	return nil
 }

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -515,9 +515,6 @@ func shouldVerifySCT(ignoreSCT bool, keyRef string, sk bool) bool {
 // loadCertsKeylessVerification loads certificates provided as a certificate chain or CA roots + CA intermediate
 // certificate files. If both certChain and caRootsFile are empty strings, the Fulcio roots are loaded.
 //
-// TODO - mention additionally verify-attestation, verify-blob, verify-blob-attestation
-// commands when they are extended to call this function.
-//
 // The co *cosign.CheckOpts is both input and output parameter - it gets updated
 // with the root and intermediate certificates needed for verification.
 func loadCertsKeylessVerification(certChainFile string,

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -223,6 +223,9 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			}
 			co.SCT = sct
 		}
+	case c.CARoots != "":
+		// CA roots + possible intermediates are already loaded into co.RootCerts with the call to
+		// loadCertsKeylessVerification above.
 	}
 
 	// NB: There are only 2 kinds of verification right now:

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -52,6 +52,8 @@ type VerifyAttestationCommand struct {
 	CertGithubWorkflowName       string
 	CertGithubWorkflowRepository string
 	CertGithubWorkflowRef        string
+	CAIntermediates              string
+	CARoots                      string
 	CertChain                    string
 	IgnoreSCT                    bool
 	SCTRef                       string
@@ -156,15 +158,8 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	}
 
 	if keylessVerification(c.KeyRef, c.Sk) {
-		// This performs an online fetch of the Fulcio roots. This is needed
-		// for verifying keyless certificates (both online and offline).
-		co.RootCerts, err = fulcio.GetRoots()
-		if err != nil {
-			return fmt.Errorf("getting Fulcio roots: %w", err)
-		}
-		co.IntermediateCerts, err = fulcio.GetIntermediates()
-		if err != nil {
-			return fmt.Errorf("getting Fulcio intermediates: %w", err)
+		if err := loadCertsKeylessVerification(c.CertChain, c.CARoots, c.CAIntermediates, co); err != nil {
+			return err
 		}
 	}
 

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -263,7 +263,8 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			return err
 		}
 	case c.CARoots != "":
-		// TODO insert CA roots + intermediates into the signature options for verification
+		// CA roots + possible intermediates are already loaded into co.RootCerts with the call to
+		// loadCertsKeylessVerification above.
 	}
 
 	// Gather the cert for the signature and add the cert along with the

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -28,7 +28,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sigstore/cosign/v2/cmd/cosign/cli/fulcio"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/v2/internal/ui"
@@ -53,6 +52,8 @@ type VerifyBlobCmd struct {
 	options.KeyOpts
 	options.CertVerifyOptions
 	CertRef                      string
+	CAIntermediates              string
+	CARoots                      string
 	CertChain                    string
 	SigRef                       string
 	CertGithubWorkflowTrigger    string
@@ -151,19 +152,10 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			return fmt.Errorf("getting Rekor public keys: %w", err)
 		}
 	}
+
 	if keylessVerification(c.KeyRef, c.Sk) {
-		// Use default TUF roots if a cert chain is not provided.
-		// This performs an online fetch of the Fulcio roots. This is needed
-		// for verifying keyless certificates (both online and offline).
-		if c.CertChain == "" {
-			co.RootCerts, err = fulcio.GetRoots()
-			if err != nil {
-				return fmt.Errorf("getting Fulcio roots: %w", err)
-			}
-			co.IntermediateCerts, err = fulcio.GetIntermediates()
-			if err != nil {
-				return fmt.Errorf("getting Fulcio intermediates: %w", err)
-			}
+		if err := loadCertsKeylessVerification(c.CertChain, c.CARoots, c.CAIntermediates, co); err != nil {
+			return err
 		}
 	}
 
@@ -249,7 +241,8 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	}
 	// Set a cert chain if provided.
 	var chainPEM []byte
-	if c.CertChain != "" {
+	switch {
+	case c.CertChain != "":
 		chain, err := loadCertChainFromFileOrURL(c.CertChain)
 		if err != nil {
 			return err
@@ -269,6 +262,8 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		if err != nil {
 			return err
 		}
+	case c.CARoots != "":
+		// TODO insert CA roots + intermediates into the signature options for verification
 	}
 
 	// Gather the cert for the signature and add the cert along with the

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -220,6 +220,9 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		if err != nil {
 			return err
 		}
+	case c.CARoots != "":
+		// CA roots + possible intermediates are already loaded into co.RootCerts with the call to
+		// loadCertsKeylessVerification above.
 	}
 	if c.BundlePath != "" {
 		b, err := cosign.FetchLocalSignedPayloadFromPath(c.BundlePath)

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -23,6 +23,12 @@ cosign verify-blob [flags]
   # Verify a simple blob and message
   cosign verify-blob --key cosign.pub (--signature <sig path>|<sig url> msg)
 
+# Verify a signature with certificate and CA certificate chain
+  cosign verify-blob --certificate cert.pem --certificate-chain certchain.pem --signature $sig <blob>
+
+  # Verify a signature with CA roots and optional intermediate certificates
+  cosign verify-blob --certificate cert.pem --ca-roots caroots.pem [--ca-intermediates caintermediates.pem] --signature $sig <blob>
+
   # Verify a signature from an environment variable
   cosign verify-blob --key cosign.pub --signature $sig msg
 

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
@@ -221,7 +222,15 @@ func LoadPrivateKey(key []byte, pass []byte) (signature.SignerVerifier, error) {
 
 	pk, err := x509.ParsePKCS8PrivateKey(x509Encoded)
 	if err != nil {
-		return nil, fmt.Errorf("parsing private key: %w", err)
+		if strings.Contains(err.Error(), "x509: failed to parse private key (use ParseECPrivateKey instead for this key format)") {
+			pk2, err2 := x509.ParseECPrivateKey(x509Encoded)
+			if err2 != nil {
+				return nil, fmt.Errorf("parsing EC private key: %w, x509.ParsePKCS8PrivateKey: %w", err2, err)
+			}
+			pk = pk2
+		} else {
+			return nil, fmt.Errorf("parsing private key: %w", err)
+		}
 	}
 	switch pk := pk.(type) {
 	case *rsa.PrivateKey:

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -74,7 +74,6 @@ func GeneratePrivateKey() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 }
 
-// TODO(jason): Move this to the only place it's used in cmd/cosign/cli/importkeypair, and unexport it.
 func ImportKeyPair(keyPath string, pf PassFunc) (*KeysBytes, error) {
 	kb, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
@@ -75,6 +74,7 @@ func GeneratePrivateKey() (*ecdsa.PrivateKey, error) {
 	return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 }
 
+// TODO(jason): Move this to the only place it's used in cmd/cosign/cli/importkeypair, and unexport it.
 func ImportKeyPair(keyPath string, pf PassFunc) (*KeysBytes, error) {
 	kb, err := os.ReadFile(filepath.Clean(keyPath))
 	if err != nil {
@@ -222,15 +222,7 @@ func LoadPrivateKey(key []byte, pass []byte) (signature.SignerVerifier, error) {
 
 	pk, err := x509.ParsePKCS8PrivateKey(x509Encoded)
 	if err != nil {
-		if strings.Contains(err.Error(), "x509: failed to parse private key (use ParseECPrivateKey instead for this key format)") {
-			pk2, err2 := x509.ParseECPrivateKey(x509Encoded)
-			if err2 != nil {
-				return nil, fmt.Errorf("parsing EC private key: %w, x509.ParsePKCS8PrivateKey: %w", err2, err)
-			}
-			pk = pk2
-		} else {
-			return nil, fmt.Errorf("parsing private key: %w", err)
-		}
+		return nil, fmt.Errorf("parsing private key: %w", err)
 	}
 	switch pk := pk.(type) {
 	case *rsa.PrivateKey:

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1062,39 +1062,40 @@ func TestVerifyWithCARoots(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		err := verifyKeylessTSAWithCARoots(imgName,
-			tt.rootRef,
-			tt.subRef,
-			tt.leafRef,
-			tsaChainRef.Name(),
-			true,
-			true)
-		hasErr := (err != nil)
-		if hasErr != tt.wantError {
-			if tt.wantError {
-				t.Errorf("%s - no expected error", tt.name)
-			} else {
-				t.Errorf("%s - unexpected error: %v", tt.name, err)
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyKeylessTSAWithCARoots(imgName,
+				tt.rootRef,
+				tt.subRef,
+				tt.leafRef,
+				tsaChainRef.Name(),
+				true,
+				true)
+			hasErr := (err != nil)
+			if hasErr != tt.wantError {
+				if tt.wantError {
+					t.Errorf("%s - no expected error", tt.name)
+				} else {
+					t.Errorf("%s - unexpected error: %v", tt.name, err)
+				}
 			}
-		}
-		if tt.skipBlob {
-			continue
-		}
-		err = verifyBlobKeylessWithCARoots(blobRef,
-			string(blobSig),
-			tt.rootRef,
-			tt.subRef,
-			tt.leafRef,
-			true,
-			true)
-		hasErr = (err != nil)
-		if hasErr != tt.wantError {
-			if tt.wantError {
-				t.Errorf("%s - no expected error", tt.name)
-			} else {
-				t.Errorf("%s - unexpected error: %v", tt.name, err)
+			if !tt.skipBlob {
+				err = verifyBlobKeylessWithCARoots(blobRef,
+					string(blobSig),
+					tt.rootRef,
+					tt.subRef,
+					tt.leafRef,
+					true,
+					true)
+				hasErr = (err != nil)
+				if hasErr != tt.wantError {
+					if tt.wantError {
+						t.Errorf("%s - no expected error", tt.name)
+					} else {
+						t.Errorf("%s - unexpected error: %v", tt.name, err)
+					}
+				}
 			}
-		}
+		})
 	}
 }
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1045,7 +1045,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 			true,
 		},
 		{
-			"wrong root undle",
+			"wrong root bundle",
 			pemrootRef02,
 			pemsubBundleRef,
 			pemleafRef,

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -953,7 +953,8 @@ func TestVerifyWithCARoots(t *testing.T) {
 
 	// Now sign the blob with one key
 	ko := options.KeyOpts{
-		KeyRef: privKeyRef,
+		KeyRef:   privKeyRef,
+		PassFunc: passFunc,
 	}
 	blobSig, err := sign.SignBlobCmd(ro, ko, blobRef, true, "", "", false)
 	if err != nil {
@@ -970,6 +971,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 		rootRef   string
 		subRef    string
 		leafRef   string
+		skipBlob  bool // skip the verify-blob test (for cases that need the image)
 		wantError bool
 	}{
 		{
@@ -977,6 +979,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemrootRef,
 			pemsubRef,
 			pemleafRef,
+			false,
 			false,
 		},
 		// NB - "confusely" switching the root and intermediate PEM files does _NOT_ (currently) produce an error
@@ -991,12 +994,14 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemrootRef,
 			pemleafRef,
 			false,
+			false,
 		},
 		{
 			"leave out the root certificate",
 			"",
 			pemsubRef,
 			pemleafRef,
+			false,
 			true,
 		},
 		{
@@ -1004,6 +1009,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemrootRef,
 			"",
 			pemleafRef,
+			false,
 			true,
 		},
 		{
@@ -1011,6 +1017,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemrootRef,
 			pemsubRef,
 			"",
+			true,
 			false,
 		},
 		{
@@ -1018,6 +1025,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemrootRef,
 			pemsubRef,
 			pemleafRef02,
+			false,
 			true,
 		},
 		{
@@ -1026,12 +1034,14 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemsubBundleRef,
 			pemleafRef,
 			false,
+			false,
 		},
 		{
 			"wrong root and intermediates bundles",
 			pemrootRef02,
 			pemsubRef02,
 			pemleafRef,
+			false,
 			true,
 		},
 		{
@@ -1039,6 +1049,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemrootRef02,
 			pemsubBundleRef,
 			pemleafRef,
+			false,
 			true,
 		},
 		{
@@ -1046,6 +1057,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 			pemrootRef,
 			pemsubRef02,
 			pemleafRef,
+			false,
 			true,
 		},
 	}
@@ -1064,6 +1076,9 @@ func TestVerifyWithCARoots(t *testing.T) {
 			} else {
 				t.Errorf("%s - unexpected error: %v", tt.name, err)
 			}
+		}
+		if tt.skipBlob {
+			continue
 		}
 		err = verifyBlobKeylessWithCARoots(blobRef,
 			string(blobSig),

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1085,8 +1085,8 @@ func TestVerifyWithCARoots(t *testing.T) {
 			tt.rootRef,
 			tt.subRef,
 			tt.leafRef,
-			false,
-			false)
+			true,
+			true)
 		hasErr = (err != nil)
 		if hasErr != tt.wantError {
 			if tt.wantError {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -247,7 +247,7 @@ func TestImportSignVerifyClean(t *testing.T) {
 
 	_, _, _ = mkimage(t, imgName)
 
-	_, privKeyPath, pubKeyPath := importKeyPair(t, td)
+	_, privKeyPath, pubKeyPath := importSampleKeyPair(t, td)
 
 	ctx := context.Background()
 
@@ -887,11 +887,7 @@ func TestVerifyWithCARoots(t *testing.T) {
 	rootCert, rootKey, _ := GenerateRootCa()
 	subCert, subKey, _ := GenerateSubordinateCa(rootCert, rootKey)
 	leafCert, privKey, _ := GenerateLeafCert("subject@mail.com", "oidc-issuer", subCert, subKey)
-	privKeyPEM, err := ecdsaPrivateKeyToPEM(privKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	privKeyRef := mkfile(string(privKeyPEM), td, t)
+	privKeyRef := importECDSAPrivateKey(t, privKey, td, "cosign-test-key.pem")
 	pemRoot := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootCert.Raw})
 	pemSub := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: subCert.Raw})
 	pemLeaf := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCert.Raw})

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -288,7 +288,7 @@ func keypair(t *testing.T, td string) (*cosign.KeysBytes, string, string) {
 // and write to the given file path. Returns the path to the imported key (<td>/<fname>)
 func importECDSAPrivateKey(t *testing.T, privKey *ecdsa.PrivateKey, td, fname string) string {
 	t.Helper()
-	x509Encoded, _ := x509.MarshalECPrivateKey(privKey)
+	x509Encoded, _ := x509.MarshalPKCS8PrivateKey(privKey)
 	encBytes, _ := encrypted.Encrypt(x509Encoded, keyPass)
 	keyPEM := pem.EncodeToMemory(&pem.Block{
 		Type:  cosign.CosignPrivateKeyPemType,

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -47,7 +47,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/theupdateframework/go-tuf/encrypted"
+	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
 
 	// Initialize all known client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -767,16 +767,4 @@ func generateCertificateBundle(genIntermediate bool) (
 	}
 
 	return caCertBuf, caPrivKeyBuf, caIntermediateCertBuf, caIntermediatePrivKeyBuf, certBuf, certBundleBuf, nil
-}
-
-func ecdsaPrivateKeyToPEM(priv *ecdsa.PrivateKey) ([]byte, error) {
-	der, err := x509.MarshalECPrivateKey(priv)
-	if err != nil {
-		return nil, err
-	}
-	block := &pem.Block{
-		Type:  "EC PRIVATE KEY",
-		Bytes: der,
-	}
-	return pem.EncodeToMemory(block), nil
 }


### PR DESCRIPTION
#### Summary

Copy the handling of non-Fulcio keys from the `verify` to all the other verify commands (`verify-attestation`,
`verify-blob`, `verify-blob-attestations`).

Fix #3759.


#### Release Note
- add keyless verification and `--ca-roots` / `--ca-intermediates` parameters to the
`verify-attestation`, `verify-blob`,  and `verify-blob-attestations` commands (in addition
to `verify`)

#### Documentation
TODO - create a corresponding https://github.com/sigstore/docs PR, in particular in https://docs.sigstore.dev/verifying/verify/#local-verifications need to mention:

```
Verify image with local certificate and local CA roots and optional CA intermediate certificates file(s):

$ cosign verify --certificate cosign.crt --ca-roots ca-roots.crt [--ca-intermediates=ca-intermediates.crt] --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com user/demo
```
The command-line help as in `cosign verify-blob --help` already mentions the new parameter even though they don't yet properly work until this change is merged and released.