### PR TITLE
Fix cert verification logic for trusted-root/SCTs

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -343,21 +343,14 @@ func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpt
 
 	// Now verify the cert, then the signature.
 
-	shouldVerifyEmbeddedSCT := !co.IgnoreSCT
-	contains, err := ContainsSCT(cert.Raw)
-	if err != nil {
-		return nil, err
-	}
-	shouldVerifyEmbeddedSCT = shouldVerifyEmbeddedSCT && contains
-	// If trusted root is available and the SCT is embedded, use the verifiers from sigstore-go (preferred).
+	// If trusted root is available, use the verifiers from sigstore-go (preferred).
 	var chains [][]*x509.Certificate
-	if co.TrustedMaterial != nil && shouldVerifyEmbeddedSCT {
+	if co.TrustedMaterial != nil {
 		if chains, err = verify.VerifyLeafCertificate(cert.NotBefore, cert, co.TrustedMaterial); err != nil {
 			return nil, err
 		}
 	} else {
-		// If the trusted root is not available, OR if the SCT is detached, use the verifiers from cosign (legacy).
-		// The certificate chains will be needed for the legacy SCT verifiers, which is why we can't use sigstore-go.
+		// If the trusted root is not available, use the verifiers from cosign (legacy).
 		chains, err = TrustedCert(cert, co.RootCerts, intermediateCerts)
 		if err != nil {
 			return nil, err
@@ -372,6 +365,10 @@ func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpt
 	// If IgnoreSCT is set, skip the SCT check
 	if co.IgnoreSCT {
 		return verifier, nil
+	}
+	contains, err := ContainsSCT(cert.Raw)
+	if err != nil {
+		return nil, err
 	}
 	if !contains && len(co.SCT) == 0 {
 		return nil, &VerificationFailure{


### PR DESCRIPTION
Previously, the logic for verifying the Fulcio leaf cert was gated on whether the verification material contained a trusted root and whether the cert had an embedded SCT. This was because the upgraded TUF client that fetched the trusted root and passed it to the sigstore-go verification routines was developed concurrently with updates to sigstore-go[1], and sigstore-go didn't initially support returning the cert chain that would allow verifying a detached SCT. When the change in sigstore-go landed, the API call was updated but the logic and the comment was not fixed. This meant that a trusted root file could not be used to verify leaf certs, unnecessarily. Since the trusted root was set, the TUF client didn't fetch the Fulcio certs independently, so the cert failed to verify. This change removes the restriction and adds a test that uses trusted root.

[1] https://github.com/sigstore/sigstore-go/pull/300

Fixes https://github.com/sigstore/cosign/issues/4284

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
