### PR TITLE
Add cosign-specific user-agent to all HTTP requests

### DIFF
--- a/cmd/cosign/cli/options/useragent.go
+++ b/cmd/cosign/cli/options/useragent.go
@@ -15,19 +15,10 @@
 package options
 
 import (
-	"fmt"
-	"runtime"
-
-	"sigs.k8s.io/release-utils/version"
+	"github.com/sigstore/cosign/v3/internal/useragent"
 )
 
-var (
-	// uaString is meant to resemble the User-Agent sent by browsers with requests.
-	// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
-	uaString = fmt.Sprintf("cosign/%s (%s; %s)", version.GetVersionInfo().GitVersion, runtime.GOOS, runtime.GOARCH)
-)
-
-// UserAgent returns the User-Agent string which `cosign` should send with HTTP requests.ß
+// UserAgent returns the User-Agent string which `cosign` should send with HTTP requests.
 func UserAgent() string {
-	return uaString
+	return useragent.Get()
 }

--- a/internal/pkg/cosign/tsa/client/client.go
+++ b/internal/pkg/cosign/tsa/client/client.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/digitorus/timestamp"
+
+	"github.com/sigstore/cosign/v3/internal/useragent"
 )
 
 // TimestampAuthorityClient should be implemented by clients that want to request timestamp responses
@@ -135,6 +137,7 @@ func (t *TimestampAuthorityClientImpl) GetTimestampResponse(tsq []byte) ([]byte,
 		return nil, fmt.Errorf("error creating HTTP request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/timestamp-query")
+	req.Header.Set("User-Agent", useragent.Get())
 
 	tsr, err := client.Do(req)
 	if err != nil {

--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -1,0 +1,64 @@
+// Copyright 2021 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package useragent
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	"sigs.k8s.io/release-utils/version"
+)
+
+var (
+	// uaString is meant to resemble the User-Agent sent by browsers with requests.
+	// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent
+	uaString = buildUserAgent()
+)
+
+// buildUserAgent constructs a user-agent string that includes both cosign and sigstore-go versions
+func buildUserAgent() string {
+	cosignVersion := version.GetVersionInfo().GitVersion
+	sigstoreGoVersion := getSigstoreGoVersion()
+
+	if sigstoreGoVersion != "" {
+		return fmt.Sprintf("cosign/%s sigstore-go/%s (%s; %s)",
+			cosignVersion, sigstoreGoVersion, runtime.GOOS, runtime.GOARCH)
+	}
+
+	// Fallback if sigstore-go version can't be determined
+	return fmt.Sprintf("cosign/%s (%s; %s)", cosignVersion, runtime.GOOS, runtime.GOARCH)
+}
+
+// getSigstoreGoVersion retrieves the version of sigstore-go from build info
+func getSigstoreGoVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+
+	for _, dep := range info.Deps {
+		if dep.Path == "github.com/sigstore/sigstore-go" {
+			return dep.Version
+		}
+	}
+
+	return ""
+}
+
+// Get returns the User-Agent string which `cosign` should send with HTTP requests.
+func Get() string {
+	return uaString
+}

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package useragent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGet(t *testing.T) {
+	ua := Get()
+
+	// Should contain "cosign/"
+	if !strings.Contains(ua, "cosign/") {
+		t.Errorf("User-Agent should contain 'cosign/', got: %s", ua)
+	}
+
+	// Should contain OS and architecture
+	if !strings.Contains(ua, "(") || !strings.Contains(ua, ")") {
+		t.Errorf("User-Agent should contain OS and architecture in parentheses, got: %s", ua)
+	}
+
+	// When built as a binary (not with go run), it should contain sigstore-go version
+	// In test mode with go test, it might not have dependency info
+	t.Logf("User-Agent: %s", ua)
+}
+
+func TestGetSigstoreGoVersion(t *testing.T) {
+	version := getSigstoreGoVersion()
+
+	// NOTE: When running 'go test', the version will typically be empty because Go
+	// doesn't embed full dependency metadata in test binaries. The Deps slice in
+	// debug.ReadBuildInfo() is empty for test executables.
+	//
+	// However, when cosign is built with 'go build', the binary DOES contain this
+	// information (verified with 'go version -m ./cosign'), and getSigstoreGoVersion()
+	// will successfully extract it at runtime.
+	//
+	// To verify this works in production, check the built binary:
+	//   $ go version -m ./cosign | grep sigstore-go
+	//   dep github.com/sigstore/sigstore-go v1.1.4 ...
+
+	if version == "" {
+		t.Log("sigstore-go version not found (expected in 'go test' mode)")
+		t.Log("In production binaries built with 'go build', the version IS available")
+	} else {
+		t.Logf("sigstore-go version found: %s", version)
+		// If version is found, it should start with 'v'
+		if len(version) > 0 && version[0] != 'v' {
+			t.Errorf("Expected version to start with 'v', got: %s", version)
+		}
+	}
+}

--- a/pkg/cosign/tuf.go
+++ b/pkg/cosign/tuf.go
@@ -21,9 +21,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sigstore/cosign/v3/internal/useragent"
 	"github.com/sigstore/cosign/v3/pkg/cosign/env"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/tuf"
+	"github.com/theupdateframework/go-tuf/v2/metadata/fetcher"
 )
 
 func TrustedRoot() (root.TrustedMaterial, error) {
@@ -61,6 +63,12 @@ func setTUFOpts() (*tuf.Options, error) {
 	if tufCacheDir := env.Getenv(env.VariableTUFRootDir); tufCacheDir != "" { //nolint:forbidigo
 		opts.CachePath = tufCacheDir
 	}
+
+	// Set custom fetcher with cosign user-agent
+	f := fetcher.NewDefaultFetcher()
+	f.SetHTTPUserAgent(useragent.Get())
+	opts.Fetcher = f
+
 	err := setTUFMirror(opts)
 	if err != nil {
 		return nil, fmt.Errorf("error setting TUF mirror: %w", err)


### PR DESCRIPTION
#### Summary

This change addresses issue #4692 by ensuring that all HTTP requests made by cosign identify with a proper user-agent that includes both the cosign version and sigstore-go version.


Fixes #4692 