### PR TITLE
Use overridden repository for new bundle format

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -249,7 +249,7 @@ func WriteReferrer(d name.Digest, artifactType string, layers []v1.Layer, annota
 	if err != nil {
 		return fmt.Errorf("failed to calculate size: %w", err)
 	}
-	err = remoteWriteLayer(d.Repository, configLayer, o.ROpt...)
+	err = remoteWriteLayer(o.TargetRepository, configLayer, o.ROpt...)
 	if err != nil {
 		return fmt.Errorf("failed to upload layer: %w", err)
 	}
@@ -269,7 +269,7 @@ func WriteReferrer(d name.Digest, artifactType string, layers []v1.Layer, annota
 			return fmt.Errorf("failed to calculate size: %w", err)
 		}
 
-		err = remoteWriteLayer(d.Repository, layer, o.ROpt...)
+		err = remoteWriteLayer(o.TargetRepository, layer, o.ROpt...)
 		if err != nil {
 			return fmt.Errorf("failed to upload layer: %w", err)
 		}
@@ -299,7 +299,7 @@ func WriteReferrer(d name.Digest, artifactType string, layers []v1.Layer, annota
 		Annotations: annotations,
 	}, artifactType}
 
-	targetRef, err := manifest.targetRef(d.Repository)
+	targetRef, err := manifest.targetRef(o.TargetRepository)
 	if err != nil {
 		return fmt.Errorf("failed to create target reference: %w", err)
 	}


### PR DESCRIPTION
Ensure COSIGN_REPOSITORY environment variable is respected both for the legacy attachment format and the new bundle format.

Fixes #4464

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
