### PR TITLE
fix: avoid panic on malformed attestation payload

### DIFF
--- a/pkg/policy/attestation.go
+++ b/pkg/policy/attestation.go
@@ -77,13 +77,17 @@ func AttestationToPayloadJSON(_ context.Context, predicateType string, verifiedA
 	}
 
 	var decodedPayload []byte
-	if val, ok := payloadData["payload"]; ok {
-		decodedPayload, err = base64.StdEncoding.DecodeString(val.(string))
-		if err != nil {
-			return nil, "", fmt.Errorf("decoding payload: %w", err)
-		}
-	} else {
+	val, ok := payloadData["payload"]
+	if !ok {
 		return nil, "", fmt.Errorf("could not find payload in payload data")
+	}
+	payloadStr, ok := val.(string)
+	if !ok {
+		return nil, "", fmt.Errorf("invalid payload: payload field is not a string (got %T)", val)
+	}
+	decodedPayload, err = base64.StdEncoding.DecodeString(payloadStr)
+	if err != nil {
+		return nil, "", fmt.Errorf("decoding payload: %w", err)
 	}
 
 	// Only apply the policy against the requested predicate type

--- a/pkg/policy/attestation_test.go
+++ b/pkg/policy/attestation_test.go
@@ -107,6 +107,7 @@ func TestFailures(t *testing.T) {
 	}{{payload: "", wantErrSubstring: "unmarshaling payload data"}, {payload: "{badness", wantErrSubstring: "unmarshaling payload data"},
 		{payload: `{"payloadType":"notmarshallable}`, wantErrSubstring: "unmarshaling payload data"},
 		{payload: `{"payload":"shou!ln'twork"}`, wantErrSubstring: "decoding payload"},
+		{payload: `{"payload":null}`, wantErrSubstring: "payload field is not a string"},
 		{payload: `{"payloadType":"finebutnopayload"}`, wantErrSubstring: "could not find payload"},
 		{payload: invalidTotoStatement, wantErrSubstring: "decoding payload: illegal base64"},
 	}


### PR DESCRIPTION
- avoid panic on malformed AttestationToPayloadJSON inputs by returning errors
- add regression test to ensure non-string payloads do not panic
- no behavior change for valid inputs