### PR TITLE
Add support for verifying root checksum in cosign initialize

### DIFF
--- a/cmd/cosign/cli/initialize.go
+++ b/cmd/cosign/cli/initialize.go
@@ -41,19 +41,22 @@ Any updated TUF repository will be written to $HOME/.sigstore/root/.
 
 Trusted keys and certificate used in cosign verification (e.g. verifying Fulcio issued certificates
 with Fulcio root CA) are pulled form the trusted metadata.`,
-		Example: `cosign initialize -mirror <url> -out <file>
+		Example: `cosign initialize --mirror <url> --out <file>
 
 # initialize root with distributed root keys, default mirror, and default out path.
 cosign initialize
 
 # initialize with an out-of-band root key file, using the default mirror.
-cosign initialize -root <url>
+cosign initialize --root <url>
 
 # initialize with an out-of-band root key file and custom repository mirror.
-cosign initialize -mirror <url> -root <url>`,
+cosign initialize --mirror <url> --root <url>
+
+# initialize with an out-of-band root key file and custom repository mirror while verifying root checksum.
+cosign initialize --mirror <url> --root <url> --root-checksum <sha512>`,
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return initialize.DoInitialize(cmd.Context(), o.Root, o.Mirror)
+			return initialize.DoInitializeWithRootChecksum(cmd.Context(), o.Root, o.Mirror, o.RootChecksum)
 		},
 	}
 

--- a/cmd/cosign/cli/options/deprecate.go
+++ b/cmd/cosign/cli/options/deprecate.go
@@ -19,3 +19,8 @@ const SBOMAttachmentDeprecation = "WARNING: SBOM attachments are deprecated " +
 	"and support will be removed in a Cosign release soon after 2024-02-22 " +
 	"(see https://github.com/sigstore/cosign/issues/2755). " +
 	"Instead, please use SBOM attestations."
+
+const RootWithoutChecksumDeprecation = "WARNING: Fetching initial root from URL " +
+	"without providing its checksum is deprecated and will be disallowed in " +
+	"a Cosing release soon after TODO. Please provide the initial root checksum " +
+	"via the --root-checksum argument."

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -22,8 +22,9 @@ import (
 
 // InitializeOptions is the top level wrapper for the initialize command.
 type InitializeOptions struct {
-	Mirror string
-	Root   string
+	Mirror       string
+	Root         string
+	RootChecksum string
 }
 
 var _ Interface = (*InitializeOptions)(nil)
@@ -36,4 +37,7 @@ func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.Root, "root", "",
 		"path to trusted initial root. defaults to embedded root")
 	_ = cmd.Flags().SetAnnotation("root", cobra.BashCompSubdirsInDir, []string{})
+
+	cmd.Flags().StringVar(&o.RootChecksum, "root-checksum", "",
+		"checksum of the initial root, required if root is downloaded via http(s). expects sha512 by default, can be changed to sha256 by providing sha256:<checksum>")
 }

--- a/pkg/blob/load.go
+++ b/pkg/blob/load.go
@@ -15,6 +15,9 @@
 package blob
 
 import (
+	"crypto/sha256"
+	"crypto/sha512"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
@@ -71,4 +74,36 @@ func LoadFileOrURL(fileRef string) ([]byte, error) {
 		}
 	}
 	return raw, nil
+}
+
+func LoadFileOrURLWithChecksum(fileRef string, checksum string) ([]byte, error) {
+	checksumParts := strings.Split(checksum, ":")
+	if len(checksumParts) >= 3 {
+		return nil, fmt.Errorf("wrong checksum input format, must have at most 1 colon: %s", checksum)
+	}
+
+	checksumAlgo := sha512.New()
+	checksumValue := checksumParts[len(checksumParts)-1]
+	if len(checksumParts) == 2 {
+		switch checksumParts[0] {
+		case "sha512": // the default set above
+		case "sha256":
+			checksumAlgo = sha256.New()
+		default:
+			return nil, fmt.Errorf("unsupported checksum algorithm: %s", checksumParts[0])
+		}
+	}
+
+	fileContent, err := LoadFileOrURL(fileRef)
+	if err != nil {
+		return nil, err
+	}
+
+	checksumAlgo.Write(fileContent)
+	computedChecksum := hex.EncodeToString(checksumAlgo.Sum(nil))
+	if computedChecksum != checksumValue {
+		return nil, fmt.Errorf("incorrect checksum for file %s: expected %s but got %s", fileRef, checksumValue, computedChecksum)
+	}
+
+	return fileContent, nil
 }

--- a/pkg/blob/load_test.go
+++ b/pkg/blob/load_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -95,5 +96,54 @@ func TestLoadURL(t *testing.T) {
 	_, err = LoadFileOrURL("invalid://url")
 	if err == nil {
 		t.Error("LoadFileOrURL(): expected error for invalid scheme")
+	}
+}
+
+func TestLoadURLWithChecksum(t *testing.T) {
+	data := []byte("test")
+
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+		rw.Write(data)
+	}))
+	defer server.Close()
+
+	// default behavior with sha512
+	actual, err := LoadFileOrURLWithChecksum(
+		server.URL,
+		"ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",
+	)
+	if err != nil {
+		t.Errorf("Reading from HTTP failed: %v", err)
+	} else if !bytes.Equal(actual, data) {
+		t.Errorf("LoadFileOrURL(HTTP) = '%s'; want '%s'", actual, data)
+	}
+
+	// override checksum algo to sha256
+	actual, err = LoadFileOrURLWithChecksum(
+		server.URL,
+		"sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
+	)
+	if err != nil {
+		t.Errorf("Reading from HTTP failed: %v", err)
+	} else if !bytes.Equal(actual, data) {
+		t.Errorf("LoadFileOrURL(HTTP) = '%s'; want '%s'", actual, data)
+	}
+
+	// ensure it fails with the wrong checksum
+	_, err = LoadFileOrURLWithChecksum(
+		server.URL,
+		"certainly not a correct checksum value",
+	)
+	if err == nil || !strings.Contains(err.Error(), "incorrect checksum") {
+		t.Errorf("Expected an 'incorrect checksum' error, got: %v", err)
+	}
+
+	// ensure it fails with incorrect algorithm
+	_, err = LoadFileOrURLWithChecksum(
+		server.URL,
+		"sha321123:foobar",
+	)
+	if err == nil || !strings.Contains(err.Error(), "unsupported checksum") {
+		t.Errorf("Expected an 'unsupported checksum' error, got: %v", err)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

The motivation for this PR is explained in and closes https://github.com/sigstore/cosign/issues/3946 - the ability to verify initial root checksum when downloading via a URL.

Some notes:
* The `DoInitialize` function still works exactly the same; it's unused here, but may be used from elsewhere (like gitsign).
* Once this PR is merged, I will send another one to utilize the new functionality in gitsign as well.
* I wasn't sure what deprecation date to set here, so I'd be glad for advice.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.
-->

Add a new `--root-checksum` flag for `cosign-initialize`. This will ensure cosign verifies the checksum of the file provided via the `--root` argument before proceeding with initialization. Using this argument will be mandated in the future for initial root obtained from URL.

#### Documentation

I don't think this requires specific callout in docs, but do let me know if you think oterwise.