### PR TITLE
feat: Add OCI 1.1+ experimental support to tree

### DIFF
--- a/cmd/cosign/cli/options/tree.go
+++ b/cmd/cosign/cli/options/tree.go
@@ -17,12 +17,18 @@ package options
 import "github.com/spf13/cobra"
 
 type TreeOptions struct {
-	Registry  RegistryOptions
-	CleanType string
+	Registry             RegistryOptions
+	RegistryExperimental RegistryExperimentalOptions
+	CleanType            string
+	ExperimentalOCI11    bool
 }
 
 var _ Interface = (*TreeOptions)(nil)
 
 func (c *TreeOptions) AddFlags(cmd *cobra.Command) {
 	c.Registry.AddFlags(cmd)
+	c.RegistryExperimental.AddFlags(cmd)
+
+	cmd.Flags().BoolVar(&c.ExperimentalOCI11, "experimental-oci11", false,
+		"set to true to enable experimental OCI 1.1 behaviour")
 }

--- a/doc/cosign_tree.md
+++ b/doc/cosign_tree.md
@@ -18,12 +18,14 @@ cosign tree [flags]
       --allow-http-registry                                                                      whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
       --allow-insecure-registry                                                                  whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
       --attachment-tag-prefix [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]   optional custom prefix to use for attached image tags. Attachment images are tagged as: [AttachmentTagPrefix]sha256-[TargetImageDigest].[AttachmentName]
+      --experimental-oci11                                                                       set to true to enable experimental OCI 1.1 behaviour
   -h, --help                                                                                     help for tree
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --registry-cacert string                                                                   path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
       --registry-client-cert string                                                              path to the X.509 certificate file in PEM format to be used for the connection to the registry
       --registry-client-key string                                                               path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry
       --registry-password string                                                                 registry basic auth password
+      --registry-referrers-mode registryReferrersMode                                            mode for fetching references from the registry. allowed: legacy, oci-1-1
       --registry-server-name string                                                              SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry
       --registry-token string                                                                    registry bearer auth token
       --registry-username string                                                                 registry basic auth username


### PR DESCRIPTION
#### Summary
Adds OCI 1.1 Referrers support to `cosign tree`.

Resolves #4204.

Example usage:

```
❯ ./cosign tree --experimental-oci11 quay.io/rbean/tree-scsa:example
📦 Supply Chain Security Related artifacts for an image: quay.io/rbean/tree-scsa:example
└── 🔐 Signatures for an image tag: quay.io/rbean/tree-scsa:sha256-b3454025ce78fa93aba879b2824a06a59e2b8c5005b2a4286368433cd0f41cde.sig
   └── 🍒 sha256:ef4e39921eeb670ea453be070877d0fef225a13f97a9f9bf107d4d04d4c0dba6
└── 💾 Attestations for an image tag: quay.io/rbean/tree-scsa:sha256-b3454025ce78fa93aba879b2824a06a59e2b8c5005b2a4286368433cd0f41cde.att
   ├── 🍒 sha256:105da535ba7425024b03685048c33a458b3147315458fc1291479bae34f34997
   └── 🍒 sha256:98c6b2784ffe8a38cc4533d9a5d845cfe4ce72c2aa7e7f00a0682718d0259472
└── 🔗 application/vnd.dev.sigstore.bundle.v0.3+json artifacts via OCI referrer: quay.io/rbean/tree-scsa@sha256:01ca3469ae921632f7bd965cb34f9c10f07a723ea68223008871e86052bcfec8
   └── 🍒 sha256:a336d1bfe93e60ae8a5cbbe546663517719d8f3ce1e628ffc0196c0cdf658314
```

#### Release Note

* Updated `cosign tree` to additionally display artifacts found via the OCI 1.1 Referrers API when `--experimental-oci11` is specified.

#### Documentation

IMO, no docs needed beyond `make docgen`.