### PR TITLE
Automatically require signed timestamp with Rekor v2 entries

### DIFF
--- a/pkg/cosign/verify_bundle.go
+++ b/pkg/cosign/verify_bundle.go
@@ -21,8 +21,11 @@ import (
 	"github.com/sigstore/sigstore-go/pkg/verify"
 )
 
-// VerifyNewBundle verifies a SigstoreBundle with the given parameters
+// VerifyNewBundle verifies a Sigstore bundle with the given parameters
 func VerifyNewBundle(_ context.Context, co *CheckOpts, artifactPolicyOption verify.ArtifactPolicyOption, bundle verify.SignedEntity) (*verify.VerificationResult, error) {
+	if err := rekorV2Bundle(bundle, co); err != nil {
+		return nil, err
+	}
 	trustedMaterial, verifierOptions, policyOptions, err := co.verificationOptions()
 	if err != nil {
 		return nil, err
@@ -32,4 +35,42 @@ func VerifyNewBundle(_ context.Context, co *CheckOpts, artifactPolicyOption veri
 		return nil, err
 	}
 	return verifier.Verify(bundle, verify.NewPolicy(artifactPolicyOption, policyOptions...))
+}
+
+// rekorV2Bundle checks if a bundle contains only Rekor v2 entries, and if so, mandates that
+// a signed timestamp is provided when verifying a certificate. Unlike Rekor v1, Rekor v2 does
+// not provide timestamps, and so when verifying a short-lived certificates, users either explicitly
+// need to specify --use-signed-timestamps, or we'll opportunistically set it here.
+// This check does nothing if users skip transparency log verification or provide a key, since
+// a trusted timestamp is unneeded.
+// If a bundle were to contain both a Rekor v1 and Rekor v2 entry, but with trust material that
+// will only successfully verify the Rekor v1 entry, this would cause a verification failure.
+// Therefore, if we have a mixed bundle, we will do nothing and require that the user explicitly
+// opt in to checking for signed timestamps.
+// There is one edge case that isn't handled - A bundle with a Rekor v2 entry with a certificate
+// that should be validated using the current time rather than a provided timestamp. If someone runs
+// into this, we can add a flag like --use-current-time.
+func rekorV2Bundle(bundle verify.SignedEntity, co *CheckOpts) error {
+	// Without a transparency log entry, users will need to opt in to verifying timestamps.
+	// With a key, there's no need for timestamps.
+	if co.IgnoreTlog || co.SigVerifier != nil {
+		return nil
+	}
+	logEntries, err := bundle.TlogEntries()
+	if err != nil {
+		return err
+	}
+	var hasRekorV1, hasRekorV2 bool
+	for _, logEntry := range logEntries {
+		// Rekor v2 entries do not specify an integrated time
+		if logEntry.IntegratedTime().IsZero() {
+			hasRekorV2 = true
+		} else {
+			hasRekorV1 = true
+		}
+	}
+	if hasRekorV2 && !hasRekorV1 {
+		co.UseSignedTimestamps = true
+	}
+	return nil
 }

--- a/pkg/cosign/verify_bundle_test.go
+++ b/pkg/cosign/verify_bundle_test.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cosign_test
+package cosign
 
 import (
 	"bytes"
@@ -25,11 +25,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"testing"
 
-	"github.com/sigstore/cosign/v3/pkg/cosign"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/testing/ca"
 	"github.com/sigstore/sigstore-go/pkg/tlog"
@@ -89,7 +90,7 @@ func TestVerifyBundle(t *testing.T) {
 
 	identity := "foo@example.com"
 	issuer := "example issuer"
-	standardIdentities := []cosign.Identity{
+	standardIdentities := []Identity{
 		{
 			Issuer:  issuer,
 			Subject: identity,
@@ -108,14 +109,14 @@ func TestVerifyBundle(t *testing.T) {
 
 	for _, tc := range []struct {
 		name                 string
-		checkOpts            *cosign.CheckOpts
+		checkOpts            *CheckOpts
 		artifactPolicyOption verify.ArtifactPolicyOption
 		entity               verify.SignedEntity
 		wantErr              bool
 	}{
 		{
 			name: "valid",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				UseSignedTimestamps: true,
@@ -127,7 +128,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "valid blob signature",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				UseSignedTimestamps: true,
@@ -139,7 +140,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "invalid, wrong artifact",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				UseSignedTimestamps: true,
@@ -151,7 +152,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "invalid blob signature, wrong artifact",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				UseSignedTimestamps: true,
@@ -163,8 +164,8 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "valid, pattern match issuer",
-			checkOpts: &cosign.CheckOpts{
-				Identities: []cosign.Identity{
+			checkOpts: &CheckOpts{
+				Identities: []Identity{
 					{
 						IssuerRegExp: ".*issuer",
 						Subject:      "foo@example.com",
@@ -180,8 +181,8 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "valid, pattern match subject",
-			checkOpts: &cosign.CheckOpts{
-				Identities: []cosign.Identity{
+			checkOpts: &CheckOpts{
+				Identities: []Identity{
 					{
 						Issuer:        "example issuer",
 						SubjectRegExp: ".*@example.com",
@@ -197,8 +198,8 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "invalid, pattern match issuer",
-			checkOpts: &cosign.CheckOpts{
-				Identities: []cosign.Identity{
+			checkOpts: &CheckOpts{
+				Identities: []Identity{
 					{
 						IssuerRegExp: ".* not my issuer",
 						Subject:      "foo@example.com",
@@ -214,8 +215,8 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "invalid, pattern match subject",
-			checkOpts: &cosign.CheckOpts{
-				Identities: []cosign.Identity{
+			checkOpts: &CheckOpts{
+				Identities: []Identity{
 					{
 						Issuer:        "example issuer",
 						SubjectRegExp: ".*@otherexample.com",
@@ -231,7 +232,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "invalid trusted material",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:      standardIdentities,
 				IgnoreSCT:       true,
 				TrustedMaterial: virtualSigstore2,
@@ -242,7 +243,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "do not require tlog, missing tlog",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				IgnoreTlog:          true,
@@ -255,7 +256,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "do not require tsa, missing tsa",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				IgnoreTlog:          false,
@@ -268,7 +269,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "require tlog, missing tlog",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				UseSignedTimestamps: true,
@@ -280,7 +281,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "require SET, missing set",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				IgnoreTlog:          false,
@@ -293,7 +294,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 		{
 			name: "require tsa, missing tsa",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				Identities:          standardIdentities,
 				IgnoreSCT:           true,
 				UseSignedTimestamps: true,
@@ -305,7 +306,7 @@ func TestVerifyBundle(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err = cosign.VerifyNewBundle(context.Background(), tc.checkOpts, tc.artifactPolicyOption, tc.entity)
+			_, err = VerifyNewBundle(context.Background(), tc.checkOpts, tc.artifactPolicyOption, tc.entity)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -362,14 +363,14 @@ func TestVerifyBundleWithSigVerifier(t *testing.T) {
 
 	for _, tc := range []struct {
 		name                 string
-		checkOpts            *cosign.CheckOpts
+		checkOpts            *CheckOpts
 		artifactPolicyOption verify.ArtifactPolicyOption
 		entity               verify.SignedEntity
 		wantErr              bool
 	}{
 		{
 			name: "valid",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				UseSignedTimestamps: true,
 				IgnoreTlog:          true,
 				TrustedMaterial:     virtualSigstore,
@@ -381,7 +382,7 @@ func TestVerifyBundleWithSigVerifier(t *testing.T) {
 		},
 		{
 			name: "invalid, wrong artifact",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				UseSignedTimestamps: true,
 				IgnoreTlog:          true,
 				TrustedMaterial:     virtualSigstore,
@@ -393,7 +394,7 @@ func TestVerifyBundleWithSigVerifier(t *testing.T) {
 		},
 		{
 			name: "invalid, sigverifier not set",
-			checkOpts: &cosign.CheckOpts{
+			checkOpts: &CheckOpts{
 				UseSignedTimestamps: true,
 				IgnoreTlog:          true,
 				TrustedMaterial:     virtualSigstore,
@@ -404,12 +405,116 @@ func TestVerifyBundleWithSigVerifier(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err = cosign.VerifyNewBundle(context.Background(), tc.checkOpts, tc.artifactPolicyOption, tc.entity)
+			_, err = VerifyNewBundle(context.Background(), tc.checkOpts, tc.artifactPolicyOption, tc.entity)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+type mockSignedEntity struct {
+	verify.SignedEntity
+	tlogEntries []*tlog.Entry
+}
+
+func (m *mockSignedEntity) TlogEntries() ([]*tlog.Entry, error) {
+	return m.tlogEntries, nil
+}
+
+type mockVerifierForBundle struct{}
+
+func (m *mockVerifierForBundle) PublicKey(_ ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return nil, nil
+}
+
+func (m *mockVerifierForBundle) VerifySignature(_, _ io.Reader, _ ...signature.VerifyOption) error {
+	return nil
+}
+
+func makeTlogEntry(t *testing.T, integratedTime int64) *tlog.Entry {
+	body := []byte(`{}`)
+	tle := &v1.TransparencyLogEntry{
+		LogIndex: 1,
+		LogId: &protocommon.LogId{
+			KeyId: []byte("ignored"),
+		},
+		KindVersion: &v1.KindVersion{
+			Kind:    "ignored",
+			Version: "ignored",
+		},
+		IntegratedTime:    integratedTime,
+		CanonicalizedBody: body,
+	}
+	entry, err := tlog.NewTlogEntry(tle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return entry
+}
+
+func TestRekorV2Bundle(t *testing.T) {
+	rekorV1Entry := makeTlogEntry(t, 1234567890)
+	rekorV2Entry := makeTlogEntry(t, 0)
+
+	tests := []struct {
+		name                        string
+		co                          *CheckOpts
+		entries                     []*tlog.Entry
+		expectedUseSignedTimestamps bool
+	}{
+		{
+			name: "IgnoreTlog true",
+			co: &CheckOpts{
+				IgnoreTlog: true,
+			},
+			entries:                     []*tlog.Entry{rekorV2Entry},
+			expectedUseSignedTimestamps: false,
+		},
+		{
+			name: "SigVerifier set",
+			co: &CheckOpts{
+				SigVerifier: &mockVerifierForBundle{},
+			},
+			entries:                     []*tlog.Entry{rekorV2Entry},
+			expectedUseSignedTimestamps: false,
+		},
+		{
+			name:                        "Rekor v1 entry",
+			co:                          &CheckOpts{},
+			entries:                     []*tlog.Entry{rekorV1Entry},
+			expectedUseSignedTimestamps: false,
+		},
+		{
+			name:                        "Rekor v2 entry",
+			co:                          &CheckOpts{},
+			entries:                     []*tlog.Entry{rekorV2Entry},
+			expectedUseSignedTimestamps: true,
+		},
+		{
+			name:                        "Mixed entries",
+			co:                          &CheckOpts{},
+			entries:                     []*tlog.Entry{rekorV1Entry, rekorV2Entry},
+			expectedUseSignedTimestamps: false,
+		},
+		{
+			name: "Already set with Rekor v1",
+			co: &CheckOpts{
+				UseSignedTimestamps: true,
+			},
+			entries:                     []*tlog.Entry{rekorV1Entry},
+			expectedUseSignedTimestamps: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := &mockSignedEntity{tlogEntries: tc.entries}
+			err := rekorV2Bundle(bundle, tc.co)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedUseSignedTimestamps, tc.co.UseSignedTimestamps)
 		})
 	}
 }


### PR DESCRIPTION
Currently, when verifying a bundle with a short-lived certificate and a Rekor v2 entry, users must specify --use-signed-timestamps and provide a signed timestamp, because Rekor v2 entries do not contain integrated timestamps unlike Rekor v1. This isn't a great UX.

This change opportunistically sets --use-signed-timestamps when we detect that a user is verifying a short-lived certificate with a Rekor v2 entry. We won't automatically set this with a mixed Rekor v1 and Rekor v2 bundle (which the tooling will not produce, this would be for any custom clients) or when verifying with a managed key.

Fixes #4500

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
