### PR TITLE
Pin conformance tests to main

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -39,6 +39,6 @@ jobs:
 
       - run: make cosign conformance
 
-      - uses: sigstore/sigstore-conformance@b0635d4101f11dbd18a50936568a1f7f55b17760 # v0.0.14
+      - uses: sigstore/sigstore-conformance@main
         with:
           entrypoint: ${{ github.workspace }}/conformance


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This PR changes the version of the conformance tests to be pinned to `main` instead of the latest release.

Previous discussion in https://github.com/sigstore/cosign/pull/3965 was unresolved, so it was merged with the conformance tests action referencing to latest release instead of `main` as a compromise.

There was a slight philosophical disagreement in the previous PR: It was opened referencing `main`, but there are some reasons you would not want to pin to main:

- Dependabot updates should keep it up to date anyway (at least up to the latest release), however this seems to have failed recently.
- Changes to main conformance tests could block unrelated changes in cosign.
- Referencing a main branch is not repeatable so could confuse cosign developers if suddenly the conformance tests were broken as a result of upstream changes.

However there are good counterpoints:

- Conformance tests recently had a ~9 month gap between releases, so even with Dependabot, there could be long periods of drift.
- It's important for conformance tests to be fixed ASAP as they could represent security flaws.

Generally I'm of the opinion that Actions should be pinned to specific version hashes for strong repeatability, however I can understand in this case that the benefit of catching conformance failures early may outweigh the drawbacks, especially after noticing the recent gap between conformance releases.

As an alternative to this PR, we could instead [add a second conformance test run that runs the main branch](https://github.com/sigstore/cosign/pull/3979) (so there would be two versions of the conformance tests run, one on the latest release and one on main). This way, we can use the most recent released version as a branch protection, and use the `main` branch one as an informative check that does not block PRs. The `main` one could even run on a nightly schedule and create an issue if there is a failure. I'm open to this option as a "stable" alternative that would give us much of the same benefit, but I'm okay with either option.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
