### PR TITLE
Add support for passing different SignerVerifier LoadOptions

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -132,7 +132,7 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 	// each access.
 	ref = digest // nolint
 
-	sv, err := sign.SignerFromKeyOpts(ctx, c.CertPath, c.CertChainPath, c.KeyOpts)
+	sv, err := sign.SignerFromKeyOptsWithSVOpts(ctx, c.CertPath, c.CertChainPath, c.KeyOpts)
 	if err != nil {
 		return fmt.Errorf("getting signer: %w", err)
 	}

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -132,7 +132,7 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 	}
 	defer predicate.Close()
 
-	sv, err := sign.SignerFromKeyOpts(ctx, c.CertPath, c.CertChainPath, c.KeyOpts)
+	sv, err := sign.SignerFromKeyOptsWithSVOpts(ctx, c.CertPath, c.CertChainPath, c.KeyOpts)
 	if err != nil {
 		return fmt.Errorf("getting signer: %w", err)
 	}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -18,7 +18,6 @@ package sign
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -138,7 +137,7 @@ func SignCmd(ro *options.RootOptions, ko options.KeyOpts, signOpts options.SignO
 	ctx, cancel := context.WithTimeout(context.Background(), ro.Timeout)
 	defer cancel()
 
-	sv, err := SignerFromKeyOpts(ctx, signOpts.Cert, signOpts.CertChain, ko)
+	sv, err := SignerFromKeyOptsWithSVOpts(ctx, signOpts.Cert, signOpts.CertChain, ko)
 	if err != nil {
 		return fmt.Errorf("getting signer: %w", err)
 	}
@@ -391,8 +390,8 @@ func signerFromSecurityKey(ctx context.Context, keySlot string) (*SignerVerifier
 	}, nil
 }
 
-func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef string, passFunc cosign.PassFunc) (*SignerVerifier, error) {
-	k, err := sigs.SignerVerifierFromKeyRef(ctx, keyRef, passFunc)
+func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef string, passFunc cosign.PassFunc, opts ...signature.LoadOption) (*SignerVerifier, error) {
+	k, err := sigs.SignerVerifierFromKeyRefWithOpts(ctx, keyRef, passFunc, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("reading key: %w", err)
 	}
@@ -521,12 +520,12 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 	return certSigner, nil
 }
 
-func signerFromNewKey() (*SignerVerifier, error) {
+func signerFromNewKey(opts ...signature.LoadOption) (*SignerVerifier, error) {
 	privKey, err := cosign.GeneratePrivateKey()
 	if err != nil {
 		return nil, fmt.Errorf("generating cert: %w", err)
 	}
-	sv, err := signature.LoadECDSASignerVerifier(privKey, crypto.SHA256)
+	sv, err := signature.LoadSignerVerifierWithOpts(privKey, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -559,7 +558,7 @@ func keylessSigner(ctx context.Context, ko options.KeyOpts, sv *SignerVerifier) 
 	}, nil
 }
 
-func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, error) {
+func SignerFromKeyOptsWithSVOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts, svOpts ...signature.LoadOption) (*SignerVerifier, error) {
 	var sv *SignerVerifier
 	var err error
 	genKey := false
@@ -567,11 +566,11 @@ func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath strin
 	case ko.Sk:
 		sv, err = signerFromSecurityKey(ctx, ko.Slot)
 	case ko.KeyRef != "":
-		sv, err = signerFromKeyRef(ctx, certPath, certChainPath, ko.KeyRef, ko.PassFunc)
+		sv, err = signerFromKeyRef(ctx, certPath, certChainPath, ko.KeyRef, ko.PassFunc, svOpts...)
 	default:
 		genKey = true
 		ui.Infof(ctx, "Generating ephemeral keys...")
-		sv, err = signerFromNewKey()
+		sv, err = signerFromNewKey(svOpts...)
 	}
 	if err != nil {
 		return nil, err
@@ -582,6 +581,10 @@ func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath strin
 	}
 
 	return sv, nil
