### PR TITLE
Fix bundle verify path for old bundle/trusted root (GHSA-whqx-f9j3-ch6m)

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1202,49 +1202,12 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, errors.New("no trusted rekor public keys provided")
 	}
 
-	if co.TrustedMaterial != nil {
-		payload := bundle.Payload
-		logID, err := hex.DecodeString(payload.LogID)
-		if err != nil {
-			return false, fmt.Errorf("decoding log ID: %w", err)
-		}
-		body, _ := base64.StdEncoding.DecodeString(payload.Body.(string))
-		entry, err := tlog.NewEntry(body, payload.IntegratedTime, payload.LogIndex, logID, bundle.SignedEntryTimestamp, nil)
-		if err != nil {
-			return false, fmt.Errorf("converting tlog entry: %w", err)
-		}
-		if err := tlog.VerifySET(entry, co.TrustedMaterial.RekorLogs()); err != nil {
-			return false, fmt.Errorf("verifying bundle with trusted root: %w", err)
-		}
-		return true, nil
-	}
-	// Make sure all the rekorPubKeys are ecsda.PublicKeys
-	for k, v := range co.RekorPubKeys.Keys {
-		if _, ok := v.PubKey.(*ecdsa.PublicKey); !ok {
-			return false, fmt.Errorf("rekor Public key for LogID %s is not type ecdsa.PublicKey", k)
-		}
-	}
-
 	if err := compareSigs(bundle.Payload.Body.(string), sig); err != nil {
 		return false, err
 	}
 
 	if err := comparePublicKey(bundle.Payload.Body.(string), sig, co); err != nil {
 		return false, err
-	}
-
-	pubKey, ok := co.RekorPubKeys.Keys[bundle.Payload.LogID]
-	if !ok {
-		return false, &VerificationFailure{
-			fmt.Errorf("verifying bundle: rekor log public key not found for payload"),
-		}
-	}
-	err = VerifySET(bundle.Payload, bundle.SignedEntryTimestamp, pubKey.PubKey.(*ecdsa.PublicKey))
-	if err != nil {
-		return false, err
-	}
-	if pubKey.Status != tuf.Active {
-		fmt.Fprintf(os.Stderr, "**Info** Successfully verified Rekor entry using an expired verification key\n")
 	}
 
 	payload, err := sig.Payload()
@@ -1268,6 +1231,45 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 	} else if bundlehash != payloadHash {
 		return false, fmt.Errorf("matching bundle to payload: bundle=%q, payload=%q", bundlehash, payloadHash)
 	}
+
+	if co.TrustedMaterial != nil {
+		payload := bundle.Payload
+		logID, err := hex.DecodeString(payload.LogID)
+		if err != nil {
+			return false, fmt.Errorf("decoding log ID: %w", err)
+		}
+		body, _ := base64.StdEncoding.DecodeString(payload.Body.(string))
+		entry, err := tlog.NewEntry(body, payload.IntegratedTime, payload.LogIndex, logID, bundle.SignedEntryTimestamp, nil)
+		if err != nil {
+			return false, fmt.Errorf("converting tlog entry: %w", err)
+		}
+		if err := tlog.VerifySET(entry, co.TrustedMaterial.RekorLogs()); err != nil {
+			return false, fmt.Errorf("verifying bundle with trusted root: %w", err)
+		}
+
+		return true, nil
+	}
+	// Make sure all the rekorPubKeys are ecsda.PublicKeys
+	for k, v := range co.RekorPubKeys.Keys {
+		if _, ok := v.PubKey.(*ecdsa.PublicKey); !ok {
+			return false, fmt.Errorf("rekor Public key for LogID %s is not type ecdsa.PublicKey", k)
+		}
+	}
+
+	pubKey, ok := co.RekorPubKeys.Keys[bundle.Payload.LogID]
+	if !ok {
+		return false, &VerificationFailure{
+			fmt.Errorf("verifying bundle: rekor log public key not found for payload"),
+		}
+	}
+	err = VerifySET(bundle.Payload, bundle.SignedEntryTimestamp, pubKey.PubKey.(*ecdsa.PublicKey))
+	if err != nil {
+		return false, err
+	}
+	if pubKey.Status != tuf.Active {
+		fmt.Fprintf(os.Stderr, "**Info** Successfully verified Rekor entry using an expired verification key\n")
+	}
+
 	return true, nil
 }
 

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -731,6 +731,84 @@ func TestVerifyImageSignatureWithSigVerifierAndRekorTSA(t *testing.T) {
 	}
 }
 
