### PR TITLE
Update conformance test binary for signing config

### DIFF
--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -30,10 +30,11 @@ var certOIDC *string
 var certSAN *string
 var identityToken *string
 var trustedRootPath *string
+var signingConfigPath *string
 
 func usage() {
 	fmt.Println("Usage:")
-	fmt.Printf("\t%s sign-bundle --identity-token TOKEN --bundle FILE FILE\n", os.Args[0])
+	fmt.Printf("\t%s sign-bundle --identity-token TOKEN [--signing-config FILE] [--trusted-root FILE] --bundle FILE FILE\n", os.Args[0])
 	fmt.Printf("\t%s verify-bundle --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE\n", os.Args[0])
 }
 
@@ -60,6 +61,9 @@ func parseArgs() {
 			i += 2
 		case "--trusted-root":
 			trustedRootPath = &os.Args[i+1]
+			i += 2
+		case "--signing-config":
+			signingConfigPath = &os.Args[i+1]
 			i += 2
 		default:
 			i++
@@ -120,6 +124,9 @@ func main() {
 	}
 	if trustedRootPath != nil {
 		args = append(args, "--trusted-root", *trustedRootPath)
+	}
+	if signingConfigPath != nil {
+		args = append(args, "--signing-config", *signingConfigPath)
 	}
 	args = append(args, os.Args[len(os.Args)-1])
 

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -90,11 +90,18 @@ func AttestBlob() *cobra.Command {
 				NewBundleFormat:          o.NewBundleFormat,
 			}
 			if o.Key == "" && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "" { // Get the trusted root if using fulcio for signing
-				trustedMaterial, err := cosign.TrustedRoot()
-				if err != nil {
-					ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)
+				if o.TrustedRootPath != "" {
+					ko.TrustedMaterial, err = root.NewTrustedRootFromPath(o.TrustedRootPath)
+					if err != nil {
+						return fmt.Errorf("loading trusted root: %w", err)
+					}
+				} else {
+					trustedMaterial, err := cosign.TrustedRoot()
+					if err != nil {
+						ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)
+					}
+					ko.TrustedMaterial = trustedMaterial
 				}
-				ko.TrustedMaterial = trustedMaterial
 			}
 			if (o.UseSigningConfig || o.SigningConfigPath != "") && o.BundlePath == "" {
 				return fmt.Errorf("must provide --bundle with --signing-config or --use-signing-config")

--- a/cmd/cosign/cli/options/attest_blob.go
+++ b/cmd/cosign/cli/options/attest_blob.go
@@ -53,6 +53,7 @@ type AttestBlobOptions struct {
 
 	UseSigningConfig  bool
 	SigningConfigPath string
+	TrustedRootPath   string
 }
 
 var _ Interface = (*AttestOptions)(nil)
@@ -104,8 +105,11 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.UseSigningConfig, "use-signing-config", false,
 		"whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format")
 
-	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config-path", "",
+	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config", "",
 		"path to a signing config file. Must provide --bundle, which will output verification material in the new format")
+
+	cmd.Flags().StringVar(&o.TrustedRootPath, "trusted-root", "",
+		"optional path to a TrustedRoot JSON file to verify a signature after signing")
 
 	cmd.Flags().StringVar(&o.Hash, "hash", "",
 		"hash of blob in hexadecimal (base16). Used if you want to sign an artifact stored elsewhere and have the hash")

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -46,6 +46,7 @@ type SignBlobOptions struct {
 
 	UseSigningConfig  bool
 	SigningConfigPath string
+	TrustedRootPath   string
 }
 
 var _ Interface = (*SignBlobOptions)(nil)
@@ -88,8 +89,11 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.UseSigningConfig, "use-signing-config", false,
 		"whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format")
 
-	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config-path", "",
+	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config", "",
 		"path to a signing config file. Must provide --bundle, which will output verification material in the new format")
