### PR TITLE
Cache signing config when calling initialize

### DIFF
--- a/cmd/cosign/cli/initialize/init.go
+++ b/cmd/cosign/cli/initialize/init.go
@@ -86,6 +86,12 @@ func doInitialize(ctx context.Context, root, mirror, rootChecksum string, forceS
 		return fmt.Errorf("storing remote: %w", err)
 	}
 
+	// Cache the signing config from the TUF repository
+	_, err = tufroot.FetchSigningConfigWithOptions(opts)
+	if err != nil {
+		ui.Warnf(ctx, "Could not fetch signing_config.json from the TUF mirror (encountered error: %v). It is recommended to use a signing config file rather than provide service URLs when signing.", err)
+	}
+	// Cache the trusted root from the TUF repository
 	trustedRoot, err := tufroot.NewLiveTrustedRoot(opts)
 	if err != nil {
 		ui.Warnf(ctx, "Could not fetch trusted_root.json from the TUF mirror (encountered error: %v), falling back to individual targets. It is recommended to update your TUF metadata repository to include trusted_root.json.", err)

--- a/cmd/cosign/cli/initialize/init_test.go
+++ b/cmd/cosign/cli/initialize/init_test.go
@@ -155,13 +155,16 @@ func TestDoInitialize(t *testing.T) {
 		expectV2   bool
 	}{
 		{
-			name:       "tuf v2 with trusted root",
-			targets:    map[string][]byte{"trusted_root.json": []byte(`{"mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1"}`)},
+			name: "tuf v2 with trusted root and signing config",
+			targets: map[string][]byte{
+				"trusted_root.json":        []byte(`{"mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1"}`),
+				"signing_config.v0.2.json": []byte(`{"mediaType": "application/vnd.dev.sigstore.signingconfig.v0.2+json"}`),
+			},
 			root:       "1.root.json",
 			wantStdOut: "",
 			wantStdErr: "",
 			wantErr:    false,
-			wantFiles:  []string{filepath.Join("targets", "trusted_root.json")},
+			wantFiles:  []string{filepath.Join("targets", "trusted_root.json"), filepath.Join("targets", "signing_config.v0.2.json")},
 			expectV2:   true,
 		},
 		{


### PR DESCRIPTION
When calling cosign initialize, the client will cache the trusted root file if available. This PR adds support for caching the signing config as well. The public-good instance's TUF repo includes this file. Private deployments likely don't use this file, so like with the trusted root, Cosign will print a warning rather than fail initialization.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
