### PR TITLE
feat(sign): support loading --cert/--cert-chain from URL and env variable

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -76,6 +76,12 @@ race conditions or (worse) malicious tampering.
   # sign a container image with a key, attaching a certificate and certificate chain
   cosign sign --key cosign.key --cert cosign.crt --cert-chain chain.crt <IMAGE DIGEST>
 
+  # sign a container image with a key, attaching a certificate and certificate chain from a URL
+  cosign sign --key cosign.key --cert https://example.com/cert --cert-chain https://example.com/cert-chain <IMAGE DIGEST> 
+
+  # sign a container image with a key, attaching a certificate and certificate chain from an environment variable
+  cosign sign --key cosign.key --cert https://example.com/cert --cert-chain https://example.com/cert-chain <IMAGE DIGEST>
+
   # sign a container in a registry which does not fully support OCI media types
   COSIGN_DOCKER_MEDIA_TYPES=1 cosign sign --key cosign.key legacy-registry.example.com/my/image@<DIGEST>
 

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -44,6 +44,7 @@ import (
 	"github.com/sigstore/cosign/v2/internal/pkg/cosign/tsa"
 	"github.com/sigstore/cosign/v2/internal/pkg/cosign/tsa/client"
 	"github.com/sigstore/cosign/v2/internal/ui"
+	"github.com/sigstore/cosign/v2/pkg/blob"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/cosign/pivkey"
 	"github.com/sigstore/cosign/v2/pkg/cosign/pkcs11key"
@@ -434,7 +435,7 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 	// Handle --cert flag
 	if certPath != "" {
 		// Allow both DER and PEM encoding
-		certBytes, err := os.ReadFile(certPath)
+		certBytes, err := blob.LoadFileOrURL(certPath)
 		if err != nil {
 			return nil, fmt.Errorf("read certificate: %w", err)
 		}
@@ -476,7 +477,7 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 
 	// Handle --cert-chain flag
 	// Accept only PEM encoded certificate chain
-	certChainBytes, err := os.ReadFile(certChainPath)
+	certChainBytes, err := blob.LoadFileOrURL(certChainPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading certificate chain from path: %w", err)
 	}


### PR DESCRIPTION
… well

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
When using `cosign sign`, `--cert` and `--certificate-chain` parameters only accept file path. Same parameters for `cosign verify` supports loading from URL as well, using `blob.LoadFileOrURL(fileRef)` instead of `os.ReadFile(path)`. This PR aims to add URL/env support to sign operation as well.

#### Release Note

- `cosign sign` now supports --cert and --certificate-chain to be loaded from URL and environment variable as well as from a file.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
