### PR TITLE
Support mTLS for TSA clients when using a signing config

### DIFF
--- a/internal/pkg/cosign/tsa/client/client.go
+++ b/internal/pkg/cosign/tsa/client/client.go
@@ -54,7 +54,7 @@ type TimestampAuthorityClientImpl struct {
 
 const defaultTimeout = 10 * time.Second
 
-func getHTTPTransport(cacertFilename, certFilename, keyFilename, serverName string, timeout time.Duration) (http.RoundTripper, error) {
+func GetHTTPTransport(cacertFilename, certFilename, keyFilename, serverName string, timeout time.Duration) (http.RoundTripper, error) {
 	if timeout == 0 {
 		timeout = defaultTimeout
 	}
@@ -123,7 +123,7 @@ func (t *TimestampAuthorityClientImpl) GetTimestampResponse(tsq []byte) ([]byte,
 
 	// if mTLS-related fields are set, create a custom Transport for the Client
 	if t.CACert != "" || t.Cert != "" {
-		tr, err := getHTTPTransport(t.CACert, t.Cert, t.Key, t.ServerName, t.Timeout)
+		tr, err := GetHTTPTransport(t.CACert, t.Cert, t.Key, t.ServerName, t.Timeout)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Partially addresses #4570

#### Summary

This change adds support for using mTLS to connect to a TSA client via sigstore-go when signing with a signing config.