### PR TITLE
Mark batch of flags for deprecation

### DIFF
--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -116,6 +116,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.IssueCertificate, "issue-certificate", false,
 		"issue a code signing certificate from Fulcio, even if a key is provided")
+	_ = cmd.Flags().MarkDeprecated("issue-certificate", "support for this flag will be removed in the future")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")

--- a/cmd/cosign/cli/options/attest_blob.go
+++ b/cmd/cosign/cli/options/attest_blob.go
@@ -85,7 +85,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output-signature", signatureExts...)
-	_ = cmd.Flags().MarkDeprecated("output-signature", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("output-signature", "please use --bundle to provide the output bundle location, which will include the signature")
 
 	cmd.Flags().StringVar(&o.OutputAttestation, "output-attestation", "",
 		"write the attestation to FILE")
@@ -94,7 +94,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
 	_ = cmd.MarkFlagFilename("key", certificateExts...)
-	_ = cmd.Flags().MarkDeprecated("output-certificate", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("output-certificate", "please use --bundle to provide the output bundle location, which will include the certificate")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")
@@ -149,7 +149,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp-bundle", "",
 		"path to an RFC 3161 timestamp bundle FILE")
 	// _ = cmd.MarkFlagFilename("rfc3161-timestamp-bundle") // no typical extensions
-	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp-bundle", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp-bundle", "please use --bundle to provide the output bundle location, which will include the signed timestamp")
 
 	cmd.Flags().BoolVar(&o.IssueCertificate, "issue-certificate", false,
 		"issue a code signing certificate from Fulcio, even if a key is provided")

--- a/cmd/cosign/cli/options/attest_blob.go
+++ b/cmd/cosign/cli/options/attest_blob.go
@@ -85,6 +85,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output-signature", signatureExts...)
+	_ = cmd.Flags().MarkDeprecated("output-signature", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().StringVar(&o.OutputAttestation, "output-attestation", "",
 		"write the attestation to FILE")
@@ -93,6 +94,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
 	_ = cmd.MarkFlagFilename("key", certificateExts...)
+	_ = cmd.Flags().MarkDeprecated("output-certificate", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")
@@ -147,7 +149,9 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp-bundle", "",
 		"path to an RFC 3161 timestamp bundle FILE")
 	// _ = cmd.MarkFlagFilename("rfc3161-timestamp-bundle") // no typical extensions
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp-bundle", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().BoolVar(&o.IssueCertificate, "issue-certificate", false,
 		"issue a code signing certificate from Fulcio, even if a key is provided")
+	_ = cmd.Flags().MarkDeprecated("issue-certificate", "support for this flag will be removed in the future")
 }

