### PR TITLE
feat: add command update-key-pair (solves #3168)

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -105,6 +105,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(Generate())
 	cmd.AddCommand(GenerateKeyPair())
 	cmd.AddCommand(ImportKeyPair())
+	cmd.AddCommand(UpdateKeyPair())
 	cmd.AddCommand(Initialize())
 	cmd.AddCommand(Load())
 	cmd.AddCommand(Manifest())

--- a/cmd/cosign/cli/options/update_key_pair.go
+++ b/cmd/cosign/cli/options/update_key_pair.go
@@ -1,0 +1,35 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// UpdateKeyPairOptions is the top level wrapper for the update-key-pair command.
+type UpdateKeyPairOptions struct {
+	// Key is the path to the existing encrypted private key file.
+	Key string
+}
+
+var _ Interface = (*UpdateKeyPairOptions)(nil)
+
+// AddFlags implements Interface
+func (o *UpdateKeyPairOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Key, "key", "k", "",
+		"path to the private key file to update the password for")
+	_ = cmd.MarkFlagFilename("key", privateKeyExts...)
+	_ = cmd.MarkFlagRequired("key")
+}

--- a/cmd/cosign/cli/update_key_pair.go
+++ b/cmd/cosign/cli/update_key_pair.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/updatekeypair"
+	"github.com/spf13/cobra"
+)
+
+func UpdateKeyPair() *cobra.Command {
+	o := &options.UpdateKeyPairOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "update-key-pair",
+		Short: "Updates the password of a private key.",
+		Long:  "Re-encrypts an existing encrypted private key with a new password.",
+		Example: `  cosign update-key-pair --key <key path>
+
+  # update the password of an existing private key
+  cosign update-key-pair --key cosign.key
+
+CAVEATS:
+  This command interactively prompts for the current password and then the new
+  password (twice for confirmation). You can use the COSIGN_PASSWORD environment
+  variable to provide the current password and COSIGN_NEW_PASSWORD to provide
+  the new password non-interactively.
+  Piping passwords is currently not supported.`,
+		PersistentPreRun: options.BindViper,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return updatekeypair.UpdateKeyPairCmd(cmd.Context(), o.Key)
+		},
+	}
+
+	o.AddFlags(cmd)
+	return cmd
+}

--- a/cmd/cosign/cli/updatekeypair/update_key_pair.go
+++ b/cmd/cosign/cli/updatekeypair/update_key_pair.go
@@ -1,0 +1,89 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updatekeypair
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/cosign/env"
+)
+
+var (
+	// Read is for fuzzing
+	Read = readPasswordFn
+)
+
+// UpdateKeyPairCmd re-encrypts the private key at keyPath with a new password.
+// The user is prompted for the current password (to decrypt) and then twice for
+// the new password (to re-encrypt with confirmation).
+// nolint
+func UpdateKeyPairCmd(_ context.Context, keyPath string) error {
+	keyBytes, err := os.ReadFile(filepath.Clean(keyPath))
+	if err != nil {
+		return fmt.Errorf("reading key file %q: %w", keyPath, err)
+	}
+
+	// Obtain the current (old) password.
+	currentPass, err := GetCurrentPass(false)
+	if err != nil {
+		return fmt.Errorf("reading current password: %w", err)
+	}
+
+	// Re-encrypt with the new password (pf is called with confirm=true inside UpdateKeyPair).
+	updatedKeyBytes, err := cosign.UpdateKeyPair(keyBytes, currentPass, GetNewPass)
+	if err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(keyPath, updatedKeyBytes, 0600); err != nil {
+		return fmt.Errorf("writing updated key file %q: %w", keyPath, err)
+	}
+
+	fmt.Fprintln(os.Stderr, "Private key password updated in", keyPath)
+	return nil
+}
+
+// GetCurrentPass reads the current (old) password used to decrypt the key.
+func GetCurrentPass(confirm bool) ([]byte, error) {
+	return Read(env.VariablePassword, confirm)
+}
+
+// GetNewPass reads the new password used to re-encrypt the key.
+func GetNewPass(confirm bool) ([]byte, error) {
+	return Read(env.VariableNewPassword, confirm)
+}
+
+// readPasswordFn reads the password for encryption or decryption.
+// It uses the specified environment variable if set, otherwise prompts interactively.
+// Piped-in passwords are not supported; use the environment variable for scripting.
+func readPasswordFn(envVar env.Variable, confirm bool) ([]byte, error) {
+	if pw, ok := env.LookupEnv(envVar); ok {
+		return []byte(pw), nil
+	}
+	if cosign.IsTerminal() {
+		if envVar == env.VariablePassword {
+			return cosign.GetPassFromTermWithPrompt(confirm, "Enter current password for private key")
+		}
+		if envVar == env.VariableNewPassword {
+			return cosign.GetPassFromTermWithPrompt(confirm, "Enter new password for private key")
+		}
+		return nil, fmt.Errorf("unsupported environment variable: %s", envVar)
+	}
+	return nil, fmt.Errorf("password not provided in environment variable %s and cannot prompt in non-interactive terminal", envVar)
+}

