### PR TITLE
Add support for GitLab group variables

### DIFF
--- a/cmd/cosign/cli/generate_key_pair.go
+++ b/cmd/cosign/cli/generate_key_pair.go
@@ -55,8 +55,9 @@ func GenerateKeyPair() *cobra.Command {
   # generate a key-pair in GitHub
   cosign generate-key-pair github://[OWNER]/[PROJECT_NAME]
 
-  # generate a key-pair in GitLab with project name
+  # generate a key-pair in GitLab with project or group name
   cosign generate-key-pair gitlab://[OWNER]/[PROJECT_NAME]
+  cosign generate-key-pair gitlab://[GROUP_NAME]
 
   # generate a key-pair in GitLab with project id
   cosign generate-key-pair gitlab://[PROJECT_ID]

--- a/doc/cosign_generate-key-pair.md
+++ b/doc/cosign_generate-key-pair.md
@@ -39,8 +39,9 @@ cosign generate-key-pair [flags]
   # generate a key-pair in GitHub
   cosign generate-key-pair github://[OWNER]/[PROJECT_NAME]
 
-  # generate a key-pair in GitLab with project name
+  # generate a key-pair in GitLab with project or group name
   cosign generate-key-pair gitlab://[OWNER]/[PROJECT_NAME]
+  cosign generate-key-pair gitlab://[GROUP_NAME]
 
   # generate a key-pair in GitLab with project id
   cosign generate-key-pair gitlab://[PROJECT_ID]

--- a/pkg/cosign/git/gitlab/gitlab.go
+++ b/pkg/cosign/git/gitlab/gitlab.go
@@ -85,57 +85,97 @@ func (g *Gl) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		}
 	}
 
-	_, passwordResp, err := client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
-		Key:              gitlab.Ptr("COSIGN_PASSWORD"),
-		Value:            gitlab.Ptr(string(keys.Password())),
-		VariableType:     gitlab.Ptr(gitlab.EnvVariableType),
-		Protected:        gitlab.Ptr(false),
-		Masked:           gitlab.Ptr(false),
-		EnvironmentScope: gitlab.Ptr("*"),
-	})
+	context, err := g.getGitlabContext(client, ref)
+	if err != nil {
+		return fmt.Errorf("cannot determine if \"%s\" is project or group: %w", ref, err)
+	}
+
+	var resp *gitlab.Response
+
+	if context == contextProject {
+		_, resp, err = client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
+			Key:              gitlab.Ptr("COSIGN_PASSWORD"),
+			Value:            gitlab.Ptr(string(keys.Password())),
+			VariableType:     gitlab.Ptr(gitlab.EnvVariableType),
+			Protected:        gitlab.Ptr(false),
+			Masked:           gitlab.Ptr(false),
+			EnvironmentScope: gitlab.Ptr("*"),
+		})
+	} else if context == contextGroup {
+		_, resp, err = client.GroupVariables.CreateVariable(ref, &gitlab.CreateGroupVariableOptions{
+			Key:              gitlab.Ptr("COSIGN_PASSWORD"),
+			Value:            gitlab.Ptr(string(keys.Password())),
+			VariableType:     gitlab.Ptr(gitlab.EnvVariableType),
+			Protected:        gitlab.Ptr(false),
+			Masked:           gitlab.Ptr(false),
+			EnvironmentScope: gitlab.Ptr("*"),
+		})
+	}
 	if err != nil {
 		ui.Warnf(ctx, "If you are using a self-hosted gitlab please set the \"GITLAB_HOST\" your server name.")
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" variable: %w", err)
 	}
 
