### PR TITLE
Fix typo in CLI help

### DIFF
--- a/cmd/cosign/cli/options/bundle.go
+++ b/cmd/cosign/cli/options/bundle.go
@@ -52,7 +52,7 @@ func (o *BundleCreateOptions) AddFlags(cmd *cobra.Command) {
 	_ = cmd.MarkFlagFilename("bundle", bundleExts...)
 
 	cmd.Flags().StringVar(&o.CertificatePath, "certificate", "",
-		"path to the signing certificate, likely from Fulco.")
+		"path to the signing certificate, likely from Fulcio.")
 	_ = cmd.MarkFlagFilename("certificate", certificateExts...)
 
 	cmd.Flags().BoolVar(&o.IgnoreTlog, "ignore-tlog", false,

--- a/doc/cosign_bundle_create.md
+++ b/doc/cosign_bundle_create.md
@@ -16,7 +16,7 @@ cosign bundle create [flags]
       --artifact string            path to artifact FILE
       --attestation string         path to attestation FILE
       --bundle string              path to old format bundle FILE
-      --certificate string         path to the signing certificate, likely from Fulco.
+      --certificate string         path to the signing certificate, likely from Fulcio.
   -h, --help                       help for create
       --ignore-tlog                ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log.
       --key string                 path to the public key file, KMS URI or Kubernetes Secret


### PR DESCRIPTION
Written "Fulco", where it should be "Fulcio".

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Fix typo. `cosign bundle create` help mentions "Fulco" instead of "Fulcio".

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

Closes #4700