+func TestVerifyImageSignatureWithMismatchedBundleAndTrustedRoot(t *testing.T) {
+	ctx := context.Background()
+	var ca root.FulcioCertificateAuthority
+	rootCert, rootKey, _ := test.GenerateRootCa()
+	ca.Root = rootCert
+	sv, _, err := signature.NewECDSASignerVerifier(elliptic.P256(), rand.Reader, crypto.SHA256)
+	if err != nil {
+		t.Fatalf("creating signer: %v", err)
+	}
+
+	leafCert, privKey, _ := test.GenerateLeafCert("subject@mail.com", "oidc-issuer", rootCert, rootKey)
+	pemLeaf := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCert.Raw})
+
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(rootCert)
+
+	payload := []byte{1, 2, 3, 4}
+	h := sha256.Sum256(payload)
+	signature1, _ := privKey.Sign(rand.Reader, h[:], crypto.SHA256)
+
+	// Create a fake bundle
+	pe, _ := proposedEntries(base64.StdEncoding.EncodeToString(signature1), payload, pemLeaf)
+	entry, _ := rtypes.UnmarshalEntry(pe[0])
+	leaf, _ := entry.Canonicalize(ctx)
+	rekorBundle := CreateTestBundle(ctx, t, sv, leaf)
+	pemBytes, _ := cryptoutils.MarshalPublicKeyToPEM(sv.Public())
+	rekorPubKeys := NewTrustedTransparencyLogPubKeys()
+	rekorPubKeys.AddTransparencyLogPubKey(pemBytes, tuf.Active)
+
+	tlogs := make(map[string]*root.TransparencyLog)
+	for k, v := range rekorPubKeys.Keys {
+		tlogs[k] = &root.TransparencyLog{PublicKey: v.PubKey, HashFunc: crypto.SHA256, ValidityPeriodStart: time.Now().Add(-1 * time.Minute)}
+	}
+
+	trustedRoot, err := root.NewTrustedRoot(root.TrustedRootMediaType01, []root.CertificateAuthority{&ca}, nil, nil, tlogs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a different bundle for a different signature
+	signature2, _ := privKey.Sign(rand.Reader, h[:], crypto.SHA256)
+	pe2, _ := proposedEntries(base64.StdEncoding.EncodeToString(signature2), payload, pemLeaf)
+	entry2, _ := rtypes.UnmarshalEntry(pe2[0])
+	leaf2, _ := entry2.Canonicalize(ctx)
+	rekorBundle2 := CreateTestBundle(ctx, t, sv, leaf2)
+
+	opts := []static.Option{static.WithCertChain(pemLeaf, []byte{}), static.WithBundle(rekorBundle2)}
+	// Create a signed entity for the original signature but with the wrong bundle for that signature
+	ociSig, _ := static.NewSignature(payload, base64.StdEncoding.EncodeToString(signature1), opts...)
+
+	_, err = VerifyImageSignature(context.TODO(), ociSig, v1.Hash{},
+		&CheckOpts{
+			RootCerts:       rootPool,
+			IgnoreSCT:       true,
+			Identities:      []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
+			TrustedMaterial: trustedRoot})
+	if err == nil || !strings.Contains(err.Error(), "signature in bundle does not match signature being verified") {
+		t.Fatalf("expected error for mismatched signature and bundle, got %v", err)
+	}
+
+	// Create a signed entity with a different key from the bundle
+	leafCert2, _, _ := test.GenerateLeafCert("subject@mail.com", "oidc-issuer", rootCert, rootKey)
+	pemLeaf2 := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCert2.Raw})
+
+	opts = []static.Option{static.WithCertChain(pemLeaf2, []byte{}), static.WithBundle(rekorBundle)}
+	ociSig, _ = static.NewSignature(payload, base64.StdEncoding.EncodeToString(signature1), opts...)
+
+	_, err = VerifyImageSignature(context.TODO(), ociSig, v1.Hash{},
+		&CheckOpts{
+			RootCerts:       rootPool,
+			IgnoreSCT:       true,
+			Identities:      []Identity{{Subject: "subject@mail.com", Issuer: "oidc-issuer"}},
+			TrustedMaterial: trustedRoot})
+	if err == nil || !strings.Contains(err.Error(), "error verifying bundle: comparing public key PEMs") {
+		t.Fatal(err)
+	}
+}
+
 func TestValidateAndUnpackCertSuccess(t *testing.T) {
 	subject := "email@email"
 	oidcIssuer := "https://accounts.google.com"


### PR DESCRIPTION
Ensure the bundle signature and key are compared to the rekor entry every time, not just when trusted root is used. Sigstore-go's VerifySET does not do this full comparison, we'd need to go through one of the more comprehensive Verify* functions to get this level of verification from the library.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
