### PR TITLE
Add support for recording creation timestamp for cosign attest

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -31,7 +31,7 @@ func Attest() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "attest",
 		Short: "Attest the supplied container image.",
-		Example: `  cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <image uri>
+		Example: `  cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--record-creation-timestamp=true|false] [--f] [--r] <image uri>
 
   # attach an attestation to a container image Google sign-in
   cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>
@@ -58,7 +58,10 @@ func Attest() *cobra.Command {
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign attest --predicate <FILE> --type <TYPE> --key cosign.key legacy-registry.example.com/my/image
 
   # supply attestation via stdin
-  echo <PAYLOAD> | cosign attest --predicate - <IMAGE>`,
+  echo <PAYLOAD> | cosign attest --predicate - <IMAGE>
+
+  # attach an attestation to a container image and honor the creation timestamp of the signature
+  cosign attest --predicate <FILE> --type <TYPE> --key cosign.key --record-creation-timestamp <IMAGE>`,
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
@@ -86,17 +89,18 @@ func Attest() *cobra.Command {
 				TSAServerURL:             o.TSAServerURL,
 			}
 			attestCommand := attest.AttestCommand{
-				KeyOpts:         ko,
-				RegistryOptions: o.Registry,
-				CertPath:        o.Cert,
-				CertChainPath:   o.CertChain,
-				NoUpload:        o.NoUpload,
-				PredicatePath:   o.Predicate.Path,
-				PredicateType:   o.Predicate.Type,
-				Replace:         o.Replace,
-				Timeout:         ro.Timeout,
-				TlogUpload:      o.TlogUpload,
-				RekorEntryType:  o.RekorEntryType,
+				KeyOpts:                 ko,
+				RegistryOptions:         o.Registry,
+				CertPath:                o.Cert,
+				CertChainPath:           o.CertChain,
+				NoUpload:                o.NoUpload,
+				PredicatePath:           o.Predicate.Path,
+				PredicateType:           o.Predicate.Type,
+				Replace:                 o.Replace,
+				Timeout:                 ro.Timeout,
+				TlogUpload:              o.TlogUpload,
+				RekorEntryType:          o.RekorEntryType,
+				RecordCreationTimestamp: o.RecordCreationTimestamp,
 			}
 
 			for _, img := range args {

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -71,16 +71,17 @@ func uploadToTlog(ctx context.Context, sv *sign.SignerVerifier, rekorURL string,
 type AttestCommand struct {
 	options.KeyOpts
 	options.RegistryOptions
-	CertPath       string
-	CertChainPath  string
-	NoUpload       bool
-	PredicatePath  string
-	PredicateType  string
-	Replace        bool
-	Timeout        time.Duration
-	TlogUpload     bool
-	TSAServerURL   string
-	RekorEntryType string
+	CertPath                string
+	CertChainPath           string
+	NoUpload                bool
+	PredicatePath           string
+	PredicateType           string
+	Replace                 bool
+	Timeout                 time.Duration
+	TlogUpload              bool
+	TSAServerURL            string
+	RekorEntryType          string
+	RecordCreationTimestamp bool
 }
 
 // nolint
@@ -226,6 +227,7 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 
 	signOpts := []mutate.SignOption{
 		mutate.WithDupeDetector(dd),
+		mutate.WithRecordCreationTimestamp(c.RecordCreationTimestamp),
 	}
 
 	if c.Replace {

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -21,16 +21,17 @@ import (
 
 // AttestOptions is the top level wrapper for the attest command.
 type AttestOptions struct {
-	Key              string
-	Cert             string
-	CertChain        string
-	NoUpload         bool
-	Recursive        bool
-	Replace          bool
-	SkipConfirmation bool
-	TlogUpload       bool
-	TSAServerURL     string
-	RekorEntryType   string
+	Key                     string
+	Cert                    string
+	CertChain               string
+	NoUpload                bool
+	Recursive               bool
+	Replace                 bool
+	SkipConfirmation        bool
+	TlogUpload              bool
+	TSAServerURL            string
+	RekorEntryType          string
+	RecordCreationTimestamp bool
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -86,4 +87,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",
 		"url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr")
+
+	cmd.Flags().BoolVar(&o.RecordCreationTimestamp, "record-creation-timestamp", false,
+		"set the createdAt timestamp in the attestation artifact to the time it was created; by default, cosign sets this to the zero value")
 }

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -37,6 +37,9 @@ cosign attest [flags]
 
   # supply attestation via stdin
   echo <PAYLOAD> | cosign attest --predicate - <IMAGE>
+
+  # attach an attestation to a container image and honor the creation timestamp of the signature
+  cosign attest --predicate <FILE> --type <TYPE> --key cosign.key --record-creation-timestamp <IMAGE>
 ```
 
 ### Options
@@ -62,6 +65,7 @@ cosign attest [flags]
       --oidc-provider string                                                                     Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
       --oidc-redirect-url string                                                                 OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --predicate string                                                                         path to the predicate file.
+      --record-creation-timestamp                                                                set the createdAt timestamp in the attestation artifact to the time it was created; by default, cosign sets this to the zero value
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -9,7 +9,7 @@ cosign attest [flags]
 ### Examples
 
 ```
-  cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--f] [--r] <image uri>
+  cosign attest --key <key path>|<kms uri> [--predicate <path>] [--a key=value] [--no-upload=true|false] [--record-creation-timestamp=true|false] [--f] [--r] <image uri>
 
   # attach an attestation to a container image Google sign-in
   cosign attest --timeout 90s --predicate <FILE> --type <TYPE> <IMAGE>


### PR DESCRIPTION
#### Summary
- cosign 2.2.0 deleted automatic, non-deterministic recording of the creation timestamp in the config layer of signatures, attestations, sboms
- cosign 2.2.4 introduced --record-creation-timestamp, but only enabled it for `cosign sign`, leaving the timestamp empty for attestations. It is a huge problem for oci registries allowing automatic cleanup policies as they won't be able to tell the creation time. GitLab for example is reporting 23 years of age for uploaded attestations

#### Release Note
* Enables --record-creation-timestamp flag for `cosign attest`

#### Documentation
attach an attestation to a container image and honor the creation timestamp of the signature
```
cosign attest --predicate <FILE> --type <TYPE> --key cosign.key --record-creation-timestamp <IMAGE>
```

#### References
- https://github.com/sigstore/cosign/issues/3120
- https://github.com/sigstore/cosign/issues/3298