### PR TITLE
Add conformance test commands to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,7 @@ cosignImagerefs
 bundle
 signature
 certificate
+sigstore-conformance
+conformance
 
 **verify-experimental*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,21 @@ make test
 
 **Make sure all tests pass** without any failures or errors.
 
+#### Conformance tests
+
+To run the conformance tests, first install the conformance test runner:
+
+```shell
+make conformance-runner
+```
+
+Then build `cosign` and `conformance` (the executable that adapts conformance tests to the cosign command), and run the tests:
+
+```shell
+make cosign conformance
+make conformance-tests
+```
+
 ### Running Lint
 
 To run the linting checks, use the following command:

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,6 @@ lint: golangci-lint ## Run golangci-lint linter
 test:
 	$(GOEXE) test $(shell $(GOEXE) list ./... | grep -v third_party/)
 
-conformance:
-	$(GOEXE) build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/conformance
-
 clean:
 	rm -rf cosign
 	rm -rf dist/
@@ -132,6 +129,34 @@ ARTIFACT_HUB_LABELS=--image-label io.artifacthub.package.readme-url="https://raw
 define create_kocache_path
   mkdir -p $(KOCACHE_PATH)
 endef
+
+###################
+# conformance tests
+###################
+
+conformance:
+	$(GOEXE) build -trimpath -ldflags "$(LDFLAGS)" -o $@ ./cmd/conformance
+
+CONFORMANCE_RUNNER_PATH = sigstore-conformance
+$(CONFORMANCE_RUNNER_PATH):
+	git clone https://github.com/sigstore/sigstore-conformance $@
+
+.PHONY: conformance-runner
+conformance-runner:
+	$(MAKE) $(CONFORMANCE_RUNNER_PATH) conformance-runner-pull conformance-runner-build
+
+.PHONY: conformance-runner-pull
+conformance-runner-pull:
+	cd $(CONFORMANCE_RUNNER_PATH) && git pull
+
+.PHONY: conformance-runner-build
+conformance-runner-build:
+	cd $(CONFORMANCE_RUNNER_PATH) && $(MAKE) dev
+
+CONFORMANCE_BIN = $(shell pwd)/conformance
+.PHONY: conformance-tests
+conformance-tests:
+	cd $(CONFORMANCE_RUNNER_PATH) && env/bin/pytest test --entrypoint=$(CONFORMANCE_BIN)
 
 ##########
 # ko build


### PR DESCRIPTION
Signed-off-by: Cody Soyland <codysoyland@github.com>

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

This adds some commands to the Makefile to make it easy to run conformance tests.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
