### PR TITLE
Don't verify SCT for a private PKI cert

### DIFF
--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -497,23 +497,6 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 	if _, err := cosign.TrustedCert(leafCert, rootPool, subPool); err != nil {
 		return nil, fmt.Errorf("unable to validate certificate chain: %w", err)
 	}
-	// Verify SCT if present in the leaf certificate.
-	contains, err := cosign.ContainsSCT(leafCert.Raw)
-	if err != nil {
-		return nil, err
-	}
-	if contains {
-		pubKeys, err := cosign.GetCTLogPubs(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("getting CTLog public keys: %w", err)
-		}
-		var chain []*x509.Certificate
-		chain = append(chain, leafCert)
-		chain = append(chain, certChain...)
-		if err := cosign.VerifyEmbeddedSCT(context.Background(), chain, pubKeys); err != nil {
-			return nil, err
-		}
-	}
 	certSigner.Chain = certChainBytes
 
 	return certSigner, nil


### PR DESCRIPTION
Remove the need to fetch TUF keys when signing with a private key and attaching a non-Fulcio certificate to the artifact bundle. Verifiers will still need to check whether the certificate contains an SCT and have a policy for verifying it.

Relates to https://github.com/sigstore/cosign/pull/3844/files#r2122409378
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
