### PR TITLE
fix: write output certificate in sign-blob with key-based signing

### DIFF
--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -243,20 +243,18 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	if outputCertificate != "" {
-		certBytes, err := extractCertificate(ctx, sv)
+		certBytes, err := sv.Bytes(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("error getting certificate: %w", err)
 		}
-		if certBytes != nil {
-			bts := certBytes
-			if b64 {
-				bts = []byte(base64.StdEncoding.EncodeToString(certBytes))
-			}
-			if err := os.WriteFile(outputCertificate, bts, 0600); err != nil {
-				return nil, fmt.Errorf("create certificate file: %w", err)
-			}
-			ui.Infof(ctx, "Wrote certificate to file %s", outputCertificate)
+
+		if b64 {
+			certBytes = []byte(base64.StdEncoding.EncodeToString(certBytes))
 		}
+		if err := os.WriteFile(outputCertificate, certBytes, 0600); err != nil {
+			return nil, fmt.Errorf("create certificate file: %w", err)
+		}
+		ui.Infof(ctx, "Wrote certificate to file %s", outputCertificate)
 	}
 
 	return sig, nil

--- a/cmd/cosign/cli/sign/sign_blob_test.go
+++ b/cmd/cosign/cli/sign/sign_blob_test.go
@@ -55,6 +55,15 @@ func TestSignBlobCmd(t *testing.T) {
 		t.Fatalf("unexpected error %v", err)
 	}
 
+	// Verify that --output-certificate writes a file when using a key
+	certData, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatalf("expected certificate file to be written: %v", err)
+	}
+	if len(certData) == 0 {
+		t.Fatal("expected non-empty certificate file")
+	}
+
 	// Test signing with a certificate
 	rootCert, rootKey, _ := test.GenerateRootCa()
 	cert, certPrivKey, _ := test.GenerateLeafCert("subject", "oidc-issuer", rootCert, rootKey)


### PR DESCRIPTION
## Summary

`sign-blob --output-certificate` silently skips writing the certificate file when signing with a private key (`--key`), while `sign --output-certificate` works fine in the same scenario.

The root cause is that `sign-blob` uses `extractCertificate()` which returns nil for non-Fulcio signers (i.e. private key based), so the file never gets written. Meanwhile, `sign` just calls `sv.Bytes()` directly and writes whatever it gets.

This patch aligns `sign-blob` with `sign` by calling `sv.Bytes()` directly, so both commands write the public key PEM when there is no Fulcio certificate.

## Changes

- `sign_blob.go`: replace `extractCertificate()` call with `sv.Bytes()` in the `--output-certificate` code path
- `sign_blob_test.go`: add assertion to verify the certificate file is actually written

## Testing

- Existing unit test `TestSignBlobCmd` passes
- Added verification that the output certificate file is non-empty when signing with a key

Fixes #4140