### PR TITLE
Fix signing/verifying annotations for new bundle

### DIFF
--- a/cmd/cosign/cli/verify/verify_test.go
+++ b/cmd/cosign/cli/verify/verify_test.go
@@ -351,7 +351,7 @@ func TestTransformOutputSuccess(t *testing.T) {
 	stmt := `{
 	  "_type": "https://in-toto.io/Statement/v0.1",
 	  "subject": [
-		{ "name": "artifact", "digest": { "sha256": "deadbeef" } }
+		{ "name": "artifact", "digest": { "sha256": "deadbeef" }, "annotations": { "foo": "bar" } }
 	  ],
 	  "predicateType": "https://slsa.dev/provenance/v0.2"
 	}`
@@ -394,4 +394,5 @@ func TestTransformOutputSuccess(t *testing.T) {
 	assert.Equal(t, name, sci.Critical.Identity.DockerReference, "docker reference mismatch")
 	assert.Equal(t, "sha256:deadbeef", sci.Critical.Image.DockerManifestDigest, "digest mismatch")
 	assert.Equal(t, "https://slsa.dev/provenance/v0.2", sci.Critical.Type, "type mismatch")
+	assert.Equal(t, map[string]any{"foo": "bar"}, sci.Optional, "missing annotation")
 }

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1716,6 +1716,11 @@ func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef nam
 				if err != nil {
 					return err
 				}
+				if co.ClaimVerifier != nil {
+					if err := co.ClaimVerifier(att, *hash, co.Annotations); err != nil {
+						return err
+					}
+				}
 				bundlesVerified[index] = true
 
 				return err

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -75,6 +75,7 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/kubernetes"
 	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -1288,6 +1289,39 @@ func TestSignVerifyBundle(t *testing.T) {
 		UseSignedTimestamps: false,
 	}
 	must(cmd.Exec(ctx, args), t)
+
+	// Add annotations and verify claims
+	_, privKeyPath, pubKeyPath = keypair(t, td)
+	ko = options.KeyOpts{
+		KeyRef:           privKeyPath,
+		PassFunc:         passFunc,
+		RekorURL:         rekorURL,
+		SkipConfirmation: true,
+	}
+	so = options.SignOptions{
+		Upload:          true,
+		NewBundleFormat: true,
+		TlogUpload:      true,
+		AnnotationOptions: options.AnnotationOptions{
+			Annotations: []string{"foo=bar"},
+		},
+	}
+	must(sign.SignCmd(ro, ko, so, []string{imgName}), t)
+	cmd = cliverify.VerifyCommand{
+		CommonVerifyOptions: options.CommonVerifyOptions{
+			TrustedRootPath: trustedRootPath,
+		},
+		KeyRef:              pubKeyPath,
+		NewBundleFormat:     true,
+		UseSignedTimestamps: false,
+		Annotations:         sigs.AnnotationsMap{Annotations: map[string]any{"foo": "bar"}},
+		CheckClaims:         true,
+	}
+	must(cmd.Exec(ctx, args), t)
+
+	// Verfying other annotations should not work
+	cmd.Annotations.Annotations["baz"] = "bat"
+	mustErr(cmd.Exec(ctx, args), t)
 }
 
 func TestAttestVerify(t *testing.T) {


### PR DESCRIPTION
Without this change, when the new bundle format is used, annotations were not being added to the payload, nor were they being checked during verification, but were still being reported as verified. This also had a side effect of the annotations not appearing in the verification output. This change fixes the issue by passing through the annotations to the statement builder during signing, and using a different in-toto `Statement` type to parse annotations from the statement during verification, as well as actually calling the claims verifier.

Fixes https://github.com/sigstore/cosign/issues/4504
The missing annotations in the display output was the least of the problems - the annotations were not being added or verified at all.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
