### PR TITLE
Fix signing and verification with ed25519 keys with bundles and Rekor

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -46,6 +46,7 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/dsse"
 	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 )
@@ -164,11 +165,14 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 		var err error
 
 		if c.Sk || c.Slot != "" || c.KeyRef != "" || c.CertPath != "" {
+			// Set no load options so that Ed25519 is preferred over Ed25519ph, required for signing DSSEs
+			var signOpts []signature.LoadOption
+			c.KeyOpts.DefaultLoadOptions = &signOpts
 			sv, _, err = cosign_sign.SignerFromKeyOpts(ctx, c.CertPath, c.CertChainPath, c.KeyOpts)
 			if err != nil {
 				return fmt.Errorf("getting signer: %w", err)
 			}
-			keypair, err = key.NewSignerVerifierKeypair(sv, c.DefaultLoadOptions)
+			keypair, err = key.NewSignerVerifierKeypair(sv, &signOpts)
 			if err != nil {
 				return fmt.Errorf("creating signerverifier keypair: %w", err)
 			}

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -165,11 +165,14 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 		var err error
 
 		if c.Sk || c.Slot != "" || c.KeyRef != "" || c.CertPath != "" {
+			// Set no load options so that Ed25519 is preferred over Ed25519ph, required for signing DSSEs
+			var signOpts []signature.LoadOption
+			c.KeyOpts.DefaultLoadOptions = &signOpts
 			sv, _, err = cosign_sign.SignerFromKeyOpts(ctx, c.CertPath, c.CertChainPath, c.KeyOpts)
 			if err != nil {
 				return fmt.Errorf("getting signer: %w", err)
 			}
-			keypair, err = key.NewSignerVerifierKeypair(sv, c.DefaultLoadOptions)
+			keypair, err = key.NewSignerVerifierKeypair(sv, &signOpts)
 			if err != nil {
 				return fmt.Errorf("creating signerverifier keypair: %w", err)
 			}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -256,11 +256,14 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 		var err error
 
 		if ko.Sk || ko.Slot != "" || ko.KeyRef != "" || signOpts.Cert != "" {
+			// Set no load options so that Ed25519 is preferred over Ed25519ph, required for signing DSSEs
+			var signLoadOpts []signature.LoadOption
+			ko.DefaultLoadOptions = &signLoadOpts
 			sv, _, err = SignerFromKeyOpts(ctx, signOpts.Cert, signOpts.CertChain, ko)
 			if err != nil {
 				return fmt.Errorf("getting signer: %w", err)
 			}
-			keypair, err = key.NewSignerVerifierKeypair(sv, ko.DefaultLoadOptions)
+			keypair, err = key.NewSignerVerifierKeypair(sv, &signLoadOpts)
 			if err != nil {
 				return fmt.Errorf("creating signerverifier keypair: %w", err)
 			}

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -87,6 +87,7 @@ func SignBlobCmd(ro *options.RootOptions, ko options.KeyOpts, payloadPath string
 		var err error
 
 		if ko.Sk || ko.Slot != "" || ko.KeyRef != "" {
+			// Default load options prefer Ed25519ph over Ed25519, required for blobs with hashedrekord
 			sv, _, err = SignerFromKeyOpts(ctx, "", "", ko)
 			if err != nil {
 				return nil, fmt.Errorf("getting signer: %w", err)

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -240,7 +240,9 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	var pubKey signature.Verifier
 	switch {
 	case keyRef != "":
-		pubKey, err = sigs.PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, c.HashAlgorithm)
+		// Set no load options so that Ed25519 is preferred over Ed25519ph, required for verifying DSSEs
+		var signOpts []signature.LoadOption
+		pubKey, err = sigs.PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, c.HashAlgorithm, &signOpts)
 		if err != nil {
 			return fmt.Errorf("loading public key: %w", err)
 		}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -40,6 +40,7 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/policy"
 	sigs "github.com/sigstore/cosign/v2/pkg/signature"
 	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore/pkg/signature"
 )
 
 // VerifyAttestationCommand verifies a signature on a supplied container image
@@ -210,7 +211,9 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	// Keys are optional!
 	switch {
 	case keyRef != "":
-		co.SigVerifier, err = sigs.PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, c.HashAlgorithm)
+		// Set no load options so that Ed25519 is preferred over Ed25519ph, required for verifying DSSEs
+		var signOpts []signature.LoadOption
+		co.SigVerifier, err = sigs.PublicKeyFromKeyRefWithHashAlgo(ctx, keyRef, c.HashAlgorithm, &signOpts)
 		if err != nil {
 			return fmt.Errorf("loading public key: %w", err)
 		}

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/sign"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -63,7 +64,11 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		if err != nil {
 			log.Fatal(err)
 		}
-		verifier, err := signature.LoadDefaultVerifier(pubKey)
+		var verifierOpts []signature.LoadOption
+		if _, ok := content.(*sign.PlainData); ok {
+			verifierOpts = append(verifierOpts, options.WithED25519ph())
+		}
+		verifier, err := signature.LoadDefaultVerifier(pubKey, verifierOpts...)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
With the recent changes we made to use sigstore-go rather than Cosign for signing and verification, ed25519 managed key support broke, because we were incorrectly specifying ed25519ph for dsse Rekor entries and not specifying ed25519ph for hashedrekord entries. This PR correctly sets load options for when signing and verifying a blob (using the prehash variant) and when signing/verifying attestations (using the pure variant). This also fixes a bug where the SignerVerifier Keypair didn't handle crypto.Hash(0) for ed25519, which specifies no hash when signing.

This has been tested with sign/verify, sign-blob/verify-blob, attest/verify-attestation, and attest-blob/verify-blob-attestation.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
