### PR TITLE
Switch e2e test `docker-compose` to `docker compose`

### DIFF
--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -19,7 +19,7 @@ set -ex
 echo "setting up OIDC provider"
 pushd ./test/fakeoidc
 oidcimg=$(ko build main.go --local)
-docker network ls | grep fulcio_default || docker network create fulcio_default
+docker network ls | grep fulcio_default || docker network create --label com.docker.compose.network=fulcio_default fulcio_default
 docker run -d --rm -p 8080:8080 --network fulcio_default --name fakeoidc $oidcimg
 cleanup_oidc() {
     echo "cleaning up oidc"
@@ -59,10 +59,10 @@ export FULCIO_METRICS_PORT=2113
 export FULCIO_CONFIG=/tmp/fulcio-config.json
 for repo in rekor fulcio; do
     pushd $repo
-    docker compose --compatibility up -d
+    docker compose up -d
     echo -n "waiting up to 60 sec for system to start"
     count=0
-    until [ $(docker compose --compatibility ps | grep -c "(healthy)") == 3 ];
+    until [ $(docker compose ps | grep -c "(healthy)") == 3 ];
     do
         if [ $count -eq 6 ]; then
            echo "! timeout reached"
@@ -80,7 +80,7 @@ cleanup_services() {
     cleanup_oidc
     for repo in rekor fulcio; do
         pushd $HOME/$repo
-        docker compose --compatibility down
+        docker compose down
         popd
     done
 }

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -59,10 +59,10 @@ export FULCIO_METRICS_PORT=2113
 export FULCIO_CONFIG=/tmp/fulcio-config.json
 for repo in rekor fulcio; do
     pushd $repo
-    docker-compose up -d
+    docker compose up -d
     echo -n "waiting up to 60 sec for system to start"
     count=0
-    until [ $(docker-compose ps | grep -c "(healthy)") == 3 ];
+    until [ $(docker compose ps | grep -c "(healthy)") == 3 ];
     do
         if [ $count -eq 6 ]; then
            echo "! timeout reached"
@@ -80,7 +80,7 @@ cleanup_services() {
     cleanup_oidc
     for repo in rekor fulcio; do
         pushd $HOME/$repo
-        docker-compose down
+        docker compose down
         popd
     done
 }

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -59,10 +59,10 @@ export FULCIO_METRICS_PORT=2113
 export FULCIO_CONFIG=/tmp/fulcio-config.json
 for repo in rekor fulcio; do
     pushd $repo
-    docker compose up -d
+    docker compose --compatibility up -d
     echo -n "waiting up to 60 sec for system to start"
     count=0
-    until [ $(docker compose ps | grep -c "(healthy)") == 3 ];
+    until [ $(docker compose --compatibility ps | grep -c "(healthy)") == 3 ];
     do
         if [ $count -eq 6 ]; then
            echo "! timeout reached"
@@ -80,7 +80,7 @@ cleanup_services() {
     cleanup_oidc
     for repo in rekor fulcio; do
         pushd $HOME/$repo
-        docker compose down
+        docker compose --compatibility down
         popd
     done
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Many cosign pull requests have e2e test failing, such as https://github.com/sigstore/cosign/actions/runs/10238677353/job/28323361888?pr=3808.

Apparently this is because `docker-compose` was removed from the ubuntu-latest and windows GitHub Actions runners late last week:

https://github.com/actions/runner-images/issues/9692

I don't follow the ecosystem closely enough to understand it, but apparently `docker compose` is what most people are using to work around this.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A