### PR TITLE
Remove stale embed import

### DIFF
--- a/cmd/cosign/cli/initialize/init.go
+++ b/cmd/cosign/cli/initialize/init.go
@@ -17,7 +17,6 @@ package initialize
 
 import (
 	"context"
-	_ "embed" // To enable the `go:embed` directive.
 	"encoding/json"
 	"fmt"
 	"os"


### PR DESCRIPTION
#### Summary

While spelunking through the code and some history, I noticed this stale import for `embed` that was originally introduced in  [#530](https://github.com/sigstore/cosign/pull/530/files#diff-ba53943a3e95d6d9831e299870f1d5359c0cc6cf1d7d9ac971ebd96ff10a2685) and subsequently removed the need for in [#747](https://github.com/sigstore/cosign/pull/747/files#diff-48db7011fe8c97368282a9b05f10b8a8defd60af7891f7a2e523e335166cbcb5), but the import wasn't removed as part of that change.

#### Release Note

NONE

#### Documentation

NONE