### PR TITLE
Verify subject with bundle only when checking claims

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -230,7 +230,14 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 			return err
 		}
 
-		_, err = cosign.VerifyNewBundle(ctx, co, sgverify.WithArtifactDigest(h.Algorithm, digest), bundle)
+		var policyOpt sgverify.ArtifactPolicyOption
+		if c.CheckClaims {
+			policyOpt = sgverify.WithArtifactDigest(h.Algorithm, digest)
+		} else {
+			policyOpt = sgverify.WithoutArtifactUnsafe()
+		}
+
+		_, err = cosign.VerifyNewBundle(ctx, co, policyOpt, bundle)
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -185,6 +185,7 @@ func TestVerifyBlobAttestationNoCheckClaims(t *testing.T) {
 		description string
 		blobPath    string
 		signature   string
+		bundlePath  string
 	}{
 		{
 			description: "verify a predicate",
@@ -198,6 +199,11 @@ func TestVerifyBlobAttestationNoCheckClaims(t *testing.T) {
 			signature:   blobSLSAProvenanceSignature,
 			// This works because we're not checking the claims. It doesn't matter what we put in here - it should pass so long as the DSSE signagure can be verified.
 			blobPath: anotherBlobPath,
+		}, {
+			description: "verify a predicate with a bundle with another blob path",
+			// From blobSLSAProvenanceSignature
+			bundlePath: makeLocalAttestNewBundle(t, "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Nsc2EuZGV2L3Byb3ZlbmFuY2UvdjAuMiIsInN1YmplY3QiOlt7Im5hbWUiOiJibG9iIiwiZGlnZXN0Ijp7InNoYTI1NiI6IjY1ODc4MWNkNGVkOWJjYTYwZGFjZDA5ZjdiYjkxNGJiNTE1MDJlOGI1ZDYxOWY1N2YzOWExZDY1MjU5NmNjMjQifX1dLCJwcmVkaWNhdGUiOnsiYnVpbGRlciI6eyJpZCI6IjIifSwiYnVpbGRUeXBlIjoieCIsImludm9jYXRpb24iOnsiY29uZmlnU291cmNlIjp7fX19fQ==", "application/vnd.in-toto+json", "MEUCIA8KjZqkrt90fzBojSwwtj3Bqb41E6ruxQk97TLnpzdYAiEAzOAjOTzyvTHqbpFDAn6zhrg6EZv7kxK5faRoVGYMh2c="),
+			blobPath:   anotherBlobPath,
 		}, {
 			description: "verify a predicate with /dev/null",
 			signature:   blobSLSAProvenanceSignature,
@@ -219,6 +225,11 @@ func TestVerifyBlobAttestationNoCheckClaims(t *testing.T) {
 				IgnoreTlog:    true,
 				CheckClaims:   false,
 				PredicateType: "slsaprovenance",
+			}
+			if test.bundlePath != "" {
+				cmd.BundlePath = test.bundlePath
+				cmd.NewBundleFormat = true
+				cmd.TrustedRootPath = writeTrustedRootFile(t, td, "{\"mediaType\":\"application/vnd.dev.sigstore.trustedroot+json;version=0.1\"}")
 			}
 			if err := cmd.Exec(ctx, test.blobPath); err != nil {
 				t.Fatalf("verifyBlobAttestation()= %v", err)


### PR DESCRIPTION
Previously, when --check-claims was set to false and a bundle in the new format was provided, we'd still try to check the in-toto subject digest and algorithm. These values weren't being set since they were conditioned on checking claims. Now, we skip digest verification if check-claims is false with a new bundle.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
