### PR TITLE
enhancement: use jq to check for test container readiness

### DIFF
--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -71,7 +71,7 @@ for repo in rekor fulcio; do
     ${docker_compose} up -d
     echo -n "waiting up to 60 sec for system to start"
     count=0
-    until [ $(${docker_compose} ps | grep -c "(healthy)") == 3 ];
+    until $(docker compose ps --format '{{json .}}' | jq -s -e '.[] | .Health == "healthy" or .Health == ""');
     do
         if [ $count -eq 18 ]; then
            echo "! timeout reached"

--- a/test/e2e_test.sh
+++ b/test/e2e_test.sh
@@ -71,7 +71,7 @@ for repo in rekor fulcio; do
     ${docker_compose} up -d
     echo -n "waiting up to 60 sec for system to start"
     count=0
-    until $(docker compose ps --format '{{json .}}' | jq -s -e '.[] | .Health == "healthy" or .Health == ""');
+    until $(${docker_compose} ps --format '{{json .}}' | jq -s -e '.[] | .Health == "healthy" or .Health == ""');
     do
         if [ $count -eq 18 ]; then
            echo "! timeout reached"


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

https://github.com/sigstore/rekor-tiles/issues/38

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Improves the way the e2e_test.sh checks for container readiness with jq.

Currently, there are exactly 3 healthcheck probes in each of fulcio and rekor's docker-compose.ymls. In the future, we should consider adding more. This PR is in preparation for that future.

The jq expression checks that all of the `.Health` properties are either 
 
- `"healthy"`, when a container does have a healthcheck defined
- `""`, when a container does not have a healthcheck defined

The script still waits until the containers are not `"unhealthy"`

## Testing process

Running e2e_test.sh locally

```log
...
++ docker compose ps --format '{{json .}}'
++ jq -s -e '.[] | .Health == "healthy" or .Health == ""'
WARN[0000] /usr/local/google/home/rpetgrave/rekor/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
+ false true true true true
...
++ docker compose ps --format '{{json .}}'
++ jq -s -e '.[] | .Health == "healthy" or .Health == ""'
WARN[0000] /usr/local/google/home/rpetgrave/rekor/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
+ true true true true true
...
+ echo 'running tests'
running tests
...
```

In the log, we see `+ false true true true true` when some containers are still not yet ready, and `+ true true true true true` when all of the containers are ready.


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Improve container readiness checks for e2e tests.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

None
