### PR TITLE
move incremental builds per commit to GHCR instead of GCR

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,5 +67,5 @@ jobs:
       - name: containers-cosign
         run: make sign-ci-containers
         env:
-          KO_PREFIX: gcr.io/projectsigstore/cosign/ci
+          KO_PREFIX: ghcr.io/sigstore/cosign/cosign/ci
           COSIGN_PASSWORD: "${{secrets.COSIGN_PASSWORD}}"


### PR DESCRIPTION
we can backfill the entries from gcr.io/projectsigstore/cosign/ci to GHCR as well, in case anyone is using these