+}
+
+func SignerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, error) {
+	return SignerFromKeyOptsWithSVOpts(ctx, certPath, certChainPath, ko)
 }
 
 type SignerVerifier struct {

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -65,7 +65,7 @@ func SignBlobCmd(ro *options.RootOptions, ko options.KeyOpts, payloadPath string
 		return nil, err
 	}
 
-	sv, err := SignerFromKeyOpts(ctx, "", "", ko)
+	sv, err := SignerFromKeyOptsWithSVOpts(ctx, "", "", ko)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -267,7 +267,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 
 	for _, img := range images {
 		if c.LocalImage {
-			verified, bundleVerified, err := cosign.VerifyLocalImageSignatures(ctx, img, co)
+			verified, bundleVerified, err := cosign.VerifyLocalImageSignaturesWithOpts(ctx, img, co)
 			if err != nil {
 				return err
 			}
@@ -283,7 +283,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 				return fmt.Errorf("resolving attachment type %s for image %s: %w", c.Attachment, img, err)
 			}
 
-			verified, bundleVerified, err := cosign.VerifyImageSignatures(ctx, ref, co)
+			verified, bundleVerified, err := cosign.VerifyImageSignaturesWithOpts(ctx, ref, co)
 			if err != nil {
 				return cosignError.WrapError(err)
 			}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -43,6 +43,7 @@ import (
 	sigs "github.com/sigstore/cosign/v2/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
@@ -186,7 +187,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	var pubKey signature.Verifier
 	switch {
 	case keyRef != "":
-		pubKey, err = sigs.PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, c.HashAlgorithm)
+		pubKey, err = sigs.PublicKeyFromKeyRefWithOpts(ctx, keyRef, signatureoptions.WithHash(c.HashAlgorithm))
 		if err != nil {
 			return fmt.Errorf("loading public key: %w", err)
 		}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -230,7 +230,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			if err != nil {
 				return err
 			}
-			pubKey, err = cosign.ValidateAndUnpackCertWithChain(cert, chain, co)
+			pubKey, err = cosign.ValidateAndUnpackCertWithOpts(cert, co, cosign.WithChain(chain))
 			if err != nil {
 				return err
 			}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -202,7 +202,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			if err != nil {
 				return err
 			}
-			co.SigVerifier, err = cosign.ValidateAndUnpackCertWithChain(cert, chain, co)
+			co.SigVerifier, err = cosign.ValidateAndUnpackCertWithOpts(cert, co, cosign.WithChain(chain))
 			if err != nil {
 				return fmt.Errorf("creating certificate verifier: %w", err)
 			}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -159,7 +159,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	// Keys are optional!
 	switch {
 	case keyRef != "":
-		co.SigVerifier, err = sigs.PublicKeyFromKeyRef(ctx, keyRef)
+		co.SigVerifier, err = sigs.PublicKeyFromKeyRefWithOpts(ctx, keyRef)
 		if err != nil {
 			return fmt.Errorf("loading public key: %w", err)
 		}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -231,7 +231,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		var bundleVerified bool
 
 		if c.LocalImage {
-			verified, bundleVerified, err = cosign.VerifyLocalImageAttestations(ctx, imageRef, co)
+			verified, bundleVerified, err = cosign.VerifyLocalImageAttestationsWithOpts(ctx, imageRef, co)
 			if err != nil {
 				return err
 			}
@@ -241,7 +241,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 				return err
 			}
 
-			verified, bundleVerified, err = cosign.VerifyImageAttestations(ctx, ref, co)
+			verified, bundleVerified, err = cosign.VerifyImageAttestationsWithOpts(ctx, ref, co)
 			if err != nil {
 				return err
 			}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -40,6 +40,7 @@ import (
 	sigs "github.com/sigstore/cosign/v2/pkg/signature"
 
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 func isb64(data []byte) bool {
@@ -214,7 +215,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			bundleCert, err := loadCertFromPEM(certBytes)
 			if err != nil {
 				// check if cert is actually a public key
-				co.SigVerifier, err = sigs.LoadPublicKeyRaw(certBytes, crypto.SHA256)
+				co.SigVerifier, err = sigs.LoadPublicKeyRawWithOpts(certBytes, signatureoptions.WithHash(crypto.SHA256))
 				if err != nil {
 					return fmt.Errorf("loading verifier from bundle: %w", err)
 				}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -170,7 +170,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	// Keys are optional!
 	switch {
 	case c.KeyRef != "":
-		co.SigVerifier, err = sigs.PublicKeyFromKeyRef(ctx, c.KeyRef)
+		co.SigVerifier, err = sigs.PublicKeyFromKeyRefWithOpts(ctx, c.KeyRef)
 		if err != nil {
 			return fmt.Errorf("loading public key: %w", err)
 		}

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -298,7 +298,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	if err != nil {
 		return err
 	}
-	if _, err = cosign.VerifyBlobSignature(ctx, signature, co); err != nil {
+	if _, err = cosign.VerifyBlobSignatureWithOpts(ctx, signature, co); err != nil {
 		return err
 	}
 

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -43,6 +43,7 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/policy"
 	sigs "github.com/sigstore/cosign/v2/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 // VerifyBlobAttestationCommand verifies an attestation on a supplied blob
@@ -260,7 +261,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 			bundleCert, err := loadCertFromPEM(certBytes)
 			if err != nil {
 				// check if cert is actually a public key
-				co.SigVerifier, err = sigs.LoadPublicKeyRaw(certBytes, crypto.SHA256)
+				co.SigVerifier, err = sigs.LoadPublicKeyRawWithOpts(certBytes, signatureoptions.WithHash(crypto.SHA256))
 				if err != nil {
 					return fmt.Errorf("loading verifier from bundle: %w", err)
 				}

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -341,7 +341,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	// TODO: This verifier only supports verification of a single signer/signature on
 	// the envelope. Either have the verifier validate that only one signature exists,
 	// or use a multi-signature verifier.
-	if _, err = cosign.VerifyBlobAttestation(ctx, signature, h, co); err != nil {
+	if _, err = cosign.VerifyBlobAttestationWithOpts(ctx, signature, h, co); err != nil {
 		return err
 	}
 

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -213,7 +213,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	opts := make([]static.Option, 0)
 	switch {
 	case c.KeyRef != "":
-		co.SigVerifier, err = sigs.PublicKeyFromKeyRef(ctx, c.KeyRef)
+		co.SigVerifier, err = sigs.PublicKeyFromKeyRefWithOpts(ctx, c.KeyRef)
 		if err != nil {
 			return fmt.Errorf("loading public key: %w", err)
 		}

--- a/cmd/cosign/cli/verify/verify_bundle.go
+++ b/cmd/cosign/cli/verify/verify_bundle.go
@@ -88,7 +88,7 @@ func verifyNewBundle(ctx context.Context, bundlePath, trustedRootPath, keyRef, s
 
 	// See if we need to wrap trusted root with provided key
 	if keyRef != "" {
-		signatureVerifier, err := sigs.PublicKeyFromKeyRef(ctx, keyRef)
+		signatureVerifier, err := sigs.PublicKeyFromKeyRefWithOpts(ctx, keyRef)
 		if err != nil {
 			return nil, err
 		}

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/sigstore/fulcio v1.6.6
 	github.com/sigstore/protobuf-specs v0.4.0
 	github.com/sigstore/rekor v1.3.9
-	github.com/sigstore/sigstore v1.8.12
+	github.com/sigstore/sigstore v1.8.13-0.20250204232249-4b62818325b7
 	github.com/sigstore/sigstore-go v0.7.0
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.8.12
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.8.12

--- a/go.sum
+++ b/go.sum
@@ -624,8 +624,8 @@ github.com/sigstore/protobuf-specs v0.4.0 h1:yoZbdh0kZYKOSiVbYyA8J3f2wLh5aUk2SQB
 github.com/sigstore/protobuf-specs v0.4.0/go.mod h1:FKW5NYhnnFQ/Vb9RKtQk91iYd0MKJ9AxyqInEwU6+OI=
 github.com/sigstore/rekor v1.3.9 h1:sUjRpKVh/hhgqGMs0t+TubgYsksArZ6poLEC3MsGAzU=
 github.com/sigstore/rekor v1.3.9/go.mod h1:xThNUhm6eNEmkJ/SiU/FVU7pLY2f380fSDZFsdDWlcM=
-github.com/sigstore/sigstore v1.8.12 h1:S8xMVZbE2z9ZBuQUEG737pxdLjnbOIcFi5v9UFfkJFc=
-github.com/sigstore/sigstore v1.8.12/go.mod h1:+PYQAa8rfw0QdPpBcT+Gl3egKD9c+TUgAlF12H3Nmjo=
+github.com/sigstore/sigstore v1.8.13-0.20250204232249-4b62818325b7 h1:dKgngAj90pDWGKB/yBt/AmSvNFzLOPvYGfEgEKRQWc4=
+github.com/sigstore/sigstore v1.8.13-0.20250204232249-4b62818325b7/go.mod h1:2lXojNsjZjkqu1//FWxq7qUcPB8Lq1KsR5hc+GkcC/4=
 github.com/sigstore/sigstore-go v0.7.0 h1:bIGPc2IbnbxnzlqQcKlh1o96bxVJ4yRElpP1gHrOH48=
 github.com/sigstore/sigstore-go v0.7.0/go.mod h1:4RrCK+i+jhx7lyOG2Vgef0/kFLbKlDI1hrioUYvkxxA=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.8.12 h1:EC3UmIaa7nV9sCgSpVevmvgvTYTkMqyrRbj5ojPp7tE=

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -210,6 +210,10 @@ func PemToECDSAKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
 // LoadPrivateKey loads a cosign PEM private key encrypted with the given passphrase,
 // and returns a SignerVerifier instance. The private key must be in the PKCS #8 format.
 func LoadPrivateKey(key []byte, pass []byte) (signature.SignerVerifier, error) {
+	return LoadPrivateKeyWithOpts(key, pass)
+}
+
+func LoadPrivateKeyWithOpts(key []byte, pass []byte, opts ...signature.LoadOption) (signature.SignerVerifier, error) {
 	// Decrypt first
 	p, _ := pem.Decode(key)
 	if p == nil {
@@ -227,14 +231,5 @@ func LoadPrivateKey(key []byte, pass []byte) (signature.SignerVerifier, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing private key: %w", err)
 	}
-	switch pk := pk.(type) {
-	case *rsa.PrivateKey:
-		return signature.LoadRSAPKCS1v15SignerVerifier(pk, crypto.SHA256)
-	case *ecdsa.PrivateKey:
-		return signature.LoadECDSASignerVerifier(pk, crypto.SHA256)
-	case ed25519.PrivateKey:
-		return signature.LoadED25519SignerVerifier(pk)
-	default:
-		return nil, errors.New("unsupported key type")
-	}
+	return signature.LoadSignerVerifierWithOpts(pk, opts...)
 }

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -17,7 +17,6 @@ package cosign
 import (
 	"bytes"
 	"context"
-	"crypto"
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"crypto/x509"
@@ -167,6 +166,60 @@ type CheckOpts struct {
 	ExperimentalOCI11 bool
 }
 
+type validateCertOpts struct {
+	chain  []*x509.Certificate
+	svOpts []signature.LoadOption
+	pool   *x509.CertPool
+}
+
+type ValidateAndUnpackCertOption func(*validateCertOpts)
+
+func WithChain(chain []*x509.Certificate) ValidateAndUnpackCertOption {
+	return func(o *validateCertOpts) {
+		o.chain = chain
+	}
+}
+
+func WithPool(pool *x509.CertPool) ValidateAndUnpackCertOption {
+	return func(o *validateCertOpts) {
+		o.pool = pool
+	}
+}
+
+func WithSignerVerifierOptions(svOpts ...signature.LoadOption) ValidateAndUnpackCertOption {
+	return func(o *validateCertOpts) {
+		o.svOpts = svOpts
+	}
+}
+
+func makeValidateAndUnpackCertOpts(co *CheckOpts, opts ...ValidateAndUnpackCertOption) (*validateCertOpts, error) {
+	o := &validateCertOpts{}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	// Pool Option has precedence over chain option
+	if o.pool == nil && o.chain != nil {
+		if len(o.chain) == 0 {
+			return nil, errors.New("no chain provided to validate certificate")
+		}
+		rootPool := x509.NewCertPool()
+		rootPool.AddCert(o.chain[len(o.chain)-1])
+		co.RootCerts = rootPool
+
+		subPool := x509.NewCertPool()
+		for _, c := range o.chain[:len(o.chain)-1] {
+			subPool.AddCert(c)
+		}
+		o.pool = subPool
+	}
+	// If no pool or chain is provided, use the one from the CheckOpts
+	if o.pool == nil {
+		o.pool = co.IntermediateCerts
+	}
+	return o, nil
+}
+
 // This is a substitutable signature verification function that can be used for verifying
 // attestations of blobs.
 type signatureVerificationFn func(
@@ -223,14 +276,33 @@ func verifyOCISignature(ctx context.Context, verifier signature.Verifier, sig pa
 // certificate chains up to a trusted root using intermediate certificate chain coming from CheckOpts.
 // Optionally verifies the subject and issuer of the certificate.
 func ValidateAndUnpackCert(cert *x509.Certificate, co *CheckOpts) (signature.Verifier, error) {
-	return ValidateAndUnpackCertWithIntermediates(cert, co, co.IntermediateCerts)
+	return ValidateAndUnpackCertWithOpts(cert, co)
 }
 
 // ValidateAndUnpackCertWithIntermediates creates a Verifier from a certificate. Verifies that the
 // certificate chains up to a trusted root using intermediate cert passed as separate argument.
 // Optionally verifies the subject and issuer of the certificate.
 func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpts, intermediateCerts *x509.CertPool) (signature.Verifier, error) {
-	verifier, err := signature.LoadVerifier(cert.PublicKey, crypto.SHA256)
+	return ValidateAndUnpackCertWithOpts(cert, co, WithPool(intermediateCerts))
+}
+
+// ValidateAndUnpackCertWithChain creates a Verifier from a certificate. Verifies that the certificate
+// chains up to the provided root. Chain should start with the parent of the certificate and end with the root.
+// Optionally verifies the subject and issuer of the certificate.
+func ValidateAndUnpackCertWithChain(cert *x509.Certificate, chain []*x509.Certificate, co *CheckOpts) (signature.Verifier, error) {
+	return ValidateAndUnpackCertWithOpts(cert, co, WithChain(chain))
+}
+
+// ValidateAndUnpackCertWithOpts creates a Verifier from a certificate. Verifies that the certificate
+// chains up to a trusted root. Optionally verifies the subject and issuer of the certificate.
+// Accept chain and signerVerifierOptions as optional parameters.
+func ValidateAndUnpackCertWithOpts(cert *x509.Certificate, co *CheckOpts, opts ...ValidateAndUnpackCertOption) (signature.Verifier, error) {
+	o, err := makeValidateAndUnpackCertOpts(co, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	verifier, err := signature.LoadVerifierWithOpts(cert.PublicKey, o.svOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("invalid certificate found on signature: %w", err)
 	}
@@ -250,7 +322,7 @@ func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpt
 	}
 
 	// Now verify the cert, then the signature.
-	chains, err := TrustedCert(cert, co.RootCerts, intermediateCerts)
+	chains, err := TrustedCert(cert, co.RootCerts, o.pool)
 
 	if err != nil {
 		return nil, err
@@ -413,26 +485,6 @@ func validateCertExtensions(ce CertExtensions, co *CheckOpts) error {
 		}
 	}
 	return nil
-}
-
-// ValidateAndUnpackCertWithChain creates a Verifier from a certificate. Verifies that the certificate
-// chains up to the provided root. Chain should start with the parent of the certificate and end with the root.
-// Optionally verifies the subject and issuer of the certificate.
-func ValidateAndUnpackCertWithChain(cert *x509.Certificate, chain []*x509.Certificate, co *CheckOpts) (signature.Verifier, error) {
-	if len(chain) == 0 {
-		return nil, errors.New("no chain provided to validate certificate")
-	}
-	rootPool := x509.NewCertPool()
-	rootPool.AddCert(chain[len(chain)-1])
-	co.RootCerts = rootPool
-
-	subPool := x509.NewCertPool()
-	for _, c := range chain[:len(chain)-1] {
-		subPool.AddCert(c)
-	}
-	co.IntermediateCerts = subPool
-
-	return ValidateAndUnpackCert(cert, co)
 }
 
 func tlogValidateEntry(ctx context.Context, client *client.Rekor, rekorPubKeys *TrustedTransparencyLogPubKeys,

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -536,14 +536,18 @@ func (fos *fakeOCISignatures) Get() ([]oci.Signature, error) {
 	return fos.signatures, nil
 }
 
-// VerifyImageSignatures does all the main cosign checks in a loop, returning the verified signatures.
+func VerifyImageSignatures(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
+	return VerifyImageSignaturesWithOpts(ctx, signedImgRef, co)
+}
+
+// VerifyImageSignaturesWithOpts does all the main cosign checks in a loop, returning the verified signatures.
 // If there were no valid signatures, we return an error.
 // Note that if co.ExperimentlOCI11 is set, we will attempt to verify
 // signatures using the experimental OCI 1.1 behavior.
-func VerifyImageSignatures(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
+func VerifyImageSignaturesWithOpts(ctx context.Context, signedImgRef name.Reference, co *CheckOpts, svOpts ...signature.LoadOption) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
 	// Try first using OCI 1.1 behavior if experimental flag is set.
 	if co.ExperimentalOCI11 {
-		verified, bundleVerified, err := verifyImageSignaturesExperimentalOCI(ctx, signedImgRef, co)
+		verified, bundleVerified, err := verifyImageSignaturesExperimentalOCI(ctx, signedImgRef, co, svOpts...)
 		if err == nil {
 			return verified, bundleVerified, nil
 		}
@@ -588,12 +592,16 @@ func VerifyImageSignatures(ctx context.Context, signedImgRef name.Reference, co 
 		}
 	}
 
-	return verifySignatures(ctx, sigs, h, co)
+	return verifySignatures(ctx, sigs, h, co, svOpts...)
 }
 
-// VerifyLocalImageSignatures verifies signatures from a saved, local image, without any network calls, returning the verified signatures.
-// If there were no valid signatures, we return an error.
 func VerifyLocalImageSignatures(ctx context.Context, path string, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
+	return VerifyLocalImageSignaturesWithOpts(ctx, path, co)
+}
+
+// VerifyLocalImageSignaturesWithOpts verifies signatures from a saved, local image, without any network calls, returning the verified signatures.
+// If there were no valid signatures, we return an error.
+func VerifyLocalImageSignaturesWithOpts(ctx context.Context, path string, co *CheckOpts, svOpts ...signature.LoadOption) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
 	// Enforce this up front.
 	if co.RootCerts == nil && co.SigVerifier == nil {
 		return nil, false, errors.New("one of verifier or root certs is required")
@@ -637,10 +645,10 @@ func VerifyLocalImageSignatures(ctx context.Context, path string, co *CheckOpts)
 		return nil, false, fmt.Errorf("no signatures associated with the image saved in %s", path)
 	}
 
-	return verifySignatures(ctx, sigs, h, co)
+	return verifySignatures(ctx, sigs, h, co, svOpts...)
 }
 
-func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
+func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *CheckOpts, svOpts ...signature.LoadOption) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
 	sl, err := sigs.Get()
 	if err != nil {
 		return nil, false, err
@@ -668,7 +676,7 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 				return
 			}
 
-			verified, err := VerifyImageSignature(ctx, sig, h, co)
+			verified, err := VerifyImageSignatureWithOpts(ctx, sig, h, co, svOpts...)
 			bundlesVerified[index] = verified
 			if err != nil {
 				t.Done(err)
@@ -716,7 +724,7 @@ func verifySignatures(ctx context.Context, sigs oci.Signatures, h v1.Hash, co *C
 //     we are in experimental mode).
 //  3. If a certificate is provided, check it's expiration using the transparency log timestamp.
 func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
-	verifyFn signatureVerificationFn, co *CheckOpts) (
+	verifyFn signatureVerificationFn, co *CheckOpts, svOpts ...signature.LoadOption) (
 	bundleVerified bool, err error) {
 	var acceptableRFC3161Time, acceptableRekorBundleTime *time.Time // Timestamps for the signature we accept, or nil if not applicable.
 
@@ -803,7 +811,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		if pool == nil {
 			pool = co.IntermediateCerts
 		}
-		verifier, err = ValidateAndUnpackCertWithOpts(cert, co, WithPool(pool))
+		verifier, err = ValidateAndUnpackCertWithOpts(cert, co, WithPool(pool), WithSignerVerifierOptions(svOpts...))
 		if err != nil {
 			return false, err
 		}
@@ -880,13 +888,23 @@ func keyBytes(sig oci.Signature, co *CheckOpts) ([]byte, error) {
 
 // VerifyBlobSignature verifies a blob signature.
 func VerifyBlobSignature(ctx context.Context, sig oci.Signature, co *CheckOpts) (bundleVerified bool, err error) {
+	return VerifyBlobSignatureWithOpts(ctx, sig, co)
+}
+
+// VerifyBlobSignatureWithOpts verifies a blob signature.
+func VerifyBlobSignatureWithOpts(ctx context.Context, sig oci.Signature, co *CheckOpts, svOpts ...signature.LoadOption) (bundleVerified bool, err error) {
 	// The hash of the artifact is unused.
-	return verifyInternal(ctx, sig, v1.Hash{}, verifyOCISignature, co)
+	return verifyInternal(ctx, sig, v1.Hash{}, verifyOCISignature, co, svOpts...)
 }
 
 // VerifyImageSignature verifies a signature
 func VerifyImageSignature(ctx context.Context, sig oci.Signature, h v1.Hash, co *CheckOpts) (bundleVerified bool, err error) {
-	return verifyInternal(ctx, sig, h, verifyOCISignature, co)
+	return VerifyImageSignatureWithOpts(ctx, sig, h, co)
+}
+
+// VerifyImageSignatureWithOpts verifies a signature
+func VerifyImageSignatureWithOpts(ctx context.Context, sig oci.Signature, h v1.Hash, co *CheckOpts, svOpts ...signature.LoadOption) (bundleVerified bool, err error) {
+	return verifyInternal(ctx, sig, h, verifyOCISignature, co, svOpts...)
 }
 
 func loadSignatureFromFile(ctx context.Context, sigRef string, signedImgRef name.Reference, co *CheckOpts) (oci.Signatures, error) {
@@ -933,9 +951,13 @@ func loadSignatureFromFile(ctx context.Context, sigRef string, signedImgRef name
 	}, nil
 }
 
-// VerifyImageAttestations does all the main cosign checks in a loop, returning the verified attestations.
-// If there were no valid attestations, we return an error.
 func VerifyImageAttestations(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+	return VerifyImageAttestationsWithOpts(ctx, signedImgRef, co)
+}
+
+// VerifyImageAttestationsWithOpts does all the main cosign checks in a loop, returning the verified attestations.
+// If there were no valid attestations, we return an error.
+func VerifyImageAttestationsWithOpts(ctx context.Context, signedImgRef name.Reference, co *CheckOpts, svOpts ...signature.LoadOption) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
 	// Enforce this up front.
 	if co.RootCerts == nil && co.SigVerifier == nil {
 		return nil, false, errors.New("one of verifier or root certs is required")
@@ -961,13 +983,17 @@ func VerifyImageAttestations(ctx context.Context, signedImgRef name.Reference, c
 		return nil, false, err
 	}
 
-	return VerifyImageAttestation(ctx, atts, h, co)
+	return VerifyImageAttestationWithOpts(ctx, atts, h, co, svOpts...)
 }
 
-// VerifyLocalImageAttestations verifies attestations from a saved, local image, without any network calls,
+func VerifyLocalImageAttestations(ctx context.Context, path string, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+	return VerifyLocalImageAttestationsWithOpts(ctx, path, co)
+}
+
+// VerifyLocalImageAttestationsWithOpts verifies attestations from a saved, local image, without any network calls,
 // returning the verified attestations.
 // If there were no valid signatures, we return an error.
-func VerifyLocalImageAttestations(ctx context.Context, path string, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+func VerifyLocalImageAttestationsWithOpts(ctx context.Context, path string, co *CheckOpts, svOpts ...signature.LoadOption) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
 	// Enforce this up front.
 	if co.RootCerts == nil && co.SigVerifier == nil {
 		return nil, false, errors.New("one of verifier or root certs is required")
@@ -1007,15 +1033,24 @@ func VerifyLocalImageAttestations(ctx context.Context, path string, co *CheckOpt
 	if err != nil {
 		return nil, false, err
 	}
-	return VerifyImageAttestation(ctx, atts, h, co)
+	return VerifyImageAttestationWithOpts(ctx, atts, h, co, svOpts...)
 }
 
 func VerifyBlobAttestation(ctx context.Context, att oci.Signature, h v1.Hash, co *CheckOpts) (
 	bool, error) {
-	return verifyInternal(ctx, att, h, verifyOCIAttestation, co)
+	return VerifyBlobAttestationWithOpts(ctx, att, h, co)
+}
+
+func VerifyBlobAttestationWithOpts(ctx context.Context, att oci.Signature, h v1.Hash, co *CheckOpts, svOpts ...signature.LoadOption) (
+	bool, error) {
+	return verifyInternal(ctx, att, h, verifyOCIAttestation, co, svOpts...)
 }
 
 func VerifyImageAttestation(ctx context.Context, atts oci.Signatures, h v1.Hash, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+	return VerifyImageAttestationWithOpts(ctx, atts, h, co)
+}
+
+func VerifyImageAttestationWithOpts(ctx context.Context, atts oci.Signatures, h v1.Hash, co *CheckOpts, svOpts ...signature.LoadOption) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
 	sl, err := atts.Get()
 	if err != nil {
 		return nil, false, err
@@ -1037,7 +1072,7 @@ func VerifyImageAttestation(ctx context.Context, atts oci.Signatures, h v1.Hash,
 				return
 			}
 			if err := func(att oci.Signature) error {
-				verified, err := verifyInternal(ctx, att, h, verifyOCIAttestation, co)
+				verified, err := verifyInternal(ctx, att, h, verifyOCIAttestation, co, svOpts...)
 				bundlesVerified[index] = verified
 				return err
 			}(att); err != nil {
@@ -1415,7 +1450,7 @@ func correctAnnotations(wanted, have map[string]interface{}) bool {
 
 // verifyImageSignaturesExperimentalOCI does all the main cosign checks in a loop, returning the verified signatures.
 // If there were no valid signatures, we return an error, using OCI 1.1+ behavior.
-func verifyImageSignaturesExperimentalOCI(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
+func verifyImageSignaturesExperimentalOCI(ctx context.Context, signedImgRef name.Reference, co *CheckOpts, svOpts ...signature.LoadOption) (checkedSignatures []oci.Signature, bundleVerified bool, err error) {
 	// Enforce this up front.
 	if co.RootCerts == nil && co.SigVerifier == nil {
 		return nil, false, errors.New("one of verifier or root certs is required")
@@ -1468,5 +1503,5 @@ func verifyImageSignaturesExperimentalOCI(ctx context.Context, signedImgRef name
 		}
 	}
 
-	return verifySignatures(ctx, sigs, h, co)
+	return verifySignatures(ctx, sigs, h, co, svOpts...)
 }

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -803,7 +803,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		if pool == nil {
 			pool = co.IntermediateCerts
 		}
-		verifier, err = ValidateAndUnpackCertWithIntermediates(cert, co, pool)
+		verifier, err = ValidateAndUnpackCertWithOpts(cert, co, WithPool(pool))
 		if err != nil {
 			return false, err
 		}

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature"
 
 	"github.com/sigstore/sigstore/pkg/signature/kms"
+	"github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 // LoadPublicKey is a wrapper for VerifierForKeyRef, hardcoding SHA256 as the hash algorithm
@@ -41,7 +42,18 @@ func LoadPublicKey(ctx context.Context, keyRef string) (verifier signature.Verif
 // VerifierForKeyRef parses the given keyRef, loads the key and returns an appropriate
 // verifier using the provided hash algorithm
 func VerifierForKeyRef(ctx context.Context, keyRef string, hashAlgorithm crypto.Hash) (verifier signature.Verifier, err error) {
+	return VerifierForKeyRefWithOpts(ctx, keyRef, options.WithHash(hashAlgorithm))
+}
+
+// VerifierForKeyRefWithOpts parses the given keyRef, loads the key and returns an appropriate
+// verifier using the provided hash algorithm and options
+func VerifierForKeyRefWithOpts(ctx context.Context, keyRef string, opts ...signature.LoadOption) (verifier signature.Verifier, err error) {
 	// The key could be plaintext, in a file, at a URL, or in KMS.
+	hashAlgorithm := crypto.SHA256
+	for _, o := range opts {
+		o.ApplyHash(&hashAlgorithm)
+	}
+
 	var perr *kms.ProviderNotFoundError
 	kmsKey, err := kms.Get(ctx, keyRef, hashAlgorithm)
 	switch {
@@ -69,7 +81,7 @@ func VerifierForKeyRef(ctx context.Context, keyRef string, hashAlgorithm crypto.
 		return nil, fmt.Errorf("pem to public key: %w", err)
 	}
 
-	return signature.LoadVerifier(pubKey, hashAlgorithm)
+	return signature.LoadVerifierWithOpts(pubKey, opts...)
 }
 
 func loadKey(keyPath string, pf cosign.PassFunc) (signature.SignerVerifier, error) {
@@ -89,11 +101,16 @@ func loadKey(keyPath string, pf cosign.PassFunc) (signature.SignerVerifier, erro
 
 // LoadPublicKeyRaw loads a verifier from a PEM-encoded public key
 func LoadPublicKeyRaw(raw []byte, hashAlgorithm crypto.Hash) (signature.Verifier, error) {
+	return LoadPublicKeyRawWithOpts(raw, options.WithHash(hashAlgorithm))
+}
+
+// LoadPublicKeyRawWithOpts loads a verifier from a PEM-encoded public key with options
+func LoadPublicKeyRawWithOpts(raw []byte, opts ...signature.LoadOption) (signature.Verifier, error) {
 	pub, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
 	if err != nil {
 		return nil, err
 	}
-	return signature.LoadVerifier(pub, hashAlgorithm)
+	return signature.LoadVerifierWithOpts(pub, opts...)
 }
 
 func SignerFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc) (signature.Signer, error) {

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -190,6 +190,10 @@ func PublicKeyFromKeyRef(ctx context.Context, keyRef string) (signature.Verifier
 }
 
 func PublicKeyFromKeyRefWithHashAlgo(ctx context.Context, keyRef string, hashAlgorithm crypto.Hash) (signature.Verifier, error) {
+	return PublicKeyFromKeyRefWithOpts(ctx, keyRef, options.WithHash(hashAlgorithm))
+}
+
+func PublicKeyFromKeyRefWithOpts(ctx context.Context, keyRef string, opts ...signature.LoadOption) (signature.Verifier, error) {
 	if strings.HasPrefix(keyRef, kubernetes.KeyReference) {
 		s, err := kubernetes.GetKeyPairSecret(ctx, keyRef)
 		if err != nil {
@@ -197,7 +201,7 @@ func PublicKeyFromKeyRefWithHashAlgo(ctx context.Context, keyRef string, hashAlg
 		}
 
 		if len(s.Data) > 0 {
-			return LoadPublicKeyRaw(s.Data["cosign.pub"], hashAlgorithm)
+			return LoadPublicKeyRawWithOpts(s.Data["cosign.pub"], opts...)
 		}
 	}
 
@@ -236,11 +240,11 @@ func PublicKeyFromKeyRefWithHashAlgo(ctx context.Context, keyRef string, hashAlg
 		}
 
 		if len(pubKey) > 0 {
-			return LoadPublicKeyRaw([]byte(pubKey), hashAlgorithm)
+			return LoadPublicKeyRawWithOpts([]byte(pubKey), opts...)
 		}
 	}
 
-	return VerifierForKeyRef(ctx, keyRef, hashAlgorithm)
+	return VerifierForKeyRefWithOpts(ctx, keyRef, opts...)
 }
 
 func PublicKeyPem(key signature.PublicKeyProvider, pkOpts ...signature.PublicKeyOption) ([]byte, error) {

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -84,7 +84,7 @@ func VerifierForKeyRefWithOpts(ctx context.Context, keyRef string, opts ...signa
 	return signature.LoadVerifierWithOpts(pubKey, opts...)
 }
 
-func loadKey(keyPath string, pf cosign.PassFunc) (signature.SignerVerifier, error) {
+func loadKey(keyPath string, pf cosign.PassFunc, opts ...signature.LoadOption) (signature.SignerVerifier, error) {
 	kb, err := blob.LoadFileOrURL(keyPath)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ func loadKey(keyPath string, pf cosign.PassFunc) (signature.SignerVerifier, erro
 			return nil, err
 		}
 	}
-	return cosign.LoadPrivateKey(kb, pass)
+	return cosign.LoadPrivateKeyWithOpts(kb, pass, opts...)
 }
 
 // LoadPublicKeyRaw loads a verifier from a PEM-encoded public key
@@ -118,6 +118,10 @@ func SignerFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc) (s
 }
 
 func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc) (signature.SignerVerifier, error) {
+	return SignerVerifierFromKeyRefWithOpts(ctx, keyRef, pf)
+}
+
+func SignerVerifierFromKeyRefWithOpts(ctx context.Context, keyRef string, pf cosign.PassFunc, opts ...signature.LoadOption) (signature.SignerVerifier, error) {
 	switch {
 	case strings.HasPrefix(keyRef, pkcs11key.ReferenceScheme):
 		pkcs11UriConfig := pkcs11key.NewPkcs11UriConfig()
@@ -146,7 +150,7 @@ func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.Pass
 		}
 
 		if len(s.Data) > 0 {
-			return cosign.LoadPrivateKey(s.Data["cosign.key"], s.Data["cosign.password"])
+			return cosign.LoadPrivateKeyWithOpts(s.Data["cosign.key"], s.Data["cosign.password"], opts...)
 		}
 	case strings.HasPrefix(keyRef, gitlab.ReferenceScheme):
 		split := strings.Split(keyRef, "://")
@@ -167,7 +171,7 @@ func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.Pass
 			return nil, err
 		}
 
-		return cosign.LoadPrivateKey([]byte(pk), []byte(pass))
+		return cosign.LoadPrivateKeyWithOpts([]byte(pk), []byte(pass), opts...)
 	}
 
 	if strings.Contains(keyRef, "://") {
@@ -182,7 +186,7 @@ func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.Pass
 		// ProviderNotFoundError is okay; loadKey handles other URL schemes
 	}
 
-	return loadKey(keyRef, pf)
+	return loadKey(keyRef, pf, opts...)
 }
 
 func PublicKeyFromKeyRef(ctx context.Context, keyRef string) (signature.Verifier, error) {


### PR DESCRIPTION
#### Summary
This is a preparation PR for https://github.com/sigstore/cosign/issues/3271 and it splits some changes required to completely add support for ed25519ph, with the idea of helping the reviewers. It was split from https://github.com/sigstore/cosign/pull/3479 .

#### Release Note
- Adds functions `SignerFromKeyOptsWithSVOpts`, `LoadPrivateKeyWithOpts`, `ValidateAndUnpackCertWithOpts`, `VerifyImageSignaturesWithOpts`, `VerifyLocalImageSignaturesWithOpts`, `VerifyBlobSignatureWithOpts`, `VerifyImageSignatureWithOpts`, `VerifyImageAttestationsWithOpts`, `VerifyLocalImageAttestationsWithOpts`, `VerifyBlobAttestationWithOpts`, `VerifyImageAttestationWithOpts`, `VerifierForKeyRefWithOpts`, `LoadPublicKeyRawWithOpts`, `SignerVerifierFromKeyRefWithOpts`, `PublicKeyFromKeyRefWithOpts`.

#### Documentation
With recent sigstore, we introduced `signature.LoadVerifierWithOpts` (and other versions for `Signer`, `SignerVerifier`). Adding support for ed25519ph would require passing some options around, however cosign is still using `signature.LoadVerifier`. This PR prepares the cosign codebase to accept `LoadOptions` and pass them around, without actually changing (yet) any behaviour.

Doing that required adding a lot of `*WithOpts` functions to avoid breaking other users who may rely on those exported functions. Please let me know if that's a good approach.

Once this is done, we can work on a smaller PR that actually adds supports for ed25519ph and pass the correct extra `LoadOptions` around.
