### PR TITLE
Default to using the new protobuf format

### DIFF
--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -107,5 +107,5 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.RecordCreationTimestamp, "record-creation-timestamp", false,
 		"set the createdAt timestamp in the attestation artifact to the time it was created; by default, cosign sets this to the zero value")
 
-	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", false, "attach a Sigstore bundle using OCI referrers API")
+	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true, "attach a Sigstore bundle using OCI referrers API")
 }

--- a/cmd/cosign/cli/options/attest_blob.go
+++ b/cmd/cosign/cli/options/attest_blob.go
@@ -93,8 +93,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 		"write everything required to verify the blob to a FILE")
 	_ = cmd.MarkFlagFilename("bundle", bundleExts...)
 
-	// TODO: have this default to true as a breaking change
-	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", false,
+	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true,
 		"output bundle in new format that contains all verification material")
 
 	cmd.Flags().StringVar(&o.Hash, "hash", "",

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -77,8 +77,7 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 		"write everything required to verify the blob to a FILE")
 	_ = cmd.MarkFlagFilename("bundle", bundleExts...)
 
-	// TODO: have this default to true as a breaking change
-	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", false,
+	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true,
 		"output bundle in new format that contains all verification material")
 
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -62,8 +62,7 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.TrustedRootPath, "trusted-root", "",
 		"Path to a Sigstore TrustedRoot JSON file. Requires --new-bundle-format to be set.")
 
-	// TODO: have this default to true as a breaking change
-	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", false,
+	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true,
 		"expect the signature/attestation to be packaged in a Sigstore bundle")
 }
 

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -43,7 +43,7 @@ cosign attest-blob [flags]
       --identity-token string             identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify              skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                        path to the private key file, KMS URI or Kubernetes Secret
-      --new-bundle-format                 output bundle in new format that contains all verification material
+      --new-bundle-format                 output bundle in new format that contains all verification material (default true)
       --oidc-client-id string             OIDC client ID for application (default "sigstore")
       --oidc-client-secret-file string    Path to file containing OIDC client secret for application
       --oidc-disable-ambient-providers    Disable ambient OIDC providers. When true, ambient credentials will not be read

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -60,7 +60,7 @@ cosign attest [flags]
       --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
-      --new-bundle-format                                                                        attach a Sigstore bundle using OCI referrers API
+      --new-bundle-format                                                                        attach a Sigstore bundle using OCI referrers API (default true)
       --no-upload                                                                                do not upload the generated attestation, but send the attestation output to STDOUT
       --oidc-client-id string                                                                    OIDC client ID for application (default "sigstore")
       --oidc-client-secret-file string                                                           Path to file containing OIDC client secret for application

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -77,7 +77,7 @@ cosign dockerfile verify [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
-      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle
+      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -71,7 +71,7 @@ cosign manifest verify [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
-      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle
+      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -45,7 +45,7 @@ cosign sign-blob [flags]
       --insecure-skip-verify             skip verifying fulcio published to the SCT (this should only be used for testing).
       --issue-certificate                issue a code signing certificate from Fulcio, even if a key is provided
       --key string                       path to the private key file, KMS URI or Kubernetes Secret
-      --new-bundle-format                output bundle in new format that contains all verification material
+      --new-bundle-format                output bundle in new format that contains all verification material (default true)
       --oidc-client-id string            OIDC client ID for application (default "sigstore")
       --oidc-client-secret-file string   Path to file containing OIDC client secret for application
       --oidc-disable-ambient-providers   Disable ambient OIDC providers. When true, ambient credentials will not be read

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -81,7 +81,7 @@ cosign verify-attestation [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
-      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle
+      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --policy strings                                                                           specify CUE or Rego files with policies to be used for validation

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -49,7 +49,7 @@ cosign verify-blob-attestation [flags]
       --insecure-ignore-tlog                            ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --max-workers int                                 the amount of maximum workers for parallel executions (default 10)
-      --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle
+      --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --offline                                         only allow offline verification
       --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -84,7 +84,7 @@ cosign verify-blob [flags]
       --insecure-ignore-tlog                            ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --max-workers int                                 the amount of maximum workers for parallel executions (default 10)
-      --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle
+      --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --offline                                         only allow offline verification
       --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -98,7 +98,7 @@ cosign verify [flags]
       --key string                                                                               path to the public key file, KMS URI or Kubernetes Secret
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
-      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle
+      --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This is a first step towards #4221, where we default `--new-bundle-format` to `true` instead of `false`.

We never did add protobuf support to `cosign sign` (see #3927 and #3139) - maybe we want to wait until that is done? Otherwise we could just have `--new-bundle-format` default to `true` when we add it to `cosign sign`.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Modified `attest`, `attest-blob`, `sign-blob`, `dockerfile-verify`, `manifest-verify`, `verify`, `verify-attestation`, `verify-blob`, `verify-blob-attestation` so that `--new-bundle-format` defaults to `true` instead of `false`.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
Ran `make docgen` as part of this PR.
