### PR TITLE
Allow signing local image without registry access

### DIFF
--- a/test/helpers.go
+++ b/test/helpers.go
@@ -254,6 +254,22 @@ var verifyOffline = func(keyRef, imageRef string, checkClaims bool, annotations 
 	return cmd.Exec(context.Background(), args)
 }
 
+var verifyImageLocally = func(keyRef, imageRef, sigFile, certFile string, skipTlogVerify bool) error {
+	cmd := cliverify.VerifyCommand{
+		KeyRef:       keyRef,
+		MaxWorkers:   10,
+		IgnoreTlog:   skipTlogVerify,
+		SignatureRef: sigFile,
+		CertVerifyOptions: options.CertVerifyOptions{
+			Cert: certFile,
+		},
+	}
+
+	args := []string{imageRef}
+
+	return cmd.Exec(context.Background(), args)
+}
+
 var ro = &options.RootOptions{Timeout: options.DefaultTimeout}
 
 func keypair(t *testing.T, td string) (*cosign.KeysBytes, string, string) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR attempts to address https://github.com/sigstore/cosign/issues/3832 - it will allow generating local signature for an image (when `--upload=false`) by using `--output-signature`/`--output-artifact`/`--output-payload` even when the remote registry is not accessible or the image hasn't yet been pushed there. Details are in the linked issue.

I only implemented this for the case the image is passed in by digest right now - it's easier to do and the code says we're going to eventually disable referencing images by tag, so I don't think it's strictly necessary there (but let me know if you think otherwise).

Verification of such signature requires the `--insecure-tlog-verify` (a.k.a.  `--private-infrastructure`) flag, which seems a little weird to me, but I think that's not something that I introduced by this PR. After some investigation, I think this is caused by the fact that the locally written files don't seem to represent a full bundle (like the one that can be generated with signing a blob or the one that gets pushed as an OCI artifact with `--upload=true`) and hence the locally created `fakeOCISignatures` object can't be used correctly in the `VerifyBundle` function in `pkg/cosign/verify.go`. I think maybe a better way to solve all of this would be to rather allow writing out full bundles for images, like we allow for `sign-blob`?

#### Release Note

* Enabled signing local images without access to registry

#### Documentation

I think the release note should be fine, but please correct me if I'm wrong.
