### PR TITLE
Fix bundle verify path for old bundle/trusted root (GHSA-whqx-f9j3-ch6m)

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1213,49 +1213,12 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, errors.New("no trusted rekor public keys provided")
 	}
 
-	if co.TrustedMaterial != nil {
-		payload := bundle.Payload
-		logID, err := hex.DecodeString(payload.LogID)
-		if err != nil {
-			return false, fmt.Errorf("decoding log ID: %w", err)
-		}
-		body, _ := base64.StdEncoding.DecodeString(payload.Body.(string))
-		entry, err := tlog.NewEntry(body, payload.IntegratedTime, payload.LogIndex, logID, bundle.SignedEntryTimestamp, nil)
-		if err != nil {
-			return false, fmt.Errorf("converting tlog entry: %w", err)
-		}
-		if err := tlog.VerifySET(entry, co.TrustedMaterial.RekorLogs()); err != nil {
-			return false, fmt.Errorf("verifying bundle with trusted root: %w", err)
-		}
-		return true, nil
-	}
-	// Make sure all the rekorPubKeys are ecsda.PublicKeys
-	for k, v := range co.RekorPubKeys.Keys {
-		if _, ok := v.PubKey.(*ecdsa.PublicKey); !ok {
-			return false, fmt.Errorf("rekor Public key for LogID %s is not type ecdsa.PublicKey", k)
-		}
-	}
-
 	if err := compareSigs(bundle.Payload.Body.(string), sig); err != nil {
 		return false, err
 	}
 
 	if err := comparePublicKey(bundle.Payload.Body.(string), sig, co); err != nil {
 		return false, err
-	}
-
-	pubKey, ok := co.RekorPubKeys.Keys[bundle.Payload.LogID]
-	if !ok {
-		return false, &VerificationFailure{
-			fmt.Errorf("verifying bundle: rekor log public key not found for payload"),
-		}
-	}
-	err = VerifySET(bundle.Payload, bundle.SignedEntryTimestamp, pubKey.PubKey.(*ecdsa.PublicKey))
-	if err != nil {
-		return false, err
-	}
-	if pubKey.Status != tuf.Active {
-		fmt.Fprintf(os.Stderr, "**Info** Successfully verified Rekor entry using an expired verification key\n")
 	}
 
 	payload, err := sig.Payload()
@@ -1279,6 +1242,45 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 	} else if bundlehash != payloadHash {
 		return false, fmt.Errorf("matching bundle to payload: bundle=%q, payload=%q", bundlehash, payloadHash)
 	}
+
+	if co.TrustedMaterial != nil {
+		payload := bundle.Payload
+		logID, err := hex.DecodeString(payload.LogID)
+		if err != nil {
+			return false, fmt.Errorf("decoding log ID: %w", err)
+		}
+		body, _ := base64.StdEncoding.DecodeString(payload.Body.(string))
+		entry, err := tlog.NewEntry(body, payload.IntegratedTime, payload.LogIndex, logID, bundle.SignedEntryTimestamp, nil)
+		if err != nil {
+			return false, fmt.Errorf("converting tlog entry: %w", err)
+		}
+		if err := tlog.VerifySET(entry, co.TrustedMaterial.RekorLogs()); err != nil {
+			return false, fmt.Errorf("verifying bundle with trusted root: %w", err)
+		}
+
+		return true, nil
+	}
+	// Make sure all the rekorPubKeys are ecsda.PublicKeys
+	for k, v := range co.RekorPubKeys.Keys {
+		if _, ok := v.PubKey.(*ecdsa.PublicKey); !ok {
+			return false, fmt.Errorf("rekor Public key for LogID %s is not type ecdsa.PublicKey", k)
+		}
+	}
+
+	pubKey, ok := co.RekorPubKeys.Keys[bundle.Payload.LogID]
+	if !ok {
+		return false, &VerificationFailure{
+			fmt.Errorf("verifying bundle: rekor log public key not found for payload"),
+		}
+	}
+	err = VerifySET(bundle.Payload, bundle.SignedEntryTimestamp, pubKey.PubKey.(*ecdsa.PublicKey))
+	if err != nil {
+		return false, err
+	}
+	if pubKey.Status != tuf.Active {
+		fmt.Fprintf(os.Stderr, "**Info** Successfully verified Rekor entry using an expired verification key\n")
+	}
+
 	return true, nil
 }
 


### PR DESCRIPTION
Ensure the bundle signature and key are compared to the rekor entry every time, not just when trusted root is used. Sigstore-go's VerifySET does not do this full comparison, we'd need to go through one of the more comprehensive Verify* functions to get this level of verification from the library.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