--- a/cmd/cosign/cli/options/bundle.go
+++ b/cmd/cosign/cli/options/bundle.go
@@ -52,7 +52,7 @@ func (o *BundleCreateOptions) AddFlags(cmd *cobra.Command) {
 	_ = cmd.MarkFlagFilename("bundle", bundleExts...)
 
 	cmd.Flags().StringVar(&o.CertificatePath, "certificate", "",
-		"path to the signing certificate, likely from Fulco.")
+		"path to the signing certificate, likely from Fulcio.")
 	_ = cmd.MarkFlagFilename("certificate", certificateExts...)
 
 	cmd.Flags().BoolVar(&o.IgnoreTlog, "ignore-tlog", false,

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -90,6 +90,8 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output-signature", signatureExts...)
+	_ = cmd.Flags().MarkDeprecated("output-signature", "support for this flag will be removed in the future. please use the new bundle output format")
+
 	cmd.Flags().StringVar(&o.OutputPayload, "output-payload", "",
 		"write the signed payload to FILE")
 	// _ = cmd.MarkFlagFilename("output-payload") // no typical extensions
@@ -97,6 +99,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
 	_ = cmd.MarkFlagFilename("output-certificate", certificateExts...)
+	_ = cmd.Flags().MarkDeprecated("output-certificate", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the image to FILE")
@@ -142,6 +145,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.IssueCertificate, "issue-certificate", false,
 		"issue a code signing certificate from Fulcio, even if a key is provided")
+	_ = cmd.Flags().MarkDeprecated("issue-certificate", "support for this flag will be removed in the future")
 
 	cmd.Flags().StringSliceVar(&o.SignContainerIdentities, "sign-container-identity", nil,
 		"manually set the .critical.docker-reference field for the signed identity, which is useful when image proxies are being used where the pull reference should match the signature, this flag is comma delimited. ex: --sign-container-identity=identity1,identity2")

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -90,7 +90,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output-signature", signatureExts...)
-	_ = cmd.Flags().MarkDeprecated("output-signature", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("output-signature", "please use --bundle to provide the output bundle location, which will include the signature")
 
 	cmd.Flags().StringVar(&o.OutputPayload, "output-payload", "",
 		"write the signed payload to FILE")
@@ -99,7 +99,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
 	_ = cmd.MarkFlagFilename("output-certificate", certificateExts...)
-	_ = cmd.Flags().MarkDeprecated("output-certificate", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("output-certificate", "please use --bundle to provide the output bundle location, which will include the certificate")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the image to FILE")

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -84,22 +84,22 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.Base64Output, "b64", true,
 		"whether to base64 encode the output")
-	_ = cmd.Flags().MarkDeprecated("b64", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("b64", "please use --bundle, which already base64 encodes content as appropriate")
 
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output-signature", signatureExts...)
-	_ = cmd.Flags().MarkDeprecated("output-signature", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("output-signature", "please use --bundle to provide the output bundle location, which will include the signature")
 
 	// TODO: remove when output flag is fully deprecated
 	cmd.Flags().StringVar(&o.Output, "output", "", "write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output", signatureExts...)
-	_ = cmd.Flags().MarkDeprecated("output", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("output", "please use --bundle to provide the output bundle location, which will include the signature")
 
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
 	_ = cmd.MarkFlagFilename("output-certificate", certificateExts...)
-	_ = cmd.Flags().MarkDeprecated("output-certificate", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("output-certificate", "please use --bundle to provide the output bundle location, which will include the certificate")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")
@@ -149,7 +149,7 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"write the RFC3161 timestamp to a file")
 	// _ = cmd.MarkFlagFilename("rfc3161-timestamp") // no typical extensions
-	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "support for this flag will be removed in the future. please use the new bundle output format")
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "please use --bundle to provide the output bundle location, which will include the signed timestamp")
 
 	cmd.Flags().BoolVar(&o.IssueCertificate, "issue-certificate", false,
 		"issue a code signing certificate from Fulcio, even if a key is provided")

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -84,18 +84,22 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.Base64Output, "b64", true,
 		"whether to base64 encode the output")
+	_ = cmd.Flags().MarkDeprecated("b64", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().StringVar(&o.OutputSignature, "output-signature", "",
 		"write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output-signature", signatureExts...)
+	_ = cmd.Flags().MarkDeprecated("output-signature", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	// TODO: remove when output flag is fully deprecated
 	cmd.Flags().StringVar(&o.Output, "output", "", "write the signature to FILE")
 	_ = cmd.MarkFlagFilename("output", signatureExts...)
+	_ = cmd.Flags().MarkDeprecated("output", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().StringVar(&o.OutputCertificate, "output-certificate", "",
 		"write the certificate to FILE")
 	_ = cmd.MarkFlagFilename("output-certificate", certificateExts...)
+	_ = cmd.Flags().MarkDeprecated("output-certificate", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"write everything required to verify the blob to a FILE")
@@ -145,9 +149,11 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"write the RFC3161 timestamp to a file")
 	// _ = cmd.MarkFlagFilename("rfc3161-timestamp") // no typical extensions
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "support for this flag will be removed in the future. please use the new bundle output format")
 
 	cmd.Flags().BoolVar(&o.IssueCertificate, "issue-certificate", false,
 		"issue a code signing certificate from Fulcio, even if a key is provided")
+	_ = cmd.Flags().MarkDeprecated("issue-certificate", "support for this flag will be removed in the future")
 
 	keyAlgorithmTypes := cosign.GetSupportedAlgorithms()
 	keyAlgorithmHelp := fmt.Sprintf("signing algorithm to use for signing/hashing (allowed %s)", strings.Join(keyAlgorithmTypes, ", "))

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -206,6 +206,7 @@ func (o *VerifyBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"path to RFC3161 timestamp FILE")
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "support for this flag will be removed in the future")
 }
 
 // VerifyDockerfileOptions is the top level wrapper for the `dockerfile verify` command.
@@ -270,6 +271,7 @@ func (o *VerifyBlobAttestationOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"path to RFC3161 timestamp FILE")
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "support for this flag will be removed in the future")
 
 	cmd.Flags().StringVar(&o.Digest, "digest", "",
 		"Digest to use for verifying in-toto subject (instead of providing a blob)")

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -206,7 +206,7 @@ func (o *VerifyBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"path to RFC3161 timestamp FILE")
-	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "support for this flag will be removed in the future")
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "please use --bundle to provide the output bundle location, which will include the signed timestamp")
 }
 
 // VerifyDockerfileOptions is the top level wrapper for the `dockerfile verify` command.
