### PR TITLE
docs(cosign): clarify RFC3161 revocation semantics

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1324,8 +1324,7 @@ func (s *sigContent) MessageSignatureContent() verify.MessageSignatureContent {
 // no root is provided with a timestamp.
 //
 // Note: This function does not perform CRL/OCSP certificate revocation checks.
-// Sigstore's default workflow relies on TUF-distributed trust material + validity metadata for revocation.
-// Private PKI deployments should enforce additional revocation policy as needed.
+// Callers are responsible for validating the TSA certificate and trusted material provided via CheckOpts according to their policy.
 func VerifyRFC3161Timestamp(sig oci.Signature, co *CheckOpts) (*timestamp.Timestamp, error) {
 	ts, err := sig.RFC3161Timestamp()
 	switch {


### PR DESCRIPTION
#### Summary

Add a short note to `VerifyRFC3161Timestamp` clarifying that RFC3161 timestamp verification does not perform CRL/OCSP revocation checks, and that Sigstore's default workflow relies on TUF-distributed trust material + validity metadata for revocation.

#### Release Note

NONE

#### Documentation

N/A (doc comment only)
