### PR TITLE
Add --ignore-pkcs11-certificate sign option

### DIFF
--- a/cmd/cosign/cli/options/key.go
+++ b/cmd/cosign/cli/options/key.go
@@ -76,4 +76,7 @@ type KeyOpts struct {
 	// SigningAlgorithm is the AlgorithmDetails string representation used to
 	// sign/hash the payload.
 	SigningAlgorithm string
+
+	// Ignore a certificate found on the PKCS11 token
+	IgnorePKCS11Certificate bool
 }

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -55,6 +55,8 @@ type SignOptions struct {
 	AnnotationOptions
 	Registry             RegistryOptions
 	RegistryExperimental RegistryExperimentalOptions
+
+	IgnorePKCS11Certificate bool
 }
 
 var _ Interface = (*SignOptions)(nil)
@@ -164,4 +166,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.TrustedRootPath, "trusted-root", "",
 		"optional path to a TrustedRoot JSON file to verify a signature after signing")
+
+	cmd.Flags().BoolVar(&o.IgnorePKCS11Certificate, "ignore-pkcs11-certificate", false,
+		"ignore a certificate from the PKCS11 token")
 }

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -127,6 +127,7 @@ race conditions or (worse) malicious tampering.
 				TSAServerName:                  o.TSAServerName,
 				TSAServerURL:                   o.TSAServerURL,
 				IssueCertificateForExistingKey: o.IssueCertificate,
+				IgnorePKCS11Certificate:        o.IgnorePKCS11Certificate,
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -226,7 +226,7 @@ func signerFromKeyOpts(ctx context.Context, certPath string, certChainPath strin
 	case ko.Sk:
 		sv, err = signerFromSecurityKey(ctx, ko.Slot)
 	case ko.KeyRef != "":
-		sv, err = signerFromKeyRef(ctx, certPath, certChainPath, ko.KeyRef, ko.PassFunc, ko.DefaultLoadOptions)
+		sv, err = signerFromKeyRef(ctx, certPath, certChainPath, ko.KeyRef, ko.PassFunc, ko.DefaultLoadOptions, ko.IgnorePKCS11Certificate)
 	default:
 		genKey = true
 		ui.Infof(ctx, "Generating ephemeral keys...")
@@ -272,7 +272,7 @@ func signerFromSecurityKey(ctx context.Context, keySlot string) (*SignerVerifier
 	}, nil
 }
 
