### PR TITLE
fix: avoid panic on malformed tlog entries

### DIFF
--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -495,6 +495,9 @@ func VerifyTLogEntryOffline(ctx context.Context, e *models.LogEntryAnon, rekorPu
 	if e.Verification == nil || e.Verification.InclusionProof == nil {
 		return errors.New("inclusion proof not provided")
 	}
+	if e.Verification.InclusionProof.RootHash == nil || e.Verification.InclusionProof.LogIndex == nil || e.Verification.InclusionProof.TreeSize == nil {
+		return errors.New("inclusion proof fields not provided")
+	}
 
 	if trustedMaterial == nil && (rekorPubKeys == nil || rekorPubKeys.Keys == nil) {
 		return errors.New("no trusted rekor public keys provided")
@@ -507,7 +510,11 @@ func VerifyTLogEntryOffline(ctx context.Context, e *models.LogEntryAnon, rekorPu
 	}
 
 	rootHash, _ := hex.DecodeString(*e.Verification.InclusionProof.RootHash)
-	entryBytes, err := base64.StdEncoding.DecodeString(e.Body.(string))
+	bodyStr, ok := e.Body.(string)
+	if !ok {
+		return fmt.Errorf("invalid body type: expected string, got %T", e.Body)
+	}
+	entryBytes, err := base64.StdEncoding.DecodeString(bodyStr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- avoid panic on malformed VerifyTLogEntryOffline inputs by returning errors
- add regression test to ensure malformed inputs do not panic
- no behavior change for valid inputs