### PR TITLE
Add staging flag to initialize with staging TUF metadata

### DIFF
--- a/cmd/cosign/cli/initialize.go
+++ b/cmd/cosign/cli/initialize.go
@@ -45,6 +45,9 @@ with Fulcio root CA) are pulled from the trusted metadata.`,
 # initialize root with distributed root keys, using the default mirror.
 cosign initialize
 
+# initialize root with distributed root keys, using the staging mirror.
+cosign initialize --staging
+
 # initialize with an out-of-band root key file, using the default mirror.
 cosign initialize --root <url>
 
@@ -55,6 +58,9 @@ cosign initialize --mirror <url> --root <url>
 cosign initialize --mirror <url> --root <url> --root-checksum <sha256>`,
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if o.Staging {
+				return initialize.DoInitializeStaging(cmd.Context())
+			}
 			return initialize.DoInitializeWithRootChecksum(cmd.Context(), o.Root, o.Mirror, o.RootChecksum)
 		},
 	}

--- a/cmd/cosign/cli/options/initialize.go
+++ b/cmd/cosign/cli/options/initialize.go
@@ -25,6 +25,7 @@ type InitializeOptions struct {
 	Mirror       string
 	Root         string
 	RootChecksum string
+	Staging      bool
 }
 
 var _ Interface = (*InitializeOptions)(nil)
@@ -40,4 +41,7 @@ func (o *InitializeOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RootChecksum, "root-checksum", "",
 		"checksum of the initial root, required if root is downloaded via http(s). expects sha256 by default, can be changed to sha512 by providing sha512:<checksum>")
+
+	cmd.Flags().BoolVar(&o.Staging, "staging", false,
+		"use the staging TUF repository")
 }

--- a/doc/cosign_initialize.md
+++ b/doc/cosign_initialize.md
@@ -30,6 +30,9 @@ cosign initialize --mirror <url>
 # initialize root with distributed root keys, using the default mirror.
 cosign initialize
 
+# initialize root with distributed root keys, using the staging mirror.
+cosign initialize --staging
+
 # initialize with an out-of-band root key file, using the default mirror.
 cosign initialize --root <url>
 
@@ -47,6 +50,7 @@ cosign initialize --mirror <url> --root <url> --root-checksum <sha256>
       --mirror string          GCS bucket to a SigStore TUF repository, or HTTP(S) base URL, or file:/// for local filestore remote (air-gap) (default "https://tuf-repo-cdn.sigstore.dev")
       --root string            path to trusted initial root. defaults to embedded root
       --root-checksum string   checksum of the initial root, required if root is downloaded via http(s). expects sha256 by default, can be changed to sha512 by providing sha512:<checksum>
+      --staging                use the staging TUF repository
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
Closes #4533 

#### Summary

This change adds a `--staging` flag to `cosign initialize` which initializes the TUF cache directory with staging TUF metadata.

This change also clears the TUF cache directory on any run of `cosign initialize` so that prod and staging TUF metadata do not coexist. 

This functionality has been tested locally.

#### Documentation

sigstore/docs#404


