### PR TITLE
Switch from cosign copy to oras copy

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -73,6 +73,7 @@ steps:
     env:
       - "GOPATH=/workspace/go"
       - "GOBIN=/workspace/bin"
+      - "DOCKER_CONFIG=/workspace/.docker"
       - PROJECT_ID=${PROJECT_ID}
       - KEY_LOCATION=${_KEY_LOCATION}
       - KEY_RING=${_KEY_RING}
@@ -90,7 +91,44 @@ steps:
       - '-c'
       - |
         echo $$GITHUB_TOKEN | docker login ghcr.io -u $$GITHUB_USER --password-stdin \
-        && make sign-release-images && make copy-signed-release-to-ghcr || true
+        && make sign-release-images || true
+
+  - name: 'ghcr.io/oras-project/oras:v1.3.1@sha256:96ef3b6ddc71d8a6b7bcdae517f6b696bcb4f8abac4ea62beec1ee482f433a83'
+    env:
+      - 'DOCKER_CONFIG=/workspace/.docker'
+    args:
+      - 'copy'
+      - '-r'
+      - 'gcr.io/${PROJECT_ID}/cosign:${_GIT_TAG}'
+      - '${_GHCR_PREFIX}/cosign:${_GIT_TAG}'
+
+  - name: 'ghcr.io/oras-project/oras:v1.3.1@sha256:96ef3b6ddc71d8a6b7bcdae517f6b696bcb4f8abac4ea62beec1ee482f433a83'
+    env:
+      - 'DOCKER_CONFIG=/workspace/.docker'
+    args:
+      - 'copy'
+      - '-r'
+      - '${_GHCR_PREFIX}/cosign:${_GIT_TAG}'
+      - '${_GHCR_PREFIX}/cosign:latest'
+
+  - name: 'ghcr.io/oras-project/oras:v1.3.1@sha256:96ef3b6ddc71d8a6b7bcdae517f6b696bcb4f8abac4ea62beec1ee482f433a83'
+    env:
+      - 'DOCKER_CONFIG=/workspace/.docker'
+    args:
+      - 'copy'
+      - '-r'
+      - 'gcr.io/${PROJECT_ID}/cosign:${_GIT_TAG}-dev'
+      - '${_GHCR_PREFIX}/cosign:${_GIT_TAG}-dev'
+
+  - name: 'ghcr.io/oras-project/oras:v1.3.1@sha256:96ef3b6ddc71d8a6b7bcdae517f6b696bcb4f8abac4ea62beec1ee482f433a83'
+    env:
+      - 'DOCKER_CONFIG=/workspace/.docker'
+    args:
+      - 'copy'
+      - '-r'
+      - '${_GHCR_PREFIX}/cosign:${_GIT_TAG}-dev'
+      - '${_GHCR_PREFIX}/cosign:latest-dev'
+
 
 availableSecrets:
   secretManager:
@@ -123,3 +161,5 @@ substitutions:
   _KEY_VERSION: '1'
   _KEY_LOCATION: 'global'
   _GITHUB_USER: 'placeholder'
+  _GHCR_PREFIX: 'ghcr.io/sigstore/cosign'
+

--- a/release/release.mk
+++ b/release/release.mk
@@ -19,14 +19,3 @@ sign-release-images: ko
 .PHONY: snapshot
 snapshot:
 	LDFLAGS="$(LDFLAGS)" goreleaser release --skip=sign,publish --snapshot --clean --timeout 120m --parallelism 1
-
-####################
-# copy image to GHCR
-####################
-
-.PHONY: copy-signed-release-to-ghcr
-copy-signed-release-to-ghcr:
-	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:$(GIT_VERSION)
-	cosign copy --force=true $(GHCR_PREFIX)/cosign:$(GIT_VERSION) $(GHCR_PREFIX)/cosign:latest
-	cosign copy $(KO_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev
-	cosign copy --force=true $(GHCR_PREFIX)/cosign:$(GIT_VERSION)-dev $(GHCR_PREFIX)/cosign:latest-dev


### PR DESCRIPTION
cosign copy does not copy referring artifacts, so we'll use oras instead as part of the build step.

Fixes #4818

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
