### PR TITLE
bump golangci-lint to v2.3.x

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -41,7 +41,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
-          version: v2.2
+          version: v2.3
 
   golangci-test-e2e:
     name: lint-test-e2e


### PR DESCRIPTION


#### Summary
- bump golangci-lint to v2.3.x