### PR TITLE
Remove --out flag from `cosign initialize`

### DIFF
--- a/cmd/cosign/cli/initialize.go
+++ b/cmd/cosign/cli/initialize.go
@@ -39,10 +39,10 @@ This will enable you to point cosign to a separate TUF root.
 Any updated TUF repository will be written to $HOME/.sigstore/root/.
 
 Trusted keys and certificate used in cosign verification (e.g. verifying Fulcio issued certificates
-with Fulcio root CA) are pulled form the trusted metadata.`,
-		Example: `cosign initialize --mirror <url> --out <file>
+with Fulcio root CA) are pulled from the trusted metadata.`,
+		Example: `cosign initialize --mirror <url>
 
-# initialize root with distributed root keys, default mirror, and default out path.
+# initialize root with distributed root keys, using the default mirror.
 cosign initialize
 
 # initialize with an out-of-band root key file, using the default mirror.

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -16,7 +16,7 @@ This will enable you to point cosign to a separate TUF root.
 Any updated TUF repository will be written to $HOME/.sigstore/root/.
 
 Trusted keys and certificate used in cosign verification (e.g. verifying Fulcio issued certificates
-with Fulcio root CA) are pulled form the trusted metadata.
+with Fulcio root CA) are pulled from the trusted metadata.
 
 ```
 cosign initialize [flags]
@@ -25,9 +25,9 @@ cosign initialize [flags]
 ### Examples
 
 ```
-cosign initialize --mirror <url> --out <file>
+cosign initialize --mirror <url>
 
-# initialize root with distributed root keys, default mirror, and default out path.
+# initialize root with distributed root keys, using the default mirror.
 cosign initialize
 
 # initialize with an out-of-band root key file, using the default mirror.


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Remove any mention of the `--out` flag from the `cosign initialize` command, since it's no longer used.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

NONE

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
