### PR TITLE
Verify validity of chain rather than just certificate

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -331,16 +331,18 @@ func verifyOCISignature(ctx context.Context, verifier signature.Verifier, sig pa
 // certificate chains up to a trusted root using intermediate certificate chain coming from CheckOpts.
 // Optionally verifies the subject and issuer of the certificate.
 func ValidateAndUnpackCert(cert *x509.Certificate, co *CheckOpts) (signature.Verifier, error) {
-	return ValidateAndUnpackCertWithIntermediates(cert, co, co.IntermediateCerts)
+	verifier, _, err := ValidateAndUnpackCertWithIntermediates(cert, co, co.IntermediateCerts)
+	return verifier, err
 }
 
 // ValidateAndUnpackCertWithIntermediates creates a Verifier from a certificate. Verifies that the
 // certificate chains up to a trusted root using intermediate cert passed as separate argument.
-// Optionally verifies the subject and issuer of the certificate.
-func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpts, intermediateCerts *x509.CertPool) (signature.Verifier, error) {
+// Optionally verifies the subject and issuer of the certificate. Returns the chain built from the
+// certificate pools. Clients must verify the validity of this chain against a provided timestamp.
+func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpts, intermediateCerts *x509.CertPool) (signature.Verifier, []*x509.Certificate, error) {
 	verifier, err := signature.LoadVerifier(cert.PublicKey, crypto.SHA256)
 	if err != nil {
-		return nil, fmt.Errorf("invalid certificate found on signature: %w", err)
+		return nil, nil, fmt.Errorf("invalid certificate found on signature: %w", err)
 	}
 
 	// Handle certificates where the Subject Alternative Name is not set to a supported
@@ -363,31 +365,37 @@ func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpt
 	var chains [][]*x509.Certificate
 	if co.TrustedMaterial != nil {
 		if chains, err = verify.VerifyLeafCertificate(cert.NotBefore, cert, co.TrustedMaterial); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	} else {
 		// If the trusted root is not available, use the verifiers from cosign (legacy).
 		chains, err = TrustedCert(cert, co.RootCerts, intermediateCerts)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
+	// handle if chains has more than one chain - grab first and print message
+	if len(chains) > 1 {
+		fmt.Fprintf(os.Stderr, "**Info** Multiple valid certificate chains found. Selecting the first for further verification.\n")
+	}
+	chain := chains[0]
+
 	err = CheckCertificatePolicy(cert, co)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// If IgnoreSCT is set, skip the SCT check
 	if co.IgnoreSCT {
-		return verifier, nil
+		return verifier, chains[0], nil
 	}
 	contains, err := ContainsSCT(cert.Raw)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if !contains && len(co.SCT) == 0 {
-		return nil, &VerificationFailure{
+		return nil, nil, &VerificationFailure{
 			fmt.Errorf("certificate does not include required embedded SCT and no detached SCT was set"),
 		}
 	}
@@ -395,38 +403,33 @@ func ValidateAndUnpackCertWithIntermediates(cert *x509.Certificate, co *CheckOpt
 	// If trusted root is available and the SCT is embedded, use the verifiers from sigstore-go (preferred).
 	if co.TrustedMaterial != nil && contains {
 		if err := verify.VerifySignedCertificateTimestamp(chains, 1, co.TrustedMaterial); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		return verifier, nil
+		return verifier, chain, nil
 	}
 
-	// handle if chains has more than one chain - grab first and print message
-	if len(chains) > 1 {
-		fmt.Fprintf(os.Stderr, "**Info** Multiple valid certificate chains found. Selecting the first to verify the SCT.\n")
+	if len(chain) < 2 {
+		return nil, nil, errors.New("certificate chain must contain at least a certificate and its issuer")
 	}
 	if contains {
-		if err := VerifyEmbeddedSCT(context.Background(), chains[0], co.CTLogPubKeys); err != nil {
-			return nil, err
+		if err := VerifyEmbeddedSCT(context.Background(), chain, co.CTLogPubKeys); err != nil {
+			return nil, nil, err
 		}
-		return verifier, nil
-	}
-	chain := chains[0]
-	if len(chain) < 2 {
-		return nil, errors.New("certificate chain must contain at least a certificate and its issuer")
+		return verifier, chain, nil
 	}
 	certPEM, err := cryptoutils.MarshalCertificateToPEM(chain[0])
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	chainPEM, err := cryptoutils.MarshalCertificatesToPEM(chain[1:])
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := VerifySCT(context.Background(), certPEM, chainPEM, co.SCT, co.CTLogPubKeys); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return verifier, nil
+	return verifier, chain, nil
 }
 
 // CheckCertificatePolicy checks that the certificate subject and issuer match
@@ -850,6 +853,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 	}
 
 	verifier := co.SigVerifier
+	var verifierChain []*x509.Certificate
 	if verifier == nil {
 		// If we don't have a public key to check against, we can try a root cert.
 		cert, err := sig.Cert()
@@ -881,10 +885,12 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 		if pool == nil {
 			pool = co.IntermediateCerts
 		}
-		verifier, err = ValidateAndUnpackCertWithIntermediates(cert, co, pool)
+		verifier, chain, err = ValidateAndUnpackCertWithIntermediates(cert, co, pool)
 		if err != nil {
 			return false, err
 		}
+		// Remove the end-entity certificate from the chain, as that will come from sig.Cert()
+		verifierChain = chain[1:]
 	}
 
 	// 1. Perform cryptographic verification of the signature using the certificate's public key.
@@ -910,14 +916,14 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 
 		if acceptableRFC3161Time != nil {
 			// Verify the cert against the timestamp time.
-			if err := CheckExpiry(cert, *acceptableRFC3161Time); err != nil {
+			if err := CheckExpiry(cert, verifierChain, *acceptableRFC3161Time); err != nil {
 				return false, fmt.Errorf("checking expiry on certificate with timestamp: %w", err)
 			}
 			expirationChecked = true
 		}
 
 		if acceptableRekorBundleTime != nil {
-			if err := CheckExpiry(cert, *acceptableRekorBundleTime); err != nil {
+			if err := CheckExpiry(cert, verifierChain, *acceptableRekorBundleTime); err != nil {
 				return false, fmt.Errorf("checking expiry on certificate with bundle: %w", err)
 			}
 			expirationChecked = true
@@ -925,7 +931,7 @@ func verifyInternal(ctx context.Context, sig oci.Signature, h v1.Hash,
 
 		// if no timestamp has been provided, use the current time
 		if !expirationChecked {
-			if err := CheckExpiry(cert, time.Now()); err != nil {
+			if err := CheckExpiry(cert, verifierChain, time.Now()); err != nil {
 				// If certificate is expired and not signed timestamp was provided then error the following message. Otherwise throw an expiration error.
 				if co.IgnoreTlog && acceptableRFC3161Time == nil {
 					return false, &VerificationFailure{
@@ -1169,21 +1175,36 @@ func VerifyImageAttestation(ctx context.Context, atts oci.Signatures, h v1.Hash,
 	return checkedAttestations, bundleVerified, nil
 }
 
-// CheckExpiry confirms the time provided is within the valid period of the cert
-func CheckExpiry(cert *x509.Certificate, it time.Time) error {
+// CheckExpiry confirms the time provided is within the valid period of the certificate and optionally
+// all issuing CA certificates.
+func CheckExpiry(cert *x509.Certificate, issuingChain []*x509.Certificate, it time.Time) error {
 	ft := func(t time.Time) string {
 		return t.Format(time.RFC3339)
 	}
 	if cert.NotAfter.Before(it) {
 		return &VerificationFailure{
-			fmt.Errorf("certificate expired before signatures were entered in log: %s is before %s",
+			fmt.Errorf("certificate expired before observed time: %s is before %s",
 				ft(cert.NotAfter), ft(it)),
 		}
 	}
 	if cert.NotBefore.After(it) {
 		return &VerificationFailure{
-			fmt.Errorf("certificate was issued after signatures were entered in log: %s is after %s",
-				ft(cert.NotAfter), ft(it)),
+			fmt.Errorf("certificate was issued after observed time: %s is after %s",
+				ft(cert.NotBefore), ft(it)),
+		}
+	}
+	for _, c := range issuingChain {
+		if c.NotAfter.Before(it) {
+			return &VerificationFailure{
+				fmt.Errorf("issuing CA certificate expired before observed time: %s is before %s",
+					ft(c.NotAfter), ft(it)),
+			}
+		}
+		if c.NotBefore.After(it) {
+			return &VerificationFailure{
+				fmt.Errorf("issuing CA certificate was issued after observed time: %s is after %s",
+					ft(c.NotBefore), ft(it)),
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
There was an assumption that a certificate would be issued during the validity period of all certificates in its chain. If a certificate was issued such that its NotAfter timestamp was past the NotAfter of another certificate in the chain, that would have not been detected. This is because during verification, we use the leaf certificate's NotBefore timestamp to verify the chain's validity, but check only the leaf certificate's validity against any provided timestamps (either from the Rekor timestamp, a signed timestamp, or the current time).

This scenario is not expected with a typical chain since a CA shouldn't issue a certificate that outlives an issuer.

This change enforces that the entire chain is valid at any of those provided timestamps.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
