### PR TITLE
Remove managed key related xfails from conformance nightly workflow

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: sigstore/sigstore-conformance@main
         with:
           entrypoint: ${{ github.workspace }}/conformance
-          xfail: "test_verify*managed-key-happy-path] test_verify*managed-key-and-trusted-root] test_verify*PATH-message-digest-mismatch_fail]"
+          xfail: "test_verify*PATH-message-digest-mismatch_fail]"
 
       - name: Create Issue on Failure
         if: failure()


### PR DESCRIPTION
Closes https://github.com/sigstore/cosign/issues/4763

#### Summary
Removes xfail for managed key tests from nightly conformance testing as these tests are now passing. 

#### Release Note
N/A

#### Documentation
N/A
