### PR TITLE
Deprecate offline flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ The following checks were performed on these signatures:
 
 ### Verify a container in an air-gapped environment
 
+**Note:** This section is out of date.
+
+**Note:** Most verification workflows require periodically requesting service keys from a TUF repository.
+For airgapped verification of signatures using the public-good instance, you will need to retrieve the
+[trusted root](https://github.com/sigstore/root-signing/blob/main/targets/trusted_root.json) file from the production
+TUF repository. The contents of this file will change without notification. By not using TUF, you will need
+to build your own mechanism to keep your airgapped copy of this file up-to-date.
+
 Cosign can do completely offline verification by verifying a [bundle](./specs/SIGNATURE_SPEC.md#properties) which is typically distributed as an annotation on the image manifest.
 As long as this annotation is present, then offline verification can be done.
 This bundle annotation is always included by default for keyless signing, so the default `cosign sign` functionality will include all materials needed for offline verification.

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -37,7 +37,8 @@ type CommonVerifyOptions struct {
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Offline, "offline", false,
-		"only allow offline verification")
+		"only verify an artifact's inclusion in a transparency log using a provided proof, rather than querying the log. May still include network requests to retrieve service keys from a TUF repository")
+	_ = cmd.Flags().MarkDeprecated("offline", "To verify in an airgapped environment, provide a --bundle with the signature and verification material, and a --trusted-root file with the service keys and certificates")
 
 	cmd.Flags().StringVar(&o.TSACertChainPath, "timestamp-certificate-chain", "",
 		"path to PEM-encoded certificate chain file for the RFC3161 timestamp authority. Must contain the root CA certificate. "+

--- a/doc/cosign_dockerfile_verify.md
+++ b/doc/cosign_dockerfile_verify.md
@@ -78,7 +78,6 @@ cosign dockerfile verify [flags]
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
       --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
-      --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure

--- a/doc/cosign_manifest_verify.md
+++ b/doc/cosign_manifest_verify.md
@@ -72,7 +72,6 @@ cosign manifest verify [flags]
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
       --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
-      --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -82,7 +82,6 @@ cosign verify-attestation [flags]
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
       --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
-      --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --policy strings                                                                           specify CUE or Rego files with policies to be used for validation
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -52,7 +52,6 @@ cosign verify-blob-attestation [flags]
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --max-workers int                                 the amount of maximum workers for parallel executions (default 10)
       --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle (default true)
-      --offline                                         only allow offline verification
       --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")
       --rfc3161-timestamp string                        path to RFC3161 timestamp FILE

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -85,7 +85,6 @@ cosign verify-blob [flags]
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
       --max-workers int                                 the amount of maximum workers for parallel executions (default 10)
       --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle (default true)
-      --offline                                         only allow offline verification
       --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")
       --rfc3161-timestamp string                        path to RFC3161 timestamp FILE

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -99,7 +99,6 @@ cosign verify [flags]
       --local-image                                                                              whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                                                          the amount of maximum workers for parallel executions (default 10)
       --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
-      --offline                                                                                  only allow offline verification
   -o, --output string                                                                            output format for the signing image information (json|text) (default "json")
       --payload string                                                                           payload path or remote URL
       --private-infrastructure                                                                   skip transparency log verification when verifying artifacts in a privately deployed infrastructure


### PR DESCRIPTION
The offline flag is misleading and is a no-op with the new Cosign v3 defaults. The flag's purpose was to prevent a client from falling back to verifying an artifact's inclusion in Rekor when a proof failed to verify. Most users thought offline verification forced the client to not make any network requests - a very reasonable assumption, but with TUF, network requests are a part of verification if the local TUF metadata has expired.

I've updated the README as well, though we need to make a far more comprehensive pass over the documentation since it's out of date given our new trusted-root/bundle flags.

Fixes #4454

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
