### PR TITLE
Add trusted-root create helper command

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -120,6 +120,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(VerifyBlob())
 	cmd.AddCommand(VerifyBlobAttestation())
 	cmd.AddCommand(Triangulate())
+	cmd.AddCommand(TrustedRoot())
 	cmd.AddCommand(Env())
 	cmd.AddCommand(version.WithFont("starwars"))
 

--- a/cmd/cosign/cli/options/trustedroot.go
+++ b/cmd/cosign/cli/options/trustedroot.go
@@ -23,6 +23,7 @@ type TrustedRootCreateOptions struct {
 	CAIntermediates  string
 	CARoots          string
 	CertChain        string
+	IgnoreSCT        bool
 	Out              string
 	RekorURL         string
 	TSACertChainPath string
@@ -52,6 +53,10 @@ func (o *TrustedRootCreateOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.MarkFlagsMutuallyExclusive("ca-roots", "certificate-chain")
 	cmd.MarkFlagsMutuallyExclusive("ca-intermediates", "certificate-chain")
+
+	cmd.Flags().BoolVar(&o.IgnoreSCT, "ignore-sct", false,
+		"when set, do not include key for verifying certificate transparency "+
+			"log. Set this if you signed with a key instead of using Fulcio.")
 
 	cmd.Flags().StringVar(&o.Out, "out", "",
 		"path to output trusted root")

--- a/cmd/cosign/cli/options/trustedroot.go
+++ b/cmd/cosign/cli/options/trustedroot.go
@@ -23,8 +23,8 @@ type TrustedRootCreateOptions struct {
 	CAIntermediates  string
 	CARoots          string
 	CertChain        string
-	IgnoreSCT        bool
-	IgnoreTlog       bool
+	CtfeKeyPath      string
+	RekorKeyPath     string
 	Out              string
 	TSACertChainPath string
 }
@@ -54,13 +54,12 @@ func (o *TrustedRootCreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.MarkFlagsMutuallyExclusive("ca-roots", "certificate-chain")
 	cmd.MarkFlagsMutuallyExclusive("ca-intermediates", "certificate-chain")
 
-	cmd.Flags().BoolVar(&o.IgnoreSCT, "ignore-sct", false,
-		"when set, do not include key for verifying certificate transparency "+
-			"log. Set this if you signed with a key instead of using Fulcio.")
+	cmd.Flags().StringVar(&o.CtfeKeyPath, "ctfe-key", "",
+		"path to a PEM-encoded public key used by certificate authority for "+
+			"certificate transparency log.")
 
-	cmd.Flags().BoolVar(&o.IgnoreTlog, "ignore-tlog", false,
-		"when set, do not include key for verifying transparency. Set this if "+
-			"you did not sign with Rekor.")
+	cmd.Flags().StringVar(&o.RekorKeyPath, "rekor-key", "",
+		"path to a PEM-encoded public key used by transparency log like Rekor.")
 
 	cmd.Flags().StringVar(&o.Out, "out", "",
 		"path to output trusted root")

--- a/cmd/cosign/cli/options/trustedroot.go
+++ b/cmd/cosign/cli/options/trustedroot.go
@@ -24,8 +24,8 @@ type TrustedRootCreateOptions struct {
 	CARoots          string
 	CertChain        string
 	IgnoreSCT        bool
+	IgnoreTlog       bool
 	Out              string
-	RekorURL         string
 	TSACertChainPath string
 }
 
@@ -58,11 +58,12 @@ func (o *TrustedRootCreateOptions) AddFlags(cmd *cobra.Command) {
 		"when set, do not include key for verifying certificate transparency "+
 			"log. Set this if you signed with a key instead of using Fulcio.")
 
+	cmd.Flags().BoolVar(&o.IgnoreTlog, "ignore-tlog", false,
+		"when set, do not include key for verifying transparency. Set this if "+
+			"you did not sign with Rekor.")
+
 	cmd.Flags().StringVar(&o.Out, "out", "",
 		"path to output trusted root")
-
-	cmd.Flags().StringVar(&o.RekorURL, "rekor-url", "",
-		"address of rekor STL server")
 
 	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-certificate-chain", "",
 		"path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. "+

--- a/cmd/cosign/cli/options/trustedroot.go
+++ b/cmd/cosign/cli/options/trustedroot.go
@@ -1,0 +1,65 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type TrustedRootCreateOptions struct {
+	CAIntermediates  string
+	CARoots          string
+	CertChain        string
+	Out              string
+	RekorURL         string
+	TSACertChainPath string
+}
+
+var _ Interface = (*TrustedRootCreateOptions)(nil)
+
+func (o *TrustedRootCreateOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.CAIntermediates, "ca-intermediates", "",
+		"path to a file of intermediate CA certificates in PEM format which will be needed "+
+			"when building the certificate chains for the signing certificate. "+
+			"The flag is optional and must be used together with --ca-roots, conflicts with "+
+			"--certificate-chain.")
+	_ = cmd.Flags().SetAnnotation("ca-intermediates", cobra.BashCompFilenameExt, []string{"cert"})
+
+	cmd.Flags().StringVar(&o.CARoots, "ca-roots", "",
+		"path to a bundle file of CA certificates in PEM format which will be needed "+
+			"when building the certificate chains for the signing certificate. Conflicts with --certificate-chain.")
+	_ = cmd.Flags().SetAnnotation("ca-roots", cobra.BashCompFilenameExt, []string{"cert"})
+
+	cmd.Flags().StringVar(&o.CertChain, "certificate-chain", "",
+		"path to a list of CA certificates in PEM format which will be needed "+
+			"when building the certificate chain for the signing certificate. "+
+			"Must start with the parent intermediate CA certificate of the "+
+			"signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.")
+	_ = cmd.Flags().SetAnnotation("certificate-chain", cobra.BashCompFilenameExt, []string{"cert"})
+
+	cmd.MarkFlagsMutuallyExclusive("ca-roots", "certificate-chain")
+	cmd.MarkFlagsMutuallyExclusive("ca-intermediates", "certificate-chain")
+
+	cmd.Flags().StringVar(&o.Out, "out", "",
+		"path to output trusted root")
+
+	cmd.Flags().StringVar(&o.RekorURL, "rekor-url", "",
+		"address of rekor STL server")
+
+	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-certificate-chain", "",
+		"path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. "+
+			"Optionally may contain intermediate CA certificates")
+}

--- a/cmd/cosign/cli/options/trustedroot.go
+++ b/cmd/cosign/cli/options/trustedroot.go
@@ -36,7 +36,7 @@ func (o *TrustedRootCreateOptions) AddFlags(cmd *cobra.Command) {
 		"path to a list of CA certificates in PEM format which will be needed "+
 			"when building the certificate chain for the signing certificate. "+
 			"Must start with the parent intermediate CA certificate of the "+
-			"signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.")
+			"signing certificate and end with the root certificate.")
 	_ = cmd.Flags().SetAnnotation("certificate-chain", cobra.BashCompFilenameExt, []string{"cert"})
 
 	cmd.Flags().StringArrayVar(&o.CtfeKeyPath, "ctfe-key", nil,

--- a/cmd/cosign/cli/options/trustedroot.go
+++ b/cmd/cosign/cli/options/trustedroot.go
@@ -20,51 +20,43 @@ import (
 )
 
 type TrustedRootCreateOptions struct {
-	CAIntermediates  string
-	CARoots          string
-	CertChain        string
-	CtfeKeyPath      string
-	RekorKeyPath     string
+	CertChain        []string
+	CtfeKeyPath      []string
+	CtfeStartTime    []string
 	Out              string
-	TSACertChainPath string
+	RekorKeyPath     []string
+	RekorStartTime   []string
+	TSACertChainPath []string
 }
 
 var _ Interface = (*TrustedRootCreateOptions)(nil)
 
 func (o *TrustedRootCreateOptions) AddFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.CAIntermediates, "ca-intermediates", "",
-		"path to a file of intermediate CA certificates in PEM format which will be needed "+
-			"when building the certificate chains for the signing certificate. "+
-			"The flag is optional and must be used together with --ca-roots, conflicts with "+
-			"--certificate-chain.")
-	_ = cmd.Flags().SetAnnotation("ca-intermediates", cobra.BashCompFilenameExt, []string{"cert"})
-
-	cmd.Flags().StringVar(&o.CARoots, "ca-roots", "",
-		"path to a bundle file of CA certificates in PEM format which will be needed "+
-			"when building the certificate chains for the signing certificate. Conflicts with --certificate-chain.")
-	_ = cmd.Flags().SetAnnotation("ca-roots", cobra.BashCompFilenameExt, []string{"cert"})
-
-	cmd.Flags().StringVar(&o.CertChain, "certificate-chain", "",
+	cmd.Flags().StringArrayVar(&o.CertChain, "certificate-chain", nil,
 		"path to a list of CA certificates in PEM format which will be needed "+
 			"when building the certificate chain for the signing certificate. "+
 			"Must start with the parent intermediate CA certificate of the "+
 			"signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.")
 	_ = cmd.Flags().SetAnnotation("certificate-chain", cobra.BashCompFilenameExt, []string{"cert"})
 
-	cmd.MarkFlagsMutuallyExclusive("ca-roots", "certificate-chain")
-	cmd.MarkFlagsMutuallyExclusive("ca-intermediates", "certificate-chain")
-
-	cmd.Flags().StringVar(&o.CtfeKeyPath, "ctfe-key", "",
+	cmd.Flags().StringArrayVar(&o.CtfeKeyPath, "ctfe-key", nil,
 		"path to a PEM-encoded public key used by certificate authority for "+
 			"certificate transparency log.")
 
-	cmd.Flags().StringVar(&o.RekorKeyPath, "rekor-key", "",
+	cmd.Flags().StringArrayVar(&o.CtfeStartTime, "ctfe-start-time", nil,
+		"RFC 3339 string describing validity start time for key use by "+
+			"certificate transparency log.")
+
+	cmd.Flags().StringVar(&o.Out, "out", "", "path to output trusted root")
+
+	cmd.Flags().StringArrayVar(&o.RekorKeyPath, "rekor-key", nil,
 		"path to a PEM-encoded public key used by transparency log like Rekor.")
 
-	cmd.Flags().StringVar(&o.Out, "out", "",
-		"path to output trusted root")
+	cmd.Flags().StringArrayVar(&o.RekorStartTime, "rekor-start-time", nil,
+		"RFC 3339 string describing validity start time for key use by "+
+			"transparency log like Rekor.")
 
-	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-certificate-chain", "",
+	cmd.Flags().StringArrayVar(&o.TSACertChainPath, "timestamp-certificate-chain", nil,
 		"path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. "+
 			"Optionally may contain intermediate CA certificates")
 }

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -43,8 +43,8 @@ func trustedRootCreate() *cobra.Command {
 		Use:   "create",
 		Short: "Create a Sigstore protobuf trusted root",
 		Long:  "Create a Sigstore protobuf trusted root by supplying verification material",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			trCreateCmd := &trustedroot.TrustedRootCreateCmd{
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			trCreateCmd := &trustedroot.CreateCmd{
 				CAIntermediates:  o.CAIntermediates,
 				CARoots:          o.CARoots,
 				CertChain:        o.CertChain,

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -48,9 +48,9 @@ func trustedRootCreate() *cobra.Command {
 				CAIntermediates:  o.CAIntermediates,
 				CARoots:          o.CARoots,
 				CertChain:        o.CertChain,
-				IgnoreSCT:        o.IgnoreSCT,
-				IgnoreTlog:       o.IgnoreTlog,
+				CtfeKeyPath:      o.CtfeKeyPath,
 				Out:              o.Out,
+				RekorKeyPath:     o.RekorKeyPath,
 				TSACertChainPath: o.TSACertChainPath,
 			}
 

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -49,8 +49,8 @@ func trustedRootCreate() *cobra.Command {
 				CARoots:          o.CARoots,
 				CertChain:        o.CertChain,
 				IgnoreSCT:        o.IgnoreSCT,
+				IgnoreTlog:       o.IgnoreTlog,
 				Out:              o.Out,
-				RekorURL:         o.RekorURL,
 				TSACertChainPath: o.TSACertChainPath,
 			}
 

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -48,6 +48,7 @@ func trustedRootCreate() *cobra.Command {
 				CAIntermediates:  o.CAIntermediates,
 				CARoots:          o.CARoots,
 				CertChain:        o.CertChain,
+				IgnoreSCT:        o.IgnoreSCT,
 				Out:              o.Out,
 				RekorURL:         o.RekorURL,
 				TSACertChainPath: o.TSACertChainPath,

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -1,0 +1,65 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/trustedroot"
+)
+
+func TrustedRoot() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "trusted-root",
+		Short: "Interact with a Sigstore protobuf trusted root",
+		Long:  "Tools for interacting with a Sigstore protobuf trusted root",
+	}
+
+	cmd.AddCommand(trustedRootCreate())
+
+	return cmd
+}
+
+func trustedRootCreate() *cobra.Command {
+	o := &options.TrustedRootCreateOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a Sigstore protobuf trusted root",
+		Long:  "Create a Sigstore protobuf trusted root by supplying verification material",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			trCreateCmd := &trustedroot.TrustedRootCreateCmd{
+				CAIntermediates:  o.CAIntermediates,
+				CARoots:          o.CARoots,
+				CertChain:        o.CertChain,
+				Out:              o.Out,
+				RekorURL:         o.RekorURL,
+				TSACertChainPath: o.TSACertChainPath,
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
+			defer cancel()
+
+			return trCreateCmd.Exec(ctx)
+		},
+	}
+
+	o.AddFlags(cmd)
+	return cmd
+}

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -45,12 +45,12 @@ func trustedRootCreate() *cobra.Command {
 		Long:  "Create a Sigstore protobuf trusted root by supplying verification material",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			trCreateCmd := &trustedroot.CreateCmd{
-				CAIntermediates:  o.CAIntermediates,
-				CARoots:          o.CARoots,
 				CertChain:        o.CertChain,
 				CtfeKeyPath:      o.CtfeKeyPath,
+				CtfeStartTime:    o.CtfeStartTime,
 				Out:              o.Out,
 				RekorKeyPath:     o.RekorKeyPath,
+				RekorStartTime:   o.RekorStartTime,
 				TSACertChainPath: o.TSACertChainPath,
 			}
 

--- a/cmd/cosign/cli/trustedroot/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot.go
@@ -25,10 +25,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
-
-	"github.com/sigstore/cosign/v2/pkg/cosign"
 )
 
 type CreateCmd struct {

--- a/cmd/cosign/cli/trustedroot/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot.go
@@ -32,7 +32,7 @@ import (
 	"github.com/sigstore/cosign/v2/internal/ui"
 )
 
-type TrustedRootCreateCmd struct {
+type CreateCmd struct {
 	CAIntermediates  string
 	CARoots          string
 	CertChain        string
@@ -41,7 +41,7 @@ type TrustedRootCreateCmd struct {
 	TSACertChainPath string
 }
 
-func (c *TrustedRootCreateCmd) Exec(ctx context.Context) error {
+func (c *CreateCmd) Exec(ctx context.Context) error {
 	var fulcioCertAuthorities []root.CertificateAuthority
 	var timestampAuthorities []root.CertificateAuthority
 	rekorTransparencyLogs := make(map[string]*root.TransparencyLog)
@@ -52,7 +52,6 @@ func (c *TrustedRootCreateCmd) Exec(ctx context.Context) error {
 			return err
 		}
 		fulcioCertAuthorities = append(fulcioCertAuthorities, *fulcioAuthority)
-
 	} else if c.CARoots != "" {
 		roots, err := parseCerts(c.CARoots)
 		if err != nil {
@@ -108,10 +107,10 @@ func (c *TrustedRootCreateCmd) Exec(ctx context.Context) error {
 
 		rekorTransparencyLog := root.TransparencyLog{
 			BaseURL:           c.RekorURL,
-			HashFunc:          crypto.Hash(crypto.SHA256),
+			HashFunc:          crypto.SHA256,
 			ID:                keyHash[:],
 			PublicKey:         pub,
-			SignatureHashFunc: crypto.Hash(crypto.SHA256),
+			SignatureHashFunc: crypto.SHA256,
 		}
 
 		rekorTransparencyLogs[keyID] = &rekorTransparencyLog
@@ -140,7 +139,7 @@ func (c *TrustedRootCreateCmd) Exec(ctx context.Context) error {
 	}
 
 	if c.Out != "" {
-		err = os.WriteFile(c.Out, trBytes, 0640)
+		err = os.WriteFile(c.Out, trBytes, 0600)
 		if err != nil {
 			return err
 		}
@@ -187,7 +186,7 @@ func parseCerts(path string) ([]*x509.Certificate, error) {
 	}
 
 	if len(certs) == 0 {
-		return nil, fmt.Errorf("No certificates in file %s", path)
+		return nil, fmt.Errorf("no certificates in file %s", path)
 	}
 
 	return certs, nil

--- a/cmd/cosign/cli/trustedroot/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot.go
@@ -29,7 +29,6 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/root"
 
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/rekor"
-	"github.com/sigstore/cosign/v2/internal/ui"
 )
 
 type CreateCmd struct {
@@ -41,7 +40,7 @@ type CreateCmd struct {
 	TSACertChainPath string
 }
 
-func (c *CreateCmd) Exec(ctx context.Context) error {
+func (c *CreateCmd) Exec(_ context.Context) error {
 	var fulcioCertAuthorities []root.CertificateAuthority
 	var timestampAuthorities []root.CertificateAuthority
 	rekorTransparencyLogs := make(map[string]*root.TransparencyLog)
@@ -144,7 +143,7 @@ func (c *CreateCmd) Exec(ctx context.Context) error {
 			return err
 		}
 	} else {
-		ui.Infof(ctx, string(trBytes))
+		fmt.Println(string(trBytes))
 	}
 
 	return nil

--- a/cmd/cosign/cli/trustedroot/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot.go
@@ -1,0 +1,194 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustedroot
+
+import (
+	"context"
+	"crypto"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
+
+	"github.com/sigstore/cosign/v2/cmd/cosign/cli/rekor"
+	"github.com/sigstore/cosign/v2/internal/ui"
+)
+
+type TrustedRootCreateCmd struct {
+	CAIntermediates  string
+	CARoots          string
+	CertChain        string
+	Out              string
+	RekorURL         string
+	TSACertChainPath string
+}
+
+func (c *TrustedRootCreateCmd) Exec(ctx context.Context) error {
+	var fulcioCertAuthorities []root.CertificateAuthority
+	var timestampAuthorities []root.CertificateAuthority
+	rekorTransparencyLogs := make(map[string]*root.TransparencyLog)
+
+	if c.CertChain != "" {
+		fulcioAuthority, err := parsePEMFile(c.CertChain)
+		if err != nil {
+			return err
+		}
+		fulcioCertAuthorities = append(fulcioCertAuthorities, *fulcioAuthority)
+
+	} else if c.CARoots != "" {
+		roots, err := parseCerts(c.CARoots)
+		if err != nil {
+			return err
+		}
+
+		var intermediates []*x509.Certificate
+		if c.CAIntermediates != "" {
+			intermediates, err = parseCerts(c.CAIntermediates)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Here we're trying to "flatten" the x509.CertPool cosign was using
+		// into a trusted root with a clear mapping between roots and
+		// intermediates. Make a guess that if there are intermediates, there
+		// is one per root.
+
+		for i, rootCert := range roots {
+			var fulcioAuthority root.CertificateAuthority
+			fulcioAuthority.Root = rootCert
+			if i < len(intermediates) {
+				fulcioAuthority.Intermediates = []*x509.Certificate{intermediates[i]}
+			}
+			fulcioCertAuthorities = append(fulcioCertAuthorities, fulcioAuthority)
+		}
+	}
+
+	if c.RekorURL != "" {
+		rekorClient, err := rekor.NewClient(c.RekorURL)
+		if err != nil {
+			return fmt.Errorf("creating Rekor client: %w", err)
+		}
+
+		rekorPubKey, err := rekorClient.Pubkey.GetPublicKey(nil)
+		if err != nil {
+			return err
+		}
+
+		block, _ := pem.Decode([]byte(rekorPubKey.Payload))
+		if block == nil {
+			return errors.New("failed to decode public key of server")
+		}
+
+		pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return err
+		}
+
+		keyHash := sha256.Sum256(block.Bytes)
+		keyID := base64.StdEncoding.EncodeToString(keyHash[:])
+
+		rekorTransparencyLog := root.TransparencyLog{
+			BaseURL:           c.RekorURL,
+			HashFunc:          crypto.Hash(crypto.SHA256),
+			ID:                keyHash[:],
+			PublicKey:         pub,
+			SignatureHashFunc: crypto.Hash(crypto.SHA256),
+		}
+
+		rekorTransparencyLogs[keyID] = &rekorTransparencyLog
+	}
+
+	if c.TSACertChainPath != "" {
+		timestampAuthority, err := parsePEMFile(c.TSACertChainPath)
+		if err != nil {
+			return err
+		}
+		timestampAuthorities = append(timestampAuthorities, *timestampAuthority)
+	}
+
+	newTrustedRoot, err := root.NewTrustedRoot(root.TrustedRootMediaType01,
+		fulcioCertAuthorities, nil, timestampAuthorities, rekorTransparencyLogs,
+	)
+	if err != nil {
+		return err
+	}
+
+	var trBytes []byte
+
+	trBytes, err = newTrustedRoot.MarshalJSON()
+	if err != nil {
+		return err
+	}
+
+	if c.Out != "" {
+		err = os.WriteFile(c.Out, trBytes, 0640)
+		if err != nil {
+			return err
+		}
+	} else {
+		ui.Infof(ctx, string(trBytes))
+	}
+
+	return nil
+}
+
+func parsePEMFile(path string) (*root.CertificateAuthority, error) {
+	certs, err := parseCerts(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var ca root.CertificateAuthority
+	ca.Root = certs[len(certs)-1]
+	if len(certs) > 1 {
+		ca.Intermediates = certs[:len(certs)-1]
+	}
+
+	return &ca, nil
+}
+
+func parseCerts(path string) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for block, contents := pem.Decode(contents); ; block, contents = pem.Decode(contents) {
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		certs = append(certs, cert)
+
+		if len(contents) == 0 {
+			break
+		}
+	}
+
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("No certificates in file %s", path)
+	}
+
+	return certs, nil
+}

--- a/cmd/cosign/cli/trustedroot/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot.go
@@ -162,7 +162,7 @@ func parseCerts(path string) ([]*x509.Certificate, error) {
 		return nil, err
 	}
 
-	for block, contents := pem.Decode(contents); ; block, contents = pem.Decode(contents) {
+	for block, contents := pem.Decode(contents); block != nil; block, contents = pem.Decode(contents) {
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return nil, err

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -79,6 +79,8 @@ func makeChain(t *testing.T, path string, size int) {
 	fd, err := os.Create(path)
 	checkErr(t, err)
 
+	defer fd.Close()
+
 	chainCert := &x509.Certificate{
 		SerialNumber:          big.NewInt(1),
 		BasicConstraintsValid: true,

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -45,7 +45,6 @@ func TestCreateCmd(t *testing.T) {
 
 	trustedrootCreate := CreateCmd{
 		CertChain:        fulcioChainPath,
-		IgnoreSCT:        true,
 		Out:              outPath,
 		TSACertChainPath: tsaChainPath,
 	}

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -44,9 +44,9 @@ func TestCreateCmd(t *testing.T) {
 	outPath := filepath.Join(td, "trustedroot.json")
 
 	trustedrootCreate := CreateCmd{
-		CertChain:        fulcioChainPath,
+		CertChain:        []string{fulcioChainPath},
 		Out:              outPath,
-		TSACertChainPath: tsaChainPath,
+		TSACertChainPath: []string{tsaChainPath},
 	}
 
 	err := trustedrootCreate.Exec(ctx)

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -35,10 +35,10 @@ func TestCreateCmd(t *testing.T) {
 	// Make some certificate chains
 	td := t.TempDir()
 
-	fulcioChainPath := filepath.Join(td, "fulcio.crt")
+	fulcioChainPath := filepath.Join(td, "fulcio.pem")
 	makeChain(t, fulcioChainPath, 2)
 
-	tsaChainPath := filepath.Join(td, "timestamp.crt")
+	tsaChainPath := filepath.Join(td, "timestamp.pem")
 	makeChain(t, tsaChainPath, 3)
 
 	outPath := filepath.Join(td, "trustedroot.json")
@@ -73,6 +73,7 @@ func TestCreateCmd(t *testing.T) {
 	if len(timestampAuthorities[0].Intermediates) != 2 {
 		t.Fatal("unexpected number of timestamp intermediate certificates")
 	}
+
 }
 
 func makeChain(t *testing.T, path string, size int) {
@@ -119,6 +120,10 @@ func makeChain(t *testing.T, path string, size int) {
 		Bytes: rootDer,
 	}
 	err = pem.Encode(fd, block)
+	checkErr(t, err)
+
+	// Ensure we handle unexpected content at the end of the PEM file
+	_, err = fd.Write([]byte("asdf\n"))
 	checkErr(t, err)
 }
 

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -45,6 +45,7 @@ func TestCreateCmd(t *testing.T) {
 
 	trustedrootCreate := CreateCmd{
 		CertChain:        fulcioChainPath,
+		IgnoreSCT:        true,
 		Out:              outPath,
 		TSACertChainPath: tsaChainPath,
 	}

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -73,7 +73,6 @@ func TestCreateCmd(t *testing.T) {
 	if len(timestampAuthorities[0].Intermediates) != 2 {
 		t.Fatal("unexpected number of timestamp intermediate certificates")
 	}
-
 }
 
 func makeChain(t *testing.T, path string, size int) {

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -1,0 +1,127 @@
+//
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustedroot
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/sigstore/sigstore-go/pkg/root"
+)
+
+func TestTrustedRootCreate(t *testing.T) {
+	ctx := context.Background()
+
+	// Make some certificate chains
+	td := t.TempDir()
+
+	fulcioChainPath := filepath.Join(td, "fulcio.crt")
+	makeChain(t, fulcioChainPath, 2)
+
+	tsaChainPath := filepath.Join(td, "timestamp.crt")
+	makeChain(t, tsaChainPath, 3)
+
+	outPath := filepath.Join(td, "trustedroot.json")
+
+	trustedrootCreate := TrustedRootCreateCmd{
+		CertChain:        fulcioChainPath,
+		Out:              outPath,
+		TSACertChainPath: tsaChainPath,
+	}
+
+	err := trustedrootCreate.Exec(ctx)
+	checkErr(t, err)
+
+	tr, err := root.NewTrustedRootFromPath(outPath)
+	checkErr(t, err)
+
+	fulcioCAs := tr.FulcioCertificateAuthorities()
+
+	if len(fulcioCAs) != 1 {
+		t.Fatal("unexpected number of fulcio certificate authorities")
+	}
+
+	if len(fulcioCAs[0].Intermediates) != 1 {
+		t.Fatal("unexpected number of fulcio intermediate certificates")
+	}
+
+	timestampAuthorities := tr.TimestampingAuthorities()
+	if len(timestampAuthorities) != 1 {
+		t.Fatal("unexpected number of timestamp authorities")
+	}
+
+	if len(timestampAuthorities[0].Intermediates) != 2 {
+		t.Fatal("unexpected number of timestamp intermediate certificates")
+	}
+}
+
+func makeChain(t *testing.T, path string, size int) {
+	fd, err := os.Create(path)
+	checkErr(t, err)
+
+	chainCert := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	chainKey, err := rsa.GenerateKey(rand.Reader, 512) //nolint:gosec
+	checkErr(t, err)
+	rootDer, err := x509.CreateCertificate(rand.Reader, chainCert, chainCert, &chainKey.PublicKey, chainKey)
+	checkErr(t, err)
+
+	for i := 1; i < size; i++ {
+		intermediateCert := &x509.Certificate{
+			SerialNumber:          big.NewInt(1 + int64(i)),
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+		intermediateKey, err := rsa.GenerateKey(rand.Reader, 512) //nolint:gosec
+		checkErr(t, err)
+		intermediateDer, err := x509.CreateCertificate(rand.Reader, intermediateCert, chainCert, &intermediateKey.PublicKey, chainKey)
+		checkErr(t, err)
+
+		block := &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: intermediateDer,
+		}
+		err = pem.Encode(fd, block)
+		checkErr(t, err)
+
+		chainCert = intermediateCert
+		chainKey = intermediateKey
+	}
+
+	// Write out root last
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: rootDer,
+	}
+	err = pem.Encode(fd, block)
+	checkErr(t, err)
+}
+
+func checkErr(t *testing.T, err error) {
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
-func TestTrustedRootCreate(t *testing.T) {
+func TestCreateCmd(t *testing.T) {
 	ctx := context.Background()
 
 	// Make some certificate chains
@@ -43,7 +43,7 @@ func TestTrustedRootCreate(t *testing.T) {
 
 	outPath := filepath.Join(td, "trustedroot.json")
 
-	trustedrootCreate := TrustedRootCreateCmd{
+	trustedrootCreate := CreateCmd{
 		CertChain:        fulcioChainPath,
 		Out:              outPath,
 		TSACertChainPath: tsaChainPath,

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -37,6 +37,7 @@ A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign sign-blob](cosign_sign-blob.md)	 - Sign the supplied blob, outputting the base64-encoded signature to stdout.
 * [cosign tree](cosign_tree.md)	 - Display supply chain security related artifacts for an image such as signatures, SBOMs and attestations
 * [cosign triangulate](cosign_triangulate.md)	 - Outputs the located cosign image reference. This is the location where cosign stores the specified artifact type.
+* [cosign trusted-root](cosign_trusted-root.md)	 - Interact with a Sigstore protobuf trusted root
 * [cosign upload](cosign_upload.md)	 - Provides utilities for uploading artifacts to a registry
 * [cosign verify](cosign_verify.md)	 - Verify a signature on the supplied container image
 * [cosign verify-attestation](cosign_verify-attestation.md)	 - Verify an attestation on the supplied container image

--- a/doc/cosign_trusted-root.md
+++ b/doc/cosign_trusted-root.md
@@ -1,0 +1,27 @@
+## cosign trusted-root
+
+Interact with a Sigstore protobuf trusted root
+
+### Synopsis
+
+Tools for interacting with a Sigstore protobuf trusted root
+
+### Options
+
+```
+  -h, --help   help for trusted-root
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
+* [cosign trusted-root create](cosign_trusted-root_create.md)	 - Create a Sigstore protobuf trusted root
+

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -17,6 +17,7 @@ cosign trusted-root create [flags]
       --ca-roots string                      path to a bundle file of CA certificates in PEM format which will be needed when building the certificate chains for the signing certificate. Conflicts with --certificate-chain.
       --certificate-chain string             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.
   -h, --help                                 help for create
+      --ignore-sct                           when set, do not include key for verifying certificate transparency log. Set this if you signed with a key instead of using Fulcio.
       --out string                           path to output trusted root
       --rekor-url string                     address of rekor STL server
       --timestamp-certificate-chain string   path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -13,7 +13,7 @@ cosign trusted-root create [flags]
 ### Options
 
 ```
-      --certificate-chain stringArray             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.
+      --certificate-chain stringArray             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate.
       --ctfe-key stringArray                      path to a PEM-encoded public key used by certificate authority for certificate transparency log.
       --ctfe-start-time stringArray               RFC 3339 string describing validity start time for key use by certificate transparency log.
   -h, --help                                      help for create

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -16,10 +16,10 @@ cosign trusted-root create [flags]
       --ca-intermediates string              path to a file of intermediate CA certificates in PEM format which will be needed when building the certificate chains for the signing certificate. The flag is optional and must be used together with --ca-roots, conflicts with --certificate-chain.
       --ca-roots string                      path to a bundle file of CA certificates in PEM format which will be needed when building the certificate chains for the signing certificate. Conflicts with --certificate-chain.
       --certificate-chain string             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.
+      --ctfe-key string                      path to a PEM-encoded public key used by certificate authority for certificate transparency log.
   -h, --help                                 help for create
-      --ignore-sct                           when set, do not include key for verifying certificate transparency log. Set this if you signed with a key instead of using Fulcio.
-      --ignore-tlog                          when set, do not include key for verifying transparency. Set this if you did not sign with Rekor.
       --out string                           path to output trusted root
+      --rekor-key string                     path to a PEM-encoded public key used by transparency log like Rekor.
       --timestamp-certificate-chain string   path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates
 ```
 

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -18,8 +18,8 @@ cosign trusted-root create [flags]
       --certificate-chain string             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.
   -h, --help                                 help for create
       --ignore-sct                           when set, do not include key for verifying certificate transparency log. Set this if you signed with a key instead of using Fulcio.
+      --ignore-tlog                          when set, do not include key for verifying transparency. Set this if you did not sign with Rekor.
       --out string                           path to output trusted root
-      --rekor-url string                     address of rekor STL server
       --timestamp-certificate-chain string   path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates
 ```
 

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -13,14 +13,14 @@ cosign trusted-root create [flags]
 ### Options
 
 ```
-      --ca-intermediates string              path to a file of intermediate CA certificates in PEM format which will be needed when building the certificate chains for the signing certificate. The flag is optional and must be used together with --ca-roots, conflicts with --certificate-chain.
-      --ca-roots string                      path to a bundle file of CA certificates in PEM format which will be needed when building the certificate chains for the signing certificate. Conflicts with --certificate-chain.
-      --certificate-chain string             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.
-      --ctfe-key string                      path to a PEM-encoded public key used by certificate authority for certificate transparency log.
-  -h, --help                                 help for create
-      --out string                           path to output trusted root
-      --rekor-key string                     path to a PEM-encoded public key used by transparency log like Rekor.
-      --timestamp-certificate-chain string   path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates
+      --certificate-chain stringArray             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.
+      --ctfe-key stringArray                      path to a PEM-encoded public key used by certificate authority for certificate transparency log.
+      --ctfe-start-time stringArray               RFC 3339 string describing validity start time for key use by certificate transparency log.
+  -h, --help                                      help for create
+      --out string                                path to output trusted root
+      --rekor-key stringArray                     path to a PEM-encoded public key used by transparency log like Rekor.
+      --rekor-start-time stringArray              RFC 3339 string describing validity start time for key use by transparency log like Rekor.
+      --timestamp-certificate-chain stringArray   path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -1,0 +1,36 @@
+## cosign trusted-root create
+
+Create a Sigstore protobuf trusted root
+
+### Synopsis
+
+Create a Sigstore protobuf trusted root by supplying verification material
+
+```
+cosign trusted-root create [flags]
+```
+
+### Options
+
+```
+      --ca-intermediates string              path to a file of intermediate CA certificates in PEM format which will be needed when building the certificate chains for the signing certificate. The flag is optional and must be used together with --ca-roots, conflicts with --certificate-chain.
+      --ca-roots string                      path to a bundle file of CA certificates in PEM format which will be needed when building the certificate chains for the signing certificate. Conflicts with --certificate-chain.
+      --certificate-chain string             path to a list of CA certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Conflicts with --ca-roots and --ca-intermediates.
+  -h, --help                                 help for create
+      --out string                           path to output trusted root
+      --rekor-url string                     address of rekor STL server
+      --timestamp-certificate-chain string   path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. Optionally may contain intermediate CA certificates
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign trusted-root](cosign_trusted-root.md)	 - Interact with a Sigstore protobuf trusted root
+

--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/sigstore/fulcio v1.6.3
 	github.com/sigstore/protobuf-specs v0.3.2
 	github.com/sigstore/rekor v1.3.6
-	github.com/sigstore/sigstore v1.8.8
-	github.com/sigstore/sigstore-go v0.6.0
+	github.com/sigstore/sigstore v1.8.9
+	github.com/sigstore/sigstore-go v0.6.1
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.8.8
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.8.8
 	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.8.8

--- a/go.sum
+++ b/go.sum
@@ -614,10 +614,10 @@ github.com/sigstore/protobuf-specs v0.3.2 h1:nCVARCN+fHjlNCk3ThNXwrZRqIommIeNKWw
 github.com/sigstore/protobuf-specs v0.3.2/go.mod h1:RZ0uOdJR4OB3tLQeAyWoJFbNCBFrPQdcokntde4zRBA=
 github.com/sigstore/rekor v1.3.6 h1:QvpMMJVWAp69a3CHzdrLelqEqpTM3ByQRt5B5Kspbi8=
 github.com/sigstore/rekor v1.3.6/go.mod h1:JDTSNNMdQ/PxdsS49DJkJ+pRJCO/83nbR5p3aZQteXc=
-github.com/sigstore/sigstore v1.8.8 h1:B6ZQPBKK7Z7tO3bjLNnlCMG+H66tO4E/+qAphX8T/hg=
-github.com/sigstore/sigstore v1.8.8/go.mod h1:GW0GgJSCTBJY3fUOuGDHeFWcD++c4G8Y9K015pwcpDI=
-github.com/sigstore/sigstore-go v0.6.0 h1:X72BkR8kXFcdhF/V5GA2fpFvCz+VyZ6fI0YgTBn5feI=
-github.com/sigstore/sigstore-go v0.6.0/go.mod h1:+RyopI/FJDE6z5WVs2sQ2nkc+zsxxByDmbp8a4HoxbA=
+github.com/sigstore/sigstore v1.8.9 h1:NiUZIVWywgYuVTxXmRoTT4O4QAGiTEKup4N1wdxFadk=
+github.com/sigstore/sigstore v1.8.9/go.mod h1:d9ZAbNDs8JJfxJrYmulaTazU3Pwr8uLL9+mii4BNR3w=
+github.com/sigstore/sigstore-go v0.6.1 h1:tGkkv1oDIER+QYU5MrjqlttQOVDWfSkmYwMqkJhB/cg=
+github.com/sigstore/sigstore-go v0.6.1/go.mod h1:Xe5GHmUeACRFbomUWzVkf/xYCn8xVifb9DgqJrV2dIw=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.8.8 h1:2zHmUvaYCwV6LVeTo+OAkTm8ykOGzA9uFlAjwDPAUWM=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.8.8/go.mod h1:OEhheBplZinUsm7W9BupafztVZV3ldkAxEHbpAeC0Pk=
 github.com/sigstore/sigstore/pkg/signature/kms/azure v1.8.8 h1:RKk4Z+qMaLORUdT7zntwMqKiYAej1VQlCswg0S7xNSY=


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes #3700

We want to help cosign users move from providing disparate verification material to a single file that contains the needed verification material.

Using a trusted root file makes it easier for users to rotate key material and specify what time period different keys were valid.

Once you create your trusted root with `cosign trusted-root create ...` you can then supply the output to verification commands that support it with `cosign verify* --trusted-root ...`

Here's an example, note that some flags can be specified more than once (for instance, if your certificate chain has rotated, or if you are supporting public good and private instance). You can specify as few or as much content as you'd like. You'll need to create or obtain certificate chains and public key files as needed:

```
$ go run cmd/cosign/main.go trusted-root create --certificate-chain fulcio-chain-public.pem --certificate-chain fulcio-chain-private.pem --timestamp-certificate-chain timestamp.pem --ctfe-key ctfe.pub --rekor-key rekor.pub
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.
-->
* Added `cosign trusted-root create` command to assist users in creating trusted root files to use in cosign verification commands

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

https://github.com/sigstore/docs/pull/327