### PR TITLE
goreleaser: Refactor git-diff hook

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ env:
 before:
   hooks:
     - go mod tidy
-    - /bin/bash -c 'if [ -n "$(git --no-pager diff --exit-code go.mod go.sum)" ]; then exit 1; fi'
+    - git --no-pager diff --exit-code go.mod go.sum
 
 gomod:
   proxy: true


### PR DESCRIPTION
The git-diff hook implementation prevents us from seeing the failure details.

Simplify so that the git diff output ends up in stdout: otherwise functionality should remain same.

CC @cpanato as original author.