--- a/cmd/cosign/cli/updatekeypair/update_key_pair_test.go
+++ b/cmd/cosign/cli/updatekeypair/update_key_pair_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package updatekeypair
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/cosign/env"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+)
+
+func TestReadPasswordFn_newEnv(t *testing.T) {
+	t.Setenv("COSIGN_NEW_PASSWORD", "newpassword")
+	b, err := readPasswordFn(env.VariableNewPassword, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff("newpassword", string(b)); diff != "" {
+		t.Fatal(diff)
+	}
+}
+
+func TestReadPasswordFn_newEnvEmptyVal(t *testing.T) {
+	t.Setenv("COSIGN_NEW_PASSWORD", "")
+	b, err := readPasswordFn(env.VariableNewPassword, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(b) > 0 {
+		t.Fatalf("expected empty string; got %q", string(b))
+	}
+}
+
+func TestUpdateKeyPairCmd(t *testing.T) {
+	td := t.TempDir()
+
+	t.Setenv("COSIGN_PASSWORD", "initialpassword")
+	t.Setenv("COSIGN_NEW_PASSWORD", "newpassword")
+
+	keys, err := cosign.GenerateKeyPair(GetCurrentPass)
+	if err != nil {
+		t.Fatalf("generating key pair: %v", err)
+	}
+
+	keyFile := td + "/cosign.key"
+	if err := os.WriteFile(keyFile, keys.PrivateBytes, 0600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+
+	// Run the update command.
+	if err := UpdateKeyPairCmd(context.Background(), keyFile); err != nil {
+		t.Fatalf("UpdateKeyPairCmd: %v", err)
+	}
+
+	// Verify the updated key can be loaded with the new password.
+	updatedKeyBytes, err := os.ReadFile(keyFile)
+	if err != nil {
+		t.Fatalf("reading updated key file: %v", err)
+	}
+
+	sv, err := cosign.LoadPrivateKey(updatedKeyBytes, []byte("newpassword"), nil)
+	if err != nil {
+		t.Fatalf("loading updated key with new password: %v", err)
+	}
+
+	// Verify the public key derived from the re-encrypted private key matches
+	// the original public key — the underlying key material must be unchanged.
+	pub, err := sv.PublicKey()
+	if err != nil {
+		t.Fatalf("getting public key from updated signer: %v", err)
+	}
+	updatedPubPEM, err := cryptoutils.MarshalPublicKeyToPEM(pub)
+	if err != nil {
+		t.Fatalf("marshalling updated public key: %v", err)
+	}
+	if diff := cmp.Diff(string(keys.PublicBytes), string(updatedPubPEM)); diff != "" {
+		t.Fatalf("public key changed after password update (-want +got):\n%s", diff)
+	}
+}
+
+func TestUpdateKeyPairCmd_WrongCurrentPassword(t *testing.T) {
+	td := t.TempDir()
+
+	t.Setenv("COSIGN_PASSWORD", "initialpassword")
+
+	keys, err := cosign.GenerateKeyPair(GetCurrentPass)
+	if err != nil {
+		t.Fatalf("generating key pair: %v", err)
+	}
+
+	keyFile := td + "/cosign.key"
+	if err := os.WriteFile(keyFile, keys.PrivateBytes, 0600); err != nil {
+		t.Fatalf("writing key file: %v", err)
+	}
+
+	t.Setenv("COSIGN_PASSWORD", "wrongpassword")
+	t.Setenv("COSIGN_NEW_PASSWORD", "newpassword")
+
+	if err := UpdateKeyPairCmd(context.Background(), keyFile); err == nil {
+		t.Fatal("expected error for wrong current password, but got none")
+	}
+}

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -38,6 +38,7 @@ A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign signing-config](cosign_signing-config.md)	 - Interact with a Sigstore protobuf signing config
 * [cosign tree](cosign_tree.md)	 - Display supply chain security related artifacts for an image such as signatures, SBOMs and attestations
 * [cosign trusted-root](cosign_trusted-root.md)	 - Interact with a Sigstore protobuf trusted root
+* [cosign update-key-pair](cosign_update-key-pair.md)	 - Updates the password of a private key.
 * [cosign upload](cosign_upload.md)	 - Provides utilities for uploading artifacts to a registry
 * [cosign verify](cosign_verify.md)	 - Verify a signature on the supplied container image
 * [cosign verify-attestation](cosign_verify-attestation.md)	 - Verify an attestation on the supplied container image

--- a/doc/cosign_update-key-pair.md
+++ b/doc/cosign_update-key-pair.md
@@ -1,0 +1,47 @@
+## cosign update-key-pair
+
+Updates the password of a private key.
+
+### Synopsis
+
+Re-encrypts an existing encrypted private key with a new password.
+
+```
+cosign update-key-pair [flags]
+```
+
+### Examples
+
+```
+  cosign update-key-pair --key <key path>
+
+  # update the password of an existing private key
+  cosign update-key-pair --key cosign.key
+
+CAVEATS:
+  This command interactively prompts for the current password and then the new
+  password (twice for confirmation). You can use the COSIGN_PASSWORD environment
+  variable to provide the current password and COSIGN_NEW_PASSWORD to provide
+  the new password non-interactively.
+  Piping passwords is currently not supported.
+```
+
+### Options
+
+```
+  -h, --help         help for update-key-pair
+  -k, --key string   path to the private key file to update the password for
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
+

--- a/pkg/cosign/common.go
+++ b/pkg/cosign/common.go
@@ -26,7 +26,15 @@ import (
 
 // TODO(jason): Move this to an internal package.
 func GetPassFromTerm(confirm bool) ([]byte, error) {
-	fmt.Fprint(os.Stderr, "Enter password for private key: ")
+	return GetPassFromTermWithPrompt(confirm, "Enter password for private key")
+}
+
+// GetPassFromTermWithPrompt reads a password from the terminal using a custom prompt.
+// prompt should not include a trailing ": "; the function appends it automatically.
+// If confirm is true, the user is asked to enter the password a second time.
+// TODO(jason): Move this to an internal package.
+func GetPassFromTermWithPrompt(confirm bool, prompt string) ([]byte, error) {
+	fmt.Fprint(os.Stderr, prompt+": ")
 	// Unnecessary convert of syscall.Stdin on *nix, but Windows is a uintptr
 	// nolint:unconvert
 	pw1, err := term.ReadPassword(int(syscall.Stdin))
@@ -37,7 +45,7 @@ func GetPassFromTerm(confirm bool) ([]byte, error) {
 	if !confirm {
 		return pw1, nil
 	}
-	fmt.Fprint(os.Stderr, "Enter password for private key again: ")
+	fmt.Fprint(os.Stderr, prompt+" again: ")
 	// Unnecessary convert of syscall.Stdin on *nix, but Windows is a uintptr
 	// nolint:unconvert
 	confirmpw, err := term.ReadPassword(int(syscall.Stdin))

--- a/pkg/cosign/env/env.go
+++ b/pkg/cosign/env/env.go
@@ -47,6 +47,7 @@ const (
 	VariableExperimental            Variable = "COSIGN_EXPERIMENTAL"
 	VariableDockerMediaTypes        Variable = "COSIGN_DOCKER_MEDIA_TYPES"
 	VariablePassword                Variable = "COSIGN_PASSWORD"
+	VariableNewPassword             Variable = "COSIGN_NEW_PASSWORD" //nolint:gosec
 	VariablePKCS11Pin               Variable = "COSIGN_PKCS11_PIN"
 	VariablePKCS11ModulePath        Variable = "COSIGN_PKCS11_MODULE_PATH"
 	VariablePKCS11IgnoreCertificate Variable = "COSIGN_PKCS11_IGNORE_CERTIFICATE"
@@ -98,6 +99,11 @@ var (
 		VariablePassword: {
 			Description: "overrides password inputs with this value",
 			Expects:     "string with a password (asks on stdin by default)",
+			Sensitive:   true,
+		},
+		VariableNewPassword: {
+			Description: "overrides new password input for the update-key-pair command",
+			Expects:     "string with the new password (asks on stdin by default)",
 			Sensitive:   true,
 		},
 		VariablePKCS11Pin: {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
This PR adds a new command `update-key-pair` that can be used to update the encryption password for existing keys generated by the command `generate-key-pair`. This solves issue #3168

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

* Added new `cosign update-key-pair` CLI command for re-encrypting an existing
  encrypted private key with a new password. The command prompts interactively
  for the current password and the new password (with confirmation). The
  `COSIGN_PASSWORD` environment variable can be used to supply the current
  password non-interactively, and the new `COSIGN_NEW_PASSWORD` environment
  variable can be used to supply the new password non-interactively.
* Added exported function `cosign.UpdateKeyPair` to the `pkg/cosign` package, allowing programmatic re-encryption of an encrypted PEM private key with a new password.


#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
This change requires a documentation update. I'll open a PR as soon as the proposed API is confirmed to be okay.