### PR TITLE
Fix for multiple WithRemote options

### DIFF
--- a/pkg/oci/remote/options.go
+++ b/pkg/oci/remote/options.go
@@ -113,6 +113,14 @@ func WithRemoteOptions(opts ...remote.Option) Option {
 	}
 }
 
+// WithMoreRemoteOptions is a functional option for adding to the default
+// remote options already specified
+func WithMoreRemoteOptions(opts ...remote.Option) Option {
+	return func(o *options) {
+		o.ROpt = append(o.ROpt, opts...)
+	}
+}
+
 // WithTargetRepository is a functional option for overriding the default
 // target repository hosting the signature and attestation tags.
 func WithTargetRepository(repo name.Repository) Option {


### PR DESCRIPTION
#### Summary
When specifying multiple sets of remote options using WithRemoteOptions, only the last set of options are used. The earlier ones are discarded. This is a problem for example, when an initial set of WithRemoteOptions are generated by command-line flags, and then additional ones need to be specified during application execution. Doing so would discard the options set by the command-line flags.

To preserve backwards compatibility, where the WithRemoteOptions function overrides the defaults, an additional function WithMoreRemoteOptions has been added, which appends the options to any existing ones.

Resolves: sigstore/cosign/#3981

#### Release Note
Function WithMoreRemoteOptions has been added that allows one to append additional remote options to those
already specified.

#### Documentation
None