### PR TITLE
Add google-compute-identity provider

### DIFF
--- a/pkg/providers/google/google.go
+++ b/pkg/providers/google/google.go
@@ -17,6 +17,7 @@ package google
 
 import (
 	"context"
+	"net/url"
 
 	"google.golang.org/api/idtoken"
 	"google.golang.org/api/impersonate"
@@ -29,6 +30,7 @@ import (
 
 func init() {
 	providers.Register("google-workload-identity", &googleWorkloadIdentity{})
+	providers.Register("google-compute-identity", &googleComputeIdentity{})
 	providers.Register("google-impersonate", &googleImpersonate{})
 }
 
@@ -57,6 +59,30 @@ func (gwi *googleWorkloadIdentity) Provide(ctx context.Context, audience string)
 		return "", err
 	}
 	return tok.AccessToken, nil
+}
+
+// googleComputeIdentity fetches an ID token directly from the GCE metadata
+// server, bypassing Application Default Credentials (ADC). This is useful when
+// running on GCE/GKE and ADC is configured (e.g. via
+// "gcloud auth application-default login") but the caller wants the identity
+// of the attached service account rather than the ADC identity.
+type googleComputeIdentity struct{}
+
+var _ providers.Interface = (*googleComputeIdentity)(nil)
+
+// Enabled implements providers.Interface
+func (gci *googleComputeIdentity) Enabled(_ context.Context) bool {
+	return metadata.OnGCE()
+}
+
+// Provide implements providers.Interface
+func (gci *googleComputeIdentity) Provide(ctx context.Context, audience string) (string, error) {
+	c := metadata.NewClient(nil)
+	tok, err := c.GetWithContext(ctx, "instance/service-accounts/default/identity?audience="+url.QueryEscape(audience)+"&format=full")
+	if err != nil {
+		return "", err
+	}
+	return tok, nil
 }
 
 type googleImpersonate struct{}


### PR DESCRIPTION
#### Summary

The existing `google-workload-identity` provider uses `idtoken.NewTokenSource`,
which follows the full Application Default Credentials (ADC) chain. When ADC
credentials are present (e.g. from `gcloud auth application-default login`),
they take priority over the GCE metadata server — even when the caller
explicitly selects `google-workload-identity` as the token provider.

This adds a new `google-compute-identity` provider that fetches ID tokens
directly from the GCE metadata server, bypassing ADC entirely. This allows
callers running on GCE/GKE to reliably use the identity of the attached
service account.

Usage (e.g. with gitsign):
```
git config gitsign.tokenProvider google-compute-identity
```

#### Release Note

Added `google-compute-identity` OIDC token provider that fetches ID tokens directly from the GCE metadata server, bypassing Application Default Credentials (ADC). This is useful when running on GCE/GKE and ADC is configured but the caller wants the identity of the attached service account.

#### Documentation

The new provider can be selected via `COSIGN_TOKEN_PROVIDER=google-compute-identity` or equivalent tool-specific configuration (e.g. `gitsign.tokenProvider`). It is only available when running on GCE/GKE.