### PR TITLE
fix: avoid panic on malformed bundle payload

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1213,11 +1213,16 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, errors.New("no trusted rekor public keys provided")
 	}
 
-	if err := compareSigs(bundle.Payload.Body.(string), sig); err != nil {
+	bodyStr, ok := bundle.Payload.Body.(string)
+	if !ok {
+		return false, fmt.Errorf("invalid bundle: payload body is not a string (got %T)", bundle.Payload.Body)
+	}
+
+	if err := compareSigs(bodyStr, sig); err != nil {
 		return false, err
 	}
 
-	if err := comparePublicKey(bundle.Payload.Body.(string), sig, co); err != nil {
+	if err := comparePublicKey(bodyStr, sig, co); err != nil {
 		return false, err
 	}
 
@@ -1230,7 +1235,7 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 		return false, fmt.Errorf("reading base64signature: %w", err)
 	}
 
-	alg, bundlehash, err := bundleHash(bundle.Payload.Body.(string), signature)
+	alg, bundlehash, err := bundleHash(bodyStr, signature)
 	if err != nil {
 		return false, fmt.Errorf("computing bundle hash: %w", err)
 	}
@@ -1249,7 +1254,7 @@ func VerifyBundle(sig oci.Signature, co *CheckOpts) (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("decoding log ID: %w", err)
 		}
-		body, _ := base64.StdEncoding.DecodeString(payload.Body.(string))
+		body, _ := base64.StdEncoding.DecodeString(bodyStr)
 		entry, err := tlog.NewEntry(body, payload.IntegratedTime, payload.LogIndex, logID, bundle.SignedEntryTimestamp, nil)
 		if err != nil {
 			return false, fmt.Errorf("converting tlog entry: %w", err)

--- a/pkg/cosign/verify_bundle_panic_test.go
+++ b/pkg/cosign/verify_bundle_panic_test.go
@@ -1,0 +1,91 @@
+package cosign
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
+	"github.com/sigstore/cosign/v3/pkg/oci"
+)
+
+type bundleSignatureStub struct {
+	bundle *bundle.RekorBundle
+}
+
+func (bss *bundleSignatureStub) Annotations() (map[string]string, error) {
+	return map[string]string{}, nil
+}
+func (bss *bundleSignatureStub) Payload() ([]byte, error)         { return []byte{}, nil }
+func (bss *bundleSignatureStub) Signature() ([]byte, error)       { return []byte{}, nil }
+func (bss *bundleSignatureStub) Base64Signature() (string, error) { return "", nil }
+func (bss *bundleSignatureStub) Cert() (*x509.Certificate, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+func (bss *bundleSignatureStub) Chain() ([]*x509.Certificate, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+func (bss *bundleSignatureStub) Bundle() (*bundle.RekorBundle, error) { return bss.bundle, nil }
+func (bss *bundleSignatureStub) RFC3161Timestamp() (*bundle.RFC3161Timestamp, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+func (bss *bundleSignatureStub) Digest() (v1.Hash, error) {
+	return v1.Hash{}, fmt.Errorf("unimplemented")
+}
+func (bss *bundleSignatureStub) DiffID() (v1.Hash, error) {
+	return v1.Hash{}, fmt.Errorf("unimplemented")
+}
+func (bss *bundleSignatureStub) Compressed() (io.ReadCloser, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+func (bss *bundleSignatureStub) Uncompressed() (io.ReadCloser, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+func (bss *bundleSignatureStub) Size() (int64, error) { return 0, fmt.Errorf("unimplemented") }
+func (bss *bundleSignatureStub) MediaType() (types.MediaType, error) {
+	return types.DockerConfigJSON, fmt.Errorf("unimplemented")
+}
+
+var _ oci.Signature = (*bundleSignatureStub)(nil)
+
+func TestVerifyBundleRejectsMalformedBundleBodyWithoutPanic(t *testing.T) {
+	rekorPubKeys := NewTrustedTransparencyLogPubKeys()
+	co := &CheckOpts{RekorPubKeys: &rekorPubKeys}
+
+	tests := []struct {
+		name string
+		body interface{}
+	}{
+		{name: "nil body", body: nil},
+		{name: "object body", body: map[string]interface{}{"k": "v"}},
+		{name: "number body", body: float64(123)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("unexpected panic: %v", r)
+				}
+			}()
+
+			sig := &bundleSignatureStub{
+				bundle: &bundle.RekorBundle{
+					Payload: bundle.RekorPayload{
+						Body:           tt.body,
+						IntegratedTime: 0,
+						LogIndex:       0,
+						LogID:          "",
+					},
+				},
+			}
+
+			if _, err := VerifyBundle(sig, co); err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
- avoid panic on malformed VerifyBundle inputs by returning errors
- add regression test to ensure malformed bundle bodies do not panic
- no behavior change for valid inputs