### PR TITLE
docs(changelog): fix sigstore URL scheme in release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2639,7 +2639,7 @@ We would love to thank the contributors:
 
 This is the first release of `cosign`!
 
-The main goal of this release is to release something we can start using to sign other releases of [sigstore](sigstore.dev) projects, including `cosign` itself.
+The main goal of this release is to release something we can start using to sign other releases of [sigstore](https://sigstore.dev) projects, including `cosign` itself.
 
 We expect many flags, commands, and formats to change going forward.
 No backwards compatibility is promised or implied.


### PR DESCRIPTION
## Summary

Fixes a stale URL scheme in `CHANGELOG.md`:

- from `[sigstore](sigstore.dev)`
- to `[sigstore](https://sigstore.dev)`

## Scope

- docs-only
- single-line change
- no code or behavior changes
