### PR TITLE
Supporting OCI Signing with X.509 Certificate Chain

### DIFF
--- a/cmd/cosign/cli/attest/attest_blob_test.go
+++ b/cmd/cosign/cli/attest/attest_blob_test.go
@@ -161,11 +161,10 @@ func TestAttestBlobCmdLocalKeyAndCert(t *testing.T) {
 					certchainref: subCertPem,
 				},
 				{
-					name:         "fail: cert chain includes root",
+					name:         "cert chain includes root",
 					keyref:       keyRef,
 					certref:      certRef,
 					certchainref: chainRef,
-					errString:    "certificate chain must not contain a self-signed (root) certificate",
 				},
 				{
 					name:         "fail: cert chain bad",

--- a/cmd/cosign/cli/attest/attest_blob_test.go
+++ b/cmd/cosign/cli/attest/attest_blob_test.go
@@ -152,13 +152,20 @@ func TestAttestBlobCmdLocalKeyAndCert(t *testing.T) {
 					name:         "cert chain matches key",
 					keyref:       keyRef,
 					certref:      certRef,
-					certchainref: chainRef,
+					certchainref: subCertPem,
 				},
 				{
 					name:         "cert chain partial",
 					keyref:       keyRef,
 					certref:      certRef,
 					certchainref: subCertPem,
+				},
+				{
+					name:         "fail: cert chain includes root",
+					keyref:       keyRef,
+					certref:      certRef,
+					certchainref: chainRef,
+					errString:    "certificate chain must not contain a self-signed (root) certificate",
 				},
 				{
 					name:         "fail: cert chain bad",

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -35,6 +35,7 @@ type CommonVerifyOptions struct {
 	UseSignedTimestamps   bool
 	NewBundleFormat       bool
 	TrustedRootPath       string
+	AllowCertificateChain bool
 }
 
 func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
@@ -74,6 +75,9 @@ func (o *CommonVerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true,
 		"expect the signature/attestation to be packaged in a Sigstore bundle")
 	_ = cmd.Flags().MarkDeprecated("new-bundle-format", "this will be the only supported format in future versions")
+
+	cmd.Flags().BoolVar(&o.AllowCertificateChain, "allow-certificate-chain", false,
+		"allow X.509 certificate chains in bundle verification material for v0.3+ bundles")
 }
 
 var verifyOutputTypes = []string{"json", "text"} // First one is the default

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -266,7 +266,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		}
 	}
 
-	keypair, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, signOpts.Cert, signOpts.CertChain)
+	keypair, certBytes, chainBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, signOpts.Cert, signOpts.CertChain)
 	if err != nil {
 		return fmt.Errorf("getting keypair and token: %w", err)
 	}
@@ -304,7 +304,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 			Data: payload,
 		}
 
-		bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, cbundleOpts)
+		bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, chainBytes, ko.SigningConfig, ko.TrustedMaterial, cbundleOpts)
 		if err != nil {
 			return fmt.Errorf("signing bundle: %w", err)
 		}

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -82,7 +82,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		ko.DefaultLoadOptions = &[]signature.LoadOption{}
 	}
 
-	keypair, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)
+	keypair, certBytes, chainBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)
 	if err != nil {
 		return nil, fmt.Errorf("getting keypair and token: %w", err)
 	}
@@ -123,7 +123,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		}
 	}
 	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
-	bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
+	bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, chainBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)
 	}

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -75,24 +75,24 @@ func (c *SignerVerifier) Close() {
 // For an ephemeral key, it also uses the key to fetch an OIDC token, the pair of which are later used to get a Fulcio cert.
 //
 // Ensure the returned SignerVerifier is closed via calling SignerVerifier.Close.
-func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain string) (sign.Keypair, []byte, string, error) {
+func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain string) (sign.Keypair, []byte, []byte, string, error) {
 	var keypair sign.Keypair
 	var ephemeralKeypair bool
 	var idToken string
 	var sv *SignerVerifier
-	var certBytes []byte
 	var err error
 
 	sv, ephemeralKeypair, err = signerFromKeyOpts(ctx, cert, certChain, ko)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("getting signer: %w", err)
+		return nil, nil, nil, "", fmt.Errorf("getting signer: %w", err)
 	}
 	keypair, err = key.NewSignerVerifierKeypair(sv, ko.DefaultLoadOptions)
 	if err != nil {
 		sv.Close()
-		return nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
+		return nil, nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
 	}
-	certBytes = sv.Cert
+	certBytes := sv.Cert
+	chainBytes := sv.Chain
 
 	if ephemeralKeypair || ko.IssueCertificateForExistingKey {
 		idToken, err = auth.RetrieveIDToken(ctx, auth.IDTokenConfig{
@@ -108,11 +108,11 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 		})
 		if err != nil {
 			sv.Close()
-			return nil, nil, "", fmt.Errorf("retrieving ID token: %w", err)
+			return nil, nil, nil, "", fmt.Errorf("retrieving ID token: %w", err)
 		}
 	}
 
-	return keypair, certBytes, idToken, nil
+	return keypair, certBytes, chainBytes, idToken, nil
 }
 
 // ShouldUploadToTlog determines whether the user wants to upload the entry to Rekor.
@@ -363,7 +363,7 @@ type CommonBundleOpts struct {
 
 // NewAttestationBundle uses signing config and trusted root to sign an attestation and create a bundle.
 func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) ([]byte, crypto.PublicKey, string, pb_go_v1.HashAlgorithm, error) {
-	keypair, certBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
+	keypair, certBytes, chainBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
 	if err != nil {
 		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting keypair and token: %w", err)
 	}
@@ -385,7 +385,7 @@ func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certCha
 	}
 	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
 
-	bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, signingConfig, trustedMaterial, signOpts)
+	bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, chainBytes, signingConfig, trustedMaterial, signOpts)
 	if err != nil {
 		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("signing bundle: %w", err)
 	}

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -349,6 +349,7 @@ The blob may be specified as a path to a file or - for stdin.`,
 				UseSignedTimestamps:          o.CommonVerifyOptions.UseSignedTimestamps,
 				TrustedRootPath:              o.CommonVerifyOptions.TrustedRootPath,
 				HashAlgorithm:                hashAlgorithm,
+				AllowCertificateChain:        o.CommonVerifyOptions.AllowCertificateChain,
 			}
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
@@ -445,6 +446,7 @@ The blob may be specified as a path to a file.`,
 				Digest:                       o.Digest,
 				DigestAlg:                    o.DigestAlg,
 				HashAlgorithm:                hashAlgorithm,
