### PR TITLE
fix: increase e2e_test docker compose timeout to 180s

### DIFF
--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -73,7 +73,7 @@ for repo in rekor fulcio; do
     count=0
     until [ $(${docker_compose} ps | grep -c "(healthy)") == 3 ];
     do
-        if [ $count -eq 6 ]; then
+        if [ $count -eq 18 ]; then
            echo "! timeout reached"
            exit 1
         else


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

When running `./test/e2e_test.sh` on a personal machine, it can a lot longer than 60 seconds for the test containers to be ready. This PR increases the timeout to 3 minutes. In the CI, the containers seem to be ready at between 20 to 30 seconds, but increasing to 3 minutes I think should be fine.

Example invocation:

```
...
+ for repo in rekor fulcio
+ pushd rekor
...
+ '[' 12 -eq 18 ']'
...
+ '[' 3 == 3 ']'
...
+ for repo in rekor fulcio
+ pushd fulcio
...
+ '[' 7 -eq 18 ']'
...
+ '[' 3 == 3 ']'
...
+ echo 'running tests'
...
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

NONE
