### PR TITLE
Add origin key for ctfe trusted root

### DIFF
--- a/cmd/cosign/cli/options/trustedroot.go
+++ b/cmd/cosign/cli/options/trustedroot.go
@@ -53,7 +53,7 @@ func (o *TrustedRootCreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringArrayVar(&o.Fulcio, "fulcio", nil,
 		"fulcio service specification, as a comma-separated key-value list.\nRequired keys: url, certificate-chain (path to PEM-encoded certificate chain). Optional keys: start-time, end-time.")
 	cmd.Flags().StringArrayVar(&o.CTFE, "ctfe", nil,
-		"ctfe service specification, as a comma-separated key-value list.\nRequired keys: url, public-key (path to PEM-encoded public key), start-time. Optional keys: end-time.")
+		"ctfe service specification, as a comma-separated key-value list.\nRequired keys: url, public-key (path to PEM-encoded public key), start-time. Optional keys: end-time, origin.")
 	cmd.Flags().StringArrayVar(&o.TSA, "tsa", nil,
 		"timestamping authority specification, as a comma-separated key-value list.\nRequired keys: url, certificate-chain (path to PEM-encoded certificate chain). Optional keys: start-time, end-time.")
 	cmd.Flags().StringArrayVar(&o.Rekor, "rekor", nil,

--- a/cmd/cosign/cli/trustedroot/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot.go
@@ -144,6 +144,14 @@ func (c *CreateCmd) Exec(_ context.Context) error {
 			if err != nil {
 				return fmt.Errorf("parsing ctfe spec: %w", err)
 			}
+			// Static CT needs origin for checkpoint ID
+			kvs, _ := parseKVs(spec)
+			if origin, ok := kvs["origin"]; ok {
+				id, ctLog.ID, err = getCheckpointID(origin, ctLog.PublicKey)
+				if err != nil {
+					return err
+				}
+			}
 			ctLogs[id] = ctLog
 		}
 	} else if deprecatedCTFEFlagsUsed {

--- a/cmd/cosign/cli/trustedroot/trustedroot_test.go
+++ b/cmd/cosign/cli/trustedroot/trustedroot_test.go
@@ -151,12 +151,13 @@ func TestCreateCmd(t *testing.T) {
 	rekorV1Spec := fmt.Sprintf("url=https://rekor.sigstore.example,public-key=%s,start-time=%s,end-time=%s", rekorV1KeyPath, startTime, endTime)
 	rekorV2Spec := fmt.Sprintf("url=https://rekor.sigstore.example,public-key=%s,start-time=%s,origin=rekor-v2.sigstore.example", rekorV2KeyPath, startTime)
 	ctfeSpec := fmt.Sprintf("url=https://ctfe.sigstore.example,public-key=%s,start-time=%s", ctfeKeyPath, startTime)
+	ctfeV2Spec := fmt.Sprintf("url=https://ctfe.sigstore.example,public-key=%s,start-time=%s,origin=ctfe.sigstore.example", ctfeKeyPath, startTime)
 
 	trustedrootCreate := CreateCmd{
 		FulcioSpecs: []string{fulcioSpec},
 		RekorSpecs:  []string{rekorV1Spec, rekorV2Spec},
 		TSASpecs:    []string{tsaSpec},
-		CTFESpecs:   []string{ctfeSpec},
+		CTFESpecs:   []string{ctfeSpec, ctfeV2Spec},
 		Out:         outPath,
 	}
 
@@ -186,7 +187,7 @@ func TestCreateCmd(t *testing.T) {
 	}
 
 	ctfeLogs := tr.CTLogs()
-	if len(ctfeLogs) != 1 {
+	if len(ctfeLogs) != 2 {
 		t.Fatalf("unexpected number of ctfe logs: %d", len(ctfeLogs))
 	}
 

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -27,7 +27,7 @@ cosign trusted-root create \
 
 ```
       --ctfe stringArray        ctfe service specification, as a comma-separated key-value list.
-                                Required keys: url, public-key (path to PEM-encoded public key), start-time. Optional keys: end-time.
+                                Required keys: url, public-key (path to PEM-encoded public key), start-time. Optional keys: end-time, origin.
       --fulcio stringArray      fulcio service specification, as a comma-separated key-value list.
                                 Required keys: url, certificate-chain (path to PEM-encoded certificate chain). Optional keys: start-time, end-time.
   -h, --help                    help for create


### PR DESCRIPTION
Static CT, like Rekor v2, needs the origin string of the log server to create a verifier, so include it when generating the trusted root.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
