### PR TITLE
Fix cosign copy --only for signatures

### DIFF
--- a/cmd/cosign/cli/options/copy.go
+++ b/cmd/cosign/cli/options/copy.go
@@ -35,7 +35,7 @@ func (o *CopyOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.CopyOnly, "only", "",
-		"custom string array to only copy specific items, this flag is comma delimited. ex: --only=sbom,sign,att")
+		"custom string array to only copy specific items, this flag is comma delimited. ex: --only=sig,att,sbom")
 
 	cmd.Flags().BoolVar(&o.SignatureOnly, "sig-only", false,
 		"[DEPRECATED] only copy the image signature")

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -36,7 +36,7 @@ cosign copy [flags]
   -f, --force                                                                                    overwrite destination image(s), if necessary
   -h, --help                                                                                     help for copy
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
-      --only string                                                                              custom string array to only copy specific items, this flag is comma delimited. ex: --only=sbom,sign,att
+      --only string                                                                              custom string array to only copy specific items, this flag is comma delimited. ex: --only=sig,att,sbom
       --platform string                                                                          only copy container image and its signatures for a specific platform image
       --registry-password string                                                                 registry basic auth password
       --registry-token string                                                                    registry bearer auth token


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

There is a bug in the `cosign copy` command for the deprecated flag, as well documentation is invalid for the CLI option.

See
https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/copy/copy.go#L192
requires to have value `sig` instead of `sign`.

Also aligned the option docs order to align with the order of the
example. https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/copy.go#L40

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Fixes the `cosign copy` command to have correct documentation and proper fallback implementation for the deprecated --sig-only commandline option.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N.A.
