### PR TITLE
Fix bug in attest-blob when using a timestamp authority with new bundles

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -175,7 +175,14 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 		opts = append(opts, static.WithCertChain(sv.Cert, sv.Chain))
 	}
 	if c.KeyOpts.TSAServerURL != "" {
-		// Here we get the response from the timestamped authority server
+		// TODO - change this when we implement protobuf / new bundle support
+		//
+		// Historically, cosign sent the entire JSON DSSE Envelope to the
+		// timestamp authority. However, when sigstore clients are verifying a
+		// bundle they will use the DSSE Sig field, so we choose what signature
+		// to send to the timestamp authority based on our output format.
+		//
+		// See cmd/cosign/cli/attest/attest_blob.go
 		responseBytes, err := tsa.GetTimestampedSignature(signedPayload, tsaclient.NewTSAClient(c.KeyOpts.TSAServerURL))
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fix bug in #3752

When adding bundle support to `attest-blob`, we sent the wrong data to the timestamp authority to sign.

You can test this by first attesting to a blob with a timestamp authority and a predicate with something like:

```
$ go run cmd/cosign/main.go attest-blob --bundle="attest-pgi.sigstore.json" --new-bundle-format=true --key=cosign.key --tlog-upload=false --timestamp-server-url="https://timestamp.githubapp.com/api/v1/timestamp" --tlog-upload=false --type=something --predicate="../sigstore-go/examples/sigstore-go-signing/intoto.txt" ../sigstore-go/examples/sigstore-go-signing/hello_world.txt
```

Then the verification which previously failed (and now succeeds) looks like:

```
$ go run cmd/cosign/main.go verify-blob-attestation --trusted-root=trusted_root_with_timestamps.public.json --use-signed-timestamps=true --insecure-ignore-tlog=true --key=cosign.pub --bundle="attest-pgi.sigstore.json" --new-bundle-format=true --type=something ../sigstore-go/examples/sigstore-go-signing/hello_world.txt
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Fixed bug that created bundles with incorrect signed timestamps when `attest-blob` was used with new bundles

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A