### PR TITLE
ci: Skip setcap for HashiCorp Vault

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -83,6 +83,7 @@ jobs:
         image: hashicorp/vault:latest
         env:
           VAULT_DEV_ROOT_TOKEN_ID: root
+          SKIP_SETCAP: "true"
         options: >-
           --health-cmd "VAULT_ADDR=http://127.0.0.1:8200 vault status"
           --health-interval 1s


### PR DESCRIPTION
#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

This change sets `SKIP_SETCAP` to `true` for HashiCorp Vault in the `e2e-tests` workflow's `e2e-kms` step.

This is an immediate workaround to address a conflict in Vault's Dockerfile introduced by v2.0.0 (see [issue](https://github.com/hashicorp/vault/issues/31919)).