### PR TITLE
Introduce a --bundle-repository flag for attest and verify-attestation

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -106,6 +106,8 @@ func Attest() *cobra.Command {
 				TlogUpload:              o.TlogUpload,
 				RekorEntryType:          o.RekorEntryType,
 				RecordCreationTimestamp: o.RecordCreationTimestamp,
+				BundleRepository:        o.BundleRepository,
+				BundleRegistry:          o.BundleRegistry,
 			}
 
 			for _, img := range args {

--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -39,6 +39,8 @@ type AttestOptions struct {
 	RekorEntryType          string
 	RecordCreationTimestamp bool
 	NewBundleFormat         bool
+	BundleRepository        string
+	BundleRegistry          RegistryOptions
 
 	Rekor       RekorOptions
 	Fulcio      FulcioOptions
@@ -58,6 +60,9 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 	o.OIDC.AddFlags(cmd)
 	o.Rekor.AddFlags(cmd)
 	o.Registry.AddFlags(cmd)
+
+	o.BundleRegistry.WithPrefix("bundle")
+	o.BundleRegistry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the private key file, KMS URI or Kubernetes Secret")
@@ -113,4 +118,8 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 		"set the createdAt timestamp in the attestation artifact to the time it was created; by default, cosign sets this to the zero value")
 
 	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", false, "attach a Sigstore bundle using OCI referrers API")
+
+	cmd.Flags().StringVar(&o.BundleRepository, "bundle-repository", "", "attach a Sigstore bundle into a different repository than the image being signed")
+
+	// TODO cdupuis add options for bundle repository auth
 }

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -32,6 +32,7 @@ type CommonVerifyOptions struct {
 	PrivateInfrastructure bool
 	UseSignedTimestamps   bool
 	NewBundleFormat       bool
+	BundleRepository      string
 	TrustedRootPath       string
 }
 
@@ -65,6 +66,9 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	// TODO: have this default to true as a breaking change
 	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", false,
 		"expect the signature/attestation to be packaged in a Sigstore bundle")
+
+	cmd.Flags().StringVar(&o.BundleRepository, "bundle-repository", "",
+		"discover a Sigstore bundle from a separate repository")
 }
 
 // VerifyOptions is the top level wrapper for the `verify` command.
@@ -139,6 +143,8 @@ type VerifyAttestationOptions struct {
 	Predicate           PredicateRemoteOptions
 	Policies            []string
 	LocalImage          bool
+
+	BundleRegistry RegistryOptions
 }
 
 var _ Interface = (*VerifyAttestationOptions)(nil)
