### PR TITLE
Require bundle output or registry upload 

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -68,6 +68,12 @@ func Attest() *cobra.Command {
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if o.NewBundleFormat && o.NoUpload && o.BundlePath == "" {
+				return fmt.Errorf("must enable upload to the OCI registry or specify a local --bundle path with --new-bundle-format")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			oidcClientSecret, err := o.OIDC.ClientSecret()
 			if err != nil {

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -147,7 +147,6 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 	}
 
 	if c.NewBundleFormat {
-		// TODO(#4534): Require bundle output or registry upload
 		if c.BundlePath != "" {
 			if err := os.WriteFile(c.BundlePath, bundleBytes, 0600); err != nil {
 				return fmt.Errorf("create bundle file: %w", err)

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -160,13 +160,10 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 	}
 
 	if c.NewBundleFormat {
-		// TODO(#4534): Require bundle output or registry upload
-		if c.BundlePath != "" {
-			if err := os.WriteFile(c.BundlePath, bundleBytes, 0600); err != nil {
-				return fmt.Errorf("create bundle file: %w", err)
-			}
-			ui.Infof(ctx, "Wrote bundle to file %s", c.BundlePath)
+		if err := os.WriteFile(c.BundlePath, bundleBytes, 0600); err != nil {
+			return fmt.Errorf("create bundle file: %w", err)
 		}
+		ui.Infof(ctx, "Wrote bundle to file %s", c.BundlePath)
 		return nil
 	}
 

--- a/cmd/cosign/cli/attest/attest_blob_test.go
+++ b/cmd/cosign/cli/attest/attest_blob_test.go
@@ -172,6 +172,7 @@ func TestAttestBlobCmdLocalKeyAndCert(t *testing.T) {
 					keyOpts := options.KeyOpts{KeyRef: tc.keyref}
 					if tc.newBundle {
 						keyOpts.NewBundleFormat = true
+						keyOpts.BundlePath = filepath.Join(td, "output.bundle")
 					}
 					at := AttestBlobCommand{
 						KeyOpts:        keyOpts,

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -15,6 +15,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/attest"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
@@ -49,6 +51,12 @@ func AttestBlob() *cobra.Command {
   echo <PAYLOAD> | cosign attest-blob --predicate - --yes`,
 
 		PersistentPreRun: options.BindViper,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if o.NewBundleFormat && o.BundlePath == "" {
+				return fmt.Errorf("must specify --bundle with --new-bundle-format")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if o.Predicate.Statement == "" && len(args) != 1 {
 				return cobra.ExactArgs(1)(cmd, args)

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -90,6 +90,12 @@ race conditions or (worse) malicious tampering.
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			if o.NewBundleFormat && !o.Upload && o.BundlePath == "" {
+				return fmt.Errorf("must enable upload to the OCI registry or specify a local --bundle path with --new-bundle-format")
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch o.Attachment {
 			case "sbom":

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -348,7 +348,6 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		ociSigs[i] = ociSig
 	}
 
-	// TODO(#4534): Require bundle output or registry upload
 	outputSignature := signOpts.OutputSignature
 	if outputSignature != "" {
 		// Add digest to suffix to differentiate each image during recursive signing

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -128,13 +128,10 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	if ko.NewBundleFormat {
-		// TODO(#4534): Require bundle output or registry upload
-		if ko.BundlePath != "" {
-			if err := os.WriteFile(ko.BundlePath, bundleBytes, 0600); err != nil {
-				return nil, fmt.Errorf("create bundle file: %w", err)
-			}
-			ui.Infof(ctx, "Wrote bundle to file %s", ko.BundlePath)
+		if err := os.WriteFile(ko.BundlePath, bundleBytes, 0600); err != nil {
+			return nil, fmt.Errorf("create bundle file: %w", err)
 		}
+		ui.Infof(ctx, "Wrote bundle to file %s", ko.BundlePath)
 		return nil, nil
 	}
 

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -62,6 +62,10 @@ func SignBlob() *cobra.Command {
 				return &options.KeyParseError{}
 			}
 
+			if o.NewBundleFormat && o.BundlePath == "" {
+				return fmt.Errorf("must specify --bundle with --new-bundle-format")
+			}
+
 			// Check if the algorithm is in the list of supported algorithms
 			supportedAlgorithms := cosign.GetSupportedAlgorithms()
 			isValid := false


### PR DESCRIPTION
Closes #4534

#### Summary

This change requires that the user enable OCI registry upload (where applicable) or specify a bundle output path so that all signing events provide material with which the user can verify the signing event.

#### Release Note

This is a **breaking change**. When using `--new-bundle-format` for signing and attestation, it is now strictly required that the resulting verification material is either uploaded to an OCI registry or written to a local file. 

Previously, there was a loophole where users could run `sign`, `attest`, `sign-blob`, or `attest-blob` with `--new-bundle-format`, but without uploading to a registry and without specifying a `--bundle` output path. This would result in a successful command but the verification material would be silently discarded, leaving nothing to verify against.

Workflows using these commands, with the new bundle format, and with both of the following behaviors, will now fail:
* Not uploading to a registry (i.e., setting `--upload=false` with `sign`, using `--no-upload` with `attest`, or using the `sign-blob` and `attest-blob` commands)
* Not saving the bundle locally (i.e., not providing the `--bundle <path>` flag) 

To fix this, such workflows must do at least one of the following:
* Upload to a registry (enabled by default)
* Save the bundle locally (i.e., provide the `--bundle <path>` flag)

This change applies only to users requesting a new-format bundle.