### PR TITLE
fix: respect COSIGN_REPOSITORY envvar in cosign verify

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1646,7 +1646,8 @@ func verifyImageSignaturesExperimentalOCI(ctx context.Context, signedImgRef name
 		}
 		// TODO: do this smarter using "created" annotations
 		lastResult := results[numResults-1]
-		st, err := name.ParseReference(fmt.Sprintf("%s@%s", digest.Repository, lastResult.Digest.String()))
+		targetRepo := ociremote.ResolveTargetRepository(digest.Context(), co.RegistryClientOpts...)
+		st, err := name.ParseReference(fmt.Sprintf("%s@%s", targetRepo, lastResult.Digest.String()))
 		if err != nil {
 			return nil, false, err
 		}
@@ -1688,9 +1689,12 @@ func GetBundles(_ context.Context, signedImgRef name.Reference, registryClientOp
 	if err != nil {
 		return nil, nil, err
 	}
+	// Resolve the target repository, which may differ from the image's
+	// repository when COSIGN_REPOSITORY is set.
+	targetRepo := ociremote.ResolveTargetRepository(digest.Context(), registryClientOpts...)
 	var bundles = make([]*sgbundle.Bundle, 0, len(index.Manifests))
 	for _, result := range index.Manifests {
-		st, err := name.ParseReference(fmt.Sprintf("%s@%s", digest.Repository, result.Digest.String()), nameOpts...)
+		st, err := name.ParseReference(fmt.Sprintf("%s@%s", targetRepo, result.Digest.String()), nameOpts...)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/oci/remote/options.go
+++ b/pkg/oci/remote/options.go
@@ -143,6 +143,15 @@ func GetEnvTargetRepository() (name.Repository, error) {
 	return name.Repository{}, nil
 }
 
+// ResolveTargetRepository returns the target repository resolved from the
+// provided options, falling back to the provided default repository.
+// This is useful for callers outside this package that need to know which
+// repository to use for constructing references.
+func ResolveTargetRepository(defaultRepo name.Repository, opts ...Option) name.Repository {
+	o := makeOptions(defaultRepo, opts...)
+	return o.TargetRepository
+}
+
 // WithNameOptions is a functional option for overriding the default
 // name options passed to GGCR.
 func WithNameOptions(opts ...name.Option) Option {

--- a/pkg/oci/remote/referrers.go
+++ b/pkg/oci/remote/referrers.go
@@ -23,12 +23,18 @@ import (
 
 // Referrers fetches references using registry options.
 func Referrers(d name.Digest, artifactType string, opts ...Option) (*v1.IndexManifest, error) {
-	o := makeOptions(name.Repository{}, opts...)
+	o := makeOptions(d.Context(), opts...)
 	rOpt := o.ROpt
 	if artifactType != "" {
 		rOpt = append(rOpt, remote.WithFilter("artifactType", artifactType))
 	}
-	idx, err := remote.Referrers(d, rOpt...)
+	// If a target repository override is set (e.g. via COSIGN_REPOSITORY),
+	// look for referrers in the target repository instead of the image's repository.
+	target := d
+	if (o.TargetRepository != name.Repository{}) && o.TargetRepository.Name() != d.Context().Name() {
+		target = o.TargetRepository.Digest(d.DigestStr())
+	}
+	idx, err := remote.Referrers(target, rOpt...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes #4591: `COSIGN_REPOSITORY` environment variable was ignored during `cosign verify` in v3.

## Root Cause

The sign path was corrected in #4473 to write referrers/bundles to the target repository, but the verify/read path still looked for signatures in the image's original repository, ignoring `COSIGN_REPOSITORY`.

Three locations in the verify path used the image's repo instead of the target repo override:

1. **`pkg/oci/remote/referrers.go`** — `Referrers()` always queried using the original digest repository, ignoring `TargetRepository` from options.
2. **`pkg/cosign/verify.go:GetBundles()`** — Constructed bundle references using `digest.Repository` (the image's repo).
3. **`pkg/cosign/verify.go:verifyImageSignaturesExperimentalOCI()`** — Same issue for signature references.

## Fix

- Fixed all three locations to respect the `TargetRepository` override from options when set.
- Added `ResolveTargetRepository()` helper to `pkg/oci/remote/options.go` — an exported function that resolves the effective target repository from options, for use by callers outside the `ociremote` package.

**Files changed**: 3 files, +23/-4 lines.

Signed-off-by: Mateen Anjum <mateenali66@gmail.com>