### PR TITLE
force when copying the latest image to overwrite

### DIFF
--- a/release/release.mk
+++ b/release/release.mk
@@ -27,6 +27,6 @@ snapshot:
 .PHONY: copy-signed-release-to-ghcr
 copy-signed-release-to-ghcr:
 	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:$(GIT_VERSION)
-	cosign copy $(GHCR_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:latest
+	cosign copy --force=true $(GHCR_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:latest
 	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev
-	cosign copy $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:latest-dev
+	cosign copy --force=true $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:latest-dev


### PR DESCRIPTION


#### Summary

- force when copying the latest image to overwrite


from the release logs

```
cosign copy ghcr.io/sigstore/cosign/cosign:v2.5.2 ghcr.io/sigstore/cosign/cosign:latest
Error: image "ghcr.io/sigstore/cosign/cosign:latest" already exists. Use `-f` to overwrite
error during command execution: image "ghcr.io/sigstore/cosign/cosign:latest" already exists. Use `-f` to overwrite
make: *** [release/release.mk:30: copy-signed-release-to-ghcr] Error 1
```