### PR TITLE
ensure we copy the latest tags on each release

### DIFF
--- a/release/release.mk
+++ b/release/release.mk
@@ -27,4 +27,6 @@ snapshot:
 .PHONY: copy-signed-release-to-ghcr
 copy-signed-release-to-ghcr:
 	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:$(GIT_VERSION)
+	cosign copy $(GHCR_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:latest
 	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev
+	cosign copy $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:latest-dev


### PR DESCRIPTION
i noticed that we're not updating the ghcr.io/sigstore/cosign/cosign `latest` tag to map to the most recent release. 