### PR TITLE
Do not load trusted root when CT env key is set

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/cosign/env"
 	"github.com/spf13/cobra"
 )
 
@@ -96,7 +97,7 @@ func Attest() *cobra.Command {
 				TSAServerURL:             o.TSAServerURL,
 				NewBundleFormat:          o.NewBundleFormat,
 			}
-			if o.Key == "" { // Get the trusted root if using fulcio for signing
+			if o.Key == "" && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "" { // Get the trusted root if using fulcio for signing
 				trustedMaterial, err := cosign.TrustedRoot()
 				if err != nil {
 					ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/cosign/env"
 	"github.com/spf13/cobra"
 )
 
@@ -84,7 +85,7 @@ func AttestBlob() *cobra.Command {
 				BundlePath:               o.BundlePath,
 				NewBundleFormat:          o.NewBundleFormat,
 			}
-			if o.Key == "" { // Get the trusted root if using fulcio for signing
+			if o.Key == "" && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "" { // Get the trusted root if using fulcio for signing
 				trustedMaterial, err := cosign.TrustedRoot()
 				if err != nil {
 					ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/cosign/env"
 	"github.com/spf13/cobra"
 )
 
@@ -130,7 +131,7 @@ race conditions or (worse) malicious tampering.
 				TSAServerURL:                   o.TSAServerURL,
 				IssueCertificateForExistingKey: o.IssueCertificate,
 			}
-			if o.Key == "" || o.IssueCertificate {
+			if (o.Key == "" || o.IssueCertificate) && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "" {
 				trustedMaterial, err := cosign.TrustedRoot()
 				if err != nil {
 					ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/v2/internal/ui"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/cosign/env"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -98,7 +99,7 @@ func SignBlob() *cobra.Command {
 				RFC3161TimestampPath:           o.RFC3161TimestampPath,
 				IssueCertificateForExistingKey: o.IssueCertificate,
 			}
-			if o.Key == "" || o.IssueCertificate {
+			if (o.Key == "" || o.IssueCertificate) && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "" {
 				trustedMaterial, err := cosign.TrustedRoot()
 				if err != nil {
 					ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)


### PR DESCRIPTION
In 32a2d62a the ability to use TUF to read and refresh trusted_root.json was added. Prior, there was already a --trusted-root flag for verify* commands, to read trusted_root.json directly without using a TUF client. This did not exist for the sign* commands, which still need key material to verify the CT key. The workaround for the sign commands was to use the SIGSTORE_CT_LOG_PUBLIC_KEY_FILE environment variable, but when the TUF client was updated, this workaround regressed. This change makes it so that this flag will still work and that the machine's cached trusted root is not used if it's not intended to be used. The permanent fix going forward should be to add the --trusted-root flags to the sign* commands.

New failures in the scaffolding env action are caused by this regression: https://github.com/sigstore/scaffolding/actions/runs/15707409511/job/44256417895

Fixes https://github.com/sigstore/cosign/issues/4251
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