@@ -271,7 +271,7 @@ func (o *VerifyBlobAttestationOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"path to RFC3161 timestamp FILE")
-	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "support for this flag will be removed in the future")
+	_ = cmd.Flags().MarkDeprecated("rfc3161-timestamp", "please use --bundle to provide the output bundle location, which will include the signed timestamp")
 
 	cmd.Flags().StringVar(&o.Digest, "digest", "",
 		"Digest to use for verifying in-toto subject (instead of providing a blob)")

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -38,9 +38,6 @@ func SignBlob() *cobra.Command {
 		Short: "Sign the supplied blob, outputting the base64-encoded signature to stdout.",
 		Example: `  cosign sign-blob --key <key path>|<kms uri> <blob>
 
-  # sign a blob with Google sign-in (experimental)
-  cosign sign-blob <FILE> --output-signature <FILE> --output-certificate <FILE>
-
   # sign a blob with a local key pair file
   cosign sign-blob --key cosign.key <FILE>
 

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -42,7 +42,6 @@ cosign attest-blob [flags]
   -h, --help                              help for attest-blob
       --identity-token string             identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify              skip verifying fulcio published to the SCT (this should only be used for testing).
-      --issue-certificate                 issue a code signing certificate from Fulcio, even if a key is provided
       --key string                        path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                 output bundle in new format that contains all verification material (default true)
       --oidc-client-id string             OIDC client ID for application (default "sigstore")
@@ -52,11 +51,8 @@ cosign attest-blob [flags]
       --oidc-provider string              Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
       --oidc-redirect-url string          OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
       --output-attestation string         write the attestation to FILE
-      --output-certificate string         write the certificate to FILE
-      --output-signature string           write the signature to FILE
       --predicate string                  path to the predicate file.
       --rekor-url string                  address of rekor STL server (default "https://rekor.sigstore.dev")
-      --rfc3161-timestamp-bundle string   path to an RFC 3161 timestamp bundle FILE
       --signing-config string             path to a signing config file. Must provide --bundle, which will output verification material in the new format
       --sk                                whether to use a hardware security key
       --slot string                       security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -33,39 +33,39 @@ cosign attest-blob [flags]
 ### Options
 
 ```
-      --bundle string                     write everything required to verify the blob to a FILE
-      --certificate string                path to the X.509 certificate for signing attestation
-      --certificate-chain string          path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signed attestation. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate.
-      --fulcio-auth-flow string           fulcio interactive oauth2 flow to use for certificate from fulcio. Defaults to determining the flow based on the runtime environment. (options) normal|device|token|client_credentials
-      --fulcio-url string                 address of sigstore PKI server (default "https://fulcio.sigstore.dev")
-      --hash string                       hash of blob in hexadecimal (base16). Used if you want to sign an artifact stored elsewhere and have the hash
-  -h, --help                              help for attest-blob
-      --identity-token string             identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
-      --insecure-skip-verify              skip verifying fulcio published to the SCT (this should only be used for testing).
-      --key string                        path to the private key file, KMS URI or Kubernetes Secret
-      --new-bundle-format                 output bundle in new format that contains all verification material (default true)
-      --oidc-client-id string             OIDC client ID for application (default "sigstore")
-      --oidc-client-secret-file string    Path to file containing OIDC client secret for application
-      --oidc-disable-ambient-providers    Disable ambient OIDC providers. When true, ambient credentials will not be read
-      --oidc-issuer string                OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
-      --oidc-provider string              Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
-      --oidc-redirect-url string          OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
-      --output-attestation string         write the attestation to FILE
-      --predicate string                  path to the predicate file.
-      --rekor-url string                  address of rekor STL server (default "https://rekor.sigstore.dev")
-      --signing-config string             path to a signing config file. Must provide --bundle, which will output verification material in the new format
-      --sk                                whether to use a hardware security key
-      --slot string                       security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
-      --statement string                  path to the statement file.
-      --timestamp-client-cacert string    path to the X.509 CA certificate file in PEM format to be used for the connection to the TSA Server
-      --timestamp-client-cert string      path to the X.509 certificate file in PEM format to be used for the connection to the TSA Server
-      --timestamp-client-key string       path to the X.509 private key file in PEM format to be used, together with the 'timestamp-client-cert' value, for the connection to the TSA Server
-      --timestamp-server-name string      SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
-      --timestamp-server-url string       url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr
-      --trusted-root string               optional path to a TrustedRoot JSON file to verify a signature after signing
-      --type string                       specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
-      --use-signing-config                whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format (default true)
-  -y, --yes                               skip confirmation prompts for non-destructive operations
+      --bundle string                    write everything required to verify the blob to a FILE
+      --certificate string               path to the X.509 certificate for signing attestation
+      --certificate-chain string         path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signed attestation. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate.
+      --fulcio-auth-flow string          fulcio interactive oauth2 flow to use for certificate from fulcio. Defaults to determining the flow based on the runtime environment. (options) normal|device|token|client_credentials
+      --fulcio-url string                address of sigstore PKI server (default "https://fulcio.sigstore.dev")
+      --hash string                      hash of blob in hexadecimal (base16). Used if you want to sign an artifact stored elsewhere and have the hash
+  -h, --help                             help for attest-blob
+      --identity-token string            identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
+      --insecure-skip-verify             skip verifying fulcio published to the SCT (this should only be used for testing).
+      --key string                       path to the private key file, KMS URI or Kubernetes Secret
+      --new-bundle-format                output bundle in new format that contains all verification material (default true)
+      --oidc-client-id string            OIDC client ID for application (default "sigstore")
+      --oidc-client-secret-file string   Path to file containing OIDC client secret for application
+      --oidc-disable-ambient-providers   Disable ambient OIDC providers. When true, ambient credentials will not be read
+      --oidc-issuer string               OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
+      --oidc-provider string             Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
+      --oidc-redirect-url string         OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
+      --output-attestation string        write the attestation to FILE
+      --predicate string                 path to the predicate file.
+      --rekor-url string                 address of rekor STL server (default "https://rekor.sigstore.dev")
+      --signing-config string            path to a signing config file. Must provide --bundle, which will output verification material in the new format
+      --sk                               whether to use a hardware security key
+      --slot string                      security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
+      --statement string                 path to the statement file.
+      --timestamp-client-cacert string   path to the X.509 CA certificate file in PEM format to be used for the connection to the TSA Server
+      --timestamp-client-cert string     path to the X.509 certificate file in PEM format to be used for the connection to the TSA Server
+      --timestamp-client-key string      path to the X.509 private key file in PEM format to be used, together with the 'timestamp-client-cert' value, for the connection to the TSA Server
+      --timestamp-server-name string     SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
+      --timestamp-server-url string      url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr
+      --trusted-root string              optional path to a TrustedRoot JSON file to verify a signature after signing
+      --type string                      specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
+      --use-signing-config               whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format (default true)
+  -y, --yes                              skip confirmation prompts for non-destructive operations
 ```
 
 ### Options inherited from parent commands

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -59,7 +59,6 @@ cosign attest [flags]
   -h, --help                                                                                     help for attest
       --identity-token string                                                                    identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
-      --issue-certificate                                                                        issue a code signing certificate from Fulcio, even if a key is provided
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                                                                        attach a Sigstore bundle using OCI referrers API (default true)

--- a/doc/cosign_bundle_create.md
+++ b/doc/cosign_bundle_create.md
@@ -16,7 +16,7 @@ cosign bundle create [flags]
       --artifact string            path to artifact FILE
       --attestation string         path to attestation FILE
       --bundle string              path to old format bundle FILE
-      --certificate string         path to the signing certificate, likely from Fulco.
+      --certificate string         path to the signing certificate, likely from Fulcio.
   -h, --help                       help for create
       --ignore-tlog                ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log.
       --key string                 path to the public key file, KMS URI or Kubernetes Secret

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -11,9 +11,6 @@ cosign sign-blob [flags]
 ```
   cosign sign-blob --key <key path>|<kms uri> <blob>
 
-  # sign a blob with Google sign-in (experimental)
-  cosign sign-blob <FILE> --output-signature <FILE> --output-certificate <FILE>
-
   # sign a blob with a local key pair file
   cosign sign-blob --key cosign.key <FILE>
 
@@ -36,7 +33,6 @@ cosign sign-blob [flags]
 ### Options
 
 ```
-      --b64                              whether to base64 encode the output (default true)
       --bundle string                    write everything required to verify the blob to a FILE
       --certificate string               path to the X.509 certificate for signing attestation
       --certificate-chain string         path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signed attestation. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate.
@@ -45,7 +41,6 @@ cosign sign-blob [flags]
   -h, --help                             help for sign-blob
       --identity-token string            identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify             skip verifying fulcio published to the SCT (this should only be used for testing).
-      --issue-certificate                issue a code signing certificate from Fulcio, even if a key is provided
       --key string                       path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                output bundle in new format that contains all verification material (default true)
       --oidc-client-id string            OIDC client ID for application (default "sigstore")
@@ -54,11 +49,7 @@ cosign sign-blob [flags]
       --oidc-issuer string               OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-provider string             Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
       --oidc-redirect-url string         OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
-      --output string                    write the signature to FILE
-      --output-certificate string        write the certificate to FILE
-      --output-signature string          write the signature to FILE
       --rekor-url string                 address of rekor STL server (default "https://rekor.sigstore.dev")
-      --rfc3161-timestamp string         write the RFC3161 timestamp to a file
       --signing-algorithm string         signing algorithm to use for signing/hashing (allowed ecdsa-sha2-256-nistp256, ecdsa-sha2-384-nistp384, ecdsa-sha2-512-nistp521, rsa-sign-pkcs1-2048-sha256, rsa-sign-pkcs1-3072-sha256, rsa-sign-pkcs1-4096-sha256) (default "ecdsa-sha2-256-nistp256")
       --signing-config string            path to a signing config file. Must provide --bundle, which will output verification material in the new format
       --sk                               whether to use a hardware security key

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -85,7 +85,6 @@ cosign sign [flags]
   -h, --help                                                                                     help for sign
       --identity-token string                                                                    identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
-      --issue-certificate                                                                        issue a code signing certificate from Fulcio, even if a key is provided
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret
       --new-bundle-format                                                                        expect the signature/attestation to be packaged in a Sigstore bundle (default true)
@@ -95,9 +94,7 @@ cosign sign [flags]
       --oidc-issuer string                                                                       OIDC provider to be used to issue ID token (default "https://oauth2.sigstore.dev/auth")
       --oidc-provider string                                                                     Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
       --oidc-redirect-url string                                                                 OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
-      --output-certificate string                                                                write the certificate to FILE
       --output-payload string                                                                    write the signed payload to FILE
-      --output-signature string                                                                  write the signature to FILE
       --payload string                                                                           path to a payload file to use rather than generating one
       --record-creation-timestamp                                                                set the createdAt timestamp in the signature artifact to the time it was created; by default, cosign sets this to the zero value
   -r, --recursive                                                                                if a multi-arch image is specified, additionally sign each discrete image

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -54,7 +54,6 @@ cosign verify-blob-attestation [flags]
       --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")
-      --rfc3161-timestamp string                        path to RFC3161 timestamp FILE
       --sct string                                      path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --signature string                                path to base64-encoded signature over attestation in DSSE format
       --signature-digest-algorithm string               digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")

--- a/doc/cosign_verify-blob.md
+++ b/doc/cosign_verify-blob.md
@@ -87,7 +87,6 @@ cosign verify-blob [flags]
       --new-bundle-format                               expect the signature/attestation to be packaged in a Sigstore bundle (default true)
       --private-infrastructure                          skip transparency log verification when verifying artifacts in a privately deployed infrastructure
       --rekor-url string                                address of rekor STL server (default "https://rekor.sigstore.dev")
-      --rfc3161-timestamp string                        path to RFC3161 timestamp FILE
       --sct string                                      path to a detached Signed Certificate Timestamp, formatted as a RFC6962 AddChainResponse struct. If a certificate contains an SCT, verification will check both the detached and embedded SCTs.
       --signature string                                signature content or path or remote URL
       --signature-digest-algorithm string               digest algorithm to use when processing a signature (sha224|sha256|sha384|sha512) (default "sha256")


### PR DESCRIPTION
Resolves https://github.com/sigstore/cosign/issues/4696
Batch of flags for depreciation. Breaking this issue up into batches to make PR review a little easier.

#### Summary
The PR marks the following flags for depreciation:

- b64
- rfc3161-timestamp
- issue-certificate
- output
- output-certificate
- output-signature

I have left the `rfc3161-timestamp` flag on the `bundle-create `command undeprecated as it seems this flag would still be needed to create bundles in the new supported format, but I can depreciate it too if v4 will not support bundle creation.

(This PR also fixes some Fulcio typos)

#### Release Note
The following flags have been marked for depreciation:
- b64
- rfc3161-timestamp
- issue-certificate
- output
- output-certificate
- output-signature