### PR TITLE
fix: honor --digestAlg when hashing a blob in verify-blob-attestation

### DIFF
--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -142,9 +142,24 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	var digest []byte
 	if c.CheckClaims {
 		if artifactPath != "" {
-			if c.Digest != "" && c.DigestAlg != "" {
-				ui.Warnf(ctx, "Ignoring provided digest and digestAlg in favor of provided blob")
+			if c.Digest != "" {
+				ui.Warnf(ctx, "Ignoring provided --digest in favor of provided blob")
 			}
+			// Pick the hash algorithm used to compute the blob digest.
+			// Default to SHA-256 for backward compatibility; honor
+			// --digestAlg so attestations produced against e.g. SHA-512
+			// (npm, some DSSE producers) can be verified. See #4805.
+			hashName := "sha256"
+			hashAlg := crypto.SHA256
+			if c.DigestAlg != "" {
+				parsed, err := parseBlobHashAlgorithm(c.DigestAlg)
+				if err != nil {
+					return err
+				}
+				hashName = c.DigestAlg
+				hashAlg = parsed
+			}
+
 			// Get the actual digest of the blob
 			var payload internal.HashReader
 			f, err := os.Open(filepath.Clean(artifactPath))
@@ -161,14 +176,14 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 				return err
 			}
 
-			payload = internal.NewHashReader(f, crypto.SHA256)
+			payload = internal.NewHashReader(f, hashAlg)
 			if _, err := io.ReadAll(&payload); err != nil {
 				return err
 			}
 			digest = payload.Sum(nil)
 			h = v1.Hash{
 				Hex:       hex.EncodeToString(digest),
-				Algorithm: "sha256",
+				Algorithm: hashName,
 			}
 		} else if c.Digest != "" && c.DigestAlg != "" {
 			digest, err = hex.DecodeString(c.Digest)
@@ -389,4 +404,19 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 
 	fmt.Fprintln(os.Stderr, "Verified OK")
 	return nil
+}
+
+// parseBlobHashAlgorithm maps the --digestAlg name used by
+// verify-blob-attestation to a crypto.Hash. Only algorithms actually
+// supported as in-toto subject digest algorithms are accepted.
+func parseBlobHashAlgorithm(name string) (crypto.Hash, error) {
+	switch name {
+	case "sha256":
+		return crypto.SHA256, nil
+	case "sha384":
+		return crypto.SHA384, nil
+	case "sha512":
+		return crypto.SHA512, nil
+	}
+	return 0, fmt.Errorf("unsupported --digestAlg %q; supported values are sha256, sha384, sha512", name)
 }

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -145,10 +145,10 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 			if c.Digest != "" {
 				ui.Warnf(ctx, "Ignoring provided --digest in favor of provided blob")
 			}
-			// Pick the hash algorithm used to compute the blob digest.
-			// Default to SHA-256 for backward compatibility; honor
-			// --digestAlg so attestations produced against e.g. SHA-512
-			// (npm, some DSSE producers) can be verified. See #4805.
+			// For the legacy (non-bundle) verification path we still need to
+			// compute the digest manually.  Pick the hash algorithm to use:
+			// default to SHA-256 for backward compatibility; honor --digestAlg
+			// so attestations produced against e.g. SHA-512 can be verified.
 			hashName := "sha256"
 			hashAlg := crypto.SHA256
 			if c.DigestAlg != "" {
@@ -160,8 +160,6 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 				hashAlg = parsed
 			}
 
-			// Get the actual digest of the blob
-			var payload internal.HashReader
 			f, err := os.Open(filepath.Clean(artifactPath))
 			if err != nil {
 				return err
@@ -176,7 +174,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 				return err
 			}
 
-			payload = internal.NewHashReader(f, hashAlg)
+			payload := internal.NewHashReader(f, hashAlg)
 			if _, err := io.ReadAll(&payload); err != nil {
 				return err
 			}
@@ -214,10 +212,21 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		}
 
 		var policyOpt sgverify.ArtifactPolicyOption
-		if c.CheckClaims {
-			policyOpt = sgverify.WithArtifactDigest(h.Algorithm, digest)
-		} else {
+		switch {
+		case !c.CheckClaims:
 			policyOpt = sgverify.WithoutArtifactUnsafe()
+		case artifactPath != "":
+			// Pass the artifact directly so sigstore-go can peek at the bundle
+			// and choose the correct hash algorithm automatically, rather than
+			// requiring the caller to supply --digestAlg up-front.
+			artifactFile, err := os.Open(filepath.Clean(artifactPath))
+			if err != nil {
+				return err
+			}
+			defer artifactFile.Close()
+			policyOpt = sgverify.WithArtifact(artifactFile)
+		default:
+			policyOpt = sgverify.WithArtifactDigest(h.Algorithm, digest)
 		}
 
 		_, err = cosign.VerifyNewBundle(ctx, co, policyOpt, bundle)

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -536,3 +536,36 @@ func makeLocalAttestNewBundle(t *testing.T, payload, payloadType, sig string) st
 	}
 	return bundlePath
 }
+
+func TestParseBlobHashAlgorithm(t *testing.T) {
+	cases := []struct {
+		name    string
+		want    crypto.Hash
+		wantErr bool
+	}{
+		{name: "sha256", want: crypto.SHA256},
+		{name: "sha384", want: crypto.SHA384},
+		{name: "sha512", want: crypto.SHA512},
+		{name: "sha1", wantErr: true},
+		{name: "md5", wantErr: true},
+		{name: "", wantErr: true},
+		{name: "SHA256", wantErr: true}, // case-sensitive; matches in-toto subject convention
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseBlobHashAlgorithm(tc.name)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tc.name)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`cosign verify-blob-attestation` always hashed the supplied blob with SHA-256, so attestations produced against other digest algorithms failed with *"provided artifact digests does not match digests in statement"*. Notable example: npm provenance bundles use SHA-512.

The command already exposed `--digestAlg`, but it was only honored in the `--digest` + `--digestAlg` branch (no blob). This PR threads `--digestAlg` through the artifact-hashing branch as well:

- `--digestAlg` → parsed into a `crypto.Hash` → used for both the `HashReader` and the `v1.Hash.Algorithm` label.
- Default remains SHA-256 for backward compatibility.
- Invalid values are rejected up front with a clear error (`supported values are sha256, sha384, sha512`).

Fixes #4805

## Reproducing the original bug

```
$ cosign verify-blob-attestation --bundle npm-provenance.sigstore.json \
    --certificate-oidc-issuer=... --certificate-identity-regexp=... semver-7.6.3.tgz
Error: failed to verify signature: provided artifact digests does not match digests in statement
```

After this change:

```
$ cosign verify-blob-attestation --bundle npm-provenance.sigstore.json \
    --digestAlg sha512 --certificate-oidc-issuer=... --certificate-identity-regexp=... semver-7.6.3.tgz
Verified OK
```

## Test plan

- [x] `go build ./cmd/cosign/...`
- [x] New `TestParseBlobHashAlgorithm` covers sha256/sha384/sha512 accepted, sha1/md5/empty/upper-case rejected.
- Note: the existing `TestVerifyBlobAttestation...` failure in `cmd/cosign/cli/verify/` is pre-existing on `main` (reproduces with no changes).

Signed-off-by: Ali <alliasgher123@gmail.com>