+				AllowCertificateChain:        o.CommonVerifyOptions.AllowCertificateChain,
 			}
 			// We only use the blob if we are checking claims.
 			if o.CheckClaims && len(args) == 0 && (o.Digest == "" || o.DigestAlg == "") {

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -128,6 +128,7 @@ against the transparency log.`,
 				ExperimentalOCI11:            o.CommonVerifyOptions.ExperimentalOCI11,
 				UseSignedTimestamps:          o.CommonVerifyOptions.UseSignedTimestamps,
 				NewBundleFormat:              o.CommonVerifyOptions.NewBundleFormat,
+				AllowCertificateChain:        o.CommonVerifyOptions.AllowCertificateChain,
 			}
 
 			if o.CommonVerifyOptions.MaxWorkers == 0 {

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -32,9 +32,11 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/cosign/attestation"
 	"github.com/sigstore/cosign/v3/pkg/oci"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	"github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
 )
 
@@ -76,6 +78,7 @@ type VerifyCommand struct {
 	MaxWorkers                   int
 	ExperimentalOCI11            bool
 	NewBundleFormat              bool
+	AllowCertificateChain        bool
 }
 
 // Exec runs the verification command
@@ -118,6 +121,9 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	if c.AllowHTTPRegistry || c.AllowInsecure {
 		c.NameOptions = append(c.NameOptions, name.Insecure)
 	}
+	if c.AllowCertificateChain {
+		ociremoteOpts = append(ociremoteOpts, ociremote.WithBundleOptions(sgbundle.AllowCertificateChain()))
+	}
 
 	co := &cosign.CheckOpts{
 		Annotations:                  c.Annotations.Annotations,
@@ -137,6 +143,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		ExperimentalOCI11:            c.ExperimentalOCI11,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
 		NewBundleFormat:              c.NewBundleFormat,
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -32,7 +32,9 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/cue"
 	"github.com/sigstore/cosign/v3/pkg/cosign/rego"
 	"github.com/sigstore/cosign/v3/pkg/oci"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/cosign/v3/pkg/policy"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 )
 
 // VerifyAttestationCommand verifies a signature on a supplied container image
@@ -106,6 +108,9 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	if c.AllowHTTPRegistry || c.AllowInsecure {
 		c.NameOptions = append(c.NameOptions, name.Insecure)
 	}
+	if c.AllowCertificateChain {
+		ociremoteOpts = append(ociremoteOpts, ociremote.WithBundleOptions(sgbundle.AllowCertificateChain()))
+	}
 
 	co := &cosign.CheckOpts{
 		RegistryClientOpts:           ociremoteOpts,
@@ -121,6 +126,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		MaxWorkers:                   c.MaxWorkers,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
 		NewBundleFormat:              c.NewBundleFormat,
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -70,6 +70,7 @@ type VerifyBlobCmd struct {
 	UseSignedTimestamps          bool
 	IgnoreTlog                   bool
 	HashAlgorithm                crypto.Hash
+	AllowCertificateChain        bool
 }
 
 // nolint
@@ -114,8 +115,9 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		Offline:                      c.Offline,
 		IgnoreTlog:                   c.IgnoreTlog,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
-		NewBundleFormat:              c.KeyOpts.NewBundleFormat && checkNewBundle(c.BundlePath),
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
+	co.NewBundleFormat = c.KeyOpts.NewBundleFormat && checkNewBundle(c.BundlePath, co.BundleOptions()...)
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 
 	// User provides a key or certificate. Otherwise, verification requires a Fulcio certificate
@@ -138,7 +140,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 	}
 
 	if co.NewBundleFormat {
-		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath)
+		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath, co.BundleOptions()...)
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -77,6 +77,8 @@ type VerifyBlobAttestationCommand struct {
 	Digest        string
 	DigestAlg     string
 	HashAlgorithm crypto.Hash
+
+	AllowCertificateChain bool
 }
 
 // Exec runs the verification command
@@ -124,8 +126,9 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		Offline:                      c.Offline,
 		IgnoreTlog:                   c.IgnoreTlog,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
-		NewBundleFormat:              c.NewBundleFormat && checkNewBundle(c.BundlePath),
+		AllowCertificateChain:        c.AllowCertificateChain,
 	}
+	co.NewBundleFormat = c.NewBundleFormat && checkNewBundle(c.BundlePath, co.BundleOptions()...)
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 
 	// User provides a key or certificate. Otherwise, verification requires a Fulcio certificate
@@ -206,7 +209,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	}
 
 	if co.NewBundleFormat {
-		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath)
+		bundle, err := sgbundle.LoadJSONFromPath(c.BundlePath, co.BundleOptions()...)
 		if err != nil {
 			return err
 		}

--- a/cmd/cosign/cli/verify/verify_bundle.go
+++ b/cmd/cosign/cli/verify/verify_bundle.go
@@ -38,8 +38,8 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 )
 
-func checkNewBundle(bundlePath string) bool {
-	_, err := sgbundle.LoadJSONFromPath(bundlePath)
+func checkNewBundle(bundlePath string, opts ...sgbundle.Option) bool {
+	_, err := sgbundle.LoadJSONFromPath(bundlePath, opts...)
 	return err == nil
 }
 

--- a/doc/cosign_verify-attestation.md
+++ b/doc/cosign_verify-attestation.md
@@ -56,6 +56,7 @@ cosign verify-attestation [flags]
 ### Options
 
 ```
+      --allow-certificate-chain                         allow X.509 certificate chains in bundle verification material for v0.3+ bundles
       --allow-http-registry                             whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
       --allow-insecure-registry                         whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
       --certificate-github-workflow-name string         contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -43,6 +43,7 @@ cosign verify-blob-attestation [flags]
 ### Options
 
 ```
+      --allow-certificate-chain                         allow X.509 certificate chains in bundle verification material for v0.3+ bundles
       --bundle string                                   path to bundle FILE
       --certificate-github-workflow-name string         contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.
       --certificate-github-workflow-ref string          contains the ref claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon.

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -53,6 +53,7 @@ cosign verify-blob [flags]
 ### Options
 
 ```
+      --allow-certificate-chain                         allow X.509 certificate chains in bundle verification material for v0.3+ bundles
       --bundle string                                   path to bundle FILE
       --certificate-github-workflow-name string         contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.
       --certificate-github-workflow-ref string          contains the ref claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon.

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -59,6 +59,7 @@ cosign verify [flags]
 ### Options
 
 ```
+      --allow-certificate-chain                         allow X.509 certificate chains in bundle verification material for v0.3+ bundles
       --allow-http-registry                             whether to allow using HTTP protocol while connecting to registries. Don't use this for anything but testing
       --allow-insecure-registry                         whether to allow insecure connections to registries (e.g., with expired or self-signed TLS certificates). Don't use this for anything but testing
   -a, --annotations strings                             extra key=value pairs to sign

--- a/go.mod
+++ b/go.mod
@@ -294,3 +294,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/sigstore/sigstore-go => github.com/yangkenneth/sigstore-go v0.0.0-20260603051341-948bf6af8ad7

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/sigstore/rekor v1.5.3
 	github.com/sigstore/rekor-tiles/v2 v2.3.0
 	github.com/sigstore/sigstore v1.10.8
-	github.com/sigstore/sigstore-go v1.2.1
+	github.com/sigstore/sigstore-go v1.2.2
 	github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8
 	github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8
 	github.com/sigstore/sigstore/pkg/signature/kms/gcp v1.10.8
@@ -294,5 +294,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/sigstore/sigstore-go => github.com/yangkenneth/sigstore-go v0.0.0-20260603051341-948bf6af8ad7

--- a/go.sum
+++ b/go.sum
@@ -616,8 +616,6 @@ github.com/sigstore/rekor-tiles/v2 v2.3.0 h1:HhMgH61UP0t899V8Fjt7pz1YdgOBptbaQdn
 github.com/sigstore/rekor-tiles/v2 v2.3.0/go.mod h1:DEFiKSyQ4nF75QRVNdOPaIH3cmvMkO2B6xDZjNYngPc=
 github.com/sigstore/sigstore v1.10.8 h1:1Mgkxvkw4AXMfIP1DOjc6kw0GkUgA8pGVpveN/EfOq4=
 github.com/sigstore/sigstore v1.10.8/go.mod h1:f9+B/4iaYimvUkySyb2mvc73n3RLqNn24grHZM/ET8M=
-github.com/sigstore/sigstore-go v1.2.1 h1:YWP/rDbBaEBvtbkj6xtwsSj38ZCFEhTVVadNOXjVe3A=
-github.com/sigstore/sigstore-go v1.2.1/go.mod h1:I8BqVwAb/SaQJ5pBu5IDFY+ksq8O/1/kCag8XUgrsko=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8 h1:tofVQ+UWJgad/69I5zbqxdFCN5gpIn9tRQP7iBzIpBw=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8/go.mod h1:73AfJE8H6w5KGCFPBu4x/OG+i1Yxgmh0L/FtV7prd88=
 github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8 h1:8Mt7J36GcUEmbiJaiFhz2tud5ZIgkfVVCe2H/WJCHmw=
@@ -706,6 +704,8 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMc
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/yangkenneth/sigstore-go v0.0.0-20260603051341-948bf6af8ad7 h1:/aMJ6RsvFAZW/OVEa7Sf4BQRlP8O/EC8x2y20n8PV4Q=
+github.com/yangkenneth/sigstore-go v0.0.0-20260603051341-948bf6af8ad7/go.mod h1:C1Jr9FQqq7LUHNRMNDvVBZgE1hlAN4ztbvQfxWRkyhE=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=

--- a/go.sum
+++ b/go.sum
@@ -616,6 +616,8 @@ github.com/sigstore/rekor-tiles/v2 v2.3.0 h1:HhMgH61UP0t899V8Fjt7pz1YdgOBptbaQdn
 github.com/sigstore/rekor-tiles/v2 v2.3.0/go.mod h1:DEFiKSyQ4nF75QRVNdOPaIH3cmvMkO2B6xDZjNYngPc=
 github.com/sigstore/sigstore v1.10.8 h1:1Mgkxvkw4AXMfIP1DOjc6kw0GkUgA8pGVpveN/EfOq4=
 github.com/sigstore/sigstore v1.10.8/go.mod h1:f9+B/4iaYimvUkySyb2mvc73n3RLqNn24grHZM/ET8M=
+github.com/sigstore/sigstore-go v1.2.2 h1:xAJ8hxaoecC0HKBYVbrwUjkeAI+GJYu6vLqbxDlD2Q0=
+github.com/sigstore/sigstore-go v1.2.2/go.mod h1:MIFwBxAHJD+/lKgZzt9n/4Zhq/3T2+EuGX8iGrIsZgU=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8 h1:tofVQ+UWJgad/69I5zbqxdFCN5gpIn9tRQP7iBzIpBw=
 github.com/sigstore/sigstore/pkg/signature/kms/aws v1.10.8/go.mod h1:73AfJE8H6w5KGCFPBu4x/OG+i1Yxgmh0L/FtV7prd88=
 github.com/sigstore/sigstore/pkg/signature/kms/azure v1.10.8 h1:8Mt7J36GcUEmbiJaiFhz2tud5ZIgkfVVCe2H/WJCHmw=
@@ -704,8 +706,6 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMc
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/yangkenneth/sigstore-go v0.0.0-20260603051341-948bf6af8ad7 h1:/aMJ6RsvFAZW/OVEa7Sf4BQRlP8O/EC8x2y20n8PV4Q=
-github.com/yangkenneth/sigstore-go v0.0.0-20260603051341-948bf6af8ad7/go.mod h1:C1Jr9FQqq7LUHNRMNDvVBZgE1hlAN4ztbvQfxWRkyhE=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=
 github.com/yashtewari/glob-intersection v0.2.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
 	"google.golang.org/protobuf/encoding/protojson"
 )
@@ -36,7 +37,7 @@ type SignOptions struct {
 	CertificateProvider sign.CertificateProvider
 }
 
-func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, idToken string, cert []byte, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial, opts SignOptions) ([]byte, error) {
+func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, idToken string, cert []byte, certChain []byte, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial, opts SignOptions) ([]byte, error) {
 	var bundleOpts sign.BundleOptions
 
 	if trustedMaterial != nil {
@@ -60,6 +61,8 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		bundleOpts.CertificateProviderOptions = &sign.CertificateProviderOptions{
 			IDToken: idToken,
 		}
+	case cert != nil && len(certChain) > 0:
+		bundleOpts.CertificateChainProvider = &localCertChainProvider{cert: cert, chain: certChain}
 	case cert != nil:
 		bundleOpts.CertificateProvider = &localCertProvider{cert}
 	default:
@@ -141,7 +144,6 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 	defer spinner.Stop()
 
 	bundle, err := sign.Bundle(content, keypair, bundleOpts)
-
 	if err != nil {
 		return nil, fmt.Errorf("error signing bundle: %w", err)
 	}
@@ -167,6 +169,31 @@ func (c *localCertProvider) GetCertificate(_ context.Context, _ sign.Keypair, _ 
 		return nil, fmt.Errorf("could not decode cert")
 	}
 	return certBlock.Bytes, nil
+}
+
+type localCertChainProvider struct {
+	cert  []byte
+	chain []byte
+}
+
+func (c *localCertChainProvider) GetCertificateChain(_ context.Context, _ sign.Keypair, _ *sign.CertificateProviderOptions) ([][]byte, error) {
+	leafCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(c.cert)
+	if err != nil || len(leafCerts) == 0 {
+		return nil, fmt.Errorf("could not decode leaf certificate")
+	}
+	chainCerts, err := cryptoutils.UnmarshalCertificatesFromPEM(c.chain)
+	if err != nil || len(chainCerts) == 0 {
+		return nil, fmt.Errorf("could not decode certificate chain")
+	}
+
+	leaf := leafCerts[0]
+	derChain := [][]byte{leaf.Raw}
+	for _, cert := range chainCerts {
+		if !cert.Equal(leaf) {
+			derChain = append(derChain, cert.Raw)
+		}
+	}
+	return derChain, nil
 }
 
 type cachingCertProvider struct {

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -15,6 +15,7 @@
 package bundle
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"encoding/pem"
@@ -189,11 +190,22 @@ func (c *localCertChainProvider) GetCertificateChain(_ context.Context, _ sign.K
 	leaf := leafCerts[0]
 	derChain := [][]byte{leaf.Raw}
 	for _, cert := range chainCerts {
-		if !cert.Equal(leaf) {
-			derChain = append(derChain, cert.Raw)
+		if cert.Equal(leaf) {
+			continue
 		}
+		if isSelfSigned(cert) {
+			continue
+		}
+		derChain = append(derChain, cert.Raw)
 	}
 	return derChain, nil
+}
+
+func isSelfSigned(cert *x509.Certificate) bool {
+	if !bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+		return false
+	}
+	return cert.CheckSignatureFrom(cert) == nil
 }
 
 type cachingCertProvider struct {

--- a/pkg/cosign/bundle/sign_test.go
+++ b/pkg/cosign/bundle/sign_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"bytes"
+	"context"
+	"crypto/x509"
+	"testing"
+
+	"github.com/sigstore/cosign/v3/internal/test"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+)
+
+func TestLocalCertChainProvider_GetCertificateChain(t *testing.T) {
+	rootCert, rootKey, err := test.GenerateRootCa()
+	if err != nil {
+		t.Fatalf("GenerateRootCa: %v", err)
+	}
+	subCert, subKey, err := test.GenerateSubordinateCa(rootCert, rootKey)
+	if err != nil {
+		t.Fatalf("GenerateSubordinateCa: %v", err)
+	}
+	leafCert, _, err := test.GenerateLeafCert("subject@mail.com", "oidc-issuer", subCert, subKey)
+	if err != nil {
+		t.Fatalf("GenerateLeafCert: %v", err)
+	}
+
+	leafPEM, err := cryptoutils.MarshalCertificateToPEM(leafCert)
+	if err != nil {
+		t.Fatalf("MarshalCertificateToPEM: %v", err)
+	}
+	rootPEM, err := cryptoutils.MarshalCertificateToPEM(rootCert)
+	if err != nil {
+		t.Fatalf("MarshalCertificateToPEM: %v", err)
+	}
+	subAndRootPEM, err := cryptoutils.MarshalCertificatesToPEM([]*x509.Certificate{subCert, rootCert})
+	if err != nil {
+		t.Fatalf("MarshalCertificatesToPEM: %v", err)
+	}
+	leafSubAndRootPEM, err := cryptoutils.MarshalCertificatesToPEM([]*x509.Certificate{leafCert, subCert, rootCert})
+	if err != nil {
+		t.Fatalf("MarshalCertificatesToPEM: %v", err)
+	}
+
+	testCases := []struct {
+		name      string
+		cert      []byte
+		chain     []byte
+		wantDER   [][]byte
+		wantError bool
+	}{
+		{
+			name:    "leaf with root-only chain",
+			cert:    leafPEM,
+			chain:   rootPEM,
+			wantDER: [][]byte{leafCert.Raw, rootCert.Raw},
+		},
+		{
+			name:    "leaf with sub and root chain",
+			cert:    leafPEM,
+			chain:   subAndRootPEM,
+			wantDER: [][]byte{leafCert.Raw, subCert.Raw, rootCert.Raw},
+		},
+		{
+			name:    "leaf already present in chain is deduped",
+			cert:    leafPEM,
+			chain:   leafSubAndRootPEM,
+			wantDER: [][]byte{leafCert.Raw, subCert.Raw, rootCert.Raw},
+		},
+		{
+			name:      "invalid leaf PEM",
+			cert:      []byte("not a pem"),
+			chain:     rootPEM,
+			wantError: true,
+		},
+		{
+			name:      "invalid chain PEM",
+			cert:      leafPEM,
+			chain:     []byte("not a pem"),
+			wantError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := &localCertChainProvider{cert: tc.cert, chain: tc.chain}
+			got, err := provider.GetCertificateChain(context.Background(), nil, nil)
+			if tc.wantError {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.wantDER) {
+				t.Fatalf("expected %d certs, got %d", len(tc.wantDER), len(got))
+			}
+			for i := range got {
+				if !bytes.Equal(got[i], tc.wantDER[i]) {
+					t.Errorf("cert at index %d does not match expected DER", i)
+				}
+			}
+		})
+	}
+}

--- a/pkg/cosign/bundle/sign_test.go
+++ b/pkg/cosign/bundle/sign_test.go
@@ -63,22 +63,22 @@ func TestLocalCertChainProvider_GetCertificateChain(t *testing.T) {
 		wantError bool
 	}{
 		{
-			name:    "leaf with root-only chain",
+			name:    "leaf with root-only chain drops the self-signed root",
 			cert:    leafPEM,
 			chain:   rootPEM,
-			wantDER: [][]byte{leafCert.Raw, rootCert.Raw},
+			wantDER: [][]byte{leafCert.Raw},
 		},
 		{
-			name:    "leaf with sub and root chain",
+			name:    "leaf with sub and root chain drops the self-signed root",
 			cert:    leafPEM,
 			chain:   subAndRootPEM,
-			wantDER: [][]byte{leafCert.Raw, subCert.Raw, rootCert.Raw},
+			wantDER: [][]byte{leafCert.Raw, subCert.Raw},
 		},
 		{
-			name:    "leaf already present in chain is deduped",
+			name:    "leaf already present in chain is deduped and root is dropped",
 			cert:    leafPEM,
 			chain:   leafSubAndRootPEM,
-			wantDER: [][]byte{leafCert.Raw, subCert.Raw, rootCert.Raw},
+			wantDER: [][]byte{leafCert.Raw, subCert.Raw},
 		},
 		{
 			name:      "invalid leaf PEM",

--- a/pkg/cosign/bundle/sign_test.go
+++ b/pkg/cosign/bundle/sign_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 The Sigstore Authors.
+// Copyright 2026 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -76,6 +76,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/signature/options"
 	"github.com/sigstore/sigstore/pkg/tuf"
 	tsaverification "github.com/sigstore/timestamp-authority/v2/pkg/verification"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // Identity specifies an issuer/subject to verify a signature against.
@@ -176,6 +177,19 @@ type CheckOpts struct {
 
 	// NewBundleFormat enables the new bundle format (Cosign Bundle Spec) and the new verifier.
 	NewBundleFormat bool
+
+	// AllowCertificateChain permits bundles with version >= v0.3 to contain
+	// X.509 certificate chains in the verification material.
+	AllowCertificateChain bool
+}
+
+// BundleOptions returns sigstore-go bundle options based on CheckOpts.
+func (co *CheckOpts) BundleOptions() []sgbundle.Option {
+	var opts []sgbundle.Option
+	if co.AllowCertificateChain {
+		opts = append(opts, sgbundle.AllowCertificateChain())
+	}
+	return opts
 }
 
 type verifyTrustedMaterial struct {
@@ -1782,7 +1796,7 @@ func HasLocalAttestationBundles(path string) (bool, error) {
 
 // GetLocalBundles retrieves v3 sigstore bundles from a local OCI layout.
 // Returns bundles, target image hash, and error. Invalid bundles are logged and skipped.
-func GetLocalBundles(path string) ([]*sgbundle.Bundle, *v1.Hash, error) {
+func GetLocalBundles(path string, bundleOpts ...sgbundle.Option) ([]*sgbundle.Bundle, *v1.Hash, error) {
 	descriptors, hash, err := getLocalBundleDescriptors(path)
 	if err != nil {
 		return nil, nil, err
@@ -1796,9 +1810,14 @@ func GetLocalBundles(path string) ([]*sgbundle.Bundle, *v1.Hash, error) {
 			continue
 		}
 
-		bundle := &sgbundle.Bundle{}
-		if err := bundle.UnmarshalJSON(bundleBytes); err != nil {
+		pb := &protobundle.Bundle{}
+		if err := protojson.Unmarshal(bundleBytes, pb); err != nil {
 			ui.Warnf(context.Background(), "Failed to unmarshal bundle %s: %v", descriptor.digest.Hex, err)
+			continue
+		}
+		bundle, err := sgbundle.NewBundle(pb, bundleOpts...)
+		if err != nil {
+			ui.Warnf(context.Background(), "Failed to create bundle %s: %v", descriptor.digest.Hex, err)
 			continue
 		}
 
@@ -1993,7 +2012,7 @@ func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef nam
 
 // verifyLocalImageAttestationsSigstoreBundle verifies attestations from local sigstore bundles
 func verifyLocalImageAttestationsSigstoreBundle(ctx context.Context, path string, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
-	bundles, hash, err := GetLocalBundles(path)
+	bundles, hash, err := GetLocalBundles(path, co.BundleOptions()...)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/cosign/verify_bundle_test.go
+++ b/pkg/cosign/verify_bundle_test.go
@@ -416,6 +416,33 @@ func TestVerifyBundleWithSigVerifier(t *testing.T) {
 	}
 }
 
+func TestCheckOptsBundleOptions(t *testing.T) {
+	testCases := []struct {
+		name                  string
+		allowCertificateChain bool
+		wantOpts              int
+	}{
+		{
+			name:                  "default returns no options",
+			allowCertificateChain: false,
+			wantOpts:              0,
+		},
+		{
+			name:                  "AllowCertificateChain adds option",
+			allowCertificateChain: true,
+			wantOpts:              1,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			co := &CheckOpts{AllowCertificateChain: tc.allowCertificateChain}
+			if got := len(co.BundleOptions()); got != tc.wantOpts {
+				t.Errorf("expected %d options, got %d", tc.wantOpts, got)
+			}
+		})
+	}
+}
+
 type mockSignedEntity struct {
 	verify.SignedEntity
 	tlogEntries []*tlog.Entry

--- a/pkg/oci/remote/options.go
+++ b/pkg/oci/remote/options.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v3/pkg/cosign/env"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 )
 
 const (
@@ -45,6 +46,7 @@ type options struct {
 	ROpt              []remote.Option
 	NameOpts          []name.Option
 	OriginalOptions   []Option
+	BundleOpts        []sgbundle.Option
 }
 
 var defaultOptions = []remote.Option{
@@ -155,5 +157,13 @@ func GetEnvTargetRepository() (name.Repository, error) {
 func WithNameOptions(opts ...name.Option) Option {
 	return func(o *options) {
 		o.NameOpts = opts
+	}
+}
+
+// WithBundleOptions is a functional option for passing sigstore-go bundle
+// options (e.g. AllowCertificateChain) when parsing bundles.
+func WithBundleOptions(opts ...sgbundle.Option) Option {
+	return func(o *options) {
+		o.BundleOpts = append(o.BundleOpts, opts...)
 	}
 }

--- a/pkg/oci/remote/options_test.go
+++ b/pkg/oci/remote/options_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 )
 
 func TestOptions(t *testing.T) {
@@ -119,6 +120,17 @@ func TestOptions(t *testing.T) {
 			SBOMSuffix:        SBOMTagSuffix,
 			TargetRepository:  repo,
 			ROpt:              append(append([]remote.Option{}, otherROpt...), moreROpt...),
+		},
+	}, {
+		name: "bundle options option",
+		opts: []Option{WithBundleOptions(sgbundle.AllowCertificateChain())},
+		want: &options{
+			SignatureSuffix:   SignatureTagSuffix,
+			AttestationSuffix: AttestationTagSuffix,
+			SBOMSuffix:        SBOMTagSuffix,
+			TargetRepository:  repo,
+			ROpt:              defaultOptions,
+			BundleOpts:        []sgbundle.Option{sgbundle.AllowCertificateChain()},
 		},
 	}}
 
@@ -216,6 +228,9 @@ func optionsEqual(o1, o2 *options) bool {
 		return false
 	}
 	if !slicesEqual(o1.OriginalOptions, o2.OriginalOptions) {
+		return false
+	}
+	if len(o1.BundleOpts) != len(o2.BundleOpts) {
 		return false
 	}
 	return true

--- a/pkg/oci/remote/signatures.go
+++ b/pkg/oci/remote/signatures.go
@@ -28,7 +28,9 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/empty"
 	"github.com/sigstore/cosign/v3/pkg/oci/internal/signature"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 const maxLayers = 1000
@@ -81,8 +83,11 @@ func Bundle(ref name.Reference, opts ...Option) (*sgbundle.Bundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	b := &sgbundle.Bundle{}
-	err = b.UnmarshalJSON(bundleBytes)
+	pb := &protobundle.Bundle{}
+	if err := protojson.Unmarshal(bundleBytes, pb); err != nil {
+		return nil, err
+	}
+	b, err := sgbundle.NewBundle(pb, o.BundleOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1204,6 +1204,253 @@ func TestSignVerifyContainerWithSigningConfigWithCertificate(t *testing.T) {
 	must(cmd.Exec(ctx, args), t)
 }
 
+func TestSignVerifyContainerWithCertificateChain(t *testing.T) {
+	tufLocalCache := t.TempDir()
+	t.Setenv("TUF_ROOT", tufLocalCache)
+	tufMirror := t.TempDir()
+	tufServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.FileServer(http.Dir(tufMirror)).ServeHTTP(w, r)
+	}))
+	mirror := tufServer.URL
+
+	leafCertPath, signChainPath, caChainPath, leafKeyPath := signingCertChain(t)
+
+	trustedRoot := prepareTrustedRootWithSelfSignedCertificate(t, caChainPath, tsaURL)
+	signingConfigStr := prepareSigningConfig(t, fulcioURL, rekorURL, "unused", tsaURL+"/api/v1/timestamp")
+
+	_, err := newTUF(tufMirror, []targetInfo{
+		{
+			name:   "trusted_root.json",
+			source: trustedRoot,
+		},
+		{
+			name:   "signing_config.v0.2.json",
+			source: signingConfigStr,
+		},
+	})
+	must(err, t)
+
+	ctx := context.Background()
+
+	rootPath := filepath.Join(tufMirror, "1.root.json")
+	must(initialize.DoInitialize(ctx, rootPath, mirror), t)
+
+	trustedMaterial, err := cosign.TrustedRoot()
+	must(err, t)
+	signingConfig, err := cosign.SigningConfig()
+	must(err, t)
+
+	ko := options.KeyOpts{
+		NewBundleFormat:  true,
+		SkipConfirmation: true,
+		KeyRef:           leafKeyPath,
+		PassFunc:         passFunc,
+		TrustedMaterial:  trustedMaterial,
+		SigningConfig:    signingConfig,
+	}
+	certVerify := options.CertVerifyOptions{
+		CertOidcIssuerRegexp: ".*",
+		CertIdentity:         "foo@bar.com",
+	}
+
+	const predicateType = "slsaprovenance"
+	predicate := `{ "buildType": "x", "builder": { "id": "2" }, "recipe": {} }`
+	predicatePath := filepath.Join(t.TempDir(), "predicate.json")
+	must(os.WriteFile(predicatePath, []byte(predicate), 0o644), t)
+
+	repo, stop := reg(t)
+	defer stop()
+
+	tests := []struct {
+		name        string
+		attestation bool
+		allowChain  bool
+		wantErr     bool
+	}{
+		{"signature without chain flag fails", false, false, true},
+		{"signature with chain flag succeeds", false, true, false},
+		{"attestation without chain flag fails", true, false, true},
+		{"attestation with chain flag succeeds", true, true, false},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			imgName := path.Join(repo, fmt.Sprintf("cosign-e2e-cert-chain-%d", i))
+			_, _, cleanup := mkimage(t, imgName)
+			defer cleanup()
+
+			var verifyErr error
+			if tc.attestation {
+				attestCmd := attest.AttestCommand{
+					KeyOpts:        ko,
+					CertPath:       leafCertPath,
+					CertChainPath:  signChainPath,
+					PredicatePath:  predicatePath,
+					PredicateType:  predicateType,
+					Timeout:        30 * time.Second,
+					RekorEntryType: "dsse",
+					TlogUpload:     false,
+				}
+				must(attestCmd.Exec(ctx, imgName), t)
+
+				verifyErr = (&cliverify.VerifyAttestationCommand{
+					CertVerifyOptions: certVerify,
+					CommonVerifyOptions: options.CommonVerifyOptions{
+						NewBundleFormat:       true,
+						AllowCertificateChain: tc.allowChain,
+					},
+					IgnoreSCT:     true,
+					PredicateType: predicateType,
+					CheckClaims:   true,
+				}).Exec(ctx, []string{imgName})
+			} else {
+				so := options.SignOptions{
+					Upload:          true,
+					NewBundleFormat: true,
+					Key:             leafKeyPath,
+					Cert:            leafCertPath,
+					CertChain:       signChainPath,
+					TlogUpload:      false,
+				}
+				must(sign.SignCmd(ctx, ro, ko, so, []string{imgName}), t)
+
+				verifyErr = (&cliverify.VerifyCommand{
+					CertVerifyOptions:     certVerify,
+					NewBundleFormat:       true,
+					IgnoreSCT:             true,
+					AllowCertificateChain: tc.allowChain,
+				}).Exec(ctx, []string{imgName})
+			}
+
+			if tc.wantErr {
+				mustErr(verifyErr, t)
+			} else {
+				must(verifyErr, t)
+			}
+		})
+	}
+}
+
+func TestSignVerifyBlobWithCertificateChain(t *testing.T) {
+	tufLocalCache := t.TempDir()
+	t.Setenv("TUF_ROOT", tufLocalCache)
+	tufMirror := t.TempDir()
+	tufServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.FileServer(http.Dir(tufMirror)).ServeHTTP(w, r)
+	}))
+	mirror := tufServer.URL
+
+	leafCertPath, signChainPath, caChainPath, leafKeyPath := signingCertChain(t)
+
+	trustedRoot := prepareTrustedRootWithSelfSignedCertificate(t, caChainPath, tsaURL)
+	signingConfigStr := prepareSigningConfig(t, fulcioURL, rekorURL, "unused", tsaURL+"/api/v1/timestamp")
+
+	_, err := newTUF(tufMirror, []targetInfo{
+		{
+			name:   "trusted_root.json",
+			source: trustedRoot,
+		},
+		{
+			name:   "signing_config.v0.2.json",
+			source: signingConfigStr,
+		},
+	})
+	must(err, t)
+
+	ctx := context.Background()
+
+	rootPath := filepath.Join(tufMirror, "1.root.json")
+	must(initialize.DoInitialize(ctx, rootPath, mirror), t)
+
+	trustedMaterial, err := cosign.TrustedRoot()
+	must(err, t)
+	signingConfig, err := cosign.SigningConfig()
+	must(err, t)
+
+	certVerify := options.CertVerifyOptions{
+		CertOidcIssuerRegexp: ".*",
+		CertIdentity:         "foo@bar.com",
+	}
+
+	blob := "someblob"
+	blobDir := t.TempDir()
+	bp := filepath.Join(blobDir, blob)
+	must(os.WriteFile(bp, []byte(blob), 0o644), t)
+
+	statement := `{"_type":"https://in-toto.io/Statement/v1","subject":[{"name":"someblob","digest":{"alg":"7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3"}}],"predicateType":"something","predicate":{}}`
+	statementPath := filepath.Join(t.TempDir(), "statement")
+	must(os.WriteFile(statementPath, []byte(statement), 0o644), t)
+
+	ko := options.KeyOpts{
+		NewBundleFormat:  true,
+		SkipConfirmation: true,
+		KeyRef:           leafKeyPath,
+		PassFunc:         passFunc,
+		TrustedMaterial:  trustedMaterial,
+		SigningConfig:    signingConfig,
+	}
+
+	tests := []struct {
+		name        string
+		attestation bool
+		allowChain  bool
+		wantErr     bool
+	}{
+		{"signature without chain flag fails", false, false, true},
+		{"signature with chain flag succeeds", false, true, false},
+		{"attestation without chain flag fails", true, false, true},
+		{"attestation with chain flag succeeds", true, true, false},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundlePath := filepath.Join(t.TempDir(), fmt.Sprintf("bundle-%d.json", i))
+			ko := ko
+			ko.BundlePath = bundlePath
+
+			var verifyErr error
+			if tc.attestation {
+				attestBlobCmd := attest.AttestBlobCommand{
+					KeyOpts:        ko,
+					CertPath:       leafCertPath,
+					CertChainPath:  signChainPath,
+					RekorEntryType: "dsse",
+					StatementPath:  statementPath,
+					TlogUpload:     false,
+				}
+				must(attestBlobCmd.Exec(ctx, bp), t)
+
+				verifyErr = (&cliverify.VerifyBlobAttestationCommand{
+					KeyOpts:               options.KeyOpts{NewBundleFormat: true, BundlePath: bundlePath},
+					CertVerifyOptions:     certVerify,
+					IgnoreSCT:             true,
+					CheckClaims:           true,
+					PredicateType:         "something",
+					Digest:                "7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
+					DigestAlg:             "alg",
+					AllowCertificateChain: tc.allowChain,
+				}).Exec(ctx, "")
+			} else {
+				_, err = sign.SignBlobCmd(ctx, ro, ko, bp, leafCertPath, signChainPath, true, "", "", false)
+				must(err, t)
+
+				verifyErr = (&cliverify.VerifyBlobCmd{
+					KeyOpts:               options.KeyOpts{NewBundleFormat: true, BundlePath: bundlePath},
+					CertVerifyOptions:     certVerify,
+					IgnoreSCT:             true,
+					AllowCertificateChain: tc.allowChain,
+				}).Exec(ctx, bp)
+			}
+
+			if tc.wantErr {
+				mustErr(verifyErr, t)
+			} else {
+				must(verifyErr, t)
+			}
+		})
+	}
+}
+
 func TestSignRekorV2NoTSA(t *testing.T) {
 	tufLocalCache := t.TempDir()
 	t.Setenv("TUF_ROOT", tufLocalCache)
@@ -5249,6 +5496,76 @@ func selfSignedCertificate() (*x509.Certificate, *ecdsa.PrivateKey, error) {
 		return nil, nil, err
 	}
 	return cert, priv, nil
+}
+
+func signingCertChain(t *testing.T) (leafCertPath, signChainPath, caChainPath, leafKeyPath string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	caTemplate := func(serial int64, cn string) *x509.Certificate {
+		return &x509.Certificate{
+			SerialNumber:          big.NewInt(serial),
+			Subject:               pkix.Name{CommonName: cn, Organization: []string{"dev"}},
+			NotBefore:             time.Now().Add(-1 * time.Minute),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+			BasicConstraintsValid: true,
+			IsCA:                  true,
+		}
+	}
+
+	newCert := func(tmpl, parent *x509.Certificate, parentKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		must(err, t)
+		if parent == nil {
+			parent, parentKey = tmpl, key
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, parent, &key.PublicKey, parentKey)
+		must(err, t)
+		cert, err := x509.ParseCertificate(der)
+		must(err, t)
+		return cert, key
+	}
+
+	writePEM := func(name string, blocks ...*pem.Block) string {
+		var buf bytes.Buffer
+		for _, b := range blocks {
+			must(pem.Encode(&buf, b), t)
+		}
+		p := filepath.Join(dir, name)
+		must(os.WriteFile(p, buf.Bytes(), 0o600), t)
+		return p
+	}
+
+	rootCert, rootKey := newCert(caTemplate(1, "root.ca"), nil, nil)
+	interCert, interKey := newCert(caTemplate(2, "intermediate.ca"), rootCert, rootKey)
+	leafCert, leafKey := newCert(&x509.Certificate{
+		SerialNumber:   big.NewInt(3),
+		Subject:        pkix.Name{CommonName: "leaf.signer", Organization: []string{"dev"}},
+		EmailAddresses: []string{"foo@bar.com"},
+		NotBefore:      time.Now().Add(-1 * time.Minute),
+		NotAfter:       time.Now().Add(24 * time.Hour),
+		KeyUsage:       x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+	}, interCert, interKey)
+
+	leafCertPath = writePEM("leaf.pem", &pem.Block{Type: "CERTIFICATE", Bytes: leafCert.Raw})
+	signChainPath = writePEM("sign-chain.pem",
+		&pem.Block{Type: "CERTIFICATE", Bytes: interCert.Raw})
+	caChainPath = writePEM("ca-chain.pem",
+		&pem.Block{Type: "CERTIFICATE", Bytes: interCert.Raw},
+		&pem.Block{Type: "CERTIFICATE", Bytes: rootCert.Raw})
+
+	privDER, err := x509.MarshalECPrivateKey(leafKey)
+	must(err, t)
+	rawKeyPath := writePEM("leaf.key", &pem.Block{Type: "EC PRIVATE KEY", Bytes: privDER})
+
+	keys, err := cosign.ImportKeyPair(rawKeyPath, passFunc)
+	must(err, t)
+	leafKeyPath = filepath.Join(dir, "import-leaf.key")
+	must(os.WriteFile(leafKeyPath, keys.PrivateBytes, 0o600), t)
+
+	return leafCertPath, signChainPath, caChainPath, leafKeyPath
 }
 
 func TestSignVerifyDetachedKeyless(t *testing.T) {

--- a/test/e2e_tsa_test.go
+++ b/test/e2e_tsa_test.go
@@ -71,7 +71,6 @@ func TestTSAMTLS(t *testing.T) {
 		Upload:     true,
 		TlogUpload: false,
 		Cert:       pemLeafRef,
-		CertChain:  pemRootRef,
 	}
 	must(sign.SignCmd(t.Context(), ro, ko, so, []string{imgName}), t)
 
@@ -329,7 +328,6 @@ func TestTSAMTLSWithSigningConfig(t *testing.T) {
 		Upload:          true,
 		TlogUpload:      false,
 		Cert:            pemLeafRef,
-		CertChain:       pemRootRef,
 		NewBundleFormat: true,
 	}
 	must(sign.SignCmd(t.Context(), ro, ko, so, []string{imgName}), t)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
- Adds support for signing and verifying using self-managed (non-Fulcio) short-lived certificates and certificate chains using the SIgstore bundle format. 
- Requires https://github.com/sigstore/sigstore-go/pull/581 as a prerequisite.

<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

**Features:**
- Currently certificate chains are [not supported](https://github.com/sigstore/sigstore-go/blob/cc06490446765e67a0e63797659f1439c3f53cc0/pkg/bundle/bundle.go#L111) in the v0.3 bundle so we are making a change remove the restriction https://github.com/sigstore/sigstore-go/pull/581.
- With this change when a user passes through an entire certificate chain through the `--certificate-chain` flag during `cosign sign` the entire chain is added to the Sigstore bundle via the `x509CertificateChain` field.
- Using the `--allow-certificate-chain` flag during `cosign verify` we allow verification of the entire certificate chain against the Trusted CA configured within the `--trusted-root` configuration.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Testing

_Generate Test PKI_

```sh
# Root CA
openssl genrsa -out /tmp/root.key 4096
openssl req -x509 -new -nodes \
  -key /tmp/root.key \
  -sha256 \
  -days 3650 \
  -out /tmp/root.crt \
  -subj "/C=US/O=Example Corporation/CN=Example Root CA" \
  -addext "basicConstraints=critical,CA:TRUE,pathlen:2" \
  -addext "keyUsage=critical,keyCertSign,cRLSign"

# Intermediate CA 2
openssl genrsa -out /tmp/intermediate-2.key 4096
openssl req -new \
  -key /tmp/intermediate-2.key \
  -out /tmp/intermediate-2.csr \
  -subj "/C=US/O=Example Corporation/CN=Example Intermediate CA 2"

cat > /tmp/intermediate-2.ext <<'EOF'
basicConstraints=critical,CA:TRUE,pathlen:1
keyUsage=critical,keyCertSign,cRLSign
subjectKeyIdentifier=hash
authorityKeyIdentifier=keyid,issuer
EOF

openssl x509 -req \
  -in /tmp/intermediate-2.csr \
  -CA /tmp/root.crt \
  -CAkey /tmp/root.key \
  -CAcreateserial \
  -out /tmp/intermediate-2.crt \
  -days 1825 \
  -sha256 \
  -extfile /tmp/intermediate-2.ext

# Intermediate CA 1
openssl genrsa -out /tmp/intermediate-1.key 4096
openssl req -new \
  -key /tmp/intermediate-1.key \
  -out /tmp/intermediate-1.csr \
  -subj "/C=US/O=Example Corporation/CN=Example Intermediate CA 1"

cat > /tmp/intermediate-1.ext <<'EOF'
basicConstraints=critical,CA:TRUE,pathlen:0
keyUsage=critical,keyCertSign,cRLSign
subjectKeyIdentifier=hash
authorityKeyIdentifier=keyid,issuer
EOF

openssl x509 -req \
  -in /tmp/intermediate-1.csr \
  -CA /tmp/intermediate-2.crt \
  -CAkey /tmp/intermediate-2.key \
  -CAcreateserial \
  -out /tmp/intermediate-1.crt \
  -days 365 \
  -sha256 \
  -extfile /tmp/intermediate-1.ext

# End-Entity Certificate
openssl genrsa -out /tmp/certificate.key 4096
openssl req -new \
  -key /tmp/certificate.key \
  -out /tmp/certificate.csr \
  -subj "/C=US/O=Example Corporation/CN=signing.test.com"

cat > /tmp/certificate.ext <<'EOF'
basicConstraints=critical,CA:FALSE
keyUsage=critical,digitalSignature
extendedKeyUsage=codeSigning
subjectAltName=URI:signing.test.com
subjectKeyIdentifier=hash
authorityKeyIdentifier=keyid,issuer
EOF

openssl x509 -req \
  -in /tmp/certificate.csr \
  -CA /tmp/intermediate-1.crt \
  -CAkey /tmp/intermediate-1.key \
  -CAcreateserial \
  -out /tmp/certificate.crt \
  -days 30 \
  -sha256 \
  -extfile /tmp/certificate.ext

# Full Certificate Chain for --certificate-chain
cat \
  /tmp/certificate.crt \
  /tmp/intermediate-1.crt \
  /tmp/intermediate-2.crt \
  /tmp/root.crt \
  > /tmp/certificate-chain.crt
```

_Configure Trusted Roots_

```sh
ROOT_DER_B64="$(openssl x509 -in /tmp/root.crt -outform DER | base64 | tr -d '\n')"
```

_trusted-roots.json_
```json
{
  "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
  "certificateAuthorities": [
    {
      "subject": {
        "organization": "Example Corporation",
        "commonName": "Example Root Certificate Authority"
      },
      "certChain": {
        "certificates": [
          {
            "rawBytes": "<ROOT_DER_B64>"
          }
        ]
      },
      "validFor": {
        "start": "2022-11-03T03:18:30Z",
        "end": "2032-10-31T03:18:30Z"
      }
    }
  ],
  "timestampAuthorities": [
    {
      "subject": {
        "organization": "sigstore.dev",
        "commonName": "sigstore-tsa-selfsigned"
      },
      "uri": "https://timestamp.sigstore.dev/api/v1/timestamp",
      "certChain": {
        "certificates": [
          {
            "rawBytes": "MIICEDCCAZagAwIBAgIUOhNULwyQYe68wUMvy4qOiyojiwwwCgYIKoZIzj0EAwMwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZDAeFw0yNTA0MDgwNjU5NDNaFw0zNTA0MDYwNjU5NDNaMC4xFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEVMBMGA1UEAxMMc2lnc3RvcmUtdHNhMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4ra2Z8hKNig2T9kFjCAToGG30jky+WQv3BzL+mKvh1SKNR/UwuwsfNCg4sryoYAd8E6isovVA3M4aoNdm9QDi50Z8nTEyvqgfDPtTIwXItfiW/AFf1V7uwkbkAoj0xxco2owaDAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFIn9eUOHz9BlRsMCRscsc1t9tOsDMB8GA1UdIwQYMBaAFJjsAe9/u1H/1JUeb4qImFMHic6/MBYGA1UdJQEB/wQMMAoGCCsGAQUFBwMIMAoGCCqGSM49BAMDA2gAMGUCMDtpsV/6KaO0qyF/UMsX2aSUXKQFdoGTptQGc0ftq1csulHPGG6dsmyMNd3JB+G3EQIxAOajvBcjpJmKb4Nv+2Taoj8Uc5+b6ih6FXCCKraSqupe07zqswMcXJTe1cExvHvvlw=="
          },
          {
            "rawBytes": "MIIB9zCCAXygAwIBAgIUV7f0GLDOoEzIh8LXSW80OJiUp14wCgYIKoZIzj0EAwMwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZDAeFw0yNTA0MDgwNjU5NDNaFw0zNTA0MDYwNjU5NDNaMDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAQUQNtfRT/ou3YATa6wB/kKTe70cfJwyRIBovMnt8RcJph/COE82uyS6FmppLLL1VBPGcPfpQPYJNXzWwi8icwhKQ6W/Qe2h3oebBb2FHpwNJDqo+TMaC/tdfkv/ElJB72jRTBDMA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBSY7AHvf7tR/9SVHm+KiJhTB4nOvzAKBggqhkjOPQQDAwNpADBmAjEAwGEGrfGZR1cen1R8/DTVMI943LssZmJRtDp/i7SfGHmGRP6gRbuj9vOK3b67Z0QQAjEAuT2H673LQEaHTcyQSZrkp4mX7WwkmF+sVbkYY5mXN+RMH13KUEHHOqASaemYWK/E"
          }
        ]
      },
      "validFor": {
        "start": "2025-07-04T00:00:00Z"
      }
    }
  ]
}
```

_Sign and Verify via Sigstore 0.3 Spec_
```sh
go build -o cosign ./cmd/cosign

cosign import-key-pair --key /tmp/certificate.key
```
```sh
cosign sign --key import-cosign.key \
    --certificate /tmp/certificate.crt \
    --certificate-chain /tmp/certificate-chain.crt \
    --new-bundle-format \
    --trusted-root trusted-roots.json \
    --tlog-upload=false \
    --use-signing-config=false \
    --timestamp-server-url https://timestamp.sigstore.dev/api/v1/timestamp \
    {IMAGE}
```
```sh
cosign verify \
    --insecure-ignore-tlog \
    --insecure-ignore-sct \
    --check-claims=true \
    --certificate-identity signing.test.com \
    --certificate-oidc-issuer-regexp ".*" \
    --trusted-root trusted-roots.json \
    --new-bundle-format \
    --use-signed-timestamps \
    --experimental-oci11 \
    --allow-certificate-chain \
    {IMAGE}

The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
```

_Example Manifest Output_

```json
{
  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
  "verificationMaterial": {
    "x509CertificateChain": {
      "certificates": [
        {
          "rawBytes": "MIIFtzCCA5+gAwIBAgIUAqG5K4otRQDaY1ksBr5qxrKUSvYwDQYJKoZIhvcNAQELBQAwTzELMAkGA1UEBhMCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xIjAgBgNVBAMMGUV4YW1wbGUgSW50ZXJtZWRpYXRlIENBIDEwHhcNMjYwNjAyMDMyMTEwWhcNMjYwNzAyMDMyMTEwWjBGMQswCQYDVQQGEwJVUzEcMBoGA1UECgwTRXhhbXBsZSBDb3Jwb3JhdGlvbjEZMBcGA1UEAwwQc2lnbmluZy50ZXN0LmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAKbYthOQTSvzpYABvTMvldMl4Ww7JUVRU77tRrYHksEK2FfQV/4c4K7nC6EFH8FvGzNRmPt4Vp9rl3IkhK0f56d9diafxLvEpP9UQW3lbf7OxhymUeszaBt4c+lj/7t02IpwsXzGjn3QM8ak9LzZShDSH5GgWsPm9gLYUpbN+XVN4m+Teu+gSP+lr9aVy+QcoHkLAwhMdKrbm3sBaS8Xl2C86vbqI0SRjh/nHIfIRWQWTMsgZ6b8P85Ybafk4yGXYv6iWHpyidANy8Q/zvrOuXgGSAMa/Pt0ZE3Z+rFpgBMfYwkkKbddSQFPFJYMAt03GBdQAkMT3dF3Kxq3ZtGJ0I7S+l84e1Bi3kl4s8g1use1rydZlah5ldwMjlrheYELwkhhX2YmMl6orEcxTqH6uDR3kPL/a2eICFDq6hBmGb4ayq4svywgS6hjyc4PZ9V0kxXbX+pXZgyVLIT1Q8pDv2TKxYC4GA83eOm8r9Ce2HSXhS7+lieqp8Glsx9yCoVYLUXWC4JFxauRvJeoak6rS7op9vMGBgvwpwCfMrpp83gMKw+40h3sProayAXk7bOzVbQZpv1QVMEmtqrrLUK3o7R85rkltgZenjlJ6/Xlx5nHTSpyfdf9XHVVEw0H60wTmSdlmsAL+MoC1urKtGawotzPeV6ARz40KCkiSnxqmBHdAgMBAAGjgZMwgZAwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwMwGwYDVR0RBBQwEoYQc2lnbmluZy50ZXN0LmNvbTAdBgNVHQ4EFgQU5iKA3SLofcQ09xTbS7x8YUngh3gwHwYDVR0jBBgwFoAU3RM1d3rF1aQHduCeDPt9HipyqgkwDQYJKoZIhvcNAQELBQADggIBALfJkIFhsk8BXlnpHIUe6LZPOx4sFniDAfYP6F5BhW4E6bLuupKBVEKtItl8tG5+hP69h7VkpQNsmEVE46Ls3yrOWXNT9/rgnwfx+MLGc6VhajaRg7EHYI/gD6q3v1NnxhtqABpowQ9VjBf8/jN+PenFS3lt6bjsztRjJ0LrvzD2LHATvq2hgBvTaulcLvKTpTDyNHX5HqncTN/RCpu4QbPDGk0vmoNUfPsE+yO6LAAsslIzCZNcCdhnqhRBDPxK1Pb97x42ABGPFiehap/4iXnUEzOGoS4Rv3V9XJaEkjzCEFOaXIMnzxZy3z5HHpTG35dqdMXIs7GddOivlh83GbUbpW3NeVXf4+h5NLYtW7KXZjkCVfHOLXKlXqQd10FQ6AK5MRHSGGYO4b1+FxJUsf/M+WFdmqXp99V3TIoq+yzdhaWc/ayfigAmANUUC2zz+HShAc7VXI40TWbd0NEpr+Lrnu/fsU8RXGdP6CpA+mSZguWshq5dZM/j/ozbi+SVDuKifNq34EVuwvTXB8pKHU/7GIzV+mLPaEZM5RGFPCBlAEt0/nGHUvtsJjwYMKrRuTOxFe8z6HUC7vd5skMKF8Zjys7MDKKjdd9Tw9joQ1C6gZ+OJG7GRBZM/MB2O7uOjTbzyW/svs5fPRwwzZ4mKoPcA/ZQ0rUJQLj41AeJfb8s"
        },
        {
          "rawBytes": "MIIFkjCCA3qgAwIBAgIUB3yPgMkueMTcoacP7LdXaoeYTDcwDQYJKoZIhvcNAQELBQAwTzELMAkGA1UEBhMCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xIjAgBgNVBAMMGUV4YW1wbGUgSW50ZXJtZWRpYXRlIENBIDIwHhcNMjYwNjAyMDMwNjQ0WhcNMjcwNjAyMDMwNjQ0WjBPMQswCQYDVQQGEwJVUzEcMBoGA1UECgwTRXhhbXBsZSBDb3Jwb3JhdGlvbjEiMCAGA1UEAwwZRXhhbXBsZSBJbnRlcm1lZGlhdGUgQ0EgMTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAMIiHF8T8Q5vTxqKMmAvwqdtOfU/T1Ec46HZiZbKjGI4DLVzh4XgXbf5YpehpXOGY18VCe/lnRgOSgaLQUuLXwzphk7jQZWF+31725iCt94WrfctL4uzYv+Fx/8PyrBnrX0dPwcwZo37+kXvEEFoW4XhSMfIDSafJ+9jNvYimB6Fl4nW1YXANgBjjCBKAiGq27HEEaHYyzHbS3O37YxLKTfEMf09anxpWibS+ivi5qrspVN5ozWgaHDNKdQvBFtEexH1drdSPMgdF48MTMU80fDGq/bZFeT4SrS1/pxuutr5Z4ruRix74b53MAk2Ta7xFHOnSNANE/E2/b6EflBROOawBG7aexWqPZhswzCcrN+dFcT7rilEQHYaxrJtOVo2MGiBEx3hgDiFQ8wV4+waP2udUKO64Eim0veHSqayd1CeszY1XmeJboD4RnDvhoL4H4IP3rvohpt4zYVf1Xs86U2+u5SzBljjJsSG1Gc9AJl3jSt03kLqq9mwuOV0bVxITPyi+V32SsoT1Y5ryGGhOIlhR9GJ9FYqjQNmsAcJ0/x6SFEiUCsHFvlMEutzVZWsuv/RX8Zmp2pb1UAZtABIsdQ3vskXzwNu3dKGTy+XH9FZtW97JeEdUM+cydQ164vuIiEsA6N6YEzwWyNYs+fJld3FN2lPh/0GxTshzVoTSEFvAgMBAAGjZjBkMBIGA1UdEwEB/wQIMAYBAf8CAQAwDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBTdEzV3esXVpAd24J4M+30eKnKqCTAfBgNVHSMEGDAWgBSYsb6WNXbDe6VJoA67bZrE0jev1TANBgkqhkiG9w0BAQsFAAOCAgEAfblz2e2xqHP7s2W1l7W74m1ymzUmBOHMc9cHDHXnKL9kJC6Uu7J7Knpyym32nWO/KEvriyJrMfp4MBNEg1JT5xhM6aymqaUd5yIXPzFAGKA9Kx/+6qOsngE4uujUiqKXGS6CjGjSTCn9y4FKOUoQNDFoQ/yibYcOJCRsXoIfgaafBVLC25Qleq3D4E/zZdSvWHjFFWIJJ67PKed/bInJfOh7uVIyqWY3naVrawcgDstINT1s2sTMA4Y6JVvMHnKh781Uuv5AX9hE3jkZ6fg6j72O3QFn4CQTCNSKKt988sHtw1xYHDRTrE50CWL1hksWxBXcvFGP1eR40fb5NH1zVhy/kleJ2ZLRfSHxM3AxCRhFEIo/W4pKC6m1ul16ycrMBCKx4MH39wp7E1uTb3to1yCPeLTZKb/TeijU7eDyhUsbNU+tX+LQfzZwMUqdGw/z8cfYEQL6yS+IC0sUL0Uh92XjG59mKE1oLUab2TmJusQEFQCtfbaESJmR2c4YmLv+vL9N/GLLTmDEGUhzJmH/xiDygPiQLjCt785mKpXogY47yvm3tSY2H2nPmlcpJvpykPf/0IsNN4px17LmsCFjGQKpUTqAbAqGfn4BjmF/Mj/Ky9K/zAAtmUk5oMD6Sbc8fma0MLpgnTOhB+OGjT+YuXqrpSHBS4gc3h0+ziTEhZc="
        },
        {
          "rawBytes": "MIIFiDCCA3CgAwIBAgIUUm6EPcztiy/FAq1uMGDVTQK2zuAwDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xGDAWBgNVBAMMD0V4YW1wbGUgUm9vdCBDQTAeFw0yNjA2MDIwMzA2MTJaFw0zMTA2MDEwMzA2MTJaME8xCzAJBgNVBAYTAlVTMRwwGgYDVQQKDBNFeGFtcGxlIENvcnBvcmF0aW9uMSIwIAYDVQQDDBlFeGFtcGxlIEludGVybWVkaWF0ZSBDQSAyMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvm/EiIdMzfmayUKL0bXhlYS1UhRszSobQ1N2DHCrJU8xE+nSEtbU/WDjLL6pjsXDFamfsA740gpoSxpLDPtg8RXQ70QA+xUzN26LeI7W96U4VEbIcl3LXGIrycU0ThDqIglLLZJWXb/ETGidIig5rlqcCxNycBc3SPnepdArZAb4BrjHV1ZBzEIPiu8XKKu8cpMOT3BIiFzp4BfH45IeVszshvZTCNZFZJi0Na0P3aJLKjhCyPyQYhiGnj5nU1j+F0yqszknfbzfFY6EsskheOVsj7KAvrWNZEleFnHNKJz2zCF8obIbTJXeYTaXOwAw4mk6A7stW9NvWh/qplabFJ5d88e2t+RN7kinCGd2kuzGop6DpYRs4yOe+NRFrnog9YYTQONje19yiI5bBNS6MGWypGAENL+NQEHEWUlMsVTC1aO/wJ1q+RZrDp5w5uJZPUWOEF1c8uqajuDlV37I/d6gM/gDyc7odhxy5QaX0pErcO5aMwSbb/eRb5jDcF2cO1qp5NRsR86565OtczLtbhBY179rmZ1wmdv9vYlrh40i5k2n0sjZ1YfhB9IBIJ05HB8D2eNf8N1QlgitaYkpQtwmsvNGcMR841C3q2KiJliiF/I5dkfre6p6GlCDsmbpmr81ylGqJDaYxJY951FQayO68VV/Jv5p4ECDBrCpZBECAwEAAaNmMGQwEgYDVR0TAQH/BAgwBgEB/wIBATAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFJixvpY1dsN7pUmgDrttmsTSN6/VMB8GA1UdIwQYMBaAFE1xXgF2LmT7PPt81K/+J9HSsyORMA0GCSqGSIb3DQEBCwUAA4ICAQCUtvB6pUFqkhmr39ip3GBe3p+UL8ey22uDbrPv3q2CHrs6UgxtM8q5u3KhPlPtcHD8cnYh8pbArzlQK4NFlervK230RY56IxiarQUDKYmKlD1lS3xHerGkjteSzscfbx3k3DzmGiBvUP5RVpTfBcPFH4axFmsMbb9iMjpRSc831bsU9t2ZQr2PcWiNeULfmBTULd+o/vwCN7/kgh6AWYZec7Ihv5QKieiJ4nUUl5jEbipUmrwMJvs+wyGOTxGAzk36j3mZEC0clk81rbpPQVkvw/I97FPq1uDcfkQDo8OBaoBaO7+v0gslIJD1YNYm0xxoALlx4UqiMY1mGGu3JdtWJgMpiD8HemOK8w+0vkA1ut2w2GCmhFy/KZ4u4gDzIzNy80W4+agR1XtgMy2VVwtGU2qCBWnJruIegIq2fjXOqs2d3/cW4FOVfc221paQNHn4XRx8jALmyEbv0Bpv8BTz3+Fssxnvr8zZdEFapl5gVIC2VaZzjXTIXUS+Vf8kCr/CvUXV4gcpTN54usJe4e0wxLxbjm2hUXRCC3PWAmf1AYqOk/8UCRerHNRRo+XDhA3LwvzZB6xQl0rf2LuBgNaMu8UJOI2NbYIlp/tMvCcCECfGW2N+SFsMV8i7N0D3a70FbgzbnjiLx+8grh+7eQaXfAh7W5jkJFI4oKOMuCvg8A=="
        },
        {
          "rawBytes": "MIIFfjCCA2agAwIBAgIUUYmPMHYpEiSk/awf+8zm9rVIjqowDQYJKoZIhvcNAQELBQAwRTELMAkGA1UEBhMCVVMxHDAaBgNVBAoME0V4YW1wbGUgQ29ycG9yYXRpb24xGDAWBgNVBAMMD0V4YW1wbGUgUm9vdCBDQTAeFw0yNjA2MDIwMzA1MzJaFw0zNjA1MzAwMzA1MzJaMEUxCzAJBgNVBAYTAlVTMRwwGgYDVQQKDBNFeGFtcGxlIENvcnBvcmF0aW9uMRgwFgYDVQQDDA9FeGFtcGxlIFJvb3QgQ0EwggIiMA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQC0otGFdpPjpXqXCR0LF7BLUr9KVi0ZMtW845moitW9/gLhbqwcNFakUbLSaPB+OZOg1798zFQvV2cL3OSdkjai619zbwW409o4DWe5rBhJbJsLmPXXPorFzQlXhe1O5T6d73JsTc0tPe1vLWkkqxHmewGWKWgpAZYDdr5bf8nZVX98vUlZAZ0QH2LxrwQ8e65kXX4rAs1TD/syssgKOyg728LfrspY8JS7WT14YgsABXE/I/iAqeccJhXWHqITLw7pASs094k6avAaz7Nh8/J9fqYhNH+xQ1M6IfI3DMShVTFeqv5sXrkURE+Y3C3Q6Gykxkqm++lZ3FvlVKlo2emJ0SaAeZIbkDldo3JdML5reuE+d1d7zY2a0+TtrThUwCtwm4b992vLIvdyDrs5XxQcWRFn7btXYU/KSar2iWTY4s/87GyqBwR9sVw24Xr/QoehH4NIJX24RJDoDbH4YVbKHk0eAKKdVXxqtJcaVTSU6j2GP34xNSrRyu+zRiKVz5OV8a0qjXNRjij7ZVUgcYua11PnLXL/OLYo8WxEG5aqZP+Erui8xLDAgTXW1aUjrsVNke8BpMPP71BNuR8+xr9dUdqLUCvxDWVon6Jwj5lpLtbZ8FbXeOdgb8HiHglaOQFzh7DNv7gUPT+X1Jm4XnC4lvo4Sdh3Ea3rz8qI820phQIDAQABo2YwZDAdBgNVHQ4EFgQUTXFeAXYuZPs8+3zUr/4n0dKzI5EwHwYDVR0jBBgwFoAUTXFeAXYuZPs8+3zUr/4n0dKzI5EwEgYDVR0TAQH/BAgwBgEB/wIBAjAOBgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQELBQADggIBACzAv2ys/kNk+pSnGaJizP1+qNLF5+15b/JJ0xpFjqjUHveBOkclFNTHzNUWPXyzAgsswbh3igZlCgKqSdH5mNmaZlhnXlU8gHhqJf3nRivkhH/xwNg0DCWnJiG/CD7P3mKHSx3I2U/fuKiE74b05jsefuYpPJPnHYIsopEjI+lWfA/iZlkRe6yIYICdnkMUSZRLNOfHt0/OwAGkz/ryfJq0HjurQr5FKY/GCZSrCKNEoZHsnZ1X1JbPGgqOpiY3z6JbZeaMgEkiErLPEs1v3tGd9kaYA3nE0O92M/fvf1ICwUA4Z+Yjx6PTGvyqxbUdihh4U0+lWqFAINSe7V6sYFysRTkVdF5WtBI0E/GbCa8EwA2+ixLVU+rwilVBe+JnYJ6lwYi8ikEkd4RwzBSv61rPmK6h/7fOQBCJIwOGwM6tLF34Cq9zusRK8T5Q9gxbL02Q48NAdk8VW8Lb4msbY1ckCpvpjZfKefljWGUfjdq7QJ2X4DwLbAQA1DZQU2VN0zf7c4Kf071QWYpMJsqDnFh8tzbCLWgcq/ehdd79MdwfWFMZ1e6CEVtoglxbhiDCmyIwLr6AwJ4PctbnsNQ0lJY6ILTB/oFJjwXQkUVR5/3VkMHPRdsnfw+cJXLXnWDV50TBeQyEMrU/TYoGmXK0ccXSgcTx2AklYWtonWemjTNn"
        }
      ]
    },
    "timestampVerificationData": {
      "rfc3161Timestamps": [
        {
          "signedTimestamp": "MIICyTADAgEAMIICwAYJKoZIhvcNAQcCoIICsTCCAq0CAQMxDTALBglghkgBZQMEAgEwgbcGCyqGSIb3DQEJEAEEoIGnBIGkMIGhAgEBBgkrBgEEAYO/MAIwMTANBglghkgBZQMEAgEFAAQgP0HrmL2/n7vC0fZhqF++/xCwac/49vtX4yi10YY3Vv4CFCNoCITB4cDi/zI7/fV1cG843DErGA8yMDI2MDYwMjAzMjE0OFowAwIBAaAypDAwLjEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MRUwEwYDVQQDEwxzaWdzdG9yZS10c2GgADGCAdswggHXAgEBMFEwOTEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MSAwHgYDVQQDExdzaWdzdG9yZS10c2Etc2VsZnNpZ25lZAIUOhNULwyQYe68wUMvy4qOiyojiwwwCwYJYIZIAWUDBAIBoIH8MBoGCSqGSIb3DQEJAzENBgsqhkiG9w0BCRABBDAcBgkqhkiG9w0BCQUxDxcNMjYwNjAyMDMyMTQ4WjAvBgkqhkiG9w0BCQQxIgQghrF3EE3YtPhm5J8VaM5sphuZmIpCB0C9EM9HiAxZEoEwgY4GCyqGSIb3DQEJEAIvMX8wfTB7MHkEIIX5J7wHq2LKw7RDVsEO/IGyxog/2nq55thw2dE6zQW3MFUwPaQ7MDkxFTATBgNVBAoTDHNpZ3N0b3JlLmRldjEgMB4GA1UEAxMXc2lnc3RvcmUtdHNhLXNlbGZzaWduZWQCFDoTVC8MkGHuvMFDL8uKjosqI4sMMAoGCCqGSM49BAMCBGcwZQIxALfusC9jvL1bzDObjKKtnIYp4Xcb/ugtgVkGBaIaTdVGrPjwu/3jOVpNN/nWtRHfsAIwK+JJBnk4KjTqShOnaXJPCeKfX+8XkQlZdbG5NOSWQ8sIzBR7Fkc5BEYbzpF8OLG1"
        }
      ]
    }
  },
  "dsseEnvelope": {
    "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCAic3ViamVjdCI6W3siZGlnZXN0Ijp7InNoYTI1NiI6ImQ1NzFiZmJhYWQwZGI3NjQwNmM2NzhmZGJhNzU0MjAyZGM1NDBmODE3OThmYjUwYjRiYzA1OTJhNDYwNmU2NTEifSwgImFubm90YXRpb25zIjp7fX1dLCAicHJlZGljYXRlVHlwZSI6Imh0dHBzOi8vc2lnc3RvcmUuZGV2L2Nvc2lnbi9zaWduL3YxIiwgInByZWRpY2F0ZSI6e319",
    "payloadType": "application/vnd.in-toto+json",
    "signatures": [
      {
        "sig": "lXBB5aSyBDFlEttNXyy/Q094t7NuQHn8dZf2U9mkHmU3rZuG50R0Igmy/oVryZjhONLmQNn+j21aeZq/ZDO2LD3xZWZUvvj59eFSxWbx2bsMKv2IDRbxqC/2Eeve1vLotyHedB4UOA9xBcg4lTE+Loij24x/CbSCiHEyQKLH4SanGRuFS2JHVaqqtxDRAgtK5u/yAUmtbauXqL3B/T1qFLfVyP/9sk71PpIbKKtedqzQcjOevM9gueh8uDpJU2IzACy/WS5RcHfgJfS6siEgAnfU+jlVGN7V8W9gUltu0kVhRTb8AqJ2TXQqlV139GbEbzJI+jjhtM8mJcodlw66FHD1R8VpXy5WD6vP9QjTFDtEMjfZo9zZ7rd1oKjboAJ+y9KBfYT8fZQOC7A6Xt+++DYJOcjETDOudXhV+RlBpssT4/mzlYUaMfht/1N4s1r6RsyxDufqmD+trxvCWwFznQeLn3yKtdCLDSyQ3HC0VMORsWx0v5IzpNMD8l2WP2+BrdzE5OxYcBN7j+TReE8uHZKkcIq4+72eES9KmQHBmYJwa77W8GT8ddE87OhsBahLl1YTyQG/i3bB5fpt9Kdh3RC277gGX1bLyAeyUakOsyVwMAGMsRt3vbX9hirkEvIPX4K+hmXC3y/HUOybEQVssqE969dEq3yq0MZJhNujQBo="
      }
    ]
  }
}
```

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

- https://docs.sigstore.dev/cosign/signing/signing_with_containers/