### PR TITLE
Ignore stage names in `dockerfile verify`

### DIFF
--- a/cmd/cosign/cli/dockerfile/verify.go
+++ b/cmd/cosign/cli/dockerfile/verify.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/go-containerregistry/pkg/logs"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/verify"
 	"github.com/sigstore/cosign/v2/internal/ui"
 )
@@ -110,7 +111,15 @@ func (fc *finderCache) getImagesFromDockerfile(ctx context.Context, dockerfile i
 	if err := fileScanner.Err(); err != nil {
 		return nil, err
 	}
-	return images, nil
+	validImages := []string{}
+	for _, image := range images {
+		if fc.isStage(image) {
+			logs.Debug.Printf("Ignoring stage name: %s", image)
+			continue
+		}
+		validImages = append(validImages, image)
+	}
+	return validImages, nil
 }
 
 func (fc *finderCache) getImageFromLine(line string) string {

--- a/cmd/cosign/cli/dockerfile/verify_test.go
+++ b/cmd/cosign/cli/dockerfile/verify_test.go
@@ -134,6 +134,16 @@ CMD bin`,
 			},
 			expected: []string{"gcr.io/gauntlet/test/one", "gcr.io/gauntlet/test/two:latest", "gcr.io/gauntlet/test/runtime", "gcr.io/someorg/someimage"},
 		},
+		{
+			name: "from-stage-ignored",
+			fileContents: `
+FROM gcr.io/someorg/sometool:sometag AS tools_image
+FROM gcr.io/someorg/someimage AS base_image
+FROM base_image
+COPY --from=tools_image /bin/sometool
+CMD bin`,
+			expected: []string{"gcr.io/someorg/sometool:sometag", "gcr.io/someorg/someimage"},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
#### Summary

Fixes #3880, allowing `dockerfile verify` to validate Dockerfiles where stage names are used in `FROM` statements

#### Release Note

* Fixed bug that made `dockerfile verify` fail when a stage name was used in `FROM` statement

#### Documentation

N/A
