### PR TITLE
Disallow --new-bundle-format and --rfc3161-timestamp

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -102,7 +102,7 @@ func Attest() *cobra.Command {
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
 				o.NewBundleFormat, "", o.Key, o.IssueCertificate,
-				"", "", "", "", ""); err != nil {
+				"", "", "", "", "", ""); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -87,7 +87,7 @@ func AttestBlob() *cobra.Command {
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
 				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate,
-				"", o.OutputAttestation, o.OutputCertificate, "", o.OutputSignature); err != nil {
+				"", o.OutputAttestation, o.OutputCertificate, "", o.OutputSignature, o.RFC3161TimestampPath); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -130,7 +130,7 @@ race conditions or (worse) malicious tampering.
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, "", o.Key, o.IssueCertificate, o.Output, "", o.OutputCertificate, o.OutputPayload, o.OutputSignature); err != nil {
+				o.NewBundleFormat, "", o.Key, o.IssueCertificate, o.Output, "", o.OutputCertificate, o.OutputPayload, o.OutputSignature, ""); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -114,7 +114,7 @@ func SignBlob() *cobra.Command {
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
 				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate,
-				o.Output, "", o.OutputCertificate, "", o.OutputSignature); err != nil {
+				o.Output, "", o.OutputCertificate, "", o.OutputSignature, o.RFC3161TimestampPath); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -641,7 +641,7 @@ func ParseSignatureAlgorithmFlag(signingAlgorithm string) (pb_go_v1.PublicKeyDet
 func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpts, useSigningConfig bool, signingConfigPath string,
 	rekorURL, fulcioURL, oidcIssuer, tsaServerURL, trustedRootPath string,
 	tlogUpload bool, newBundleFormat bool, bundlePath string, keyRef string, issueCertificate bool,
-	output, outputAttestation, outputCertificate, outputPayload, outputSignature string) error {
+	output, outputAttestation, outputCertificate, outputPayload, outputSignature, outputTimestamp string) error {
 	var err error
 	// If a signing config is used, then service URLs cannot be specified
 	if (useSigningConfig || signingConfigPath != "") &&
@@ -699,6 +699,9 @@ func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpt
 	}
 	if newBundleFormat && outputPayload != "" {
 		ui.Warnf(context.Background(), "--output-payload is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputTimestamp != "" {
+		ui.Warnf(context.Background(), "--rfc3161-timestamp is deprecated when using --new-bundle-format and will be ignored")
 	}
 	if newBundleFormat && output != "" {
 		ui.Warnf(context.Background(), "--output is deprecated when using --new-bundle-format and will be ignored")


### PR DESCRIPTION
With the modern bundle format, the signed timestamp output flag will be ignored. We should log a warning like with the other output flags.

Fixes #4594

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
