### PR TITLE
update to use go1.22.7 and golangci-lint 

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -212,4 +212,4 @@ jobs:
 
     - name: Collect diagnostics
       if: ${{ failure() }}
-      uses: chainguard-dev/actions/kind-diag@84c993eaf02da1c325854fb272a4df9184bd80fc # main
+      uses: chainguard-dev/actions/kind-diag@9ba949ac63357c725a9438f3e05a1e33d313498e # main

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -39,7 +39,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.59
+          version: v1.60
           args: --timeout=5m
 
   golangci-test-e2e:
@@ -58,5 +58,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.59
+          version: v1.60
           args: --timeout=5m --build-tags e2e ./test

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -151,7 +151,7 @@ jobs:
 
     - name: Collect diagnostics
       if: ${{ failure() }}
-      uses: chainguard-dev/actions/kind-diag@84c993eaf02da1c325854fb272a4df9184bd80fc # main
+      uses: chainguard-dev/actions/kind-diag@9ba949ac63357c725a9438f3e05a1e33d313498e # main
 
     - name: Create vuln attestation for it
       run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Collect diagnostics
         if: ${{ failure() }}
-        uses: chainguard-dev/actions/kind-diag@84c993eaf02da1c325854fb272a4df9184bd80fc # main
+        uses: chainguard-dev/actions/kind-diag@9ba949ac63357c725a9438f3e05a1e33d313498e # main
 
   e2e-windows-powershell-tests:
     name: Run PowerShell E2E tests

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -31,9 +31,9 @@ jobs:
     steps:
       - name: Check Signature
         run: |
-          cosign verify ghcr.io/gythialy/golang-cross:v1.22.6-0@sha256:34ba9945085680b8966b78929e3520478ec9ea38a315fa13d8d5e0ce6355d0d2 \
+          cosign verify ghcr.io/gythialy/golang-cross:v1.22.7-0@sha256:cb23bfe5773191f1ccc9d60fb73392d5ffc87257e2e019ffe81edb8b352a5284 \
           --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.6-0"
+          --certificate-identity "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.7-0"
         env:
           TUF_ROOT: /tmp
 
@@ -43,7 +43,7 @@ jobs:
       - check-signature
 
     container:
-      image: ghcr.io/gythialy/golang-cross:v1.22.6-0@sha256:34ba9945085680b8966b78929e3520478ec9ea38a315fa13d8d5e0ce6355d0d2
+      image: ghcr.io/gythialy/golang-cross:v1.22.7-0@sha256:cb23bfe5773191f1ccc9d60fb73392d5ffc87257e2e019ffe81edb8b352a5284
       volumes:
         - /usr:/host_usr
         - /opt:/host_opt

--- a/cmd/cosign/cli/templates/help_flags_printer.go
+++ b/cmd/cosign/cli/templates/help_flags_printer.go
@@ -60,7 +60,7 @@ func (p *HelpFlagPrinter) PrintHelpFlag(flag *flag.Flag) {
 	}
 	appendTabStr := strings.ReplaceAll(wrappedStr, "\n", "\n\t")
 
-	fmt.Fprintf(p.out, appendTabStr+"\n\n")
+	fmt.Fprintf(p.out, "%s\n\n", appendTabStr)
 }
 
 // writeFlag will output the help flag based

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/cosign/v2
 
-go 1.22.6
+go 1.22.7
 
 require (
 	cuelang.org/go v0.9.2

--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -38,14 +38,14 @@ steps:
       - TUF_ROOT=/tmp
     args:
       - 'verify'
-      - 'ghcr.io/gythialy/golang-cross:v1.22.6-0@sha256:34ba9945085680b8966b78929e3520478ec9ea38a315fa13d8d5e0ce6355d0d2'
+      - 'ghcr.io/gythialy/golang-cross:v1.22.7-0@sha256:cb23bfe5773191f1ccc9d60fb73392d5ffc87257e2e019ffe81edb8b352a5284'
       - '--certificate-oidc-issuer'
       - "https://token.actions.githubusercontent.com"
       - '--certificate-identity'
-      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.6-0"
+      - "https://github.com/gythialy/golang-cross/.github/workflows/release-golang-cross.yml@refs/tags/v1.22.7-0"
 
   # maybe we can build our own image and use that to be more in a safe side
-  - name: ghcr.io/gythialy/golang-cross:v1.22.6-0@sha256:34ba9945085680b8966b78929e3520478ec9ea38a315fa13d8d5e0ce6355d0d2
+  - name: ghcr.io/gythialy/golang-cross:v1.22.7-0@sha256:cb23bfe5773191f1ccc9d60fb73392d5ffc87257e2e019ffe81edb8b352a5284
     entrypoint: /bin/sh
     dir: "go/src/sigstore/cosign"
     env:
@@ -68,7 +68,7 @@ steps:
         gcloud auth configure-docker \
         && make release
 
-  - name: ghcr.io/gythialy/golang-cross:v1.22.6-0@sha256:34ba9945085680b8966b78929e3520478ec9ea38a315fa13d8d5e0ce6355d0d2
+  - name: ghcr.io/gythialy/golang-cross:v1.22.7-0@sha256:cb23bfe5773191f1ccc9d60fb73392d5ffc87257e2e019ffe81edb8b352a5284
     entrypoint: 'bash'
     dir: "go/src/sigstore/cosign"
     env:


### PR DESCRIPTION
- update to use go1.22.7
- update golangci-lint to v1.60