### PR TITLE
Fix segfault when no attestations are found

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1041,9 +1041,6 @@ func VerifyImageAttestations(ctx context.Context, signedImgRef name.Reference, c
 	if err != nil {
 		return nil, false, err
 	}
-	if atts == nil {
-		return nil, false, errors.New("unable to find attestations")
-	}
 
 	return VerifyImageAttestation(ctx, atts, h, co)
 }
@@ -1091,9 +1088,6 @@ func VerifyLocalImageAttestations(ctx context.Context, path string, co *CheckOpt
 	if err != nil {
 		return nil, false, err
 	}
-	if atts == nil {
-		return nil, false, errors.New("unable to find attestations")
-	}
 	return VerifyImageAttestation(ctx, atts, h, co)
 }
 
@@ -1103,6 +1097,9 @@ func VerifyBlobAttestation(ctx context.Context, att oci.Signature, h v1.Hash, co
 }
 
 func VerifyImageAttestation(ctx context.Context, atts oci.Signatures, h v1.Hash, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+	if atts == nil {
+		return nil, false, errors.New("no attestations provided")
+	}
 	sl, err := atts.Get()
 	if err != nil {
 		return nil, false, err

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1648,6 +1648,12 @@ func TestVerifyRFC3161Timestamp(t *testing.T) {
 	}
 }
 
+func TestVerifyImageAttestation(t *testing.T) {
+	if _, _, err := VerifyImageAttestation(context.TODO(), nil, v1.Hash{}, nil); err == nil {
+		t.Error("VerifyImageAttestation() should error when given nil attestations")
+	}
+}
+
 // Mock Rekor client
 type mockEntriesClient struct {
 	entries.ClientService


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Fixes #4468.

Note that this does not implement `cosign save` with the new attestations (as described in #4470), but at least it won't segfault.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Fixed segfault with subcommands `verify` and `verify-attestation` when called with `--local-image=true` and no attestations were found

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A