### PR TITLE
disable fuzzer on policy evaluation code path

### DIFF
--- a/pkg/policy/fuzz_test.go
+++ b/pkg/policy/fuzz_test.go
@@ -15,6 +15,7 @@
 
 package policy
 
+/* disabling since this effectively just fuzzes rego & cue vs something in cosign
 import (
 	"context"
 	"runtime"
@@ -52,3 +53,4 @@ func FuzzEvaluatePolicyAgainstJSON(f *testing.F) {
 		EvaluatePolicyAgainstJSON(context.Background(), name, choosePolicyType, policyBody, jsonBytes)
 	})
 }
+*/


### PR DESCRIPTION
`EvaluatePolicyAgainstJSON` is a thin wrapper around calling `cue` or `rego` and we're getting fuzzing reports that aren't really bugs in cosign. 