### PR TITLE
avoid double-loading trustedroot from file

### DIFF
--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -276,10 +276,6 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		// If a trusted root path is provided, we will use it to verify the bundle.
 		// Otherwise, the verifier will default to the public good instance.
 		// co.TrustedMaterial is already loaded from c.TrustedRootPath above,
-		// the check below is to serve as a reminder to developers and to future-proof.
-		if co.TrustedMaterial == nil {
-			panic("internal cosign error co.TrustedMaterial is nil with non-empty c.TrustedRootPath")
-		}
 	case c.CARoots != "":
 		// CA roots + possible intermediates are already loaded into co.RootCerts with the call to
 		// loadCertsKeylessVerification above.

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -275,9 +275,10 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 
 		// If a trusted root path is provided, we will use it to verify the bundle.
 		// Otherwise, the verifier will default to the public good instance.
-		co.TrustedMaterial, err = root.NewTrustedRootFromPath(c.TrustedRootPath)
-		if err != nil {
-			return fmt.Errorf("creating trusted root from path: %w", err)
+		// co.TrustedMaterial is already loaded from c.TrustedRootPath above,
+		// the check below is to serve as a reminder to developers and to future-proof.
+		if co.TrustedMaterial == nil {
+			panic("internal cosign error co.TrustedMaterial is nil with non-empty c.TrustedRootPath")
 		}
 	case c.CARoots != "":
 		// CA roots + possible intermediates are already loaded into co.RootCerts with the call to


### PR DESCRIPTION
#### Summary
In [cmd/cosign/cli/verify/verify_attestation.go](https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/verify/verify_attestation.go)
we call root.NewTrustedRootFromPath twice both times with the same condition if c.TrustedRootPath != "" :
* L137-138 https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/verify/verify_attestation.go#L137-L138
* L271, 278 https://github.com/sigstore/cosign/blob/main/cmd/cosign/cli/verify/verify_attestation.go#L271-L278

This change removes the second duplicate one - a check for non-nil `co.TrustedMaterial` added as a reminder to developers and to guard against potential future changes.

On `#cosign` Slack, @znewman01 [said](https://sigstore.slack.com/archives/C01PZKDL4DP/p1750864075461449?thread_ts=1750860467.217359&cid=C01PZKDL4DP):
> From a quick look, it seems like these checks could be combined

#### Release Note
NONE

#### Documentation
n/a