### PR TITLE
Fixes to cosign sign / verify for the new bundle format

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -18,7 +18,6 @@ package attest
 import (
 	"bytes"
 	"context"
-	"crypto"
 	_ "crypto/sha256" // for `crypto.SHA256`
 	"encoding/json"
 	"fmt"
@@ -252,10 +251,9 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 		if err != nil {
 			return err
 		}
-		var pubKey *crypto.PublicKey
-		pk, err := sv.PublicKey()
-		if err == nil {
-			pubKey = &pk
+		pubKey, err := sv.PublicKey()
+		if err != nil {
+			return err
 		}
 		bundleBytes, err := cbundle.MakeNewBundle(pubKey, rekorEntry, payload, signedPayload, signerBytes, timestampBytes)
 		if err != nil {

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -290,10 +290,9 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 	if c.BundlePath != "" {
 		var contents []byte
 		if c.NewBundleFormat {
-			var pubKey *crypto.PublicKey
-			pk, err := sv.PublicKey()
-			if err == nil {
-				pubKey = &pk
+			pubKey, err := sv.PublicKey()
+			if err != nil {
+				return err
 			}
 
 			contents, err = cbundle.MakeNewBundle(pubKey, rekorEntry, payload, sig, signer, timestampBytes)

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -305,10 +305,9 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 		return fmt.Errorf("constructing client options: %w", err)
 	}
 
-	var pubKey *crypto.PublicKey
-	pk, err := sv.PublicKey()
-	if err == nil {
-		pubKey = &pk
+	pubKey, err := sv.PublicKey()
+	if err != nil {
+		return err
 	}
 
 	bundleBytes, err := cbundle.MakeNewBundle(pubKey, rekorEntry, payload, signedPayload, signerBytes, timestampBytes)

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -109,6 +109,7 @@ against the transparency log.`,
 			v := &verify.VerifyCommand{
 				RegistryOptions:              o.Registry,
 				CertVerifyOptions:            o.CertVerify,
+				CommonVerifyOptions:          o.CommonVerifyOptions,
 				CheckClaims:                  o.CheckClaims,
 				KeyRef:                       o.Key,
 				CertRef:                      o.CertVerify.Cert,

--- a/pkg/cosign/bundle/protobundle.go
+++ b/pkg/cosign/bundle/protobundle.go
@@ -75,14 +75,14 @@ func MakeProtobufBundle(hint string, rawCert []byte, rekorEntry *models.LogEntry
 	return bundle, nil
 }
 
-func MakeNewBundle(pubKey *crypto.PublicKey, rekorEntry *models.LogEntryAnon, payload, sig, signer, timestampBytes []byte) ([]byte, error) {
+func MakeNewBundle(pubKey crypto.PublicKey, rekorEntry *models.LogEntryAnon, payload, sig, signer, timestampBytes []byte) ([]byte, error) {
 	// Determine if the signer is a certificate or not
 	var hint string
 	var rawCert []byte
 
 	cert, err := cryptoutils.UnmarshalCertificatesFromPEM(signer)
 	if err != nil || len(cert) == 0 {
-		pkixPubKey, err := x509.MarshalPKIXPublicKey(*pubKey)
+		pkixPubKey, err := x509.MarshalPKIXPublicKey(pubKey)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cosign/bundle/protobundle.go
+++ b/pkg/cosign/bundle/protobundle.go
@@ -80,7 +80,8 @@ func MakeNewBundle(pubKey *crypto.PublicKey, rekorEntry *models.LogEntryAnon, pa
 	var hint string
 	var rawCert []byte
 
-	if pubKey != nil {
+	cert, err := cryptoutils.UnmarshalCertificatesFromPEM(signer)
+	if err != nil || len(cert) == 0 {
 		pkixPubKey, err := x509.MarshalPKIXPublicKey(*pubKey)
 		if err != nil {
 			return nil, err
@@ -88,10 +89,6 @@ func MakeNewBundle(pubKey *crypto.PublicKey, rekorEntry *models.LogEntryAnon, pa
 		hashedBytes := sha256.Sum256(pkixPubKey)
 		hint = base64.StdEncoding.EncodeToString(hashedBytes[:])
 	} else {
-		cert, err := cryptoutils.UnmarshalCertificatesFromPEM(signer)
-		if err != nil {
-			return nil, err
-		}
 		rawCert = cert[0].Raw
 	}
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1043,6 +1043,8 @@ func TestSignVerifyBundle(t *testing.T) {
 		NewBundleFormat:     true,
 		UseSignedTimestamps: false,
 	}
+
+	must(cmd.Exec(ctx, args), t)
 }
 
 func TestAttestVerify(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

While doing additional testing of #4316 a few issues were uncovered:

- `cosign verify` did not use content provided by `--trusted-root`
- `cosign sign` with Fulcio and `--new-protobuf-format=true` was not properly constructing the bundle with a signing certificate
- The end-to-end test wasn't performing one the verifications it was supposed to be doing

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

- Fixed bug in `cosign verify` where it did not use content provided by `--trusted-root`
- Fixed bug in bundle created with `cosign sign --new-protobuf-format=true` with Fulcio certificate

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A