-func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef string, passFunc cosign.PassFunc, defaultLoadOptions *[]signature.LoadOption) (*SignerVerifier, error) {
+func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef string, passFunc cosign.PassFunc, defaultLoadOptions *[]signature.LoadOption, ignorePKCS11Certificate bool) (*SignerVerifier, error) {
 	k, err := sigs.SignerVerifierFromKeyRef(ctx, keyRef, passFunc, defaultLoadOptions)
 	if err != nil {
 		return nil, fmt.Errorf("reading key: %w", err)
@@ -288,29 +288,32 @@ func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef strin
 	// token as the private key. If it's not there, show a warning to the
 	// user.
 	if pkcs11Key, ok := k.(*pkcs11key.Key); ok {
-		certFromPKCS11, _ := pkcs11Key.Certificate()
 		certSigner.close = pkcs11Key.Close
 
-		if certFromPKCS11 == nil {
-			ui.Warnf(ctx, "no x509 certificate retrieved from the PKCS11 token")
-		} else {
-			pemBytes, err := cryptoutils.MarshalCertificateToPEM(certFromPKCS11)
-			if err != nil {
-				pkcs11Key.Close()
-				return nil, err
+		if !ignorePKCS11Certificate {
+			certFromPKCS11, _ := pkcs11Key.Certificate()
+
+			if certFromPKCS11 == nil {
+				ui.Warnf(ctx, "no x509 certificate retrieved from the PKCS11 token")
+			} else {
+				pemBytes, err := cryptoutils.MarshalCertificateToPEM(certFromPKCS11)
+				if err != nil {
+					pkcs11Key.Close()
+					return nil, err
+				}
+				// Check that the provided public key and certificate key match
+				pubKey, err := k.PublicKey()
+				if err != nil {
+					pkcs11Key.Close()
+					return nil, err
+				}
+				if cryptoutils.EqualKeys(pubKey, certFromPKCS11.PublicKey) != nil {
+					pkcs11Key.Close()
+					return nil, errors.New("pkcs11 key and certificate do not match")
+				}
+				leafCert = certFromPKCS11
+				certSigner.Cert = pemBytes
 			}
-			// Check that the provided public key and certificate key match
-			pubKey, err := k.PublicKey()
-			if err != nil {
-				pkcs11Key.Close()
-				return nil, err
-			}
-			if cryptoutils.EqualKeys(pubKey, certFromPKCS11.PublicKey) != nil {
-				pkcs11Key.Close()
-				return nil, errors.New("pkcs11 key and certificate do not match")
-			}
-			leafCert = certFromPKCS11
-			certSigner.Cert = pemBytes
 		}
 	}
 

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -108,7 +108,7 @@ func Test_signerFromKeyRefSuccess(t *testing.T) {
 	ctx := context.Background()
 	keyFile, certFile, chainFile, privKey, cert, chain := generateCertificateFiles(t, tmpDir, pass("foo"))
 
-	signer, err := signerFromKeyRef(ctx, certFile, chainFile, keyFile, pass("foo"), nil)
+	signer, err := signerFromKeyRef(ctx, certFile, chainFile, keyFile, pass("foo"), nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error generating signer: %v", err)
 	}
@@ -147,17 +147,17 @@ func Test_signerFromKeyRefFailure(t *testing.T) {
 	_, certFile2, chainFile2, _, _, _ := generateCertificateFiles(t, tmpDir2, pass("bar"))
 
 	// Public keys don't match
-	_, err := signerFromKeyRef(ctx, certFile2, chainFile2, keyFile, pass("foo"), nil)
+	_, err := signerFromKeyRef(ctx, certFile2, chainFile2, keyFile, pass("foo"), nil, false)
 	if err == nil || err.Error() != "public key in certificate does not match the provided public key" {
 		t.Fatalf("expected mismatched keys error, got %v", err)
 	}
 	// Certificate chain cannot be verified
-	_, err = signerFromKeyRef(ctx, certFile, chainFile2, keyFile, pass("foo"), nil)
+	_, err = signerFromKeyRef(ctx, certFile, chainFile2, keyFile, pass("foo"), nil, false)
 	if err == nil || !strings.Contains(err.Error(), "unable to validate certificate chain") {
 		t.Fatalf("expected chain verification error, got %v", err)
 	}
 	// Certificate chain specified without certificate
-	_, err = signerFromKeyRef(ctx, "", chainFile2, keyFile, pass("foo"), nil)
+	_, err = signerFromKeyRef(ctx, "", chainFile2, keyFile, pass("foo"), nil, false)
 	if err == nil || !strings.Contains(err.Error(), "no leaf certificate found or provided while specifying chain") {
 		t.Fatalf("expected no leaf error, got %v", err)
 	}
@@ -177,7 +177,7 @@ func Test_signerFromKeyRefFailureEmptyChainFile(t *testing.T) {
 		t.Fatalf("failed to write chain file: %v", err)
 	}
 
-	_, err = signerFromKeyRef(ctx, certFile, tmpChainFile.Name(), keyFile, pass("foo"), nil)
+	_, err = signerFromKeyRef(ctx, certFile, tmpChainFile.Name(), keyFile, pass("foo"), nil, false)
 	if err == nil || err.Error() != "no certificates in certificate chain" {
 		t.Fatalf("expected empty chain error, got %v", err)
 	}

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -84,6 +84,7 @@ cosign sign [flags]
       --fulcio-url string                                                                        address of sigstore PKI server (default "https://fulcio.sigstore.dev")
   -h, --help                                                                                     help for sign
       --identity-token string                                                                    identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
+      --ignore-pkcs11-certificate                                                                ignore a certificate from the PKCS11 token
       --insecure-skip-verify                                                                     skip verifying fulcio published to the SCT (this should only be used for testing).
       --k8s-keychain                                                                             whether to use the kubernetes keychain instead of the default keychain (supports workload identity).
       --key string                                                                               path to the private key file, KMS URI or Kubernetes Secret


### PR DESCRIPTION
#### Summary

When `cosign sign` operates with a PKCS11 token, and the token contains a certificate (along with keys), cosign uncoditionally puts the certificate to the verification material in the sigstore bundle.

This option allows us to have the public key identifier (not the certificate) in the produced sigstore bundle. It may be useful in scenarios when a token is used for signing, and verification is performed with a public key file extracted from the token.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->


<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

`cosign sign` gets the `--ignore-pkcs11-certificate` option.
