### PR TITLE
Fix DSSE predicate check (GHSA-w6c6-c85g-mmv6)

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -210,6 +210,41 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 			return err
 		}
 
+		sigContent, err := bundle.SignatureContent()
+		if err != nil {
+			return fmt.Errorf("fetching signature content: %w", err)
+		}
+
+		envContent := sigContent.EnvelopeContent()
+		if envContent == nil {
+			return fmt.Errorf("bundle does not contain a DSSE envelope")
+		}
+
+		rawEnv := envContent.RawEnvelope()
+		if rawEnv == nil {
+			return fmt.Errorf("bundle does not contain a raw DSSE envelope")
+		}
+
+		payloadBytes, err := json.Marshal(rawEnv)
+		if err != nil {
+			return fmt.Errorf("marshaling envelope: %w", err)
+		}
+
+		att, err := static.NewAttestation(payloadBytes)
+		if err != nil {
+			return fmt.Errorf("creating attestation from envelope: %w", err)
+		}
+
+		// This checks the predicate type -- if no error is returned and no payload is, then
+		// the attestation is not of the given predicate type.
+		b, gotPredicateType, err := policy.AttestationToPayloadJSON(ctx, c.PredicateType, att)
+		if err != nil {
+			return fmt.Errorf("converting to consumable policy validation: %w", err)
+		}
+		if b == nil {
+			return fmt.Errorf("invalid predicate type, expected %s got %s", c.PredicateType, gotPredicateType)
+		}
+
 		ui.Infof(ctx, "Verified OK")
 		return nil
 	}
@@ -344,7 +379,11 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 
 	// This checks the predicate type -- if no error is returned and no payload is, then
 	// the attestation is not of the given predicate type.
