### PR TITLE
fix: write output certificate in sign-blob when signing with key

### DIFF
--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -243,20 +243,15 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	if outputCertificate != "" {
-		certBytes, err := extractCertificate(ctx, sv)
+		rekorBytes, err := sv.Bytes(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("create certificate file: %w", err)
 		}
-		if certBytes != nil {
-			bts := certBytes
-			if b64 {
-				bts = []byte(base64.StdEncoding.EncodeToString(certBytes))
-			}
-			if err := os.WriteFile(outputCertificate, bts, 0600); err != nil {
-				return nil, fmt.Errorf("create certificate file: %w", err)
-			}
-			ui.Infof(ctx, "Wrote certificate to file %s", outputCertificate)
+
+		if err := os.WriteFile(outputCertificate, rekorBytes, 0600); err != nil {
+			return nil, fmt.Errorf("create certificate file: %w", err)
 		}
+		ui.Infof(ctx, "Certificate wrote in the file %s", outputCertificate)
 	}
 
 	return sig, nil

--- a/cmd/cosign/cli/sign/sign_blob_test.go
+++ b/cmd/cosign/cli/sign/sign_blob_test.go
@@ -55,6 +55,22 @@ func TestSignBlobCmd(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
+	// Verify that --output-certificate writes the public key when signing with --key
+	certBytes, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("expected certificate file to exist: %v", err)
+	}
+	if len(certBytes) == 0 {
+		t.Fatal("expected certificate file to contain public key PEM data, got empty file")
+	}
+	block, _ := pem.Decode(certBytes)
+	if block == nil {
+		t.Fatal("expected certificate file to contain valid PEM data")
+	}
+	if block.Type != "PUBLIC KEY" {
+		t.Fatalf("expected PEM type 'PUBLIC KEY', got %q", block.Type)
+	}
+
 	// Test signing with a certificate
 	rootCert, rootKey, _ := test.GenerateRootCa()
 	cert, certPrivKey, _ := test.GenerateLeafCert("subject", "oidc-issuer", rootCert, rootKey)


### PR DESCRIPTION
## Summary

- Fix `--output-certificate` flag not writing any file when using `cosign sign-blob --key`
- Align `sign-blob`'s certificate output behavior with `sign`'s implementation

## Motivation

As reported in #4140, `cosign sign-blob --key cosign.key --output-certificate certificate.crt` silently produces no certificate file, while `cosign sign --key cosign.key --output-certificate certificate.crt` correctly writes the public key to the output file.

## Root Cause

The `sign-blob` command used `extractCertificate()` to handle `--output-certificate`, which calls `sv.Bytes()` and then attempts to parse the result as a PEM certificate via `UnmarshalCertificatesFromPEM`. When signing with `--key`, `sv.Bytes()` returns a PEM-encoded **public key** (not a certificate), so `UnmarshalCertificatesFromPEM` fails and `extractCertificate` returns `nil` — causing nothing to be written.

In contrast, the `sign` command calls `sv.Bytes()` directly and writes whatever it returns (certificate or public key) to the output file.

## Changes

- **`cmd/cosign/cli/sign/sign_blob.go`**: Replace `extractCertificate()` call in the `--output-certificate` handler with a direct `sv.Bytes()` call, consistent with how `sign` handles it. The `extractCertificate` function is retained as it is still used in the old bundle format path where certificate-only filtering is appropriate.
- **`cmd/cosign/cli/sign/sign_blob_test.go`**: Add assertions verifying that the output certificate file is created and contains valid PEM public key data when signing with `--key`.

## Test Plan

- [x] Existing `TestSignBlobCmd` passes
- [x] New test assertions verify the output certificate file exists, is non-empty, and contains a valid `PUBLIC KEY` PEM block
- [x] `go test ./cmd/cosign/cli/sign/ -run TestSignBlobCmd -v` passes

Fixes #4140