### PR TITLE
Require exclusively a SigningConfig or service URLs when signing

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -102,6 +102,18 @@ func Attest() *cobra.Command {
 				IssueCertificateForExistingKey: o.IssueCertificate,
 				NewBundleFormat:                o.NewBundleFormat,
 			}
+			// If a signing config is used, then service URLs cannot be specified
+			if (o.UseSigningConfig || o.SigningConfigPath != "") &&
+				((o.Rekor.URL != "" && o.Rekor.URL != options.DefaultRekorURL) ||
+					(o.Fulcio.URL != "" && o.Fulcio.URL != options.DefaultFulcioURL) ||
+					(o.OIDC.Issuer != "" && o.OIDC.Issuer != options.DefaultOIDCIssuerURL) ||
+					o.TSAServerURL != "") {
+				return fmt.Errorf("cannot specify service URLs and use signing config")
+			}
+			// Signing config requires a bundle as output for verification materials since sigstore-go is used
+			if (o.UseSigningConfig || o.SigningConfigPath != "") && !o.NewBundleFormat {
+				return fmt.Errorf("must provide --new-bundle-format with --signing-config or --use-signing-config")
+			}
 			// Fetch a trusted root when:
 			// * requesting a certificate and no CT log key is provided to verify an SCT
 			// * using a signing config and signing using sigstore-go
@@ -118,10 +130,6 @@ func Attest() *cobra.Command {
 						ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)
 					}
 				}
-			}
-
-			if (o.UseSigningConfig || o.SigningConfigPath != "") && !o.NewBundleFormat {
-				return fmt.Errorf("must provide --new-bundle-format with --signing-config or --use-signing-config")
 			}
 			if o.UseSigningConfig {
 				ko.SigningConfig, err = cosign.SigningConfig()

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -90,6 +90,18 @@ func AttestBlob() *cobra.Command {
 				BundlePath:                     o.BundlePath,
 				NewBundleFormat:                o.NewBundleFormat,
 			}
+			// If a signing config is used, then service URLs cannot be specified
+			if (o.UseSigningConfig || o.SigningConfigPath != "") &&
+				((o.Rekor.URL != "" && o.Rekor.URL != options.DefaultRekorURL) ||
+					(o.Fulcio.URL != "" && o.Fulcio.URL != options.DefaultFulcioURL) ||
+					(o.OIDC.Issuer != "" && o.OIDC.Issuer != options.DefaultOIDCIssuerURL) ||
+					o.TSAServerURL != "") {
+				return fmt.Errorf("cannot specify service URLs and use signing config")
+			}
+			// Signing config requires a bundle as output for verification materials since sigstore-go is used
+			if (o.UseSigningConfig || o.SigningConfigPath != "") && o.BundlePath == "" {
+				return fmt.Errorf("must provide --bundle with --signing-config or --use-signing-config")
+			}
 			// Fetch a trusted root when:
 			// * requesting a certificate and no CT log key is provided to verify an SCT
 			// * using a signing config and signing using sigstore-go
@@ -106,9 +118,6 @@ func AttestBlob() *cobra.Command {
 						ui.Warnf(context.Background(), "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)
 					}
 				}
-			}
-			if (o.UseSigningConfig || o.SigningConfigPath != "") && o.BundlePath == "" {
-				return fmt.Errorf("must provide --bundle with --signing-config or --use-signing-config")
 			}
 			if o.UseSigningConfig {
 				ko.SigningConfig, err = cosign.SigningConfig()


### PR DESCRIPTION
A signing config is a source of truth for the service URLs. We will disallow specifying multiple sources of truth for service URLs if the default values are overridden. This aligns with the verification path, where the new bundle format cannot also be used with detached verification material.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