-	if b, gotPredicateType, err := policy.AttestationToPayloadJSON(ctx, c.PredicateType, signature); b == nil && err == nil {
+	b, gotPredicateType, err := policy.AttestationToPayloadJSON(ctx, c.PredicateType, signature)
+	if err != nil {
+		return fmt.Errorf("converting to consumable policy validation: %w", err)
+	}
+	if b == nil {
 		return fmt.Errorf("invalid predicate type, expected %s got %s", c.PredicateType, gotPredicateType)
 	}
 

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -15,15 +15,25 @@
 package verify
 
 import (
+	"bytes"
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"testing"
 
+	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protodsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/dsse"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
@@ -120,8 +130,9 @@ func TestVerifyBlobAttestation(t *testing.T) {
 		}, {
 			description: "verify new bundle with public key",
 			// From blobSLSAProvenanceSignature
-			bundlePath: makeLocalAttestNewBundle(t, "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Nsc2EuZGV2L3Byb3ZlbmFuY2UvdjAuMiIsInN1YmplY3QiOlt7Im5hbWUiOiJibG9iIiwiZGlnZXN0Ijp7InNoYTI1NiI6IjY1ODc4MWNkNGVkOWJjYTYwZGFjZDA5ZjdiYjkxNGJiNTE1MDJlOGI1ZDYxOWY1N2YzOWExZDY1MjU5NmNjMjQifX1dLCJwcmVkaWNhdGUiOnsiYnVpbGRlciI6eyJpZCI6IjIifSwiYnVpbGRUeXBlIjoieCIsImludm9jYXRpb24iOnsiY29uZmlnU291cmNlIjp7fX19fQ==", "application/vnd.in-toto+json", "MEUCIA8KjZqkrt90fzBojSwwtj3Bqb41E6ruxQk97TLnpzdYAiEAzOAjOTzyvTHqbpFDAn6zhrg6EZv7kxK5faRoVGYMh2c="),
-			blobPath:   blobPath,
+			bundlePath:    makeLocalAttestNewBundle(t, "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Nsc2EuZGV2L3Byb3ZlbmFuY2UvdjAuMiIsInN1YmplY3QiOlt7Im5hbWUiOiJibG9iIiwiZGlnZXN0Ijp7InNoYTI1NiI6IjY1ODc4MWNkNGVkOWJjYTYwZGFjZDA5ZjdiYjkxNGJiNTE1MDJlOGI1ZDYxOWY1N2YzOWExZDY1MjU5NmNjMjQifX1dLCJwcmVkaWNhdGUiOnsiYnVpbGRlciI6eyJpZCI6IjIifSwiYnVpbGRUeXBlIjoieCIsImludm9jYXRpb24iOnsiY29uZmlnU291cmNlIjp7fX19fQ==", "application/vnd.in-toto+json", "MEUCIA8KjZqkrt90fzBojSwwtj3Bqb41E6ruxQk97TLnpzdYAiEAzOAjOTzyvTHqbpFDAn6zhrg6EZv7kxK5faRoVGYMh2c="),
+			blobPath:      blobPath,
+			predicateType: "slsaprovenance",
 		}, {
 			description: "verify new bundle with public key - bad sig",
 			// From blobSLSAProvenanceSignature
@@ -304,6 +315,182 @@ func TestVerifyBlobAttestationMutuallyExclusiveFlags(t *testing.T) {
 			if !errors.Is(err, tt.expectedError) {
 				t.Fatalf("expected %T, got: %T, %v", tt.expectedError, err, err)
 			}
+		})
+	}
+}
+
+func TestVerifyBlobAttestation_MalformedPayloads(t *testing.T) {
+	ctx := context.Background()
+	td := t.TempDir()
+
+	leafPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := signature.LoadECDSASignerVerifier(leafPriv, crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubKeyBytes, err := cryptoutils.MarshalPublicKeyToPEM(signer.Public())
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyRef := writeBlobFile(t, td, string(pubKeyBytes), "cosign.pub")
+	blobPath := writeBlobFile(t, td, "blob", "blob")
+
+	dsseSigner := dsse.WrapSigner(signer, "application/vnd.in-toto+json")
+
+	tests := []struct {
+		description   string
+		predicateType string
+		setupEnv      func() (string, error)
+	}{
+		{
+			description:   "missing predicate type",
+			predicateType: "",
+			setupEnv: func() (string, error) {
+				envBytes, err := dsseSigner.SignMessage(bytes.NewReader([]byte(`{"_type": "https://in-toto.io/Statement/v0.1"}`)))
+				return string(envBytes), err
+			},
+		},
+		{
+			description:   "missing payload field in json",
+			predicateType: "slsaprovenance",
+			setupEnv: func() (string, error) {
+				env := ssldsse.Envelope{
+					PayloadType: "application/vnd.in-toto+json",
+					Payload:     "",
+				}
+				pae := ssldsse.PAE(env.PayloadType, []byte(env.Payload))
+				sigBytes, err := signer.SignMessage(bytes.NewReader(pae))
+				if err != nil {
+					return "", err
+				}
+				env.Signatures = []ssldsse.Signature{{Sig: base64.StdEncoding.EncodeToString(sigBytes)}}
+				envJSONBytes, err := json.Marshal(env)
+				if err != nil {
+					return "", err
+				}
+				var m map[string]interface{}
+				if err := json.Unmarshal(envJSONBytes, &m); err != nil {
+					return "", err
+				}
+				delete(m, "payload")
+				envJSONBytes, err = json.Marshal(m)
+				return string(envJSONBytes), err
+			},
+		},
+		{
+			description:   "payload is valid base64 but inner is not valid in-toto statement",
+			predicateType: "slsaprovenance",
+			setupEnv: func() (string, error) {
+				envBytes, err := dsseSigner.SignMessage(bytes.NewReader([]byte(`not-json`)))
+				return string(envBytes), err
+			},
+		},
+		{
+			description:   "unmarshaling ProvenanceStatementSLSA02",
+			predicateType: "slsaprovenance",
+			setupEnv: func() (string, error) {
+				malformedSlsa := `{"_type": "https://in-toto.io/Statement/v0.1", "predicateType": "https://slsa.dev/provenance/v0.2", "predicate": {"builder": []}}`
+				envBytes, err := dsseSigner.SignMessage(bytes.NewReader([]byte(malformedSlsa)))
+				return string(envBytes), err
+			},
+		},
+		{
+			description:   "unmarshaling CosignVulnStatement",
+			predicateType: "vuln",
+			setupEnv: func() (string, error) {
+				malformedVuln := `{"_type": "https://in-toto.io/Statement/v0.1", "predicateType": "https://cosign.sigstore.dev/attestation/vuln/v1", "predicate": {"scanner": []}}`
+				envBytes, err := dsseSigner.SignMessage(bytes.NewReader([]byte(malformedVuln)))
+				return string(envBytes), err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			sigStr, err := tc.setupEnv()
+			if err != nil {
+				t.Fatalf("failed to setup envelope: %v", err)
+			}
+
+			t.Run("Standalone Signature", func(t *testing.T) {
+				sigRef := writeBlobFile(t, td, sigStr, "signature")
+
+				cmd := VerifyBlobAttestationCommand{
+					KeyOpts:       options.KeyOpts{KeyRef: keyRef},
+					SignaturePath: sigRef,
+					IgnoreTlog:    true,
+					CheckClaims:   false,
+					PredicateType: tc.predicateType,
+				}
+
+				err = cmd.Exec(ctx, blobPath)
+				if err == nil {
+					t.Fatalf("[%s Standalone] FAIL: swallowed error, returned Verified OK", tc.description)
+				} else {
+					t.Logf("[%s Standalone] PASS: returned error: %v", tc.description, err)
+				}
+			})
+
+			t.Run("Old Bundle Format", func(t *testing.T) {
+				bundleData := map[string]interface{}{
+					"base64Signature": base64.StdEncoding.EncodeToString([]byte(sigStr)),
+					"cert":            string(pubKeyBytes),
+				}
+				bundleBytes, err := json.Marshal(bundleData)
+				if err != nil {
+					t.Fatalf("failed to marshal old bundle: %v", err)
+				}
+				bundleRef := writeBlobFile(t, td, string(bundleBytes), "bundle.json")
+
+				cmd := VerifyBlobAttestationCommand{
+					KeyOpts:       options.KeyOpts{KeyRef: keyRef, BundlePath: bundleRef},
+					IgnoreTlog:    true,
+					CheckClaims:   false,
+					PredicateType: tc.predicateType,
+				}
+
+				err = cmd.Exec(ctx, blobPath)
+				if err == nil {
+					t.Fatalf("[%s Old Bundle] FAIL: swallowed error, returned Verified OK", tc.description)
+				} else {
+					t.Logf("[%s Old Bundle] PASS: returned error: %v", tc.description, err)
+				}
+			})
+
+			t.Run("New Bundle Format", func(t *testing.T) {
+				var envJSON struct {
+					PayloadType string `json:"payloadType"`
+					Payload     string `json:"payload"`
+					Signatures  []struct {
+						Sig string `json:"sig"`
+					} `json:"signatures"`
+				}
+				if err := json.Unmarshal([]byte(sigStr), &envJSON); err != nil {
+					t.Fatalf("failed to unmarshal dsse envelope: %v", err)
+				}
+				if len(envJSON.Signatures) == 0 {
+					t.Fatalf("no signatures in dsse envelope")
+				}
+				bundlePath := makeLocalAttestNewBundle(t, envJSON.Payload, envJSON.PayloadType, envJSON.Signatures[0].Sig)
+
+				cmd := VerifyBlobAttestationCommand{
+					KeyOpts:         options.KeyOpts{KeyRef: keyRef, BundlePath: bundlePath, NewBundleFormat: true},
+					IgnoreTlog:      true,
+					CheckClaims:     false,
+					PredicateType:   tc.predicateType,
+					TrustedRootPath: writeTrustedRootFile(t, td, "{\"mediaType\":\"application/vnd.dev.sigstore.trustedroot+json;version=0.1\"}"),
+				}
+
+				err = cmd.Exec(ctx, blobPath)
+				if err == nil {
+					t.Fatalf("[%s New Bundle] FAIL: swallowed error, returned Verified OK", tc.description)
+				} else {
+					t.Logf("[%s New Bundle] PASS: returned error: %v", tc.description, err)
+				}
+			})
 		})
 	}
 }

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -1043,6 +1043,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			SignaturePath: "", // Sig is fetched from bundle
 			KeyOpts:       options.KeyOpts{BundlePath: bundlePath},
 			IgnoreSCT:     true,
+			PredicateType: "customFoo",
 		}
 		if err := cmd.Exec(context.Background(), blobPath); err != nil {
 			t.Fatal(err)
@@ -1080,6 +1081,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			SignaturePath: "", // Sig is fetched from bundle
 			KeyOpts:       options.KeyOpts{BundlePath: bundlePath},
 			IgnoreSCT:     true,
+			PredicateType: "customFoo",
 		}
 		if err := cmd.Exec(context.Background(), blobPath); err != nil {
 			t.Fatal(err)
@@ -1412,6 +1414,7 @@ func TestVerifyBlobCmdWithBundle(t *testing.T) {
 			KeyOpts:       options.KeyOpts{BundlePath: bundlePath},
 			IgnoreSCT:     true,
 			CheckClaims:   false, // Intentionally false. This checks the subject claim. This is tested in verify_blob_attestation_test.go
+			PredicateType: "customFoo",
 		}
 		if err := cmd.Exec(context.Background(), blobPath); err != nil {
 			t.Fatal(err)

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -1728,7 +1728,7 @@ func writeTimestampFile(t *testing.T, td string, ts *bundle.RFC3161Timestamp, na
 	return path
 }
 
-func writeTrustedRootFile(t *testing.T, td, contents string) string {
+func writeTrustedRootFile(t *testing.T, td, contents string) string { //nolint: unparam
 	path := filepath.Join(td, "trusted_root.json")
 	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
 		t.Fatal(err)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1009,6 +1009,7 @@ func TestSignAttestVerifyBlobWithSigningConfig(t *testing.T) {
 		Digest:              "7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
 		DigestAlg:           "alg",
 		CheckClaims:         true,
+		PredicateType:       "something",
 	}
 	err = verifyBlobAttestationCmd.Exec(ctx, "")
 	must(err, t)
@@ -1389,10 +1390,11 @@ func TestSignVerifyWithSigningConfigWithKey(t *testing.T) {
 	// Verify an attestation with the key in the trusted root
 	ko.KeyRef = pubKeyPath
 	verifyBlobAttestationCmd := cliverify.VerifyBlobAttestationCommand{
-		KeyOpts:     ko,
-		Digest:      "7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
-		DigestAlg:   "alg",
-		CheckClaims: true,
+		KeyOpts:       ko,
+		Digest:        "7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
+		DigestAlg:     "alg",
+		CheckClaims:   true,
+		PredicateType: "something",
 	}
 	err = verifyBlobAttestationCmd.Exec(ctx, "")
 	must(err, t)


### PR DESCRIPTION
AttestationToPayloadJSON parses the attestation and checks that the predicate type matches the expected type provided by the user. Previously, when this function was called for old-format bundles and detached signatures, any error returned was silently ignored, so malformed attestations would be accepted and cosign would report a successful verification. For new-format bundles, this check was never performed at all, so the attestaion would be accepted even if it did not match the type given by the user. This change ensures that errors are handled correctly and that the check is performed for both paths.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
