### PR TITLE
Update GoReleaser configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -184,7 +184,7 @@ nfpms:
     vendor: Sigstore
     homepage: https://sigstore.dev
     maintainer: Sigstore Authors 86837369+sigstore-bot@users.noreply.github.com
-    builds:
+    ids:
       - linux
     description: Container Signing, Verification and Storage in an OCI registry.
     license: "Apache License 2.0"
@@ -198,7 +198,7 @@ nfpms:
         type: "symlink"
 
 archives:
-  - format: binary
+  - formats: [binary]
     name_template: "{{ .Binary }}"
     allow_different_binary_count: true
 
@@ -206,7 +206,7 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: SNAPSHOT-{{ .ShortCommit }}
+  version_template: SNAPSHOT-{{ .ShortCommit }}
 
 release:
   prerelease: allow # remove this when we start publishing non-prerelease or set to auto


### PR DESCRIPTION
#### Summary
This small PR updates the GoReleaser configuration to resolve the following warnings: 
```
DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotname_template for more info
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
DEPRECATED: nfpms.builds should not be used anymore, check https://goreleaser.com/deprecations#nfpmsbuilds for more info
```
see [CI logs](https://github.com/sigstore/cosign/actions/runs/14758126554/job/41431662317#step:7:18) for more infromation.

#### Release Note
Update GoReleaser configuration to resolve deprecation warnings.

#### Documentation
