### PR TITLE
Support mTLS towards container registry

### DIFF
--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -236,7 +236,7 @@ func (o *RegistryOptions) getTLSConfig() (*tls.Config, error) {
 	if o.RegistryClientCert != "" && o.RegistryClientKey != "" {
 		cert, err := tls.LoadX509KeyPair(o.RegistryClientCert, o.RegistryClientKey)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read CA certs from cert %s, key %s: %w",
+			return nil, fmt.Errorf("unable to read client certs from cert %s, key %s: %w",
 				o.RegistryClientCert, o.RegistryClientKey, err)
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}

--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -17,10 +17,12 @@ package options
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 
 	ecr "github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
 	"github.com/chrismellard/docker-credential-acr-env/pkg/credhelper"
@@ -45,6 +47,10 @@ type RegistryOptions struct {
 	RefOpts            ReferenceOptions
 	Keychain           Keychain
 	AuthConfig         authn.AuthConfig
+	RegistryCACert     string
+	RegistryClientCert string
+	RegistryClientKey  string
+	RegistryServerName string
 
 	// RegistryClientOpts allows overriding the result of GetRegistryClientOpts.
 	RegistryClientOpts []remote.Option
@@ -71,6 +77,18 @@ func (o *RegistryOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.AuthConfig.RegistryToken, "registry-token", "",
 		"registry bearer auth token")
+
+	cmd.Flags().StringVar(&o.RegistryCACert, "registry-cacert", "",
+		"path to the X.509 CA certificate file in PEM format to be used for the connection to the registry")
+
+	cmd.Flags().StringVar(&o.RegistryClientCert, "registry-client-cert", "",
+		"path to the X.509 certificate file in PEM format to be used for the connection to the registry")
+
+	cmd.Flags().StringVar(&o.RegistryClientKey, "registry-client-key", "",
+		"path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry")
+
+	cmd.Flags().StringVar(&o.RegistryServerName, "registry-server-name", "",
+		"SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry")
 
 	o.RefOpts.AddFlags(cmd)
 }
@@ -131,8 +149,9 @@ func (o *RegistryOptions) GetRegistryClientOpts(ctx context.Context) []remote.Op
 		opts = append(opts, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	}
 
-	if o.AllowInsecure {
-		opts = append(opts, remote.WithTransport(&http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}})) // #nosec G402
+	tlsConfig, err := o.getTLSConfig()
+	if err == nil {
+		opts = append(opts, remote.WithTransport(&http.Transport{TLSClientConfig: tlsConfig}))
 	}
 
 	// Reuse a remote.Pusher and a remote.Puller for all operations that use these opts.
@@ -192,4 +211,42 @@ var _ Interface = (*RegistryExperimentalOptions)(nil)
 func (o *RegistryExperimentalOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Var(&o.RegistryReferrersMode, "registry-referrers-mode",
 		"mode for fetching references from the registry. allowed: legacy, oci-1-1")
+}
+
+func (o *RegistryOptions) getTLSConfig() (*tls.Config, error) {
+	var tlsConfig tls.Config
+
+	if o.RegistryCACert != "" {
+		f, err := os.Open(o.RegistryCACert)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		caCertBytes, err := io.ReadAll(f)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read CA certs from %s: %w", o.RegistryCACert, err)
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caCertBytes) {
+			return nil, fmt.Errorf("no valid CA certs found in %s", o.RegistryCACert)
+		}
+		tlsConfig.RootCAs = pool
+	}
+
+	if o.RegistryClientCert != "" && o.RegistryClientKey != "" {
+		cert, err := tls.LoadX509KeyPair(o.RegistryClientCert, o.RegistryClientKey)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read CA certs from cert %s, key %s: %w",
+				o.RegistryClientCert, o.RegistryClientKey, err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	if o.RegistryServerName != "" {
+		tlsConfig.ServerName = o.RegistryServerName
+	}
+
+	tlsConfig.InsecureSkipVerify = o.AllowInsecure // #nosec G402
+
+	return &tlsConfig, nil
 }

