### PR TITLE
Support stdout output for attest-blob bundles

### DIFF
--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -52,7 +52,11 @@ func AttestBlob() *cobra.Command {
   cosign attest-blob --predicate <FILE> --type <TYPE> --key hashivault://[KEY] <BLOB>
 
   # supply attestation via stdin
-  echo <PAYLOAD> | cosign attest-blob --predicate - --yes`,
+  echo <PAYLOAD> | cosign attest-blob --predicate - --yes
+
+  # create a JSONL file with multiple attestations by outputting bundles to stdout
+  cosign attest-blob --key cosign.key --predicate <FILE1> --type <TYPE> --bundle=- <BLOB> >> attestations.jsonl
+  cosign attest-blob --key cosign.key --predicate <FILE2> --type <TYPE> --bundle=- <BLOB> >> attestations.jsonl`,
 
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/cosign/cli/options/attest_blob.go
+++ b/cmd/cosign/cli/options/attest_blob.go
@@ -95,7 +95,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	_ = cmd.MarkFlagFilename("key", certificateExts...)
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
-		"write everything required to verify the blob to a FILE")
+		"write everything required to verify the blob to a FILE (use \"-\" for stdout)")
 	_ = cmd.MarkFlagFilename("bundle", bundleExts...)
 
 	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true,

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -514,6 +514,11 @@ func WriteNewBundleWithSigningConfig(ctx context.Context, ko options.KeyOpts, ce
 	}
 
 	if bundleOpts.BundlePath != "" {
+		// If bundleOpts.BundlePath is "-", write to stdout with trailing newline
+		if bundleOpts.BundlePath == "-" {
+			fmt.Fprintln(os.Stdout, string(bundle))
+			return nil
+		}
 		if err := os.WriteFile(bundleOpts.BundlePath, bundle, 0600); err != nil {
 			return fmt.Errorf("creating bundle file: %w", err)
 		}

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -28,12 +28,16 @@ cosign attest-blob [flags]
 
   # supply attestation via stdin
   echo <PAYLOAD> | cosign attest-blob --predicate - --yes
+
+  # create a JSONL file with multiple attestations by outputting bundles to stdout
+  cosign attest-blob --key cosign.key --predicate <FILE1> --type <TYPE> --bundle=- <BLOB> >> attestations.jsonl
+  cosign attest-blob --key cosign.key --predicate <FILE2> --type <TYPE> --bundle=- <BLOB> >> attestations.jsonl
 ```
 
 ### Options
 
 ```
-      --bundle string                     write everything required to verify the blob to a FILE
+      --bundle string                     write everything required to verify the blob to a FILE (use "-" for stdout)
       --certificate string                path to the X.509 certificate in PEM format to include in the OCI Signature
       --certificate-chain string          path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signing certificate. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate. Included in the OCI Signature
       --fulcio-auth-flow string           fulcio interactive oauth2 flow to use for certificate from fulcio. Defaults to determining the flow based on the runtime environment. (options) normal|device|token|client_credentials


### PR DESCRIPTION
#### Summary

This enables `attest-blob --bundle=-` to write bundles to stdout with a trailing newline, allowing users to create JSONL files containing multiple attestations by redirecting and appending output.

This change adds support for the convention of using "-" to represent stdout. When the bundle path is "-", the bundle is written to stdout instead of a file, and the signature output is suppressed to avoid conflicts.

Changes:
- Add stdout detection in attest/attest_blob.go and signcommon/common.go
- Suppress signature output when bundle goes to stdout
- Add comprehensive test coverage in attest_blob_test.go
- Update flag description and add JSONL example to documentation

Example usage, appending two predicates about the same blob to the same jsonl file.
```
cosign attest-blob --key key.key --predicate pred1.json \ --type slsaprovenance --bundle=- blob.txt >> attestations.jsonl
cosign attest-blob --key key.key --predicate pred2.json \ --type slsaprovenance --bundle=- blob.txt >> attestations.jsonl
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #4494

#### Release Note

Added support for writing blob attestations to stdout.

#### Documentation

I don't think this needs any special docs update, but I'm open to it if you think there's somewhere it should be noted.