### PR TITLE
fix: pin 6 unpinned action(s)

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -42,7 +42,7 @@ jobs:
 
       - run: make cosign conformance
 
-      - uses: sigstore/sigstore-conformance@main
+      - uses: sigstore/sigstore-conformance@711e3a7a666653df5be821ab5fb44b598edbe438 # main
         with:
           entrypoint: ${{ github.workspace }}/conformance
           xfail: "test_verify*PATH-message-digest-mismatch_fail]"

--- a/.github/workflows/cut-release.yml
+++ b/.github/workflows/cut-release.yml
@@ -36,7 +36,7 @@ concurrency: cut-release
 jobs:
   cut-release:
     name: Cut release
-    uses: sigstore/community/.github/workflows/reusable-release.yml@main
+    uses: sigstore/community/.github/workflows/reusable-release.yml@187381b77390665f46135fbad0ed9ec1ccaeb0ce # main
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/depsreview.yml
+++ b/.github/workflows/depsreview.yml
@@ -26,4 +26,4 @@ jobs:
     permissions:
       contents: read
 
-    uses: sigstore/community/.github/workflows/reusable-dependency-review.yml@main
+    uses: sigstore/community/.github/workflows/reusable-dependency-review.yml@187381b77390665f46135fbad0ed9ec1ccaeb0ce # main

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: imjasonh/setup-crane@6da1ae018866400525525ce74ff892880c099987 # v0.5
 
       - name: Install cluster + sigstore
-        uses: sigstore/scaffolding/actions/setup@main
+        uses: sigstore/scaffolding/actions/setup@a1aa4c33287ee7bd82a075a150fbb05f80a94bde # main
         with:
           version: ${{ env.SCAFFOLDING_RELEASE_VERSION }}
 
@@ -154,7 +154,7 @@ jobs:
         mirror: mirror.gcr.io
 
     - name: Install cluster + sigstore
-      uses: sigstore/scaffolding/actions/setup@main
+      uses: sigstore/scaffolding/actions/setup@a1aa4c33287ee7bd82a075a150fbb05f80a94bde # main
       with:
         version: ${{ env.SCAFFOLDING_RELEASE_VERSION }}
 

--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -77,7 +77,7 @@ jobs:
         make cosign
 
     - name: Install cluster + sigstore
-      uses: sigstore/scaffolding/actions/setup@main
+      uses: sigstore/scaffolding/actions/setup@a1aa4c33287ee7bd82a075a150fbb05f80a94bde # main
       with:
         legacy-variables: "false"
         k8s-version: ${{ matrix.k8s-version }}


### PR DESCRIPTION
## Summary

This PR hardens your CI/CD workflows against supply chain attacks by pinning 6 third-party GitHub Actions to immutable commit SHAs.

| Rule | Severity | File | Fix |
|------|----------|------|-----|
| RGS-007 | medium | `e2e-tests.yml` | Pinned 2 actions to commit SHAs |
| RGS-007 | medium | `conformance-nightly.yml` | Pinned 1 action to commit SHA |
| RGS-007 | medium | `cut-release.yml` | Pinned 1 action to commit SHA |
| RGS-007 | medium | `depsreview.yml` | Pinned 1 action to commit SHA |
| RGS-007 | medium | `kind-verify-attestation.yaml` | Pinned 1 action to commit SHA |

## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **SHA pinning**: `action@v3` becomes `action@abc123 # v3` - original version preserved as comment
- No workflow logic, triggers, or permissions are modified

We've had 22 merges so far including next.js, keras, webpack, svelte, apache/superset, and excalidraw. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))