### PR TITLE
fix(sign): closing SignerVerifier too early when signing with a security key

### DIFF
--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -77,6 +77,11 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	keypair, sv, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)
+	defer func() {
+		if sv != nil {
+			sv.Close()
+		}
+	}()
 	if err != nil {
 		return nil, fmt.Errorf("getting keypair and token: %w", err)
 	}

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -88,6 +88,8 @@ func (c *SignerVerifier) Bytes(ctx context.Context) ([]byte, error) {
 
 // GetKeypairAndToken creates a keypair object from provided key or cert flags or generates an ephemeral key.
 // For an ephemeral key, it also uses the key to fetch an OIDC token, the pair of which are later used to get a Fulcio cert.
+//
+// Ensure the returned SignerVerifier is closed via calling SignerVerifier.Close.
 func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain string) (sign.Keypair, *SignerVerifier, []byte, string, error) {
 	var keypair sign.Keypair
 	var ephemeralKeypair bool
@@ -105,11 +107,6 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 		return nil, nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
 	}
 	certBytes = sv.Cert
-	defer func() {
-		if sv != nil {
-			sv.Close()
-		}
-	}()
 
 	if ephemeralKeypair || ko.IssueCertificateForExistingKey {
 		if ko.SigningConfig == nil {
@@ -512,7 +509,12 @@ func WriteBundle(ctx context.Context, sv *SignerVerifier, rekorEntry *models.Log
 
 // WriteNewBundleWithSigningConfig uses signing config and trusted root to fetch responses from services for the bundle and writes the bundle to the OCI remote layer.
 func WriteNewBundleWithSigningConfig(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) error {
-	keypair, _, certBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
+	keypair, sv, certBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
+	defer func() {
+		if sv != nil {
+			sv.Close()
+		}
+	}()
 	if err != nil {
 		return fmt.Errorf("getting keypair and token: %w", err)
 	}


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary

Fixes an error occurring when using a security key, such as a Yubikey or PKCS11 key for signing. The SignerVerifier was wrapped in a SignerVerifierKeypair and the underlying SignerVerifier closed before consuming the keypair to create the signature. This fix moves the deferred SignerVerifier.Close() call to the same function the sign method is called with the keypair.

Triggering the bug and testing the fix can be performed e.g. with the following command:

```
cosign sign --sk <IMAGE DIGEST>
```

Note that this requires compiling via `cosign-pivkey-pkcs11key` make target and a Yubikey initialized using the following commands (note that these commands will reset the Yubikey PIV application and wipe the existing keys):

```
cosign piv-tool reset
cosign piv-tool generate-key
```

#### Release Note

Fixed an error occurring when using a security key, such as a Yubikey or PKCS11 key for signing caused by early closing of the HSM.
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
