### PR TITLE
4554: Closes 4554 - Add warning when --output* is used

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -101,7 +101,8 @@ func Attest() *cobra.Command {
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, "", o.Key, o.IssueCertificate); err != nil {
+				o.NewBundleFormat, "", o.Key, o.IssueCertificate,
+				"", "", "", "", ""); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -86,7 +86,8 @@ func AttestBlob() *cobra.Command {
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate); err != nil {
+				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate,
+				"", o.OutputAttestation, o.OutputCertificate, "", o.OutputSignature); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -16,7 +16,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -24,7 +23,6 @@ import (
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon"
-	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -132,18 +130,8 @@ race conditions or (worse) malicious tampering.
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, "", o.Key, o.IssueCertificate); err != nil {
+				o.NewBundleFormat, "", o.Key, o.IssueCertificate, o.Output, "", o.OutputCertificate, o.OutputPayload, o.OutputSignature); err != nil {
 				return err
-			}
-
-			if o.NewBundleFormat && o.OutputSignature != "" {
-				ui.Warnf(context.Background(), "--output-signature is deprecated when using --new-bundle-format and will be ignored")
-			}
-			if o.NewBundleFormat && o.OutputCertificate != "" {
-				ui.Warnf(context.Background(), "--output-certificate is deprecated when using --new-bundle-format and will be ignored")
-			}
-			if o.NewBundleFormat && o.Output != "" {
-				ui.Warnf(context.Background(), "--output is deprecated when using --new-bundle-format and will be ignored")
 			}
 
 			if err := sign.SignCmd(cmd.Context(), ro, ko, *o, args); err != nil {

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -116,7 +116,8 @@ func SignBlob() *cobra.Command {
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate); err != nil {
+				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate,
+				o.Output, "", o.OutputCertificate, "", o.OutputSignature); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -646,7 +646,8 @@ func ParseSignatureAlgorithmFlag(signingAlgorithm string) (pb_go_v1.PublicKeyDet
 // LoadTrustedMaterialAndSigningConfig loads the trusted material and signing config from the given options.
 func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpts, useSigningConfig bool, signingConfigPath string,
 	rekorURL, fulcioURL, oidcIssuer, tsaServerURL, trustedRootPath string,
-	tlogUpload bool, newBundleFormat bool, bundlePath string, keyRef string, issueCertificate bool) error {
+	tlogUpload bool, newBundleFormat bool, bundlePath string, keyRef string, issueCertificate bool,
+	output, outputAttestation, outputCertificate, outputPayload, outputSignature string) error {
 	var err error
 	// If a signing config is used, then service URLs cannot be specified
 	if (useSigningConfig || signingConfigPath != "") &&
@@ -691,5 +692,23 @@ func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpt
 			return fmt.Errorf("error getting signing config from TUF: %w", err)
 		}
 	}
+
+	// TODO: Remove deprecated output flags warning in a future release (when flags are removed)
+	if newBundleFormat && outputSignature != "" {
+		ui.Warnf(context.Background(), "--output-signature is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputAttestation != "" {
+		ui.Warnf(context.Background(), "--output-attestation is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputCertificate != "" {
+		ui.Warnf(context.Background(), "--output-certificate is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputPayload != "" {
+		ui.Warnf(context.Background(), "--output-payload is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && output != "" {
+		ui.Warnf(context.Background(), "--output is deprecated when using --new-bundle-format and will be ignored")
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
Fixes 4554

#### Release Note
In Cosign <3.0.2, previously, `--output`, `--output-certificate` and `--output-signature` were silently ignored when `--new-bundle-format=true`. With this fix, a warning message is printed out for the user's attention.


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