--- a/cmd/cosign/cli/options/registry_test.go
+++ b/cmd/cosign/cli/options/registry_test.go
@@ -1,0 +1,206 @@
+package options
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+)
+
+func generatePrivateKey(t *testing.T) *rsa.PrivateKey {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return privateKey
+}
+
+func writePrivateKey(t *testing.T, privateKey *rsa.PrivateKey, fileLocation string) {
+	// Encode the private key to PEM format
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	// Write the private key to the specified file
+	err := os.WriteFile(fileLocation, privateKeyPEM, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func generateCertificate(t *testing.T, isCa bool) (certficateLocation, privateKeyLocation string) {
+	certficateLocation = createTempFile(t)
+	privateKeyLocation = createTempFile(t)
+
+	// Generate a private key for the CA
+	privateKey := generatePrivateKey(t)
+
+	// Create a self-signed certificate for the CA
+	caTemplate := &x509.Certificate{
+		Subject: pkix.Name{
+			CommonName: "Test CA",
+		},
+		NotBefore:             time.Now().Add(time.Hour*-24),
+		NotAfter:              time.Now().Add(time.Hour*24),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  isCa,
+		SerialNumber: big.NewInt(1337),
+	}
+
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Encode the CA certificate to PEM format
+	caCertPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caCertDER,
+	})
+
+	// Write the CA certificate to the specified file
+	err = os.WriteFile(certficateLocation, caCertPEM, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writePrivateKey(t, privateKey, privateKeyLocation)
+
+	return certficateLocation, privateKeyLocation
+}
+
+
+func TestGetTLSConfig(t *testing.T) {
+	validCaCertificate, validCaKey := generateCertificate(t, true)
+	validClientCertificate, validClientKey := generateCertificate(t, false)
+
+	t.Cleanup(func() {
+		removeTempFile(t, validCaCertificate)
+		removeTempFile(t, validCaKey)
+		removeTempFile(t, validClientCertificate)
+		removeTempFile(t, validClientKey)
+	})
+
+	tests := []struct {
+		name               string
+		registryCACert     string
+		registryClientCert string
+		registryClientKey  string
+		registryServerName string
+		allowInsecure      bool
+		expectError        string
+	}{
+		{
+			name:               "Valid CA Cert, Client Cert and Key, Server Name, Allow Insecure",
+			registryCACert:     validCaCertificate,
+			registryClientCert: validClientCertificate,
+			registryClientKey:  validClientKey,
+			registryServerName: "example.com",
+			allowInsecure:      true,
+		},
+		{
+			name: "Wrong key for client cert",
+			registryCACert: validCaCertificate,
+			registryClientCert: validClientCertificate,
+			registryClientKey: validCaKey, // using ca key for client cert must fail
+			registryServerName: "example.com",
+			allowInsecure: true,
+			expectError: fmt.Sprintf("unable to read client certs from cert %s, key %s: tls: private key does not match public key", validClientCertificate, validCaKey),
+		},
+		{
+			name: "Wrong ca key",
+			registryCACert: validClientKey, // using client key for ca cert must fail
+			registryClientCert: validClientCertificate,
+			registryClientKey: validClientKey,
+			registryServerName: "example.com",
+			allowInsecure: true,
+			expectError: fmt.Sprintf("no valid CA certs found in %s", validClientKey),
+		},
+		{
+			name: "Invalid CA path",
+			registryCACert: "/not/existing/path/fooobar", // this path is not expected to exist
+			registryClientCert: validClientCertificate,
+			registryClientKey: validClientKey,
+			registryServerName: "example.com",
+			allowInsecure: true,
+			expectError: fmt.Sprintf("open /not/existing/path/fooobar: no such file or directory"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &RegistryOptions{
+				RegistryCACert:     tt.registryCACert,
+				RegistryClientCert: tt.registryClientCert,
+				RegistryClientKey:  tt.registryClientKey,
+				RegistryServerName: tt.registryServerName,
+				AllowInsecure:      tt.allowInsecure,
+			}
+
+			tlsConfig, err := o.getTLSConfig()
+			if tt.expectError != "" {
+				if err == nil || err.Error() != tt.expectError {
+					t.Errorf("getTLSConfig()\nerror: \"%v\",\nexpectError: \"%v\"", err, tt.expectError)
+					return
+				}
+			} else {
+				if err != nil {
+					t.Errorf("getTLSConfig() error = %v, expectError %v", err, tt.expectError)
+					return
+				}
+			}
+
+			if err == nil {
+				if tt.registryCACert != "" {
+					if tlsConfig.RootCAs == nil {
+						t.Errorf("Expected RootCAs to be set")
+					}
+				}
+
+				if tt.registryClientCert != "" && tt.registryClientKey != "" {
+					if len(tlsConfig.Certificates) == 0 {
+						t.Errorf("Expected Certificates to be set")
+					}
+				}
+
+				if tt.registryServerName != "" {
+					if tlsConfig.ServerName != tt.registryServerName {
+						t.Errorf("Expected ServerName to be %s, got %s", tt.registryServerName, tlsConfig.ServerName)
+					}
+				}
+
+				if tt.allowInsecure {
+					if !tlsConfig.InsecureSkipVerify {
+						t.Errorf("Expected InsecureSkipVerify to be true")
+					}
+				}
+			}
+		})
+	}
+}
+
+// Helper function to create temporary files for testing
+func createTempFile(t *testing.T) string {
+	tmpfile, err := os.CreateTemp("", "registry-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tmpfile.Name()
+}
+
+// Helper function to remove temporary files after testing
+func removeTempFile(t *testing.T, filename string) {
+	if err := os.Remove(filename); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/doc/cosign_attach_attestation.md
+++ b/doc/cosign_attach_attestation.md
@@ -29,7 +29,11 @@ cosign attach attestation [flags]
       --attestation stringArray                                                                  path to the attestation envelope
   -h, --help                                                                                     help for attestation
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_attach_sbom.md
+++ b/doc/cosign_attach_sbom.md
@@ -27,8 +27,12 @@ cosign attach sbom [flags]
   -h, --help                                                                                     help for sbom
       --input-format string                                                                      type of sbom input format (json|xml|text)
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
       --registry-referrers-mode registryReferrersMode                                            mode for fetching references from the registry. allowed: legacy, oci-1-1
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --sbom string                                                                              path to the sbom, or {-} for stdin

--- a/doc/cosign_attach_signature.md
+++ b/doc/cosign_attach_signature.md
@@ -40,7 +40,11 @@ cosign attach signature [flags]
   -h, --help                                                                                     help for signature
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --payload string                                                                           path to the payload covered by the signature
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --rekor-response string                                                                    path to the rekor bundle

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -67,7 +67,11 @@ cosign attest [flags]
       --predicate string                                                                         path to the predicate file.
       --record-creation-timestamp                                                                set the createdAt timestamp in the attestation artifact to the time it was created; by default, cosign sets this to the zero value
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --rekor-entry-type string                                                                  specifies the type to be used for a rekor entry upload. Options are intoto or dsse (default).  (default "dsse")

--- a/doc/cosign_clean.md
+++ b/doc/cosign_clean.md
@@ -21,7 +21,11 @@ cosign clean [flags]
   -f, --force                                                                                    do not prompt for confirmation
   -h, --help                                                                                     help for clean
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --type CLEAN_TYPE                                                                          a type of clean: <signature|attestation|sbom|all> (sbom is deprecated) (default all)

--- a/doc/cosign_copy.md
+++ b/doc/cosign_copy.md
@@ -38,7 +38,11 @@ cosign copy [flags]
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --only string                                                                              custom string array to only copy specific items, this flag is comma delimited. ex: --only=sbom,sign,att
       --platform string                                                                          only copy container image and its signatures for a specific platform image
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --sig-only                                                                                 [DEPRECATED] only copy the image signature

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -81,7 +81,11 @@ cosign dockerfile verify [flags]
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --rekor-url string                                                                         address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_download_attestation.md
+++ b/doc/cosign_download_attestation.md
@@ -22,7 +22,11 @@ cosign download attestation [flags]
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --platform string                                                                          download attestation for a specific platform image
       --predicate-type string                                                                    download attestation with matching predicateType
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_download_sbom.md
+++ b/doc/cosign_download_sbom.md
@@ -27,7 +27,11 @@ cosign download sbom [flags]
   -h, --help                                                                                     help for sbom
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --platform string                                                                          download SBOM for a specific platform image
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_download_signature.md
+++ b/doc/cosign_download_signature.md
@@ -20,7 +20,11 @@ cosign download signature [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for signature
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_generate.md
+++ b/doc/cosign_generate.md
@@ -36,7 +36,11 @@ cosign generate [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for generate
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_load.md
+++ b/doc/cosign_load.md
@@ -25,7 +25,11 @@ cosign load [flags]
       --dir string                                                                               path to directory where the signed image is stored on disk
   -h, --help                                                                                     help for load
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -75,7 +75,11 @@ cosign manifest verify [flags]
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --rekor-url string                                                                         address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_save.md
+++ b/doc/cosign_save.md
@@ -25,7 +25,11 @@ cosign save [flags]
       --dir string                                                                               path to dir where the signed image should be stored on disk
   -h, --help                                                                                     help for save
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -99,8 +99,12 @@ cosign sign [flags]
       --payload string                                                                           path to a payload file to use rather than generating one
       --record-creation-timestamp                                                                set the createdAt timestamp in the signature artifact to the time it was created; by default, cosign sets this to the zero value
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
       --registry-referrers-mode registryReferrersMode                                            mode for fetching references from the registry. allowed: legacy, oci-1-1
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --rekor-url string                                                                         address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_tree.md
+++ b/doc/cosign_tree.md
@@ -20,7 +20,11 @@ cosign tree [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for tree
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_triangulate.md
+++ b/doc/cosign_triangulate.md
@@ -20,7 +20,11 @@ cosign triangulate [flags]
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
   -h, --help                                                                                     help for triangulate
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --type string                                                                              related attachment to triangulate (attestation|sbom|signature|digest), default signature (sbom is deprecated) (default "signature")

--- a/doc/cosign_upload_blob.md
+++ b/doc/cosign_upload_blob.md
@@ -41,7 +41,11 @@ cosign upload blob [flags]
   -f, --files strings                                                                            <filepath>:[platform/arch]
   -h, --help                                                                                     help for blob
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_upload_wasm.md
+++ b/doc/cosign_upload_wasm.md
@@ -21,7 +21,11 @@ cosign upload wasm [flags]
   -f, --file string                                                                              path to the wasm file to upload
   -h, --help                                                                                     help for wasm
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
 ```

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -85,7 +85,11 @@ cosign verify-attestation [flags]
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --policy strings                                                                           specify CUE or Rego files with policies to be used for validation
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --rekor-url string                                                                         address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -102,7 +102,11 @@ cosign verify [flags]
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure
+      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
+      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
+      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username
       --rekor-url string                                                                         address of rekor STL server (default "https://rekor.sigstore.dev")


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->
Some container registries require that the client present a certificate when establishing the connection. There is currently no way of specifying this when using cosign.
This change adds four arguments that allows the users to specify the root CA, the client cert and the client key and the expected SAN name.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Config changes (additions, deletions, updates)
  * None
* API additions—new endpoint, new response fields, or newly accepted request parameters
  * None
* Database changes (any)
  * None
* Websocket additions or changes
  * None
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
  * It is now possible to specify client certificates (mTLS) for container registry connections
* New features and improvements, including behavioural changes, UI changes and CLI changes
  * It is now possible to specify client certificates (mTLS) for container registry connections
* Bug fixes and fixes of previous known issues
  * None
* Deprecation warnings, breaking changes, or compatibility notes
  * None

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
Documentation has been added for these new arguments added:
```
      --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
      --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
      --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
      --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
```

Closes #3915