### PR TITLE
fuzzing: add fuzzers for multiple packages

### DIFF
--- a/pkg/cosign/attestation/fuzz_test.go
+++ b/pkg/cosign/attestation/fuzz_test.go
@@ -1,0 +1,56 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attestation
+
+import (
+	"bytes"
+	"testing"
+)
+
+func FuzzGenerateStatement(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, predicate []byte, digest, repo string, stmttType int) {
+		var statementType string
+		switch stmttType % 9 {
+		case 0:
+			statementType = "slsaprovenance"
+		case 1:
+			statementType = "slsaprovenance02"
+		case 2:
+			statementType = "slsaprovenance1"
+		case 3:
+			statementType = "spdx"
+		case 4:
+			statementType = "spdxjson"
+		case 5:
+			statementType = "cyclonedx"
+		case 6:
+			statementType = "link"
+		case 7:
+			statementType = "vuln"
+		case 8:
+			statementType = "openvex"
+		default:
+			statementType = ""
+		}
+		opts := GenerateOpts{
+			Predicate: bytes.NewReader(predicate),
+			Type:      statementType,
+			Digest:    digest,
+			Repo:      repo,
+		}
+		GenerateStatement(opts)
+	})
+}

--- a/pkg/cosign/cue/fuzz_test.go
+++ b/pkg/cosign/cue/fuzz_test.go
@@ -1,0 +1,26 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cue
+
+import (
+	"testing"
+)
+
+func FuzzValidateJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, jsonBody []byte, entrypoint string) {
+		ValidateJSON(jsonBody, []string{entrypoint})
+	})
+}

--- a/pkg/cosign/fuzz_test.go
+++ b/pkg/cosign/fuzz_test.go
@@ -1,0 +1,123 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
+)
+
+var (
+	defaultFuzzRef = "fuzz/test"
+)
+
+func fuzzPass(s string) PassFunc {
+	return func(_ bool) ([]byte, error) {
+		return []byte(s), nil
+	}
+}
+
+func FuzzImportKeyPairLoadPrivateKey(f *testing.F) {
+	f.Add([]byte(validrsa), []byte("password"))
+	f.Add([]byte(validrsapkcs1), []byte("password"))
+	f.Add([]byte(validrsapkcs8), []byte("password"))
+	f.Add([]byte(validecp256), []byte("password"))
+	f.Add([]byte(validecp384), []byte("password"))
+	f.Add([]byte(validecp521), []byte("password"))
+	f.Add([]byte(validecpkcs8), []byte("password"))
+	f.Add([]byte(ed25519key), []byte("password"))
+	f.Add([]byte(pemcosignkey), []byte("password"))
+	f.Add([]byte(pemcosigneckey), []byte("password"))
+	f.Add([]byte(pemsigstorekey), []byte("password"))
+	f.Fuzz(func(t *testing.T, pemData, password []byte) {
+		path := t.TempDir()
+		keyFilePath := filepath.Join(path, "fuzzKey")
+		err := os.WriteFile(keyFilePath, pemData, 0x755)
+		if err != nil {
+			return
+		}
+		keyBytes, err := ImportKeyPair(keyFilePath, fuzzPass(string(password)))
+		if err != nil {
+			return
+		}
+		// Loading the private key should also work.
+		_, err = LoadPrivateKey(keyBytes.PrivateBytes, password)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func FuzzSigVerify(f *testing.F) {
+	f.Fuzz(func(t *testing.T, sigData, payloadData []byte, verificationTest int) {
+		path := t.TempDir()
+		sigPath := filepath.Join(path, "sigFile")
+		err := os.WriteFile(sigPath, sigData, 0x755)
+		if err != nil {
+			return
+		}
+		payloadPath := filepath.Join(path, "payloadFile")
+		err = os.WriteFile(payloadPath, payloadData, 0x755)
+		if err != nil {
+			return
+		}
+		ref, err := name.ParseReference(defaultFuzzRef)
+		if err != nil {
+			panic(err)
+		}
+		sigs, err := loadSignatureFromFile(context.Background(), sigPath, ref, &CheckOpts{PayloadRef: payloadPath})
+		if err != nil {
+			return
+		}
+		switch verificationTest % 5 {
+		case 0:
+			VerifyImageAttestation(context.Background(), sigs, v1.Hash{}, &CheckOpts{IgnoreTlog: true})
+		case 1:
+			verifySignatures(context.Background(), sigs, v1.Hash{}, &CheckOpts{IgnoreTlog: true})
+		case 2:
+			sl, err := sigs.Get()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, sig := range sl {
+				VerifyBlobSignature(context.Background(), sig, &CheckOpts{IgnoreTlog: true})
+			}
+		case 3:
+			sl, err := sigs.Get()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, sig := range sl {
+				VerifyImageSignature(context.Background(), sig, v1.Hash{}, &CheckOpts{IgnoreTlog: true})
+			}
+		case 4:
+			sl, err := sigs.Get()
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, sig := range sl {
+				mutate.Signature(sig)
+			}
+		}
+	})
+}

--- a/pkg/cosign/rego/fuzz_test.go
+++ b/pkg/cosign/rego/fuzz_test.go
@@ -1,0 +1,26 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rego
+
+import (
+	"testing"
+)
+
+func FuzzValidateJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, jsonBody []byte, entrypoint string) {
+		ValidateJSON(jsonBody, []string{entrypoint})
+	})
+}

--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -1,0 +1,30 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policy
+
+import (
+	"context"
+	"testing"
+)
+
+var policyTypes = []string{"cue", "rego"}
+
+func FuzzEvaluatePolicyAgainstJSON(f *testing.F) {
+	f.Fuzz(func(_ *testing.T, name, policyBody string, jsonBytes []byte, policyType uint8) {
+		choosePolicyType := policyTypes[int(policyType)%len(policyTypes)]
+		EvaluatePolicyAgainstJSON(context.Background(), name, choosePolicyType, policyBody, jsonBytes)
+	})
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Adds fuzz tests for different packages:

- `FuzzEvaluatePolicyAgainstJSON`: Tests rego and cue policy evaluation.
- `FuzzGenerateStatement`: Tests `GenerateStatement` with random predicate, repo and digest string
- `FuzzValidateJSON`: Tests `ValidateJSON` of the cue and rego packages.
- `FuzzImportKeyPairLoadPrivateKey`: Tests `ImportKeyPair` and `LoadPrivateKey`
- `FuzzSigVerify`: Tests different verification APIs.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
