### PR TITLE
Backport bundle detection to sign and attest

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -144,6 +144,17 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		NewBundleFormat:              c.NewBundleFormat,
 	}
 
+	// Check to see if we are using the new bundle format or not
+	if !c.LocalImage {
+		ref, err := name.ParseReference(images[0], c.NameOptions...)
+		if err == nil && !c.NewBundleFormat {
+			newBundles, _, err := cosign.GetBundles(ctx, ref, co)
+			if len(newBundles) > 0 && err == nil {
+				co.NewBundleFormat = true
+			}
+		}
+	}
+
 	if c.TrustedRootPath != "" {
 		co.TrustedMaterial, err = root.NewTrustedRootFromPath(c.TrustedRootPath)
 		if err != nil {
@@ -161,7 +172,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		}
 	}
 
-	if c.NewBundleFormat {
+	if co.NewBundleFormat {
 		if c.CertRef != "" {
 			return fmt.Errorf("unsupported: certificate may not be provided using --certificate when using --new-bundle-format (cert must be in bundle)")
 		}
@@ -184,7 +195,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	}
 
 	// If we are using signed timestamps and there is no trusted root, we need to load the TSA certificates
-	if co.UseSignedTimestamps && co.TrustedMaterial == nil && !c.NewBundleFormat {
+	if co.UseSignedTimestamps && co.TrustedMaterial == nil && !co.NewBundleFormat {
 		tsaCertificates, err := cosign.GetTSACerts(ctx, c.TSACertChainPath, cosign.GetTufTargets)
 		if err != nil {
 			return fmt.Errorf("unable to load TSA certificates: %w", err)
@@ -194,7 +205,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		co.TSAIntermediateCertificates = tsaCertificates.IntermediateCerts
 	}
 
-	if !c.IgnoreTlog && !c.NewBundleFormat {
+	if !c.IgnoreTlog && !co.NewBundleFormat {
 		if c.RekorURL != "" {
 			rekorClient, err := rekor.NewClient(c.RekorURL)
 			if err != nil {
@@ -251,7 +262,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 			return fmt.Errorf("initializing piv token verifier: %w", err)
 		}
 	case certRef != "":
-		if c.NewBundleFormat {
+		if co.NewBundleFormat {
 			// This shouldn't happen because we already checked for this above in checkSigstoreBundleUnsupportedOptions
 			return fmt.Errorf("unsupported: certificate reference currently not supported with --new-bundle-format")
 		}
@@ -322,7 +333,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		var bundleVerified bool
 
 		if c.LocalImage {
-			if c.NewBundleFormat {
+			if co.NewBundleFormat {
 				verified, bundleVerified, err = cosign.VerifyLocalImageAttestations(ctx, img, co)
 				if err != nil {
 					return err
@@ -341,7 +352,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 				return fmt.Errorf("parsing reference: %w", err)
 			}
 
-			if c.NewBundleFormat {
+			if co.NewBundleFormat {
 				// OCI bundle always contains attestation
 				verified, bundleVerified, err = cosign.VerifyImageAttestations(ctx, ref, co)
 				if err != nil {

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -121,6 +121,18 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
 		NewBundleFormat:              c.NewBundleFormat,
 	}
+
+	// Check to see if we are using the new bundle format or not
+	if !c.LocalImage {
+		ref, err := name.ParseReference(images[0], c.NameOptions...)
+		if err == nil && !c.NewBundleFormat {
+			newBundles, _, err := cosign.GetBundles(ctx, ref, co)
+			if len(newBundles) > 0 && err == nil {
+				co.NewBundleFormat = true
+			}
+		}
+	}
+
 	if c.CheckClaims {
 		co.ClaimVerifier = cosign.IntotoSubjectClaimVerifier
 	}
@@ -141,7 +153,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		}
 	}
 
-	if c.NewBundleFormat {
+	if co.NewBundleFormat {
 		if err = checkSigstoreBundleUnsupportedOptions(c); err != nil {
 			return err
 		}
@@ -151,7 +163,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	}
 
 	// Ignore Signed Certificate Timestamp if the flag is set or a key is provided
-	if co.TrustedMaterial == nil && shouldVerifySCT(c.IgnoreSCT, c.KeyRef, c.Sk) && !c.NewBundleFormat {
+	if co.TrustedMaterial == nil && shouldVerifySCT(c.IgnoreSCT, c.KeyRef, c.Sk) && !co.NewBundleFormat {
 		co.CTLogPubKeys, err = cosign.GetCTLogPubs(ctx)
 		if err != nil {
 			return fmt.Errorf("getting ctlog public keys: %w", err)
@@ -159,7 +171,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	}
 
 	// If we are using signed timestamps, we need to load the TSA certificates
-	if co.UseSignedTimestamps && co.TrustedMaterial == nil && !c.NewBundleFormat {
+	if co.UseSignedTimestamps && co.TrustedMaterial == nil && !co.NewBundleFormat {
 		tsaCertificates, err := cosign.GetTSACerts(ctx, c.TSACertChainPath, cosign.GetTufTargets)
 		if err != nil {
 			return fmt.Errorf("unable to load TSA certificates: %w", err)
@@ -217,7 +229,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			return fmt.Errorf("initializing piv token verifier: %w", err)
 		}
 	case c.CertRef != "":
-		if c.NewBundleFormat {
+		if co.NewBundleFormat {
 			// This shouldn't happen because we already checked for this above in checkSigstoreBundleUnsupportedOptions
 			return fmt.Errorf("unsupported: certificate reference currently not supported with --new-bundle-format")
 		}
@@ -260,7 +272,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 			co.SCT = sct
 		}
 	case c.TrustedRootPath != "":
-		if !c.NewBundleFormat {
+		if !co.NewBundleFormat {
 			return fmt.Errorf("unsupported: trusted root path currently only supported with --new-bundle-format")
 		}
 

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1618,7 +1618,7 @@ func verifyImageSignaturesExperimentalOCI(ctx context.Context, signedImgRef name
 	return verifySignatures(ctx, sigs, h, co)
 }
 
-func getBundles(_ context.Context, signedImgRef name.Reference, co *CheckOpts) ([]*sgbundle.Bundle, *v1.Hash, error) {
+func GetBundles(_ context.Context, signedImgRef name.Reference, co *CheckOpts) ([]*sgbundle.Bundle, *v1.Hash, error) {
 	// This is a carefully optimized sequence for fetching the signatures of the
 	// entity that minimizes registry requests when supplied with a digest input
 	digest, err := ociremote.ResolveDigest(signedImgRef, co.RegistryClientOpts...)
@@ -1665,7 +1665,7 @@ func getBundles(_ context.Context, signedImgRef name.Reference, co *CheckOpts) (
 
 // verifyImageAttestationsSigstoreBundle verifies attestations from attached sigstore bundles
 func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (checkedAttestations []oci.Signature, atLeastOneBundleVerified bool, err error) {
-	bundles, hash, err := getBundles(ctx, signedImgRef, co)
+	bundles, hash, err := GetBundles(ctx, signedImgRef, co)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/cosign/verify_oci_test.go
+++ b/pkg/cosign/verify_oci_test.go
@@ -53,7 +53,7 @@ func TestGetBundles_Empty(t *testing.T) {
 	assert.NoError(t, err)
 
 	// If tag doesn't exist, should return ErrImageTagNotFound
-	bundles, hash, err := getBundles(context.Background(), ref, &CheckOpts{})
+	bundles, hash, err := GetBundles(context.Background(), ref, &CheckOpts{})
 	imgTagNotFound := &ErrImageTagNotFound{}
 	assert.ErrorAs(t, err, &imgTagNotFound)
 	assert.Len(t, bundles, 0)
@@ -65,7 +65,7 @@ func TestGetBundles_Empty(t *testing.T) {
 	assert.NoError(t, remote.Write(ref, img))
 
 	// Check that no matching attestation error is returned
-	bundles, hash, err = getBundles(context.Background(), ref, &CheckOpts{})
+	bundles, hash, err = GetBundles(context.Background(), ref, &CheckOpts{})
 	var noMatchErr *ErrNoMatchingAttestations
 	assert.ErrorAs(t, err, &noMatchErr)
 	assert.Len(t, bundles, 0)
@@ -81,7 +81,7 @@ func TestGetBundles_Empty(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Should still return no matching attestation error, as it failed to parse the bundle
-	bundles, hash, err = getBundles(context.Background(), ref, &CheckOpts{})
+	bundles, hash, err = GetBundles(context.Background(), ref, &CheckOpts{})
 	assert.ErrorAs(t, err, &noMatchErr)
 	assert.Len(t, bundles, 0)
 	assert.Nil(t, hash)
@@ -111,7 +111,7 @@ func TestGetBundles_Valid(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Retrieve the attestation
-	bundles, hash, err := getBundles(context.Background(), ref, &CheckOpts{})
+	bundles, hash, err := GetBundles(context.Background(), ref, &CheckOpts{})
 	assert.NoError(t, err)
 	assert.Len(t, bundles, 1)
 	assert.NotNil(t, hash)


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

For #4531; to help folks on older Cosign versions start adopting new bundle formats without making verification more complicated.

Tested with:
```
$ go run cmd/cosign/main.go sign --new-bundle-format=true localhost:1338/demo/sigstore-go-verification-ce4f5bf3233ac2b951c3667b2d19da3a@sha256:9f596f3fcea4eee0c4d2fb266adc5ed7024441cb7cf9b9a058c29ac501871d2a
...
$ go run cmd/cosign/main.go verify --certificate-oidc-issuer="..." --certificate-identity="..." localhost:1338/demo/sigstore-go-verification-ce4f5bf3233ac2b951c3667b2d19da3a@sha256:9f596f3fcea4eee0c4d2fb266adc5ed7024441cb7cf9b9a058c29ac501871d2a
...
The following checks were performed on each of these signatures:
  - The cosign claims were validated
  - Existence of the claims in the transparency log was verified offline
  - The code-signing certificate was verified using trusted certificate authority certificates
...
```

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* Backported new protobuf bundle detection to subcommands `verify` and `verify-attestation`

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A