### PR TITLE
Revert "Fix formatting of CODEOWNERS"

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-* @sigstore/cosign-codeowners
+@sigstore/cosign-codeowners
 
 # The CODEOWNERS are managed via a GitHub team, but the current list is (in alphabetical order):
 


### PR DESCRIPTION
Reverts sigstore/cosign#3957

One of Sigstore's admins helps maintain a number of repos without explicitly being a codeowner. It seems like almost every repo across the Sigstore org has this same syntax error, which means effectively we haven't been using codeowners files for approvals. I have a few thoughts on ideas to fix this, but for now, I'm reverting this change so the admin can continue merging PRs.

A few ideas for fixes:

* Remove requiring codeowners approvals (each repo should be making that decision, and it's not ideal for the lack of notifications)
* Remove push restrictions (-1 on this, this mandates those with maintain can merge, but not those with write, which lets us implement review vs merge permissions)
* Allow admins to bypass branch protection rules (-1 on this, insider risk mitigation)