### PR TITLE
Sign exclusively via sigstore-go

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -19,13 +19,16 @@ import (
 	"context"
 	_ "crypto/sha256" // for `crypto.SHA256`
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon"
+	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign/attestation"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	cremote "github.com/sigstore/cosign/v3/pkg/cosign/remote"
@@ -33,6 +36,8 @@ import (
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	"github.com/sigstore/cosign/v3/pkg/types"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	"github.com/sigstore/sigstore/pkg/signature"
 )
 
 // nolint
@@ -123,64 +128,107 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 	bundleOpts := signcommon.CommonBundleOpts{
 		Payload:       payload,
 		Digest:        digest,
-		PredicateType: types.CosignSignPredicateType,
+		PredicateType: predicateURI,
 		BundlePath:    c.BundlePath,
 		Upload:        !c.NoUpload,
 		OCIRemoteOpts: ociremoteOpts,
 	}
 
-	if c.SigningConfig != nil {
-		return signcommon.WriteNewBundleWithSigningConfig(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
+	if c.SigningConfig == nil {
+		c.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(c.KeyOpts, c.TlogUpload)
+		if err != nil {
+			return fmt.Errorf("creating signing config: %w", err)
+		}
 	}
 
-	bundleComponents, closeSV, err := signcommon.GetBundleComponents(ctx, c.CertPath, c.CertChainPath, c.KeyOpts, c.NoUpload, c.TlogUpload, payload, digest, c.RekorEntryType)
+	bundleBytes, pubKey, pubKeyPem, hashAlgProto, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
 	if err != nil {
-		return fmt.Errorf("getting bundle components: %w", err)
+		return fmt.Errorf("creating bundle: %w", err)
 	}
-	defer closeSV()
 
-	sv := bundleComponents.SV
+	if c.NewBundleFormat {
+		// TODO(#4534): Require bundle output or registry upload
+		if c.BundlePath != "" {
+			if err := os.WriteFile(c.BundlePath, bundleBytes, 0600); err != nil {
+				return fmt.Errorf("create bundle file: %w", err)
+			}
+			ui.Infof(ctx, "Wrote bundle to file %s", c.BundlePath)
+		}
 
-	if c.NoUpload && c.BundlePath == "" {
-		fmt.Println(string(bundleComponents.SignedPayload))
+		if !c.NoUpload {
+			if err := ociremote.WriteAttestationNewBundleFormat(digest, bundleBytes, bundleOpts.PredicateType, ociremoteOpts...); err != nil {
+				return fmt.Errorf("writing bundle: %w", err)
+			}
+		}
 		return nil
 	}
 
-	opts := []static.Option{static.WithLayerMediaType(types.DssePayloadType)}
-	if sv.Cert != nil {
-		opts = append(opts, static.WithCertChain(sv.Cert, sv.Chain))
+	var pb protobundle.Bundle
+	if err := protojson.Unmarshal(bundleBytes, &pb); err != nil {
+		return fmt.Errorf("unmarshalling bundle: %w", err)
 	}
 
-	if bundleComponents.RFC3161Timestamp != nil {
-		opts = append(opts, static.WithRFC3161Timestamp(bundleComponents.RFC3161Timestamp))
-	}
-
-	predicateType, err := options.ParsePredicateType(c.PredicateType)
+	bundleComponents, err := signcommon.ExtractComponentsFromProtoBundle(&pb)
 	if err != nil {
-		return err
+		return fmt.Errorf("extracting components from bundle: %w", err)
 	}
 
-	bundleOpts.PredicateType = predicateType
+	legacyBundleBytes, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents, pubKeyPem)
+	if err != nil {
+		return fmt.Errorf("creating legacy bundle: %w", err)
+	}
+
+	if c.BundlePath != "" {
+		if err := os.WriteFile(c.BundlePath, legacyBundleBytes, 0600); err != nil {
+			return fmt.Errorf("create bundle file: %w", err)
+		}
+		ui.Infof(ctx, "Wrote bundle to file %s", c.BundlePath)
+	}
+
+	if c.NoUpload {
+		return nil
+	}
+
+	certPem, chainPem := signcommon.EncodeCertificatesToPEM(bundleComponents.Certificates)
+
+	opts := []static.Option{
+		static.WithLayerMediaType(types.DssePayloadType),
+		static.WithAnnotations(map[string]string{
+			"predicateType": predicateURI,
+		}),
+	}
+	if certPem != nil {
+		opts = append(opts, static.WithCertChain(certPem, chainPem))
+	}
+
+	if len(bundleComponents.RFC3161Timestamps) > 0 {
+		opts = append(opts, static.WithRFC3161Timestamp(cbundle.TimestampToRFC3161Timestamp(bundleComponents.RFC3161Timestamps[0].GetSignedTimestamp())))
+	}
 
 	predicateTypeAnnotation := map[string]string{
-		"predicateType": predicateType,
+		"predicateType": predicateURI,
 	}
 	// Add predicateType as manifest annotation
 	opts = append(opts, static.WithAnnotations(predicateTypeAnnotation))
 
-	if bundleComponents.RekorEntry != nil {
-		opts = append(opts, static.WithBundle(cbundle.EntryToBundle(bundleComponents.RekorEntry)))
+	if len(bundleComponents.RekorEntries) > 0 {
+		opts = append(opts, static.WithBundle(signcommon.RekorBundleFromProtoTlogEntry(bundleComponents.RekorEntries[0])))
 	}
 
-	if c.KeyOpts.NewBundleFormat {
-		return signcommon.WriteBundle(ctx, sv, bundleComponents.RekorEntry, bundleOpts, bundleComponents.SignedPayload, bundleComponents.SignerBytes, bundleComponents.TimestampBytes)
+	ociSig, err := static.NewAttestation(bundleComponents.Signature, opts...)
+	if err != nil {
+		return fmt.Errorf("creating attestation: %w", err)
 	}
 
 	// We don't actually need to access the remote entity to attach things to it
 	// so we use a placeholder here.
 	se := ociremote.SignedUnknown(digest, ociremoteOpts...)
 
-	dd := cremote.NewDupeDetector(sv)
+	ddVerifier, err := signature.LoadVerifier(pubKey, signcommon.ProtoHashAlgoToHash(hashAlgProto))
+	if err != nil {
+		return fmt.Errorf("loading verifier: %w", err)
+	}
+	dd := cremote.NewDupeDetector(ddVerifier)
 	signOpts := []mutate.SignOption{
 		mutate.WithDupeDetector(dd),
 		mutate.WithRecordCreationTimestamp(c.RecordCreationTimestamp),
@@ -191,15 +239,10 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 		signOpts = append(signOpts, mutate.WithReplaceOp(ro))
 	}
 
-	sig, err := static.NewAttestation(bundleComponents.SignedPayload, opts...)
-	if err != nil {
-		return err
-	}
-
 	// Attach the attestation to the entity.
-	newSE, err := mutate.AttachAttestationToEntity(se, sig, signOpts...)
+	newSE, err := mutate.AttachAttestationToEntity(se, ociSig, signOpts...)
 	if err != nil {
-		return err
+		return fmt.Errorf("attaching attestation: %w", err)
 	}
 
 	// Publish the attestations associated with this entity

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"crypto"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -32,11 +31,12 @@ import (
 	intotov1 "github.com/in-toto/attestation/go/v1"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon"
-	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign/attestation"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
-	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 // nolint
@@ -146,85 +146,92 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 		BundlePath: c.BundlePath,
 	}
 
-	if c.SigningConfig != nil {
-		return signcommon.WriteNewBundleWithSigningConfig(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
+	if c.SigningConfig == nil {
+		var err error
+		c.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(c.KeyOpts, c.TlogUpload)
+		if err != nil {
+			return fmt.Errorf("creating signing config: %w", err)
+		}
 	}
 
-	bundleComponents, closeSV, err := signcommon.GetBundleComponents(ctx, c.CertPath, c.CertChainPath, c.KeyOpts, false, c.TlogUpload, payload, nil, c.RekorEntryType)
+	bundleBytes, _, pubKeyPem, _, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
 	if err != nil {
-		return fmt.Errorf("getting bundle components: %w", err)
+		return fmt.Errorf("creating bundle: %w", err)
 	}
-	defer closeSV()
 
-	sv := bundleComponents.SV
+	if c.NewBundleFormat {
+		// TODO(#4534): Require bundle output or registry upload
+		if c.BundlePath != "" {
+			if err := os.WriteFile(c.BundlePath, bundleBytes, 0600); err != nil {
+				return fmt.Errorf("create bundle file: %w", err)
+			}
+			ui.Infof(ctx, "Wrote bundle to file %s", c.BundlePath)
+		}
+		return nil
+	}
 
-	signedPayload := cosign.LocalSignedPayload{}
+	var pb protobundle.Bundle
+	if err := protojson.Unmarshal(bundleBytes, &pb); err != nil {
+		return fmt.Errorf("unmarshalling bundle: %w", err)
+	}
 
-	if bundleComponents.RekorEntry != nil {
-		signedPayload.Bundle = cbundle.EntryToBundle(bundleComponents.RekorEntry)
+	bundleComponents, err := signcommon.ExtractComponentsFromProtoBundle(&pb)
+	if err != nil {
+		return err
 	}
 
 	if c.BundlePath != "" {
-		var contents []byte
-		if c.NewBundleFormat {
-			pubKey, err := sv.PublicKey()
-			if err != nil {
-				return err
-			}
-
-			contents, err = cbundle.MakeNewBundle(pubKey, bundleComponents.RekorEntry, payload, bundleComponents.SignedPayload, bundleComponents.SignerBytes, bundleComponents.TimestampBytes)
-			if err != nil {
-				return err
-			}
-		} else {
-			signedPayload.Base64Signature = base64.StdEncoding.EncodeToString(bundleComponents.SignedPayload)
-			signedPayload.Cert = base64.StdEncoding.EncodeToString(bundleComponents.SignerBytes)
-
-			contents, err = json.Marshal(signedPayload)
-			if err != nil {
-				return err
-			}
+		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents, pubKeyPem)
+		if err != nil {
+			return fmt.Errorf("creating legacy bundle: %w", err)
 		}
 
 		if err := os.WriteFile(c.BundlePath, contents, 0600); err != nil {
 			return fmt.Errorf("create bundle file: %w", err)
 		}
-		fmt.Fprintln(os.Stderr, "Bundle wrote in the file ", c.BundlePath)
+		ui.Infof(ctx, "Wrote bundle to file %s", c.BundlePath)
 	}
 
 	if c.OutputSignature != "" {
-		if err := os.WriteFile(c.OutputSignature, bundleComponents.SignedPayload, 0600); err != nil {
+		if err := os.WriteFile(c.OutputSignature, bundleComponents.Signature, 0600); err != nil {
 			return fmt.Errorf("create signature file: %w", err)
 		}
 		fmt.Fprintf(os.Stderr, "Signature written in %s\n", c.OutputSignature)
 	} else {
-		fmt.Fprintln(os.Stdout, string(bundleComponents.SignedPayload))
+		fmt.Fprintln(os.Stdout, string(bundleComponents.Signature))
 	}
 
 	if c.OutputAttestation != "" {
 		if err := os.WriteFile(c.OutputAttestation, payload, 0600); err != nil {
-			return fmt.Errorf("create signature file: %w", err)
+			return fmt.Errorf("create attestation file: %w", err)
 		}
 		fmt.Fprintf(os.Stderr, "Attestation written in %s\n", c.OutputAttestation)
 	}
 
 	if c.OutputCertificate != "" {
-		cert, err := cryptoutils.UnmarshalCertificatesFromPEM(bundleComponents.SignerBytes)
-		// signer is a certificate
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Could not output signer certificate. Was a certificate used? ", err)
-			return nil
-
+		if len(bundleComponents.Certificates) == 0 {
+			return fmt.Errorf("no certificate found in bundle")
 		}
-		if len(cert) != 1 {
-			fmt.Fprintln(os.Stderr, "Could not output signer certificate. Expected a single certificate")
-			return nil
-		}
-		bts := bundleComponents.SignerBytes
-		if err := os.WriteFile(c.OutputCertificate, bts, 0600); err != nil {
+		certPem, _ := signcommon.EncodeCertificatesToPEM(bundleComponents.Certificates)
+		if err := os.WriteFile(c.OutputCertificate, certPem, 0600); err != nil {
 			return fmt.Errorf("create certificate file: %w", err)
 		}
 		fmt.Fprintln(os.Stderr, "Certificate written to file ", c.OutputCertificate)
+	}
+
+	if c.RFC3161TimestampPath != "" {
+		if len(bundleComponents.RFC3161Timestamps) == 0 {
+			return fmt.Errorf("no RFC3161 timestamp found in bundle")
+		}
+		legacyTimestamp := cbundle.TimestampToRFC3161Timestamp(bundleComponents.RFC3161Timestamps[0].GetSignedTimestamp())
+		ts, err := json.Marshal(legacyTimestamp)
+		if err != nil {
+			return fmt.Errorf("marshalling timestamp: %w", err)
+		}
+		if err := os.WriteFile(c.RFC3161TimestampPath, ts, 0600); err != nil {
+			return fmt.Errorf("create timestamp file: %w", err)
+		}
+		fmt.Fprintln(os.Stderr, "Timestamp wrote in the file ", c.RFC3161TimestampPath)
 	}
 
 	return nil

--- a/cmd/cosign/cli/options/fulcio.go
+++ b/cmd/cosign/cli/options/fulcio.go
@@ -26,7 +26,7 @@ type FulcioOptions struct {
 	URL                      string
 	AuthFlow                 string
 	IdentityToken            string
-	InsecureSkipFulcioVerify bool
+	InsecureSkipFulcioVerify bool // Deprecated: SCT verification is no longer performed during signing/attestation.
 }
 
 var _ Interface = (*FulcioOptions)(nil)
@@ -46,4 +46,5 @@ func (o *FulcioOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.InsecureSkipFulcioVerify, "insecure-skip-verify", false,
 		"skip verifying fulcio published to the SCT (this should only be used for testing).")
+	_ = cmd.Flags().MarkDeprecated("insecure-skip-verify", "SCT verification is no longer performed during signing/attestation.")
 }

--- a/cmd/cosign/cli/options/key.go
+++ b/cmd/cosign/cli/options/key.go
@@ -54,6 +54,7 @@ type KeyOpts struct {
 	// for valid values.
 	FulcioAuthFlow string
 
+	// Deprecated: SCT verification is no longer performed during signing/attestation.
 	// Modeled after InsecureSkipVerify in tls.Config, this disables
 	// verifying the SCT.
 	InsecureSkipFulcioVerify bool

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -21,30 +21,31 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	intotov1 "github.com/in-toto/attestation/go/v1"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/v3/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon"
-	icos "github.com/sigstore/cosign/v3/internal/pkg/cosign"
-	ifulcio "github.com/sigstore/cosign/v3/internal/pkg/cosign/fulcio"
-	ipayload "github.com/sigstore/cosign/v3/internal/pkg/cosign/payload"
-	irekor "github.com/sigstore/cosign/v3/internal/pkg/cosign/rekor"
-	"github.com/sigstore/cosign/v3/internal/pkg/cosign/tsa"
 	"github.com/sigstore/cosign/v3/internal/pkg/cosign/tsa/client"
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
+	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	cremote "github.com/sigstore/cosign/v3/pkg/cosign/remote"
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	"github.com/sigstore/cosign/v3/pkg/oci/walk"
 	"github.com/sigstore/cosign/v3/pkg/types"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/sigstore/sigstore/pkg/signature"
 	sigPayload "github.com/sigstore/sigstore/pkg/signature/payload"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -196,17 +197,37 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 		OCIRemoteOpts: ociremoteOpts,
 	}
 
-	if ko.SigningConfig != nil {
-		return signcommon.WriteNewBundleWithSigningConfig(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
+	if ko.SigningConfig == nil {
+		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
+		if err != nil {
+			return fmt.Errorf("should upload to tlog: %w", err)
+		}
+		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko, shouldUpload)
+		if err != nil {
+			return fmt.Errorf("creating signing config: %w", err)
+		}
 	}
 
-	bundleComponents, closeSV, err := signcommon.GetBundleComponents(ctx, signOpts.Cert, signOpts.CertChain, ko, false, signOpts.TlogUpload, payload, digest, "dsse")
+	bundleBytes, _, _, _, err := signcommon.NewAttestationBundle(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
 	if err != nil {
-		return fmt.Errorf("getting bundle components: %w", err)
+		return err
 	}
-	defer closeSV()
 
-	return signcommon.WriteBundle(ctx, bundleComponents.SV, bundleComponents.RekorEntry, bundleOpts, bundleComponents.SignedPayload, bundleComponents.SignerBytes, bundleComponents.TimestampBytes)
+	if signOpts.BundlePath != "" {
+		if err := os.WriteFile(signOpts.BundlePath, bundleBytes, 0600); err != nil {
+			return fmt.Errorf("create bundle file: %w", err)
+		}
+		ui.Infof(ctx, "Wrote bundle to file %s", signOpts.BundlePath)
+	}
+
+	if signOpts.Upload {
+		ui.Infof(ctx, "Pushing signature to: %s", digest.Repository)
+		if err := ociremote.WriteAttestationNewBundleFormat(digest, bundleBytes, bundleOpts.PredicateType, bundleOpts.OCIRemoteOpts...); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko options.KeyOpts, signOpts options.SignOptions,
@@ -234,61 +255,89 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		payloads = append(payloads, payload)
 	}
 
-	sv, closeSV, err := signcommon.GetSignerVerifier(ctx, signOpts.Cert, signOpts.CertChain, ko)
-	if err != nil {
-		return fmt.Errorf("getting signer: %w", err)
-	}
-	defer closeSV()
-
-	dd := cremote.NewDupeDetector(sv)
-
-	var s icos.Signer
-	s = ipayload.NewSigner(sv)
-	if sv.Cert != nil {
-		s = ifulcio.NewSigner(s, sv.Cert, sv.Chain)
-	}
-
-	if ko.TSAServerURL != "" {
-		if ko.TSAClientCACert == "" && ko.TSAClientCert == "" { // no mTLS params or custom CA
-			s = tsa.NewSigner(s, client.NewTSAClient(ko.TSAServerURL))
-		} else {
-			s = tsa.NewSigner(s, client.NewTSAClientMTLS(ko.TSAServerURL,
-				ko.TSAClientCACert,
-				ko.TSAClientCert,
-				ko.TSAClientKey,
-				ko.TSAServerName,
-			))
-		}
-	}
-	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-	if err != nil {
-		return fmt.Errorf("should upload to tlog: %w", err)
-	}
-	if shouldUpload {
-		rClient, err := rekor.NewClient(ko.RekorURL)
+	if ko.SigningConfig == nil {
+		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
 		if err != nil {
-			return err
+			return fmt.Errorf("should upload to tlog: %w", err)
 		}
-		s = irekor.NewSigner(s, rClient)
+		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko, shouldUpload)
+		if err != nil {
+			return fmt.Errorf("creating signing config: %w", err)
+		}
 	}
+
+	keypair, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, signOpts.Cert, signOpts.CertChain)
+	if err != nil {
+		return fmt.Errorf("getting keypair and token: %w", err)
+	}
+	if closer, ok := keypair.(interface{ Close() }); ok {
+		defer closer.Close()
+	}
+
+	var tsaClientTransport http.RoundTripper
+	if ko.TSAClientCACert != "" || (ko.TSAClientCert != "" && ko.TSAClientKey != "") {
+		tsaClientTransport, err = client.GetHTTPTransport(ko.TSAClientCACert, ko.TSAClientCert, ko.TSAClientKey, ko.TSAServerName, 30*time.Second)
+		if err != nil {
+			return fmt.Errorf("getting TSA client transport: %w", err)
+		}
+	}
+	cbundleOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
 
 	ociSigs := make([]oci.Signature, len(payloads))
 	b64sigs := make([]string, len(payloads))
 
-	for i, payload := range payloads {
-		ociSig, _, err := s.Sign(ctx, bytes.NewReader(payload))
-		if err != nil {
-			return err
-		}
-		ociSigs[i] = ociSig
+	var leafCertPem []byte
 
-		b64sig, err := ociSig.Base64Signature()
-		if err != nil {
-			return err
+	for i, payload := range payloads {
+		content := &sign.PlainData{
+			Data: payload,
 		}
+
+		bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, cbundleOpts)
+		if err != nil {
+			return fmt.Errorf("signing bundle: %w", err)
+		}
+
+		var pb protobundle.Bundle
+		if err := protojson.Unmarshal(bundleBytes, &pb); err != nil {
+			return fmt.Errorf("unmarshalling bundle: %w", err)
+		}
+
+		bundleComponents, err := signcommon.ExtractComponentsFromProtoBundle(&pb)
+		if err != nil {
+			return fmt.Errorf("extracting components from bundle: %w", err)
+		}
+
+		certPem, chainPem := signcommon.EncodeCertificatesToPEM(bundleComponents.Certificates)
+		if i == 0 {
+			leafCertPem = certPem
+		}
+
+		b64sig := base64.StdEncoding.EncodeToString(bundleComponents.Signature)
 		b64sigs[i] = b64sig
+
+		var opts []static.Option
+		if certPem != nil {
+			opts = append(opts, static.WithCertChain(certPem, chainPem))
+		}
+
+		if len(bundleComponents.RFC3161Timestamps) > 0 {
+			opts = append(opts, static.WithRFC3161Timestamp(cbundle.TimestampToRFC3161Timestamp(bundleComponents.RFC3161Timestamps[0].GetSignedTimestamp())))
+		}
+
+		if len(bundleComponents.RekorEntries) > 0 {
+			opts = append(opts, static.WithBundle(signcommon.RekorBundleFromProtoTlogEntry(bundleComponents.RekorEntries[0])))
+		}
+
+		ociSig, err := static.NewSignature(payload, b64sig, opts...)
+		if err != nil {
+			return fmt.Errorf("creating signature: %w", err)
+		}
+
+		ociSigs[i] = ociSig
 	}
 
+	// TODO(#4534): Require bundle output or registry upload
 	outputSignature := signOpts.OutputSignature
 	if outputSignature != "" {
 		// Add digest to suffix to differentiate each image during recursive signing
@@ -311,12 +360,18 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	}
 
 	if signOpts.OutputCertificate != "" {
-		rekorBytes, err := sv.Bytes(ctx)
-		if err != nil {
-			return fmt.Errorf("create certificate file: %w", err)
+		var outBytes []byte
+		if len(leafCertPem) > 0 {
+			outBytes = leafCertPem
+		} else {
+			pubPem, err := keypair.GetPublicKeyPem()
+			if err != nil {
+				return fmt.Errorf("getting public key pem: %w", err)
+			}
+			outBytes = []byte(pubPem)
 		}
 
-		if err := os.WriteFile(signOpts.OutputCertificate, rekorBytes, 0600); err != nil {
+		if err := os.WriteFile(signOpts.OutputCertificate, outBytes, 0600); err != nil {
 			return fmt.Errorf("create certificate file: %w", err)
 		}
 		// TODO: maybe accept a --b64 flag as well?
@@ -346,6 +401,13 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	if !signOpts.Upload {
 		return nil
 	}
+
+	hashAlgo := signcommon.ProtoHashAlgoToHash(keypair.GetHashAlgorithm())
+	ddVerifier, err := signature.LoadVerifier(keypair.GetPublicKey(), hashAlgo)
+	if err != nil {
+		return fmt.Errorf("loading verifier: %w", err)
+	}
+	dd := cremote.NewDupeDetector(ddVerifier)
 
 	// Attach the signature to the entity.
 	var newSE oci.SignedEntity

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -281,7 +281,18 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 			return fmt.Errorf("getting TSA client transport: %w", err)
 		}
 	}
-	cbundleOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
+	var certProvider sign.CertificateProvider
+	if idToken != "" {
+		certProvider, err = cbundle.NewCachingFulcioProvider(ko.SigningConfig)
+		if err != nil {
+			return fmt.Errorf("creating caching Fulcio provider: %w", err)
+		}
+	}
+
+	cbundleOpts := cbundle.SignOptions{
+		TSAClientTransport:  tsaClientTransport,
+		CertificateProvider: certProvider,
+	}
 
 	ociSigs := make([]oci.Signature, len(payloads))
 	b64sigs := make([]string, len(payloads))

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -18,35 +18,26 @@ package sign
 import (
 	"context"
 	"crypto"
-	"crypto/sha256"
-	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
-
-	"google.golang.org/protobuf/encoding/protojson"
+	"time"
 
 	"net/http"
-	"time"
 
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon"
 	internal "github.com/sigstore/cosign/v3/internal/pkg/cosign"
 	"github.com/sigstore/cosign/v3/internal/pkg/cosign/tsa/client"
 	"github.com/sigstore/cosign/v3/internal/ui"
-	"github.com/sigstore/cosign/v3/pkg/cosign"
 	cbundle "github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
-	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
-	rekorclient "github.com/sigstore/rekor/pkg/generated/client"
-	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore-go/pkg/sign"
-	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
-	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func getPayload(ctx context.Context, payloadPath string, hashFunction crypto.Hash) (internal.HashReader, func() error, error) {
@@ -76,56 +67,34 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		ko.DefaultLoadOptions = &[]signature.LoadOption{}
 	}
 
-	keypair, sv, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)
-	defer func() {
-		if sv != nil {
-			sv.Close()
+	var shouldUpload bool
+	var err error
+
+	if ko.SigningConfig == nil {
+		shouldUpload, err = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
+		if err != nil {
+			return nil, fmt.Errorf("upload to tlog: %w", err)
 		}
-	}()
+		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko, shouldUpload)
+		if err != nil {
+			return nil, fmt.Errorf("creating signing config: %w", err)
+		}
+	}
+
+	keypair, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)
 	if err != nil {
 		return nil, fmt.Errorf("getting keypair and token: %w", err)
 	}
+	if closer, ok := keypair.(interface{ Close() }); ok {
+		defer closer.Close()
+	}
 
-	hashFunction := protoHashAlgoToHash(keypair.GetHashAlgorithm())
+	hashFunction := signcommon.ProtoHashAlgoToHash(keypair.GetHashAlgorithm())
 	payload, closePayload, err := getPayload(ctx, payloadPath, hashFunction)
 	if err != nil {
 		return nil, fmt.Errorf("getting payload: %w", err)
 	}
 	defer closePayload()
-
-	if ko.SigningConfig != nil {
-		data, err := io.ReadAll(&payload)
-		if err != nil {
-			return nil, fmt.Errorf("reading payload: %w", err)
-		}
-		content := &sign.PlainData{
-			Data: data,
-		}
-
-		var tsaClientTransport http.RoundTripper
-		if ko.TSAClientCACert != "" || (ko.TSAClientCert != "" && ko.TSAClientKey != "") {
-			tsaClientTransport, err = client.GetHTTPTransport(ko.TSAClientCACert, ko.TSAClientCert, ko.TSAClientKey, ko.TSAServerName, 30*time.Second)
-			if err != nil {
-				return nil, fmt.Errorf("getting TSA client transport: %w", err)
-			}
-		}
-		signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
-
-		bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
-		if err != nil {
-			return nil, fmt.Errorf("signing bundle: %w", err)
-		}
-		if err := os.WriteFile(ko.BundlePath, bundle, 0600); err != nil {
-			return nil, fmt.Errorf("create bundle file: %w", err)
-		}
-		ui.Infof(ctx, "Wrote bundle to file %s", ko.BundlePath)
-		return bundle, nil
-	}
-
-	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
-	if err != nil {
-		return nil, fmt.Errorf("upload to tlog: %w", err)
-	}
 
 	if hashFunction != crypto.SHA256 && !ko.NewBundleFormat && (shouldUpload || (!ko.Sk && ko.KeyRef == "")) {
 		ui.Infof(ctx, "Non SHA256 hash function is not supported for old bundle format. Use --new-bundle-format to use the new bundle format or use different signing key/algorithm.")
@@ -137,89 +106,56 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		ui.Infof(ctx, "Continuing with non SHA256 hash function and old bundle format")
 	}
 
-	sig, err := sv.SignMessage(&payload, signatureoptions.WithContext(ctx))
+	data, err := io.ReadAll(&payload)
 	if err != nil {
-		return nil, fmt.Errorf("signing blob: %w", err)
+		return nil, fmt.Errorf("reading payload: %w", err)
 	}
-	digest := payload.Sum(nil)
-
-	signedPayload := cosign.LocalSignedPayload{}
-
-	timestampBytes, _, err := signcommon.GetRFC3161Timestamp(sig, ko)
-	if err != nil {
-		return nil, fmt.Errorf("getting timestamp: %w", err)
+	content := &sign.PlainData{
+		Data: data,
 	}
 
-	signer, err := sv.Bytes(ctx)
-	if err != nil {
-		return nil, err
+	var tsaClientTransport http.RoundTripper
+	if ko.TSAClientCACert != "" || (ko.TSAClientCert != "" && ko.TSAClientKey != "") {
+		tsaClientTransport, err = client.GetHTTPTransport(ko.TSAClientCACert, ko.TSAClientCert, ko.TSAClientKey, ko.TSAServerName, 30*time.Second)
+		if err != nil {
+			return nil, fmt.Errorf("getting TSA client transport: %w", err)
+		}
 	}
-	rekorEntry, err := signcommon.UploadToTlog(ctx, ko, nil, shouldUpload, signer, func(r *rekorclient.Rekor, b []byte) (*models.LogEntryAnon, error) {
-		return cosign.TLogUploadWithCustomHash(ctx, r, sig, &payload, b)
-	})
+	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
+	bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
 	if err != nil {
-		return nil, err
-	}
-	if rekorEntry != nil {
-		signedPayload.Bundle = cbundle.EntryToBundle(rekorEntry)
+		return nil, fmt.Errorf("signing bundle: %w", err)
 	}
 
-	// if bundle is specified, just do that and ignore the rest
+	if ko.NewBundleFormat {
+		// TODO(#4534): Require bundle output or registry upload
+		if ko.BundlePath != "" {
+			if err := os.WriteFile(ko.BundlePath, bundleBytes, 0600); err != nil {
+				return nil, fmt.Errorf("create bundle file: %w", err)
+			}
+			ui.Infof(ctx, "Wrote bundle to file %s", ko.BundlePath)
+		}
+		return nil, nil
+	}
+
+	var pb protobundle.Bundle
+	if err := protojson.Unmarshal(bundleBytes, &pb); err != nil {
+		return nil, fmt.Errorf("unmarshalling bundle: %w", err)
+	}
+
+	bundleComponents, err := signcommon.ExtractComponentsFromProtoBundle(&pb)
+	if err != nil {
+		return nil, fmt.Errorf("extracting components from bundle: %w", err)
+	}
+
 	if ko.BundlePath != "" {
-		var contents []byte
-		if ko.NewBundleFormat {
-			// Determine if signature is certificate or not
-			var hint string
-			var rawCert []byte
-
-			cert, err := cryptoutils.UnmarshalCertificatesFromPEM(signer)
-			if err != nil || len(cert) == 0 {
-				pubKey, err := sv.PublicKey()
-				if err != nil {
-					return nil, err
-				}
-				pkixPubKey, err := x509.MarshalPKIXPublicKey(pubKey)
-				if err != nil {
-					return nil, err
-				}
-				hashedBytes := sha256.Sum256(pkixPubKey)
-				hint = base64.StdEncoding.EncodeToString(hashedBytes[:])
-			} else {
-				rawCert = cert[0].Raw
-			}
-
-			bundle, err := cbundle.MakeProtobufBundle(hint, rawCert, rekorEntry, timestampBytes)
-			if err != nil {
-				return nil, err
-			}
-
-			bundle.Content = &protobundle.Bundle_MessageSignature{
-				MessageSignature: &protocommon.MessageSignature{
-					MessageDigest: &protocommon.HashOutput{
-						Algorithm: hashFuncToProtoBundle(payload.HashFunc()),
-						Digest:    digest,
-					},
-					Signature: sig,
-				},
-			}
-
-			contents, err = protojson.Marshal(bundle)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			signedPayload.Base64Signature = base64.StdEncoding.EncodeToString(sig)
-
-			certBytes, err := extractCertificate(ctx, sv)
-			if err != nil {
-				return nil, err
-			}
-			signedPayload.Cert = base64.StdEncoding.EncodeToString(certBytes)
-
-			contents, err = json.Marshal(signedPayload)
-			if err != nil {
-				return nil, err
-			}
+		pubKeyPem, err := keypair.GetPublicKeyPem()
+		if err != nil {
+			return nil, fmt.Errorf("getting public key pem: %w", err)
+		}
+		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents, pubKeyPem)
+		if err != nil {
+			return nil, fmt.Errorf("creating legacy bundle: %w", err)
 		}
 
 		if err := os.WriteFile(ko.BundlePath, contents, 0600); err != nil {
@@ -229,80 +165,54 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	if outputSignature != "" {
-		var bts = sig
+		bts := bundleComponents.Signature
 		if b64 {
-			bts = []byte(base64.StdEncoding.EncodeToString(sig))
+			bts = []byte(base64.StdEncoding.EncodeToString(bundleComponents.Signature))
 		}
 		if err := os.WriteFile(outputSignature, bts, 0600); err != nil {
 			return nil, fmt.Errorf("create signature file: %w", err)
 		}
 		ui.Infof(ctx, "Wrote signature to file %s", outputSignature)
 	} else {
+		bts := bundleComponents.Signature
 		if b64 {
-			sig = []byte(base64.StdEncoding.EncodeToString(sig))
-			fmt.Println(string(sig))
-		} else if _, err := os.Stdout.Write(sig); err != nil {
-			// No newline if using the raw signature
-			return nil, err
+			bts = []byte(base64.StdEncoding.EncodeToString(bundleComponents.Signature))
+			fmt.Println(string(bts))
+		} else {
+			if _, err := os.Stdout.Write(bts); err != nil {
+				return nil, err
+			}
 		}
 	}
 
-	if outputCertificate != "" {
-		certBytes, err := extractCertificate(ctx, sv)
+	if outputCertificate != "" && len(bundleComponents.Certificates) > 0 {
+		certPem, _ := signcommon.EncodeCertificatesToPEM(bundleComponents.Certificates)
+		var bts []byte
+		if b64 {
+			bts = []byte(base64.StdEncoding.EncodeToString(certPem))
+		} else {
+			bts = certPem
+		}
+		if err := os.WriteFile(outputCertificate, bts, 0600); err != nil {
+			return nil, fmt.Errorf("create certificate file: %w", err)
+		}
+		ui.Infof(ctx, "Wrote certificate to file %s", outputCertificate)
+	}
+
+	if len(bundleComponents.RFC3161Timestamps) > 0 && ko.RFC3161TimestampPath != "" {
+		legacyTimestamp := cbundle.TimestampToRFC3161Timestamp(bundleComponents.RFC3161Timestamps[0].GetSignedTimestamp())
+		ts, err := json.Marshal(legacyTimestamp)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("marshalling timestamp: %w", err)
 		}
-		if certBytes != nil {
-			bts := certBytes
-			if b64 {
-				bts = []byte(base64.StdEncoding.EncodeToString(certBytes))
-			}
-			if err := os.WriteFile(outputCertificate, bts, 0600); err != nil {
-				return nil, fmt.Errorf("create certificate file: %w", err)
-			}
-			ui.Infof(ctx, "Wrote certificate to file %s", outputCertificate)
+		if err := os.WriteFile(ko.RFC3161TimestampPath, ts, 0600); err != nil {
+			return nil, fmt.Errorf("create timestamp file: %w", err)
 		}
+		ui.Infof(ctx, "Wrote timestamp to file %s", ko.RFC3161TimestampPath)
 	}
 
-	return sig, nil
-}
-
-// Extract an encoded certificate from the SignerVerifier. Returns (nil, nil) if verifier is not a certificate.
-func extractCertificate(ctx context.Context, sv *signcommon.SignerVerifier) ([]byte, error) {
-	signer, err := sv.Bytes(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error getting signer: %w", err)
+	if b64 {
+		return []byte(base64.StdEncoding.EncodeToString(bundleComponents.Signature)), nil
 	}
-	cert, err := cryptoutils.UnmarshalCertificatesFromPEM(signer)
-	// signer is a certificate
-	if err == nil && len(cert) == 1 {
-		return signer, nil
-	}
-	return nil, nil
-}
-
-func hashFuncToProtoBundle(hashFunc crypto.Hash) protocommon.HashAlgorithm {
-	switch hashFunc {
-	case crypto.SHA256:
-		return protocommon.HashAlgorithm_SHA2_256
-	case crypto.SHA384:
-		return protocommon.HashAlgorithm_SHA2_384
-	case crypto.SHA512:
-		return protocommon.HashAlgorithm_SHA2_512
-	default:
-		return protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED
-	}
-}
-
-func protoHashAlgoToHash(hashFunc protocommon.HashAlgorithm) crypto.Hash {
-	switch hashFunc {
-	case protocommon.HashAlgorithm_SHA2_256:
-		return crypto.SHA256
-	case protocommon.HashAlgorithm_SHA2_384:
-		return crypto.SHA384
-	case protocommon.HashAlgorithm_SHA2_512:
-		return crypto.SHA512
-	default:
-		return crypto.Hash(0)
-	}
+	return bundleComponents.Signature, nil
 }

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -17,7 +17,10 @@ package signcommon
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
@@ -29,8 +32,6 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/sigstore/cosign/v3/cmd/cosign/cli/fulcio"
-	"github.com/sigstore/cosign/v3/cmd/cosign/cli/fulcio/fulcioverifier"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/rekor"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/privacy"
@@ -46,16 +47,17 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/pkcs11key"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	sigs "github.com/sigstore/cosign/v3/pkg/signature"
-	"github.com/sigstore/cosign/v3/pkg/types"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	pb_go_v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	prototrustroot "github.com/sigstore/protobuf-specs/gen/pb-go/trustroot/v1"
 	rekorclient "github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/sign"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
-	"github.com/sigstore/sigstore/pkg/signature/dsse"
-	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 )
 
 // SignerVerifier contains keys or certs to sign and verify.
@@ -73,24 +75,11 @@ func (c *SignerVerifier) Close() {
 	}
 }
 
-// Bytes returns the raw bytes of the cert or key.
-func (c *SignerVerifier) Bytes(ctx context.Context) ([]byte, error) {
-	if c.Cert != nil {
-		return c.Cert, nil
-	}
-
-	pemBytes, err := sigs.PublicKeyPem(c, signatureoptions.WithContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-	return pemBytes, nil
-}
-
 // GetKeypairAndToken creates a keypair object from provided key or cert flags or generates an ephemeral key.
 // For an ephemeral key, it also uses the key to fetch an OIDC token, the pair of which are later used to get a Fulcio cert.
 //
 // Ensure the returned SignerVerifier is closed via calling SignerVerifier.Close.
-func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain string) (sign.Keypair, *SignerVerifier, []byte, string, error) {
+func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain string) (sign.Keypair, []byte, string, error) {
 	var keypair sign.Keypair
 	var ephemeralKeypair bool
 	var idToken string
@@ -100,63 +89,34 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 
 	sv, ephemeralKeypair, err = signerFromKeyOpts(ctx, cert, certChain, ko)
 	if err != nil {
-		return nil, nil, nil, "", fmt.Errorf("getting signer: %w", err)
+		return nil, nil, "", fmt.Errorf("getting signer: %w", err)
 	}
 	keypair, err = key.NewSignerVerifierKeypair(sv, ko.DefaultLoadOptions)
 	if err != nil {
-		return nil, nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
+		sv.Close()
+		return nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
 	}
 	certBytes = sv.Cert
 
 	if ephemeralKeypair || ko.IssueCertificateForExistingKey {
-		if ko.SigningConfig == nil {
-			sv, err = keylessSigner(ctx, ko, sv)
-		} else {
-			idToken, err = auth.RetrieveIDToken(ctx, auth.IDTokenConfig{
-				TokenOrPath:      ko.IDToken,
-				DisableProviders: ko.OIDCDisableProviders,
-				Provider:         ko.OIDCProvider,
-				AuthFlow:         ko.FulcioAuthFlow,
-				SkipConfirm:      ko.SkipConfirmation,
-				OIDCServices:     ko.SigningConfig.OIDCProviderURLs(),
-				ClientID:         ko.OIDCClientID,
-				ClientSecret:     ko.OIDCClientSecret,
-				RedirectURL:      ko.OIDCRedirectURL,
-			})
-		}
+		idToken, err = auth.RetrieveIDToken(ctx, auth.IDTokenConfig{
+			TokenOrPath:      ko.IDToken,
+			DisableProviders: ko.OIDCDisableProviders,
+			Provider:         ko.OIDCProvider,
+			AuthFlow:         ko.FulcioAuthFlow,
+			SkipConfirm:      ko.SkipConfirmation,
+			OIDCServices:     ko.SigningConfig.OIDCProviderURLs(),
+			ClientID:         ko.OIDCClientID,
+			ClientSecret:     ko.OIDCClientSecret,
+			RedirectURL:      ko.OIDCRedirectURL,
+		})
 		if err != nil {
-			return nil, nil, nil, "", fmt.Errorf("retrieving ID token: %w", err)
+			sv.Close()
+			return nil, nil, "", fmt.Errorf("retrieving ID token: %w", err)
 		}
 	}
 
-	return keypair, sv, certBytes, idToken, nil
-}
-
-func keylessSigner(ctx context.Context, ko options.KeyOpts, sv *SignerVerifier) (*SignerVerifier, error) {
-	var (
-		k   *fulcio.Signer
-		err error
-	)
-
-	if _, ok := sv.SignerVerifier.(*signature.ED25519phSignerVerifier); ok {
-		return nil, fmt.Errorf("ed25519ph unsupported by Fulcio")
-	}
-
-	if ko.InsecureSkipFulcioVerify {
-		if k, err = fulcio.NewSigner(ctx, ko, sv); err != nil {
-			return nil, fmt.Errorf("getting key from Fulcio: %w", err)
-		}
-	} else {
-		if k, err = fulcioverifier.NewSigner(ctx, ko, sv); err != nil {
-			return nil, fmt.Errorf("getting key from Fulcio: %w", err)
-		}
-	}
-
-	return &SignerVerifier{
-		Cert:           k.Cert,
-		Chain:          k.Chain,
-		SignerVerifier: k,
-	}, nil
+	return keypair, certBytes, idToken, nil
 }
 
 // ShouldUploadToTlog determines whether the user wants to upload the entry to Rekor.
@@ -201,21 +161,6 @@ func shouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 		}
 	}
 	return true
-}
-
-// GetSignerVerifier generates a SignerVerifier from provided key flags.
-func GetSignerVerifier(ctx context.Context, cert, certChain string, ko options.KeyOpts) (*SignerVerifier, func(), error) {
-	sv, genKey, err := signerFromKeyOpts(ctx, cert, certChain, ko)
-	if err != nil {
-		return nil, nil, fmt.Errorf("getting signer from opts: %w", err)
-	}
-	if genKey || ko.IssueCertificateForExistingKey {
-		sv, err = keylessSigner(ctx, ko, sv)
-		if err != nil {
-			return nil, nil, fmt.Errorf("getting Fulcio signer: %w", err)
-		}
-	}
-	return sv, sv.Close, nil
 }
 
 func signerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, bool, error) {
@@ -507,16 +452,14 @@ func WriteBundle(ctx context.Context, sv *SignerVerifier, rekorEntry *models.Log
 	return ociremote.WriteAttestationNewBundleFormat(bundleOpts.Digest, bundleBytes, bundleOpts.PredicateType, bundleOpts.OCIRemoteOpts...)
 }
 
-// WriteNewBundleWithSigningConfig uses signing config and trusted root to fetch responses from services for the bundle and writes the bundle to the OCI remote layer.
-func WriteNewBundleWithSigningConfig(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) error {
-	keypair, sv, certBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
-	defer func() {
-		if sv != nil {
-			sv.Close()
-		}
-	}()
+// NewAttestationBundle uses signing config and trusted root to sign an attestation and create a bundle.
+func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) ([]byte, crypto.PublicKey, string, pb_go_v1.HashAlgorithm, error) {
+	keypair, certBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
 	if err != nil {
-		return fmt.Errorf("getting keypair and token: %w", err)
+		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting keypair and token: %w", err)
+	}
+	if closer, ok := keypair.(interface{ Close() }); ok {
+		defer closer.Close()
 	}
 
 	content := &sign.DSSEData{
@@ -528,92 +471,29 @@ func WriteNewBundleWithSigningConfig(ctx context.Context, ko options.KeyOpts, ce
 	if ko.TSAClientCACert != "" || (ko.TSAClientCert != "" && ko.TSAClientKey != "") {
 		tsaClientTransport, err = client.GetHTTPTransport(ko.TSAClientCACert, ko.TSAClientCert, ko.TSAClientKey, ko.TSAServerName, 30*time.Second)
 		if err != nil {
-			return fmt.Errorf("getting TSA client transport: %w", err)
+			return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting TSA client transport: %w", err)
 		}
 	}
 	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
 
 	bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, signingConfig, trustedMaterial, signOpts)
 	if err != nil {
-		return fmt.Errorf("signing bundle: %w", err)
+		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("signing bundle: %w", err)
 	}
 
-	if bundleOpts.BundlePath != "" {
-		if err := os.WriteFile(bundleOpts.BundlePath, bundle, 0600); err != nil {
-			return fmt.Errorf("creating bundle file: %w", err)
-		}
-		ui.Infof(ctx, "Wrote bundle to file %s", bundleOpts.BundlePath)
-		return nil
+	pubKeyPem, err := keypair.GetPublicKeyPem()
+	if err != nil {
+		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting public key pem: %w", err)
 	}
-	if !bundleOpts.Upload {
-		return nil
-	}
-	return ociremote.WriteAttestationNewBundleFormat(bundleOpts.Digest, bundle, bundleOpts.PredicateType, bundleOpts.OCIRemoteOpts...)
+
+	return bundle, keypair.GetPublicKey(), pubKeyPem, keypair.GetHashAlgorithm(), nil
 }
 
-type bundleComponents struct {
-	SV               *SignerVerifier
-	SignedPayload    []byte
-	TimestampBytes   []byte
-	RFC3161Timestamp *cbundle.RFC3161Timestamp
-	SignerBytes      []byte
-	RekorEntry       *models.LogEntryAnon
-}
-
-// GetBundleComponents fetches data needed to compose the bundle or disparate verification material for any signing command.
-func GetBundleComponents(ctx context.Context, cert, certChain string, ko options.KeyOpts, noupload, tlogUpload bool, payload []byte, digest name.Reference, rekorEntryType string) (*bundleComponents, func(), error) { //nolint:revive
-	bc := &bundleComponents{}
-	var err error
-	var closeSV func()
-	bc.SV, closeSV, err = GetSignerVerifier(ctx, cert, certChain, ko)
-	if err != nil {
-		return nil, nil, fmt.Errorf("getting signer: %w", err)
-	}
-	wrapped := dsse.WrapSigner(bc.SV, types.IntotoPayloadType)
-
-	bc.SignedPayload, err = wrapped.SignMessage(bytes.NewReader(payload), signatureoptions.WithContext(ctx))
-	if err != nil {
-		closeSV()
-		return nil, nil, fmt.Errorf("signing: %w", err)
-	}
-	if noupload {
-		return bc, closeSV, nil
-	}
-	// We need to decide what signature to send to the timestamp authority.
-	//
-	// Historically, cosign sent `signedPayload`, which is the entire JSON DSSE
-	// Envelope. However, when sigstore clients are verifying a bundle they
-	// will use the DSSE Sig field, so we choose what signature to send to
-	// the timestamp authority based on our output format.
-	tsaPayload := bc.SignedPayload
-	if ko.NewBundleFormat {
-		tsaPayload, err = cosign.GetDSSESigBytes(bc.SignedPayload)
-		if err != nil {
-			closeSV()
-			return nil, nil, fmt.Errorf("getting DSSE signature: %w", err)
-		}
-	}
-	bc.TimestampBytes, bc.RFC3161Timestamp, err = GetRFC3161Timestamp(tsaPayload, ko)
-	if err != nil {
-		closeSV()
-		return nil, nil, fmt.Errorf("getting timestamp: %w", err)
-	}
-	bc.SignerBytes, err = bc.SV.Bytes(ctx)
-	if err != nil {
-		closeSV()
-		return nil, nil, fmt.Errorf("converting signer to bytes: %w", err)
-	}
-	bc.RekorEntry, err = UploadToTlog(ctx, ko, digest, tlogUpload, bc.SignerBytes, func(r *rekorclient.Rekor, b []byte) (*models.LogEntryAnon, error) {
-		if rekorEntryType == "intoto" {
-			return cosign.TLogUploadInTotoAttestation(ctx, r, bc.SignedPayload, b)
-		}
-		return cosign.TLogUploadDSSEEnvelope(ctx, r, bc.SignedPayload, b)
-	})
-	if err != nil {
-		closeSV()
-		return nil, nil, fmt.Errorf("uploading to tlog: %w", err)
-	}
-	return bc, closeSV, nil
+type BundleComponents struct {
+	Signature         []byte
+	Certificates      []*pb_go_v1.X509Certificate
+	RekorEntries      []*protorekor.TransparencyLogEntry
+	RFC3161Timestamps []*pb_go_v1.RFC3161SignedTimestamp
 }
 
 // ParseOCIReference parses a string reference to an OCI image into a reference, warning if the reference did not include a digest.
@@ -662,7 +542,7 @@ func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpt
 	}
 	// Fetch a trusted root when:
 	// * requesting a certificate and no CT log key is provided to verify an SCT
-	// * using a signing config and signing using sigstore-go
+	// * using a signing config
 	if ((keyRef == "" || issueCertificate) && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "") ||
 		(useSigningConfig || signingConfigPath != "") {
 		if trustedRootPath != "" {
@@ -710,4 +590,182 @@ func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpt
 	}
 
 	return nil
+}
+
+// ExtractComponentsFromProtoBundle extracts the components from a protobuf bundle.
+func ExtractComponentsFromProtoBundle(bundle *protobundle.Bundle) (*BundleComponents, error) {
+	if bundle == nil {
+		return nil, fmt.Errorf("bundle is nil")
+	}
+
+	var sig []byte
+	if dsseEnv := bundle.GetDsseEnvelope(); dsseEnv != nil {
+		var err error
+		sig, err = json.Marshal(dsseEnv)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling dsse envelope: %w", err)
+		}
+	} else if ms := bundle.GetMessageSignature(); ms != nil {
+		sig = ms.GetSignature()
+	}
+
+	if sig == nil {
+		return nil, fmt.Errorf("bundle does not contain a message signature or dsse envelope")
+	}
+
+	bc := &BundleComponents{
+		Signature: sig,
+	}
+
+	if vm := bundle.GetVerificationMaterial(); vm != nil {
+		if chain := vm.GetX509CertificateChain(); chain != nil && len(chain.GetCertificates()) > 0 {
+			bc.Certificates = chain.GetCertificates()
+		} else if cert := vm.GetCertificate(); cert != nil {
+			bc.Certificates = []*pb_go_v1.X509Certificate{cert}
+		}
+		if tlogEntries := vm.GetTlogEntries(); len(tlogEntries) > 0 {
+			bc.RekorEntries = tlogEntries
+		}
+		if tvd := vm.GetTimestampVerificationData(); tvd != nil {
+			if timestamps := tvd.GetRfc3161Timestamps(); len(timestamps) > 0 {
+				bc.RFC3161Timestamps = timestamps
+			}
+		}
+	}
+
+	return bc, nil
+}
+
+// EncodeCertificatesToPEM encodes certificates to PEM format.
+func EncodeCertificatesToPEM(certs []*pb_go_v1.X509Certificate) ([]byte, []byte) {
+	if len(certs) == 0 {
+		return nil, nil
+	}
+
+	var parsedCerts []*x509.Certificate
+	for _, cert := range certs {
+		c, err := x509.ParseCertificate(cert.GetRawBytes())
+		if err != nil {
+			continue
+		}
+		parsedCerts = append(parsedCerts, c)
+	}
+
+	if len(parsedCerts) == 0 {
+		return nil, nil
+	}
+
+	certPem, _ := cryptoutils.MarshalCertificateToPEM(parsedCerts[0])
+	var chainPem []byte
+	if len(parsedCerts) > 1 {
+		chainPem, _ = cryptoutils.MarshalCertificatesToPEM(parsedCerts[1:])
+	}
+	return certPem, chainPem
+}
+
+// RekorBundleFromProtoTlogEntry creates a RekorBundle from a protobuf TransparencyLogEntry.
+func RekorBundleFromProtoTlogEntry(entry *protorekor.TransparencyLogEntry) *cbundle.RekorBundle {
+	return &cbundle.RekorBundle{
+		SignedEntryTimestamp: entry.GetInclusionPromise().GetSignedEntryTimestamp(),
+		Payload: cbundle.RekorPayload{
+			Body:           entry.GetCanonicalizedBody(),
+			IntegratedTime: entry.GetIntegratedTime(),
+			LogIndex:       entry.GetLogIndex(),
+			LogID:          hex.EncodeToString(entry.GetLogId().GetKeyId()),
+		},
+	}
+}
+
+// NewLegacyBundleFromProtoBundleComponents creates a legacy bundle from a protobuf bundle.
+func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents, pubKeyPem string) ([]byte, error) {
+	signedPayload := cosign.LocalSignedPayload{
+		Base64Signature: base64.StdEncoding.EncodeToString(bc.Signature),
+	}
+
+	if len(bc.Certificates) > 0 {
+		certPem, _ := EncodeCertificatesToPEM(bc.Certificates)
+		signedPayload.Cert = base64.StdEncoding.EncodeToString(certPem)
+	} else if pubKeyPem != "" {
+		signedPayload.Cert = base64.StdEncoding.EncodeToString([]byte(pubKeyPem))
+	}
+
+	if len(bc.RekorEntries) > 0 {
+		signedPayload.Bundle = RekorBundleFromProtoTlogEntry(bc.RekorEntries[0])
+	}
+
+	return json.Marshal(signedPayload)
+}
+
+// NewSigningConfigFromKeyOpts creates a signing config from key options.
+// This only supports Rekor v1. Rekor v2 requires a user-provided signing config.
+func NewSigningConfigFromKeyOpts(ko options.KeyOpts, tlogUpload bool) (*root.SigningConfig, error) {
+	var fulcioServices []root.Service
+	if ko.FulcioURL != "" {
+		fulcioServices = append(fulcioServices, root.Service{
+			URL:                 ko.FulcioURL,
+			MajorAPIVersion:     1,
+			ValidityPeriodStart: time.Now(),
+		})
+	}
+
+	var oidcServices []root.Service
+	if ko.OIDCIssuer != "" {
+		oidcServices = append(oidcServices, root.Service{
+			URL:                 ko.OIDCIssuer,
+			MajorAPIVersion:     1,
+			ValidityPeriodStart: time.Now(),
+		})
+	}
+
+	var rekorServices []root.Service
+	var rekorConfig root.ServiceConfiguration
+	if ko.RekorURL != "" && tlogUpload {
+		rekorServices = append(rekorServices, root.Service{
+			URL:                 ko.RekorURL,
+			MajorAPIVersion:     1,
+			ValidityPeriodStart: time.Now(),
+		})
+		rekorConfig = root.ServiceConfiguration{
+			Selector: prototrustroot.ServiceSelector_ANY,
+			Count:    1,
+		}
+	}
+
+	var tsaServices []root.Service
+	var tsaConfig root.ServiceConfiguration
+	if ko.TSAServerURL != "" {
+		tsaServices = append(tsaServices, root.Service{
+			URL:                 ko.TSAServerURL,
+			MajorAPIVersion:     1,
+			ValidityPeriodStart: time.Now(),
+		})
+		tsaConfig = root.ServiceConfiguration{
+			Selector: prototrustroot.ServiceSelector_ANY,
+			Count:    1,
+		}
+	}
+
+	return root.NewSigningConfig(
+		root.SigningConfigMediaType02,
+		fulcioServices,
+		oidcServices,
+		rekorServices,
+		rekorConfig,
+		tsaServices,
+		tsaConfig,
+	)
+}
+
+// ProtoHashAlgoToHash converts a protobuf HashAlgorithm to a crypto.Hash.
+func ProtoHashAlgoToHash(ha pb_go_v1.HashAlgorithm) crypto.Hash {
+	switch ha {
+	case pb_go_v1.HashAlgorithm_SHA2_256:
+		return crypto.SHA256
+	case pb_go_v1.HashAlgorithm_SHA2_384:
+		return crypto.SHA384
+	case pb_go_v1.HashAlgorithm_SHA2_512:
+		return crypto.SHA512
+	default:
+		return crypto.Hash(0)
+	}
 }

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -41,7 +41,6 @@ cosign attest-blob [flags]
       --hash string                      hash of blob in hexadecimal (base16). Used if you want to sign an artifact stored elsewhere and have the hash
   -h, --help                             help for attest-blob
       --identity-token string            identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
-      --insecure-skip-verify             skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                       path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                output bundle in new format that contains all verification material (default true)
       --oidc-client-id string            OIDC client ID for application (default "sigstore")

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -58,7 +58,6 @@ cosign attest [flags]
       --fulcio-url string                                                                        address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for attest
       --identity-token string                                                                    identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
-      --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                                                                        attach a Sigstore bundle using OCI referrers API (default true)

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -40,7 +40,6 @@ cosign sign-blob [flags]
       --fulcio-url string                address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                             help for sign-blob
       --identity-token string            identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
-      --insecure-skip-verify             skip verifying fulcio published to the SCT (this should only be used for testing).
       --key string                       path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                output bundle in new format that contains all verification material (default true)
       --oidc-client-id string            OIDC client ID for application (default "sigstore")

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -84,7 +84,6 @@ cosign sign [flags]
       --fulcio-url string                                                                        address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
       --identity-token string                                                                    identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
-      --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)

--- a/internal/key/svkeypair.go
+++ b/internal/key/svkeypair.go
@@ -135,3 +135,10 @@ func (k *SignerVerifierKeypair) SignData(ctx context.Context, data []byte) ([]by
 	}
 	return sig, digest, nil
 }
+
+// Close closes the underlying SignerVerifier if it has a Close() method.
+func (k *SignerVerifierKeypair) Close() {
+	if closer, ok := k.sv.(interface{ Close() }); ok {
+		closer.Close()
+	}
+}

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -79,11 +79,13 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		keyTrustedMaterial := root.NewTrustedPublicKeyMaterial(func(_ string) (root.TimeConstrainedVerifier, error) {
 			return key, nil
 		})
-		trustedMaterial := &verifyTrustedMaterial{
-			TrustedMaterial:    bundleOpts.TrustedRoot,
-			keyTrustedMaterial: keyTrustedMaterial,
+		if bundleOpts.TrustedRoot != nil {
+			trustedMaterial := &verifyTrustedMaterial{
+				TrustedMaterial:    bundleOpts.TrustedRoot,
+				keyTrustedMaterial: keyTrustedMaterial,
+			}
+			bundleOpts.TrustedRoot = trustedMaterial
 		}
-		bundleOpts.TrustedRoot = trustedMaterial
 	}
 
 	if len(signingConfig.TimestampAuthorityURLs()) != 0 {

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -52,7 +52,7 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 			}
 		}
 	case idToken != "":
-		provider, err := NewFulcioProvider(signingConfig)
+		provider, err := newFulcioProvider(signingConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -184,7 +184,7 @@ func (c *cachingCertProvider) GetCertificate(ctx context.Context, keypair sign.K
 	return c.fetch()
 }
 
-func NewFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvider, error) {
+func newFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvider, error) {
 	if len(signingConfig.FulcioCertificateAuthorityURLs()) == 0 {
 		return nil, fmt.Errorf("no fulcio URLs provided in signing config")
 	}
@@ -201,7 +201,7 @@ func NewFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvi
 }
 
 func NewCachingFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvider, error) {
-	provider, err := NewFulcioProvider(signingConfig)
+	provider, err := newFulcioProvider(signingConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/sigstore/cosign/v3/internal/ui"
@@ -31,7 +32,8 @@ import (
 )
 
 type SignOptions struct {
-	TSAClientTransport http.RoundTripper
+	TSAClientTransport  http.RoundTripper
+	CertificateProvider sign.CertificateProvider
 }
 
 func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, idToken string, cert []byte, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial, opts SignOptions) ([]byte, error) {
@@ -42,20 +44,19 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 	}
 
 	switch {
-	case idToken != "":
-		if len(signingConfig.FulcioCertificateAuthorityURLs()) == 0 {
-			return nil, fmt.Errorf("no fulcio URLs provided in signing config")
+	case opts.CertificateProvider != nil:
+		bundleOpts.CertificateProvider = opts.CertificateProvider
+		if idToken != "" {
+			bundleOpts.CertificateProviderOptions = &sign.CertificateProviderOptions{
+				IDToken: idToken,
+			}
 		}
-		fulcioSvc, err := root.SelectService(signingConfig.FulcioCertificateAuthorityURLs(), sign.FulcioAPIVersions, time.Now())
+	case idToken != "":
+		provider, err := NewFulcioProvider(signingConfig)
 		if err != nil {
 			return nil, err
 		}
-		fulcioOpts := &sign.FulcioOptions{
-			BaseURL: fulcioSvc.URL,
-			Timeout: 30 * time.Second,
-			Retries: 1,
-		}
-		bundleOpts.CertificateProvider = sign.NewFulcio(fulcioOpts)
+		bundleOpts.CertificateProvider = provider
 		bundleOpts.CertificateProviderOptions = &sign.CertificateProviderOptions{
 			IDToken: idToken,
 		}
@@ -166,4 +167,43 @@ func (c *localCertProvider) GetCertificate(_ context.Context, _ sign.Keypair, _ 
 		return nil, fmt.Errorf("could not decode cert")
 	}
 	return certBlock.Bytes, nil
+}
+
+type cachingCertProvider struct {
+	provider sign.CertificateProvider
+	once     sync.Once
+	fetch    func() ([]byte, error)
+}
+
+func (c *cachingCertProvider) GetCertificate(ctx context.Context, keypair sign.Keypair, opts *sign.CertificateProviderOptions) ([]byte, error) {
+	c.once.Do(func() {
+		c.fetch = sync.OnceValues(func() ([]byte, error) {
+			return c.provider.GetCertificate(ctx, keypair, opts)
+		})
+	})
+	return c.fetch()
+}
+
+func NewFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvider, error) {
+	if len(signingConfig.FulcioCertificateAuthorityURLs()) == 0 {
+		return nil, fmt.Errorf("no fulcio URLs provided in signing config")
+	}
+	fulcioSvc, err := root.SelectService(signingConfig.FulcioCertificateAuthorityURLs(), sign.FulcioAPIVersions, time.Now())
+	if err != nil {
+		return nil, err
+	}
+	fulcioOpts := &sign.FulcioOptions{
+		BaseURL: fulcioSvc.URL,
+		Timeout: 30 * time.Second,
+		Retries: 1,
+	}
+	return sign.NewFulcio(fulcioOpts), nil
+}
+
+func NewCachingFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvider, error) {
+	provider, err := NewFulcioProvider(signingConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &cachingCertProvider{provider: provider}, nil
 }

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -200,6 +200,9 @@ func newFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvi
 	return sign.NewFulcio(fulcioOpts), nil
 }
 
+// NewCachingFulcioProvider creates a caching Fulcio provider from the given signing config.
+// This function should not be used in long-running processes, as the certificate will
+// expire.
 func NewCachingFulcioProvider(signingConfig *root.SigningConfig) (sign.CertificateProvider, error) {
 	provider, err := newFulcioProvider(signingConfig)
 	if err != nil {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -4735,6 +4735,82 @@ func TestSignVerifyMultipleIdentities(t *testing.T) {
 	must(verify(pubKeyPath, imgName, true, nil, "", false), t)
 }
 
+func TestSignVerifyMultipleIdentitiesKeyless(t *testing.T) {
+	td := t.TempDir()
+
+	// set up SIGSTORE_ variables to point to keys for the local instances
+	err := setLocalEnv(t, td)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// unset the roots that were generated for timestamp signing, they won't work here
+	err = fulcioroots.ReInit()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo, stop := reg(t)
+	defer stop()
+
+	imgName := path.Join(repo, "cosign-e2e")
+
+	imgRef, _, cleanup := mkimage(t, imgName)
+	defer cleanup()
+
+	identityToken, err := getOIDCToken()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify should fail at first
+	issuer := os.Getenv("ISSUER_URL")
+	verifyCmd := cliverify.VerifyCommand{
+		CertVerifyOptions: options.CertVerifyOptions{
+			CertOidcIssuer: issuer,
+			CertIdentity:   certID,
+		},
+		RekorURL:    rekorURL,
+		CheckClaims: true,
+	}
+	mustErr(verifyCmd.Exec(t.Context(), []string{imgName}), t)
+
+	// Now sign the image with multiple container identities
+	ko := options.KeyOpts{
+		FulcioURL:        fulcioURL,
+		RekorURL:         rekorURL,
+		IDToken:          identityToken,
+		SkipConfirmation: true,
+	}
+	so := options.SignOptions{
+		Upload:                  true,
+		TlogUpload:              true,
+		SignContainerIdentities: []string{"registry/cosign-e2e:tag1", "registry/cosign-e2e:tag2"},
+	}
+	must(sign.SignCmd(t.Context(), ro, ko, so, []string{imgName}), t)
+
+	// Now verify should work
+	must(verifyCmd.Exec(t.Context(), []string{imgName}), t)
+
+	// Fetch signatures and check if certificates are identical
+	si, err := ociremote.SignedEntity(imgRef)
+	must(err, t)
+	sigs, err := si.Signatures()
+	must(err, t)
+	gottenSigs, err := sigs.Get()
+	must(err, t)
+
+	assert.Len(t, gottenSigs, 2, "expected 2 signatures")
+
+	cert1, err := gottenSigs[0].Cert()
+	must(err, t)
+	cert2, err := gottenSigs[1].Cert()
+	must(err, t)
+
+	// Compare raw bytes of certificates to ensure they are the same
+	assert.Equal(t, cert1.Raw, cert2.Raw, "expected certificates to be identical")
+}
+
 func TestTree(t *testing.T) {
 	repo, stop := reg(t)
 	defer stop()

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -657,19 +657,8 @@ func TestSignVerifyWithTUFMirror(t *testing.T) {
 	tests := []struct {
 		name          string
 		targets       []targetInfo
-		wantSignErr   bool
 		wantVerifyErr bool
 	}{
-		{
-			name: "invalid CT key name with no usage",
-			targets: []targetInfo{
-				{
-					name:   "ct.pub",
-					source: ctLogKey,
-				},
-			},
-			wantSignErr: true,
-		},
 		{
 			name: "standard key names",
 			targets: []targetInfo{
@@ -819,10 +808,6 @@ func TestSignVerifyWithTUFMirror(t *testing.T) {
 				SkipConfirmation: true,
 			}
 			gotErr := sign.SignCmd(ctx, ro, ko, so, []string{imgName})
-			if test.wantSignErr {
-				mustErr(gotErr, t)
-				return
-			}
 			must(gotErr, t)
 
 			// Verify an image
@@ -856,11 +841,7 @@ func TestSignVerifyWithTUFMirror(t *testing.T) {
 			ko.BundlePath = bundlePath
 			ko.RFC3161TimestampPath = tsPath
 			_, gotErr = sign.SignBlobCmd(ctx, ro, ko, bp, "", "", true, "", "", true)
-			if test.wantSignErr {
-				mustErr(gotErr, t)
-			} else {
-				must(gotErr, t)
-			}
+			must(gotErr, t)
 
 			// Verify a blob
 			verifyBlobCmd := cliverify.VerifyBlobCmd{


### PR DESCRIPTION
Closes #4570

#### Summary

This change refactors the signing path in all signing and attestation commands such that all signing events occur via sigstore-go, not just those in which a signing config is used. 

#### Release Note

In cases where a signing config is not used, a signing config is constructed using TUF- or flag-provided URLs. When a legacy bundle is requested, a legacy bundle is constructed from the new-format bundle provided by sigstore-go.