@@ -151,6 +157,9 @@ func (o *VerifyAttestationOptions) AddFlags(cmd *cobra.Command) {
 	o.Registry.AddFlags(cmd)
 	o.Predicate.AddFlags(cmd)
 	o.CommonVerifyOptions.AddFlags(cmd)
+
+	o.BundleRegistry.WithPrefix("bundle")
+	o.BundleRegistry.AddFlags(cmd)
 
 	cmd.Flags().StringVar(&o.Key, "key", "",
 		"path to the public key file, KMS URI or Kubernetes Secret")

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -246,6 +246,7 @@ against the transparency log.`,
 				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
 				MaxWorkers:                   o.CommonVerifyOptions.MaxWorkers,
 				UseSignedTimestamps:          o.CommonVerifyOptions.UseSignedTimestamps,
+				BundleRegistry:               o.BundleRegistry,
 			}
 
 			if o.CommonVerifyOptions.MaxWorkers == 0 {

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -72,6 +72,8 @@ type VerifyAttestationCommand struct {
 	IgnoreTlog                   bool
 	MaxWorkers                   int
 	UseSignedTimestamps          bool
+
+	BundleRegistry options.RegistryOptions
 }
 
 // Exec runs the verification command
@@ -98,6 +100,11 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		return fmt.Errorf("constructing client options: %w", err)
 	}
 
+	bundleOciremoteOpts, err := c.BundleRegistry.ClientOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("constructing client options: %w", err)
+	}
+
 	co := &cosign.CheckOpts{
 		RegistryClientOpts:           ociremoteOpts,
 		CertGithubWorkflowTrigger:    c.CertGithubWorkflowTrigger,
@@ -112,6 +119,8 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		MaxWorkers:                   c.MaxWorkers,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
 		NewBundleFormat:              c.NewBundleFormat,
+		BundleRepository:             c.BundleRepository,
+		BundleRegistryClientOpts:     bundleOciremoteOpts,
 	}
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier

--- a/pkg/cosign/verify_oci_test.go
+++ b/pkg/cosign/verify_oci_test.go
@@ -77,7 +77,7 @@ func TestGetBundles_Empty(t *testing.T) {
 	digestRef := ref.Context().Digest(desc.Digest.String())
 
 	// Write invalid attestation
-	err = ociremote.WriteAttestationNewBundleFormat(digestRef, []byte("invalid"), "foo/bar")
+	err = ociremote.WriteAttestationNewBundleFormat(digestRef, digestRef, []byte("invalid"), "foo/bar", []ociremote.Option{}, []ociremote.Option{})
 	assert.NoError(t, err)
 
 	// Should still return no matching attestation error, as it failed to parse the bundle
@@ -107,7 +107,7 @@ func TestGetBundles_Valid(t *testing.T) {
 	digestRef := ref.Context().Digest(desc.Digest.String())
 
 	// Write valid test attestation
-	err = ociremote.WriteAttestationNewBundleFormat(digestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1")
+	err = ociremote.WriteAttestationNewBundleFormat(digestRef, digestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1", []ociremote.Option{}, []ociremote.Option{})
 	assert.NoError(t, err)
 
 	// Retrieve the attestation
@@ -175,7 +175,7 @@ func TestVerifyImageAttestationsSigstoreBundle(t *testing.T) {
 	digestRef := ref.Context().Digest(desc.Digest.String())
 
 	// Write valid test attestation
-	err = ociremote.WriteAttestationNewBundleFormat(digestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1")
+	err = ociremote.WriteAttestationNewBundleFormat(digestRef, digestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1", []ociremote.Option{}, []ociremote.Option{})
 	assert.NoError(t, err)
 
 	// Verify the attestation
@@ -215,7 +215,7 @@ func TestVerifyImageAttestationsSigstoreBundle(t *testing.T) {
 	digestRef = ref2.Context().Digest(desc.Digest.String())
 
 	// Write valid test attestation
-	err = ociremote.WriteAttestationNewBundleFormat(digestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1")
+	err = ociremote.WriteAttestationNewBundleFormat(digestRef, digestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1", []ociremote.Option{}, []ociremote.Option{})
 	assert.NoError(t, err)
 
 	// Verify the attestation

--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -224,8 +224,9 @@ func (taggable taggableManifest) MediaType() (types.MediaType, error) {
 	return taggable.mediaType, nil
 }
 
-func WriteAttestationNewBundleFormat(d name.Digest, bundleBytes []byte, predicateType string, opts ...Option) error {
+func WriteAttestationNewBundleFormat(ad name.Digest, d name.Digest, bundleBytes []byte, predicateType string, opts []Option, aopts []Option) error {
 	o := makeOptions(d.Repository, opts...)
+	ao := makeOptions(ad.Repository, aopts...)
 
 	signTarget := d.String()
 	ref, err := name.ParseReference(signTarget, o.NameOpts...)
@@ -247,7 +248,7 @@ func WriteAttestationNewBundleFormat(d name.Digest, bundleBytes []byte, predicat
 	if err != nil {
 		return fmt.Errorf("failed to calculate size: %w", err)
 	}
-	err = remote.WriteLayer(d.Repository, configLayer, o.ROpt...)
+	err = remote.WriteLayer(ad.Repository, configLayer, ao.ROpt...)
 	if err != nil {
 		return fmt.Errorf("failed to upload layer: %w", err)
 	}
@@ -270,7 +271,7 @@ func WriteAttestationNewBundleFormat(d name.Digest, bundleBytes []byte, predicat
 		return fmt.Errorf("failed to calculate size: %w", err)
 	}
 
-	err = remote.WriteLayer(d.Repository, layer, o.ROpt...)
+	err = remote.WriteLayer(ad.Repository, layer, ao.ROpt...)
 	if err != nil {
 		return fmt.Errorf("failed to upload layer: %w", err)
 	}
@@ -304,12 +305,12 @@ func WriteAttestationNewBundleFormat(d name.Digest, bundleBytes []byte, predicat
 		},
 	}, bundleMediaType}
 
-	targetRef, err := manifest.targetRef(d.Repository)
+	targetRef, err := manifest.targetRef(ad.Repository)
 	if err != nil {
 		return fmt.Errorf("failed to create target reference: %w", err)
 	}
 
-	if err := remote.Put(targetRef, manifest, o.ROpt...); err != nil {
+	if err := remote.Put(targetRef, manifest, ao.ROpt...); err != nil {
 		return fmt.Errorf("failed to upload manifest: %w", err)
 	}
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This PR allows `attest` and `verify-attestation` to write and read new bundles from a different repository which could be in a different registry too. This fits nicely in with the OCI 1.1 spec with referrers across repository and registry. 

For more context see the following Slack thread in the sigstore workspace: https://sigstore.slack.com/archives/C01PZKDL4DP/p1744297310330889?thread_ts=1744066602.516959&cid=C01PZKDL4DP

Here's an example on how this could be used:

##### Create and sign a new reference type:

```
$ cosign attest --predicate predicate.json \
   --type https://foo.com \
   --new-bundle-format \
   --bundle-repository registry.scout.docker.com/cdupuis/frontend \
  cdupuis/frontend@sha256:a737c5caf9f0487f34117b8a5714eb469343d36dcd183cb6fb3869dadef2a6e7
```

##### Discover reference types from a foreign referrer endpoint 
```
$ regctl artifact list cdupuis/frontend:main --platform linux/arm64 \
  --external registry.scout.docker.com/cdupuis/frontend

regctl artifact list cdupuis/frontend:main --platform linux/arm64 --external registry.scout.docker.com/cdupuis/frontend
Subject:                               docker.io/cdupuis/frontend@sha256:a737c5caf9f0487f34117b8a5714eb469343d36dcd183cb6fb3869dadef2a6e7
Source:                                registry.scout.docker.com/cdupuis/frontend:latest
                                       
Referrers:                             
                                       
  Name:                                registry.scout.docker.com/cdupuis/frontend@sha256:9d1edbcfdf23df065ad1dfbb980ba4ab7ba93f6b48da85272ec9fbeb59872cd5
  Digest:                              sha256:9d1edbcfdf23df065ad1dfbb980ba4ab7ba93f6b48da85272ec9fbeb59872cd5
  MediaType:                           application/vnd.oci.image.manifest.v1+json
  ArtifactType:                        application/vnd.dev.sigstore.bundle.v0.3+json
  Annotations:                         
    dev.sigstore.bundle.content:       dsse-envelope
    dev.sigstore.bundle.predicateType: https://foo.com
    org.opencontainers.image.created:  2025-04-14T17:06:10Z
```

##### Verify the attestation 
```
$ cosign verify-attestation --certificate-identity=cd@docker.com \
  --certificate-oidc-issuer=https://github.com/login/oauth \     
  --type https://foo.com \
  --new-bundle-format \
  --bundle-repository registry.scout.docker.com/cdupuis/frontend \
  cdupuis/frontend@sha256:a737c5caf9f0487f34117b8a5714eb469343d36dcd183cb6fb3869dadef2a6e7

Verification for cdupuis/frontend@sha256:a737c5caf9f0487f34117b8a5714eb469343d36dcd183cb6fb3869dadef2a6e7 --
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
{"payload":"eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL2Zvby5jb20iLCJzdWJqZWN0IjpbeyJuYW1lIjoiaW5kZXguZG9ja2VyLmlvL2NkdXB1aXMvZnJvbnRlbmQiLCJkaWdlc3QiOnsic2hhMjU2IjoiYTczN2M1Y2FmOWYwNDg3ZjM0MTE3YjhhNTcxNGViNDY5MzQzZDM2ZGNkMTgzY2I2ZmIzODY5ZGFkZWYyYTZlNyJ9fV0sInByZWRpY2F0ZSI6eyJmb28iOiJiYXIifX0=","payloadType":"application/vnd.in-toto+json","signatures":[{"sig":"MEYCIQC4Zu+hIJifPnl4ll/ZOmrzS7NHDicKre1gN9Mqu3zz3QIhAKx9aR/FpXtw9DnQKlOrU409z5kl8VkWwdZ8ByUddkDZ"}]}
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

_not yet_

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

_not yet_

#### Todos

- [ ] discuss and agree on usefulness of this feature
- [ ] add tests

cc @codysoyland @haydentherapper 
