### PR TITLE
Add nightly conformance test workflow

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -50,7 +50,7 @@ jobs:
             const { owner, repo } = context.repo;
             const runId = context.runId;
             const issueTitle = 'Conformance Tests Failed';
-            const issueBody = `The nightly conformance tests have failed. Please check the logs for more details.\n\nWorkflow run: https://github.com/${owner}/${repo}/actions/runs/${runId}\n\ncc @sigstore/security-response-team`;
+            const issueBody = `The nightly conformance tests have failed. Please check the logs for more details.\n\nWorkflow run: https://github.com/${owner}/${repo}/actions/runs/${runId}\n\ncc @sigstore/security-response-team @sigstore/cosign-codeowners`;
             const issueLabel = 'bug';
 
             const existingIssues = await github.rest.issues.listForRepo({

--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -42,16 +42,17 @@ jobs:
 
       - name: Create Issue on Failure
         if: failure()
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
+            const runId = context.runId;
             const issueTitle = 'Conformance Tests Failed';
-            const issueBody = `The nightly conformance tests have failed. Please check the logs for more details.`;
+            const issueBody = `The nightly conformance tests have failed. Please check the logs for more details.\n\nWorkflow run: https://github.com/${owner}/${repo}/actions/runs/${runId}\n\ncc @sigstore/security-response-team`;
             const issueLabel = 'bug';
 
-            const existingIssues = await github.issues.listForRepo({
+            const existingIssues = await github.rest.issues.listForRepo({
               owner,
               repo,
               state: 'open',
@@ -61,7 +62,7 @@ jobs:
             const issueExists = existingIssues.data.some(issue => issue.title === issueTitle);
 
             if (!issueExists) {
-              await github.issues.create({
+              await github.rest.issues.create({
                 owner,
                 repo,
                 title: issueTitle,

--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -17,6 +17,7 @@ name: Conformance Tests Nightly
 on:
   schedule:
     - cron: '0 0 * * *' # 12:00 AM UTC
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -1,0 +1,71 @@
+# Copyright 2024 The Sigstore Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Conformance Tests Nightly
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # 12:00 AM UTC
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
+
+      - run: make cosign conformance
+
+      - uses: sigstore/sigstore-conformance@main
+        with:
+          entrypoint: ${{ github.workspace }}/conformance
+
+      - name: Create Issue on Failure
+        if: failure()
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issueTitle = 'Conformance Tests Failed';
+            const issueBody = `The nightly conformance tests have failed. Please check the logs for more details.`;
+            const issueLabel = 'bug';
+
+            const existingIssues = await github.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: issueLabel,
+            });
+
+            const issueExists = existingIssues.data.some(issue => issue.title === issueTitle);
+
+            if (!issueExists) {
+              await github.issues.create({
+                owner,
+                repo,
+                title: issueTitle,
+                body: issueBody,
+                labels: [issueLabel],
+              });
+            }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This is an alternative / supplement to https://github.com/sigstore/cosign/pull/3978, as way of automatically running conformance tests against the current main branch of sigstore-conformance. This will run nightly at midnight UTC and report an issue on failure.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