-	if passwordResp.StatusCode < 200 && passwordResp.StatusCode >= 300 {
-		bodyBytes, _ := io.ReadAll(passwordResp.Body)
+	if resp.StatusCode < 200 && resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
 	ui.Infof(ctx, "Password written to \"COSIGN_PASSWORD\" variable")
 
-	_, privateKeyResp, err := client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
-		Key:          gitlab.Ptr("COSIGN_PRIVATE_KEY"),
-		Value:        gitlab.Ptr(string(keys.PrivateBytes)),
-		VariableType: gitlab.Ptr(gitlab.EnvVariableType),
-		Protected:    gitlab.Ptr(false),
-		Masked:       gitlab.Ptr(false),
-	})
+	if context == contextProject {
+		_, resp, err = client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
+			Key:          gitlab.Ptr("COSIGN_PRIVATE_KEY"),
+			Value:        gitlab.Ptr(string(keys.PrivateBytes)),
+			VariableType: gitlab.Ptr(gitlab.EnvVariableType),
+			Protected:    gitlab.Ptr(false),
+			Masked:       gitlab.Ptr(false),
+		})
+	} else if context == contextGroup {
+		_, resp, err = client.GroupVariables.CreateVariable(ref, &gitlab.CreateGroupVariableOptions{
+			Key:          gitlab.Ptr("COSIGN_PRIVATE_KEY"),
+			Value:        gitlab.Ptr(string(keys.PrivateBytes)),
+			VariableType: gitlab.Ptr(gitlab.EnvVariableType),
+			Protected:    gitlab.Ptr(false),
+			Masked:       gitlab.Ptr(false),
+		})
+
+	}
 	if err != nil {
 		return fmt.Errorf("could not create \"COSIGN_PRIVATE_KEY\" variable: %w", err)
 	}
 
-	if privateKeyResp.StatusCode < 200 && privateKeyResp.StatusCode >= 300 {
-		bodyBytes, _ := io.ReadAll(privateKeyResp.Body)
+	if resp.StatusCode < 200 && resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("%s", bodyBytes)
 	}
 
 	ui.Infof(ctx, "Private key written to \"COSIGN_PRIVATE_KEY\" variable")
 
-	_, publicKeyResp, err := client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
-		Key:          gitlab.Ptr("COSIGN_PUBLIC_KEY"),
-		Value:        gitlab.Ptr(string(keys.PublicBytes)),
-		VariableType: gitlab.Ptr(gitlab.EnvVariableType),
-		Protected:    gitlab.Ptr(false),
-		Masked:       gitlab.Ptr(false),
-	})
+	if context == contextProject {
+		_, resp, err = client.ProjectVariables.CreateVariable(ref, &gitlab.CreateProjectVariableOptions{
+			Key:          gitlab.Ptr("COSIGN_PUBLIC_KEY"),
+			Value:        gitlab.Ptr(string(keys.PublicBytes)),
+			VariableType: gitlab.Ptr(gitlab.EnvVariableType),
+			Protected:    gitlab.Ptr(false),
+			Masked:       gitlab.Ptr(false),
+		})
+	} else if context == contextGroup {
+		_, resp, err = client.GroupVariables.CreateVariable(ref, &gitlab.CreateGroupVariableOptions{
+			Key:          gitlab.Ptr("COSIGN_PUBLIC_KEY"),
+			Value:        gitlab.Ptr(string(keys.PublicBytes)),
+			VariableType: gitlab.Ptr(gitlab.EnvVariableType),
+			Protected:    gitlab.Ptr(false),
+			Masked:       gitlab.Ptr(false),
+		})
+
+	}
 	if err != nil {
 		return fmt.Errorf("could not create \"COSIGN_PUBLIC_KEY\" variable: %w", err)
 	}
 
-	if publicKeyResp.StatusCode < 200 && publicKeyResp.StatusCode >= 300 {
-		bodyBytes, _ := io.ReadAll(publicKeyResp.Body)
+	if resp.StatusCode < 200 && resp.StatusCode >= 300 {
+		bodyBytes, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("%s", bodyBytes)
 	}
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR refactors `pkg/cosign/git/gitlab/gitlab.go` to make it work with both project variables and group variables. This is mainly used when running
```shell
cosign generate-key-pair gitlab://<path>
```
This solves #2914 for GitLab.

#### Release Note

* GitLab go-cloud style URIs now work both projects and groups.

#### Documentation

This probably does not require any change in docs apart from the ones included in this PR.
