### PR TITLE
fix: set tls config while retaining other fields from default http transport

### DIFF
--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -151,7 +151,9 @@ func (o *RegistryOptions) GetRegistryClientOpts(ctx context.Context) []remote.Op
 
 	tlsConfig, err := o.getTLSConfig()
 	if err == nil {
-		opts = append(opts, remote.WithTransport(&http.Transport{TLSClientConfig: tlsConfig}))
+		tr := http.DefaultTransport.(*http.Transport).Clone()
+		tr.TLSClientConfig = tlsConfig
+		opts = append(opts, remote.WithTransport(tr))
 	}
 
 	// Reuse a remote.Pusher and a remote.Puller for all operations that use these opts.


### PR DESCRIPTION
Signed-off-by: Nianyu Shen <xiaoyu9964@gmail.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
original issue https://github.com/sigstore/cosign/issues/3269
Proxy from environment variable is not respected while setting insecure true.
At https://github.com/sigstore/cosign/blob/87c08b00fca8a96a2ef756cee3953372a5783a45/cmd/cosign/cli/options/registry.go#L154, its initializing an empty transport with only insecure set but those default behaviors from default transport is also gone. In this case, proxy value from envs is removed. The fix is to clone a default transport object and override the tlsconfig inside it.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
