### PR TITLE
support managed keys in conformance testing

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,4 +47,4 @@ jobs:
       - uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
         with:
           entrypoint: ${{ github.workspace }}/conformance
-          xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root] test_verify*PATH-message-digest-mismatch_fail]"
+          xfail: "test_verify*PATH-message-digest-mismatch_fail]"

--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -31,12 +31,13 @@ var certSAN *string
 var identityToken *string
 var trustedRootPath *string
 var signingConfigPath *string
+var keyPath *string
 var inToto bool
 
 func usage() {
 	fmt.Println("Usage:")
 	fmt.Printf("\t%s sign-bundle [--in-toto] --identity-token TOKEN [--signing-config FILE] [--trusted-root FILE] --bundle FILE FILE\n", os.Args[0])
-	fmt.Printf("\t%s verify-bundle --bundle FILE --certificate-identity IDENTITY --certificate-oidc-issuer URL [--trusted-root FILE] FILE\n", os.Args[0])
+	fmt.Printf("\t%s verify-bundle --bundle FILE [--certificate-identity IDENTITY] [--certificate-oidc-issuer URL] [--key FILE] [--trusted-root FILE] FILE\n", os.Args[0])
 }
 
 func parseArgs() {
@@ -65,6 +66,9 @@ func parseArgs() {
 			i += 2
 		case "--signing-config":
 			signingConfigPath = &os.Args[i+1]
+			i += 2
+		case "--key":
+			keyPath = &os.Args[i+1]
 			i += 2
 		case "--in-toto":
 			inToto = true
@@ -135,6 +139,9 @@ func main() {
 	}
 	if signingConfigPath != nil {
 		args = append(args, "--signing-config", *signingConfigPath)
+	}
+	if keyPath != nil {
+		args = append(args, "--key", *keyPath)
 	}
 	if inToto {
 		args = append(args, "--statement")

--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -37,7 +37,7 @@ var inToto bool
 func usage() {
 	fmt.Println("Usage:")
 	fmt.Printf("\t%s sign-bundle [--in-toto] --identity-token TOKEN [--signing-config FILE] [--trusted-root FILE] --bundle FILE FILE\n", os.Args[0])
-	fmt.Printf("\t%s verify-bundle --bundle FILE [--certificate-identity IDENTITY] [--certificate-oidc-issuer URL] [--key FILE] [--trusted-root FILE] FILE\n", os.Args[0])
+	fmt.Printf("\t%s verify-bundle --bundle FILE [--certificate-identity IDENTITY --certificate-oidc-issuer URL] [--key FILE] [--trusted-root FILE] FILE\n", os.Args[0])
 }
 
 func parseArgs() {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

Working on [#4644](https://github.com/sigstore/cosign/issues/4644)

#### Summary
This change is to support conformance tests that pass a key for verification instead of using certificate identity. The other failure from this issue (`test_verify\[PATH-message-digest-mismatch_fail]`) is not addressed in this change.