### PR TITLE
feat: add retry with exponential backoff for Fulcio and Rekor RPCs

### DIFF
--- a/cmd/cosign/cli/fulcio/fulcio.go
+++ b/cmd/cosign/cli/fulcio/fulcio.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/internal/auth"
 	"github.com/sigstore/cosign/v3/internal/pkg/cosign/fulcio/fulcioroots"
+	"github.com/sigstore/cosign/v3/internal/pkg/retry"
 	"github.com/sigstore/fulcio/pkg/api"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
@@ -61,7 +62,16 @@ func GetCert(_ context.Context, sv signature.SignerVerifier, idToken, flow, oidc
 
 	fmt.Fprintln(os.Stderr, "Retrieving signed certificate...")
 
-	return fClient.SigningCert(cr, tok)
+	var resp *api.CertificateResponse
+	err = retry.Do(context.Background(), func() error {
+		var certErr error
+		resp, certErr = fClient.SigningCert(cr, tok)
+		return certErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 type Signer struct {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ThalesIgnite/crypto11 v1.2.5
 	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.11.0
 	github.com/buildkite/agent/v3 v3.118.0
+	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/depcheck-test/depcheck-test v0.0.0-20220607135614-199033aaa936
@@ -129,7 +130,6 @@ require (
 	github.com/buildkite/go-pipeline v0.16.0 // indirect
 	github.com/buildkite/interpolate v0.1.5 // indirect
 	github.com/buildkite/roko v1.4.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect

--- a/internal/pkg/retry/retry.go
+++ b/internal/pkg/retry/retry.go
@@ -1,0 +1,99 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+const (
+	defaultMaxRetries = 3
+	defaultMaxElapsed = 30 * time.Second
+)
+
+// Retriable wraps an error to indicate it can be retried.
+type Retriable struct {
+	Err error
+}
+
+func (r *Retriable) Error() string { return r.Err.Error() }
+func (r *Retriable) Unwrap() error { return r.Err }
+
+// HTTPError represents an HTTP error with a status code.
+type HTTPError interface {
+	error
+	Code() int
+}
+
+// IsRetriable checks if an error should be retried.
+// Retriable errors are: network errors, 5xx server errors, and 429 rate limits.
+func IsRetriable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Explicit retriable wrapper
+	var r *Retriable
+	if errors.As(err, &r) {
+		return true
+	}
+
+	// Network errors (DNS, connection refused, timeout)
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	// HTTP status code checks
+	var httpErr HTTPError
+	if errors.As(err, &httpErr) {
+		code := httpErr.Code()
+		// 429 Too Many Requests or 5xx Server Errors
+		return code == 429 || (code >= 500 && code <= 599)
+	}
+
+	return false
+}
+
+// Do runs fn with exponential backoff. fn is retried only when it returns
+// an error that IsRetriable considers transient.
+func Do(ctx context.Context, fn func() error) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = defaultMaxElapsed
+
+	retryCount := 0
+	wrapped := func() error {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+		if !IsRetriable(err) {
+			return backoff.Permanent(err)
+		}
+		retryCount++
+		if retryCount > defaultMaxRetries {
+			return backoff.Permanent(fmt.Errorf("max retries exceeded: %w", err))
+		}
+		return err
+	}
+
+	return backoff.Retry(wrapped, backoff.WithContext(bo, ctx))
+}

--- a/internal/pkg/retry/retry_test.go
+++ b/internal/pkg/retry/retry_test.go
@@ -1,0 +1,114 @@
+// Copyright 2024 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type testHTTPError struct {
+	code int
+	msg  string
+}
+
+func (e *testHTTPError) Error() string { return e.msg }
+func (e *testHTTPError) Code() int     { return e.code }
+
+func TestIsRetriable(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"plain error", errors.New("something broke"), false},
+		{"500 server error", &testHTTPError{500, "internal server error"}, true},
+		{"502 bad gateway", &testHTTPError{502, "bad gateway"}, true},
+		{"503 unavailable", &testHTTPError{503, "service unavailable"}, true},
+		{"429 rate limit", &testHTTPError{429, "too many requests"}, true},
+		{"400 bad request", &testHTTPError{400, "bad request"}, false},
+		{"403 forbidden", &testHTTPError{403, "forbidden"}, false},
+		{"404 not found", &testHTTPError{404, "not found"}, false},
+		{"retriable wrapper", &Retriable{Err: errors.New("transient")}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRetriable(tt.err); got != tt.want {
+				t.Errorf("IsRetriable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDo_Success(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestDo_RetryThenSuccess(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), func() error {
+		calls++
+		if calls < 3 {
+			return &testHTTPError{503, "unavailable"}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDo_NonRetriableError(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), func() error {
+		calls++
+		return &testHTTPError{403, "forbidden"}
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call (no retry for 403), got %d", calls)
+	}
+}
+
+func TestDo_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := Do(ctx, func() error {
+		return fmt.Errorf("should not run")
+	})
+	if err == nil {
+		t.Fatal("expected error for cancelled context")
+	}
+}

--- a/pkg/cosign/tlog.go
+++ b/pkg/cosign/tlog.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag/conv"
+	"github.com/sigstore/cosign/v3/internal/pkg/retry"
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v3/pkg/cosign/env"
@@ -188,11 +189,20 @@ func GetRekorPubs(ctx context.Context) (*TrustedTransparencyLogPubKeys, error) {
 // sign path to validate return responses are consistent from Rekor.
 func rekorPubsFromClient(rekorClient *client.Rekor) (*TrustedTransparencyLogPubKeys, error) {
 	publicKeys := NewTrustedTransparencyLogPubKeys()
-	pubOK, err := rekorClient.Pubkey.GetPublicKey(nil)
+
+	var pubPayload string
+	err := retry.Do(context.Background(), func() error {
+		pubOK, pubErr := rekorClient.Pubkey.GetPublicKey(nil)
+		if pubErr != nil {
+			return pubErr
+		}
+		pubPayload = pubOK.Payload
+		return nil
+	})
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch rekor public key from rekor: %w", err)
 	}
-	if err := publicKeys.AddTransparencyLogPubKey([]byte(pubOK.Payload), tuf.Active); err != nil {
+	if err := publicKeys.AddTransparencyLogPubKey([]byte(pubPayload), tuf.Active); err != nil {
 		return nil, fmt.Errorf("constructRekorPubKey: %w", err)
 	}
 	return &publicKeys, nil
@@ -238,7 +248,20 @@ func TLogUploadInTotoAttestation(ctx context.Context, rekorClient *client.Rekor,
 func doUpload(ctx context.Context, rekorClient *client.Rekor, pe models.ProposedEntry) (*models.LogEntryAnon, error) {
 	params := entries.NewCreateLogEntryParamsWithContext(ctx)
 	params.SetProposedEntry(pe)
-	resp, err := rekorClient.Entries.CreateLogEntry(params)
+
+	var resp *entries.CreateLogEntryCreated
+	err := retry.Do(ctx, func() error {
+		var createErr error
+		resp, createErr = rekorClient.Entries.CreateLogEntry(params)
+		if createErr != nil {
+			// Don't retry conflict errors - the entry already exists
+			var existsErr *entries.CreateLogEntryConflict
+			if errors.As(createErr, &existsErr) {
+				return createErr
+			}
+		}
+		return createErr
+	})
 	if err != nil {
 		// If the entry already exists, we get a specific error.
 		// Here, we display the proof and succeed.
@@ -404,7 +427,13 @@ func verifyUUID(entryUUID string, e models.LogEntryAnon) error {
 func GetTlogEntry(ctx context.Context, rekorClient *client.Rekor, entryUUID string) (*models.LogEntryAnon, error) {
 	params := entries.NewGetLogEntryByUUIDParamsWithContext(ctx)
 	params.SetEntryUUID(entryUUID)
-	resp, err := rekorClient.Entries.GetLogEntryByUUID(params)
+
+	var resp *entries.GetLogEntryByUUIDOK
+	err := retry.Do(ctx, func() error {
+		var getErr error
+		resp, getErr = rekorClient.Entries.GetLogEntryByUUID(params)
+		return getErr
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +497,13 @@ func FindTlogEntry(ctx context.Context, rekorClient *client.Rekor,
 	searchLogQuery.SetEntries(proposedEntries)
 
 	searchParams.SetEntry(&searchLogQuery)
-	resp, err := rekorClient.Entries.SearchLogQuery(searchParams)
+
+	var resp *entries.SearchLogQueryOK
+	err = retry.Do(ctx, func() error {
+		var searchErr error
+		resp, searchErr = rekorClient.Entries.SearchLogQuery(searchParams)
+		return searchErr
+	})
 	if err != nil {
 		return nil, fmt.Errorf("searching log query: %w", err)
 	}


### PR DESCRIPTION
## Summary

Transient network errors or server-side 5xx responses during signing can fail expensive CI jobs at the very end. This adds retry logic with exponential backoff around Fulcio and Rekor API calls so that temporary failures don't break entire pipelines.

## Changes

New `internal/pkg/retry` package using `cenkalti/backoff/v4` (already an indirect dep):
- `IsRetriable()` checks if an error should be retried (5xx, 429, network errors)
- `Do()` wraps a function with exponential backoff, max 3 retries, 30s timeout
- Non-retriable errors (400, 403, 404) fail immediately

Wrapped call sites:
- **Fulcio**: `GetCert()` - certificate signing request
- **Rekor**: `doUpload()` - create log entry (conflict errors skip retry)
- **Rekor**: `GetTlogEntry()` - fetch entry by UUID
- **Rekor**: `FindTlogEntry()` - search log query
- **Rekor**: `rekorPubsFromClient()` - fetch public key

## Testing

- Unit tests for retry package cover: success, retry-then-success, non-retriable errors, context cancellation
- All existing tests pass

```
go test ./internal/pkg/retry/ -v
go build ./cmd/cosign/cli/fulcio/
go build ./pkg/cosign/
```

Fixes #2198