+
+	cmd.Flags().StringVar(&o.TrustedRootPath, "trusted-root", "",
+		"optional path to a TrustedRoot JSON file to verify a signature after signing")
 
 	cmd.Flags().BoolVarP(&o.SkipConfirmation, "yes", "y", false,
 		"skip confirmation prompts for non-destructive operations")

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -101,11 +101,18 @@ func SignBlob() *cobra.Command {
 				IssueCertificateForExistingKey: o.IssueCertificate,
 			}
 			if (o.Key == "" || o.IssueCertificate) && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "" {
-				trustedMaterial, err := cosign.TrustedRoot()
-				if err != nil {
-					ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)
+				if o.TrustedRootPath != "" {
+					ko.TrustedMaterial, err = root.NewTrustedRootFromPath(o.TrustedRootPath)
+					if err != nil {
+						return fmt.Errorf("loading trusted root: %w", err)
+					}
+				} else {
+					trustedMaterial, err := cosign.TrustedRoot()
+					if err != nil {
+						ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)
+					}
+					ko.TrustedMaterial = trustedMaterial
 				}
-				ko.TrustedMaterial = trustedMaterial
 			}
 			if (o.UseSigningConfig || o.SigningConfigPath != "") && o.BundlePath == "" {
 				return fmt.Errorf("must provide --bundle with --signing-config or --use-signing-config")

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -57,7 +57,7 @@ cosign attest-blob [flags]
       --rekor-entry-type string           specifies the type to be used for a rekor entry upload (dsse|intoto) (default "dsse")
       --rekor-url string                  address of rekor STL server (default "https://rekor.sigstore.dev")
       --rfc3161-timestamp-bundle string   path to an RFC 3161 timestamp bundle FILE
-      --signing-config-path string        path to a signing config file. Must provide --bundle, which will output verification material in the new format
+      --signing-config string             path to a signing config file. Must provide --bundle, which will output verification material in the new format
       --sk                                whether to use a hardware security key
       --slot string                       security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --statement string                  path to the statement file.
@@ -67,6 +67,7 @@ cosign attest-blob [flags]
       --timestamp-server-name string      SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
       --timestamp-server-url string       url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr
       --tlog-upload                       whether or not to upload to the tlog (default true)
+      --trusted-root string               optional path to a TrustedRoot JSON file to verify a signature after signing
       --type string                       specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
       --use-signing-config                whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format
   -y, --yes                               skip confirmation prompts for non-destructive operations

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -57,7 +57,7 @@ cosign sign-blob [flags]
       --output-signature string          write the signature to FILE
       --rekor-url string                 address of rekor STL server (default "https://rekor.sigstore.dev")
       --rfc3161-timestamp string         write the RFC3161 timestamp to a file
-      --signing-config-path string       path to a signing config file. Must provide --bundle, which will output verification material in the new format
+      --signing-config string            path to a signing config file. Must provide --bundle, which will output verification material in the new format
       --sk                               whether to use a hardware security key
       --slot string                      security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --timestamp-client-cacert string   path to the X.509 CA certificate file in PEM format to be used for the connection to the TSA Server
@@ -66,6 +66,7 @@ cosign sign-blob [flags]
       --timestamp-server-name string     SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
       --timestamp-server-url string      url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr
       --tlog-upload                      whether or not to upload to the tlog (default true)
+      --trusted-root string              optional path to a TrustedRoot JSON file to verify a signature after signing
       --use-signing-config               whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format
   -y, --yes                              skip confirmation prompts for non-destructive operations
 ```


### PR DESCRIPTION
The signing config will now be provided on the sign path to test Rekor v2, along with the trusted root for verifying bundles on the sign path.

This also adds support for providing a trusted root with sign-blob/attest-blob. Currently, you can either provide just the CT log key or we'll fetch the trusted root from the initialized TUF repo. Since we are providing the trusted root for staging during signing now, this PR also lets the user provide the trusted root they'll use for verifying during signing.

This also updates the signing config flag name to drop `-path` for uniformity. This is fine to do since we haven't cut a release of Cosign with this feature yet.

Fixes https://github.com/sigstore/cosign/issues/4356

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
