### PR TITLE
Support trusted root in cosign verification

### DIFF
--- a/cmd/cosign/cli/verify/verify_bundle.go
+++ b/cmd/cosign/cli/verify/verify_bundle.go
@@ -18,14 +18,28 @@ package verify
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"fmt"
 	"time"
 
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	protodsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor/pkg/generated/client"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/tle"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/fulcio/certificate"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/verify"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
 
+	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/cosign/pivkey"
 	sigs "github.com/sigstore/cosign/v2/pkg/signature"
 )
@@ -36,27 +50,26 @@ type verifyTrustedMaterial struct {
 }
 
 func (v *verifyTrustedMaterial) PublicKeyVerifier(hint string) (root.TimeConstrainedVerifier, error) {
+	if v.keyTrustedMaterial == nil {
+		return nil, fmt.Errorf("no key in trusted material to verify with")
+	}
 	return v.keyTrustedMaterial.PublicKeyVerifier(hint)
 }
 
-func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, slot, certOIDCIssuer, certOIDCIssuerRegex, certIdentity, certIdentityRegexp, githubWorkflowTrigger, githubWorkflowSHA, githubWorkflowName, githubWorkflowRepository, githubWorkflowRef, artifactRef string, sk, ignoreTlog, useSignedTimestamps, ignoreSCT bool) error {
-	bundle, err := sgbundle.LoadJSONFromPath(bundlePath)
-	if err != nil {
-		return err
-	}
-
+func verifyNewBundle(ctx context.Context, bundle *sgbundle.Bundle, trustedRootPath, keyRef, slot, certOIDCIssuer, certOIDCIssuerRegex, certIdentity, certIdentityRegexp, githubWorkflowTrigger, githubWorkflowSHA, githubWorkflowName, githubWorkflowRepository, githubWorkflowRef, artifactRef string, sk, ignoreTlog, useSignedTimestamps, ignoreSCT bool) (*verify.VerificationResult, error) {
 	var trustedroot *root.TrustedRoot
+	var err error
 
 	if trustedRootPath == "" {
 		// Assume we're using public good instance; fetch via TUF
 		trustedroot, err = root.FetchTrustedRoot()
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
 		trustedroot, err = root.NewTrustedRootFromPath(trustedRootPath)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -66,7 +79,7 @@ func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, s
 	if keyRef != "" {
 		signatureVerifier, err := sigs.PublicKeyFromKeyRef(ctx, keyRef)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		newExpiringKey := root.NewExpiringKey(signatureVerifier, time.Time{}, time.Time{})
@@ -76,12 +89,12 @@ func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, s
 	} else if sk {
 		s, err := pivkey.GetKeyWithSlot(slot)
 		if err != nil {
-			return fmt.Errorf("opening piv token: %w", err)
+			return nil, fmt.Errorf("opening piv token: %w", err)
 		}
 		defer s.Close()
 		signatureVerifier, err := s.Verifier()
 		if err != nil {
-			return fmt.Errorf("loading public key from token: %w", err)
+			return nil, fmt.Errorf("loading public key from token: %w", err)
 		}
 
 		newExpiringKey := root.NewExpiringKey(signatureVerifier, time.Time{}, time.Time{})
@@ -95,7 +108,7 @@ func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, s
 	verificationMaterial := bundle.GetVerificationMaterial()
 
 	if verificationMaterial == nil {
-		return fmt.Errorf("no verification material in bundle")
+		return nil, fmt.Errorf("no verification material in bundle")
 	}
 
 	if verificationMaterial.GetPublicKey() != nil {
@@ -103,12 +116,12 @@ func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, s
 	} else {
 		sanMatcher, err := verify.NewSANMatcher(certIdentity, certIdentityRegexp)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		issuerMatcher, err := verify.NewIssuerMatcher(certOIDCIssuer, certOIDCIssuerRegex)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		extensions := certificate.Extensions{
@@ -121,7 +134,7 @@ func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, s
 
 		certIdentity, err := verify.NewCertificateIdentity(sanMatcher, issuerMatcher, extensions)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		identityPolicies = append(identityPolicies, verify.WithCertificateIdentity(certIdentity))
@@ -149,15 +162,156 @@ func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, s
 	// Perform verification
 	payload, err := payloadBytes(artifactRef)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	buf := bytes.NewBuffer(payload)
 
 	sev, err := verify.NewSignedEntityVerifier(trustedmaterial, verifierConfig...)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = sev.Verify(bundle, verify.NewPolicy(verify.WithArtifact(buf), identityPolicies...))
-	return err
+	return sev.Verify(bundle, verify.NewPolicy(verify.WithArtifact(buf), identityPolicies...))
+}
+
+func assembleNewBundle(ctx context.Context, sigBytes, signedTimestamp []byte, envelope *dsse.Envelope, artifactRef string, cert *x509.Certificate, ignoreTlog bool, sigVerifier signature.Verifier, pkOpts []signature.PublicKeyOption, rekorClient *client.Rekor) (*sgbundle.Bundle, error) {
+	payload, err := payloadBytes(artifactRef)
+	if err != nil {
+		return nil, err
+	}
+	buf := bytes.NewBuffer(payload)
+	digest := sha256.Sum256(buf.Bytes())
+
+	pb := &protobundle.Bundle{
+		MediaType:            "application/vnd.dev.sigstore.bundle+json;version=0.3",
+		VerificationMaterial: &protobundle.VerificationMaterial{},
+	}
+
+	if envelope != nil && len(envelope.Signatures) > 0 {
+		sigDecode, err := base64.StdEncoding.DecodeString(envelope.Signatures[0].Sig)
+		if err != nil {
+			return nil, err
+		}
+
+		sig := &protodsse.Signature{
+			Sig: sigDecode,
+		}
+
+		payloadDecode, err := base64.StdEncoding.DecodeString(envelope.Payload)
+		if err != nil {
+			return nil, err
+		}
+
+		pb.Content = &protobundle.Bundle_DsseEnvelope{
+			DsseEnvelope: &protodsse.Envelope{
+				Payload:     payloadDecode,
+				PayloadType: envelope.PayloadType,
+				Signatures:  []*protodsse.Signature{sig},
+			},
+		}
+	} else {
+		pb.Content = &protobundle.Bundle_MessageSignature{
+			MessageSignature: &protocommon.MessageSignature{
+				MessageDigest: &protocommon.HashOutput{
+					Algorithm: protocommon.HashAlgorithm_SHA2_256,
+					Digest:    digest[:],
+				},
+				Signature: sigBytes,
+			},
+		}
+	}
+
+	if cert != nil {
+		pb.VerificationMaterial.Content = &protobundle.VerificationMaterial_Certificate{
+			Certificate: &protocommon.X509Certificate{
+				RawBytes: cert.Raw,
+			},
+		}
+	} else if sigVerifier != nil {
+		pub, err := sigVerifier.PublicKey(pkOpts...)
+		if err != nil {
+			return nil, err
+		}
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(pub)
+		if err != nil {
+			return nil, err
+		}
+		hashedBytes := sha256.Sum256(pubKeyBytes)
+
+		pb.VerificationMaterial.Content = &protobundle.VerificationMaterial_PublicKey{
+			PublicKey: &protocommon.PublicKeyIdentifier{
+				Hint: base64.StdEncoding.EncodeToString(hashedBytes[:]),
+			},
+		}
+	}
+
+	if len(signedTimestamp) > 0 {
+		ts := &protocommon.RFC3161SignedTimestamp{
+			SignedTimestamp: signedTimestamp,
+		}
+
+		pb.VerificationMaterial.TimestampVerificationData = &protobundle.TimestampVerificationData{
+			Rfc3161Timestamps: []*protocommon.RFC3161SignedTimestamp{ts},
+		}
+	}
+
+	if !ignoreTlog {
+		var pem []byte
+		var err error
+		if cert != nil {
+			pem, err = cryptoutils.MarshalCertificateToPEM(cert)
+			if err != nil {
+				return nil, err
+			}
+		} else if sigVerifier != nil {
+			pub, err := sigVerifier.PublicKey(pkOpts...)
+			if err != nil {
+				return nil, err
+			}
+			pem, err = cryptoutils.MarshalPublicKeyToPEM(pub)
+			if err != nil {
+				return nil, err
+			}
+		}
+		var sigB64 string
+		var payload []byte
+		if envelope != nil {
+			payload = sigBytes
+		} else {
+			sigB64 = base64.StdEncoding.EncodeToString(sigBytes)
+			payload = buf.Bytes()
+		}
+
+		tlogEntries, err := cosign.FindTlogEntry(ctx, rekorClient, sigB64, payload, pem)
+		if err != nil {
+			return nil, err
+		}
+		if len(tlogEntries) == 0 {
+			return nil, fmt.Errorf("unable to find tlog entry")
+		}
+		// Attempt to verify with the earliest integrated entry
+		var earliestLogEntry models.LogEntryAnon
+		var earliestLogEntryTime *time.Time
+		for _, e := range tlogEntries {
+			entryTime := time.Unix(*e.IntegratedTime, 0)
+			if earliestLogEntryTime == nil || entryTime.Before(*earliestLogEntryTime) {
+				earliestLogEntryTime = &entryTime
+				earliestLogEntry = e
+			}
+		}
+
+		tlogEntry, err := tle.GenerateTransparencyLogEntry(earliestLogEntry)
+		if err != nil {
+			return nil, err
+		}
+
+		pb.VerificationMaterial.TlogEntries = []*protorekor.TransparencyLogEntry{tlogEntry}
+	}
+
+	b, err := sgbundle.NewBundle(pb)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
 }


### PR DESCRIPTION
Fixes #3700

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

We recently added partial trusted root support to cosign when you are verifying a protobuf bundle, but this did not cover the case where you are using an old bundle, or using disparate signed material on disk.

This implements trusted root support for those cases by assembling the materials into a protobuf bundle, thus fixing some TODOs from when we added protobuf bundle support.

Generally to test I would recommend signing something and then verifying it with a trusted root, like:
```
$ go run cmd/cosign/main.go sign-blob --identity-token='...' --output-certificate=detached.crt --output-signature=detached.sig ../sigstore-go/examples/sigstore-go-signing/hello_world.txt

$ go run cmd/cosign/main.go verify-blob --trusted-root=trusted_root.public.json --certificate=detached.crt --signature=detached.sig --certificate-oidc-issuer="https://token.actions.githubusercontent.com" --certificate-identity="https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" ../sigstore-go/examples/sigstore-go-signing/hello_world.txt
```

Or:
```
$ go run cmd/cosign/main.go attest-blob --identity-token='...' --bundle=old_bundle_attestation.json --type=something --predicate="../sigstore-go/examples/sigstore-go-signing/intoto.txt" ../sigstore-go/examples/sigstore-go-signing/hello_world.txt

$ go run cmd/cosign/main.go verify-blob-attestation --trusted-root=trusted_root.public.json --bundle=old_bundle_attestation.json --certificate-oidc-issuer="https://token.actions.githubusercontent.com" --certificate-identity="https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main" --type=something ../sigstore-go/examples/sigstore-go-signing/hello_world.txt
```

It's also a good idea to test with a timestamp authority, although you need to create a trusted root file that corresponds to your chosen timestamp authority. For example:

```
$ go run cmd/cosign/main.go attest-blob --key=cosign.key --tlog-upload=false --timestamp-server-url="https://timestamp.githubapp.com/api/v1/timestamp" --rfc3161-timestamp-bundle="attest.ts" --output-signature=attest.sig --tlog-upload=false --type=something --predicate="../sigstore-go/examples/sigstore-go-signing/intoto.txt" ../sigstore-go/examples/sigstore-go-signing/hello_world.txt

$ go run cmd/cosign/main.go verify-blob-attestation --trusted-root=trusted_root_with_timestamps.public.json --use-signed-timestamps=true --insecure-ignore-tlog=true --key=cosign.pub --rfc3161-timestamp="attest.ts" --signature=attest.sig --type=something ../sigstore-go/examples/sigstore-go-signing/hello_world.txt
```


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Added support for using a [protobuf trusted root](https://github.com/sigstore/protobuf-specs/blob/main/protos/sigstore_trustroot.proto) to verify signed material, either on disk or in a legacy cosign bundle format (i.e. not the protobuf bundle format).

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A?