### PR TITLE
factor out keyless verification certificate loading function

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -175,54 +175,8 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		}
 	}
 	if keylessVerification(c.KeyRef, c.Sk) {
-		switch {
-		case c.CertChain != "":
-			chain, err := loadCertChainFromFileOrURL(c.CertChain)
-			if err != nil {
-				return err
-			}
-			co.RootCerts = x509.NewCertPool()
-			co.RootCerts.AddCert(chain[len(chain)-1])
-			if len(chain) > 1 {
-				co.IntermediateCerts = x509.NewCertPool()
-				for _, cert := range chain[:len(chain)-1] {
-					co.IntermediateCerts.AddCert(cert)
-				}
-			}
-		case c.CARoots != "":
-			caRoots, err := loadCertChainFromFileOrURL(c.CARoots)
-			if err != nil {
-				return err
-			}
-			co.RootCerts = x509.NewCertPool()
-			if len(caRoots) > 0 {
-				for _, cert := range caRoots {
-					co.RootCerts.AddCert(cert)
-				}
-			}
-			if c.CAIntermediates != "" {
-				caIntermediates, err := loadCertChainFromFileOrURL(c.CAIntermediates)
-				if err != nil {
-					return err
-				}
-				if len(caIntermediates) > 0 {
-					co.IntermediateCerts = x509.NewCertPool()
-					for _, cert := range caIntermediates {
-						co.IntermediateCerts.AddCert(cert)
-					}
-				}
-			}
-		default:
-			// This performs an online fetch of the Fulcio roots from a TUF repository.
-			// This is needed for verifying keyless certificates (both online and offline).
-			co.RootCerts, err = fulcio.GetRoots()
-			if err != nil {
-				return fmt.Errorf("getting Fulcio roots: %w", err)
-			}
-			co.IntermediateCerts, err = fulcio.GetIntermediates()
-			if err != nil {
-				return fmt.Errorf("getting Fulcio intermediates: %w", err)
-			}
+		if err := handleKeylessVerification(c.CertChain, c.CARoots, c.CAIntermediates, co); err != nil {
+			return err
 		}
 	}
 	keyRef := c.KeyRef
@@ -555,4 +509,70 @@ func shouldVerifySCT(ignoreSCT bool, keyRef string, sk bool) bool {
 		return false
 	}
 	return true
+}
+
+// handleKeylessVerification handles the verification of keyless signatures
+// for the verify command.
+//
+// TODO(dmitris) - mention additionally verify-attestation, verify-blob, verify-blob-attestation
+// commands when they are extended to call this function.
+//
+// The co *cosign.CheckOpts is both input and output parameter - it gets updated
+// with the root and intermediate certificates needed for verification.
+// If both certChain and caRootsFile are empty strings, the Fulcio roots are loaded.
+func handleKeylessVerification(certChainFile string,
+	caRootsFile string,
+	caIntermediatesFile string,
+	co *cosign.CheckOpts) error {
+	var err error
+	switch {
+	case certChainFile != "":
+		chain, err := loadCertChainFromFileOrURL(certChainFile)
+		if err != nil {
+			return err
+		}
+		co.RootCerts = x509.NewCertPool()
+		co.RootCerts.AddCert(chain[len(chain)-1])
+		if len(chain) > 1 {
+			co.IntermediateCerts = x509.NewCertPool()
+			for _, cert := range chain[:len(chain)-1] {
+				co.IntermediateCerts.AddCert(cert)
+			}
+		}
+	case caRootsFile != "":
+		caRoots, err := loadCertChainFromFileOrURL(caRootsFile)
+		if err != nil {
+			return err
+		}
+		co.RootCerts = x509.NewCertPool()
+		if len(caRoots) > 0 {
+			for _, cert := range caRoots {
+				co.RootCerts.AddCert(cert)
+			}
+		}
+		if caIntermediatesFile != "" {
+			caIntermediates, err := loadCertChainFromFileOrURL(caIntermediatesFile)
+			if err != nil {
+				return err
+			}
+			if len(caIntermediates) > 0 {
+				co.IntermediateCerts = x509.NewCertPool()
+				for _, cert := range caIntermediates {
+					co.IntermediateCerts.AddCert(cert)
+				}
+			}
+		}
+	default:
+		// This performs an online fetch of the Fulcio roots from a TUF repository.
+		// This is needed for verifying keyless certificates (both online and offline).
+		co.RootCerts, err = fulcio.GetRoots()
+		if err != nil {
+			return fmt.Errorf("getting Fulcio roots: %w", err)
+		}
+		co.IntermediateCerts, err = fulcio.GetIntermediates()
+		if err != nil {
+			return fmt.Errorf("getting Fulcio intermediates: %w", err)
+		}
+	}
+	return nil
 }

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -514,7 +514,7 @@ func shouldVerifySCT(ignoreSCT bool, keyRef string, sk bool) bool {
 // loadCertsKeylessVerification loads certificates for the verification of keyless signatures
 // for the verify command.
 //
-// TODO(dmitris) - mention additionally verify-attestation, verify-blob, verify-blob-attestation
+// TODO - mention additionally verify-attestation, verify-blob, verify-blob-attestation
 // commands when they are extended to call this function.
 //
 // The co *cosign.CheckOpts is both input and output parameter - it gets updated

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -175,7 +175,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		}
 	}
 	if keylessVerification(c.KeyRef, c.Sk) {
-		if err := handleKeylessVerification(c.CertChain, c.CARoots, c.CAIntermediates, co); err != nil {
+		if err := loadCertsKeylessVerification(c.CertChain, c.CARoots, c.CAIntermediates, co); err != nil {
 			return err
 		}
 	}
@@ -511,7 +511,7 @@ func shouldVerifySCT(ignoreSCT bool, keyRef string, sk bool) bool {
 	return true
 }
 
-// handleKeylessVerification handles the verification of keyless signatures
+// loadCertsKeylessVerification loads certificates for the verification of keyless signatures
 // for the verify command.
 //
 // TODO(dmitris) - mention additionally verify-attestation, verify-blob, verify-blob-attestation
@@ -520,7 +520,7 @@ func shouldVerifySCT(ignoreSCT bool, keyRef string, sk bool) bool {
 // The co *cosign.CheckOpts is both input and output parameter - it gets updated
 // with the root and intermediate certificates needed for verification.
 // If both certChain and caRootsFile are empty strings, the Fulcio roots are loaded.
-func handleKeylessVerification(certChainFile string,
+func loadCertsKeylessVerification(certChainFile string,
 	caRootsFile string,
 	caIntermediatesFile string,
 	co *cosign.CheckOpts) error {

--- a/test/helpers_test.go
+++ b/test/helpers_test.go
@@ -86,7 +86,6 @@ func verifyCertificateChain(t *testing.T, certChainFile string) {
 	}
 
 	// Check if the file contents are a PEM-encoded TLS certificate
-	t.Logf("DMDEBUG 76 before isPEMEncodedCertChain")
 	if !isPEMEncodedCertChain(data) {
 		t.Fatalf("file %s doesn't contain a valid PEM-encoded TLS certificate chain", certChainFile)
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Factor out the code loading certificates for keyless verification (from a certificate chain, provided roots / intermediate or from Fulcio)  into a helper function `loadCertsKeylessVerification`.  This reduces the size of the long method `VerifyCommand.Exec` (from the current 252 to 206 lines), helps with unit testing, and will later allow the same logic and helper function to be shared and called from `verify_attestation.go`, `verify_blob.go` etc. (related to #3759).

The helper function has a corresponding unit test, the est coverage in the `cmd/cosign/cli/verify` is increased from **38.2%** of statements in the trunk version to **42.6%**.

#### Release Note
NONE

#### Documentation
n/a - no updates needed
