### PR TITLE
Fix 'the' typo in copyright name

### DIFF
--- a/cmd/cosign/cli/copy/copy_test.go
+++ b/cmd/cosign/cli/copy/copy_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 the Sigstore Authors.
+// Copyright 2023 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cosign/cli/verify/verify_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_attestation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 the Sigstore Authors.
+// Copyright 2022 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 the Sigstore Authors.
+// Copyright 2022 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 the Sigstore Authors.
+// Copyright 2022 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/oci/platform/platform.go
+++ b/pkg/oci/platform/platform.go
@@ -1,4 +1,4 @@
-// Copyright 2023 the Sigstore Authors.
+// Copyright 2023 The Sigstore Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hi!  Would you consider this?  It comes up in the Debian copyright QA tooling as a mismatch.  All other files already uses capitalized `The` so this fix only for consistency(/OCD).

/Simon