### PR TITLE
sort properly Go imports

### DIFF
--- a/cmd/cosign/cli/piv_tool.go
+++ b/cmd/cosign/cli/piv_tool.go
@@ -20,10 +20,9 @@ package cli
 import (
 	"encoding/json"
 
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/pivcli"
+	"github.com/spf13/cobra"
 )
 
 var pivToolForce bool

--- a/cmd/cosign/cli/pkcs11_tool.go
+++ b/cmd/cosign/cli/pkcs11_tool.go
@@ -18,10 +18,9 @@
 package cli
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/pkcs11cli"
+	"github.com/spf13/cobra"
 )
 
 var pkcs11ToolForce bool

--- a/cmd/cosign/cli/public_key.go
+++ b/cmd/cosign/cli/public_key.go
@@ -18,11 +18,10 @@ package cli
 import (
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/publickey"
+	"github.com/spf13/cobra"
 )
 
 func PublicKey() *cobra.Command {

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -19,11 +19,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/sign"
+	"github.com/spf13/cobra"
 )
 
 func Sign() *cobra.Command {

--- a/cmd/cosign/cli/tree.go
+++ b/cmd/cosign/cli/tree.go
@@ -20,13 +20,11 @@ import (
 	"fmt"
 	"os"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/spf13/cobra"
-
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	ociremote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	"github.com/spf13/cobra"
 )
 
 func Tree() *cobra.Command {

--- a/cmd/cosign/cli/triangulate.go
+++ b/cmd/cosign/cli/triangulate.go
@@ -18,10 +18,9 @@ package cli
 import (
 	"flag"
 
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/triangulate"
+	"github.com/spf13/cobra"
 )
 
 func Triangulate() *cobra.Command {

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -18,10 +18,9 @@ package cli
 import (
 	"context"
 
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/trustedroot"
+	"github.com/spf13/cobra"
 )
 
 func TrustedRoot() *cobra.Command {

--- a/cmd/cosign/cli/upload.go
+++ b/cmd/cosign/cli/upload.go
@@ -18,10 +18,9 @@ package cli
 import (
 	"flag"
 
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/upload"
+	"github.com/spf13/cobra"
 )
 
 func Upload() *cobra.Command {

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -20,12 +20,10 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
-
-	"github.com/spf13/cobra"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/verify"
 	"github.com/sigstore/cosign/v2/internal/ui"
+	"github.com/spf13/cobra"
 )
 
 const ignoreTLogMessage = "Skipping tlog verification is an insecure practice that lacks of transparency and auditability verification for the %s."

--- a/pkg/cosign/attestation/attestation.go
+++ b/pkg/cosign/attestation/attestation.go
@@ -23,10 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/in-toto/in-toto-golang/in_toto"
 	slsa02 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	slsa1 "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v1"
-
-	"github.com/in-toto/in-toto-golang/in_toto"
 )
 
 const (

--- a/pkg/cosign/cue/cue_test.go
+++ b/pkg/cosign/cue/cue_test.go
@@ -18,7 +18,6 @@ package cue
 import (
 	"fmt"
 	"os"
-
 	"testing"
 )
 

--- a/pkg/cosign/errors_test.go
+++ b/pkg/cosign/errors_test.go
@@ -15,10 +15,9 @@
 package cosign
 
 import (
+	"errors"
 	"fmt"
 	"testing"
-
-	"errors"
 )
 
 func TestErrors(t *testing.T) {

--- a/pkg/cosign/kubernetes/client.go
+++ b/pkg/cosign/kubernetes/client.go
@@ -17,9 +17,9 @@ package kubernetes
 import (
 	"fmt"
 
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/client-go/kubernetes"
 
-	utilversion "k8s.io/apimachinery/pkg/util/version"
 	// Initialize all known client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"

--- a/pkg/cosign/kubernetes/secret.go
+++ b/pkg/cosign/kubernetes/secret.go
@@ -21,12 +21,11 @@ import (
 	"os"
 	"strings"
 
+	"github.com/sigstore/cosign/v2/pkg/cosign"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-
-	"github.com/sigstore/cosign/v2/pkg/cosign"
 )
 
 const (

--- a/pkg/cosign/kubernetes/secret_test.go
+++ b/pkg/cosign/kubernetes/secret_test.go
@@ -18,11 +18,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sigstore/cosign/v2/pkg/cosign"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-
-	"github.com/sigstore/cosign/v2/pkg/cosign"
 )
 
 func TestSecret(t *testing.T) {

--- a/pkg/cosign/pivkey/pivkey.go
+++ b/pkg/cosign/pivkey/pivkey.go
@@ -32,9 +32,8 @@ import (
 	"syscall"
 
 	"github.com/go-piv/piv-go/v2/piv"
-	"golang.org/x/term"
-
 	"github.com/sigstore/sigstore/pkg/signature"
+	"golang.org/x/term"
 )
 
 var (

--- a/pkg/policy/attestation.go
+++ b/pkg/policy/attestation.go
@@ -23,10 +23,9 @@ import (
 	"fmt"
 
 	"github.com/in-toto/in-toto-golang/in_toto"
-	"github.com/sigstore/cosign/v2/pkg/oci"
-
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/pkg/cosign/attestation"
+	"github.com/sigstore/cosign/v2/pkg/oci"
 )
 
 // PayloadProvider is a subset of oci.Signature that only provides the


### PR DESCRIPTION
#### Summary
As in the previously merged #4061 and #4062, sort the Go imports to be in the alphabetical order (mostly the "third-party" = non-stdlib imports though `pkg/cosign/errors_test.go` had the stdlib imports in a wrong order).
As mentioned in #4062,
> I propose to keep all the third-party (non-stdlib) imports in just one block to make it easier for the IDEs to properly sort those imports on addition or deletion.

I didn't change the existing  extra blank lines where they don't violate the alphabetical sorted order of the imports.

#### Release Note
NONE

#### Documentation
n/a