### PR TITLE
fix: pass NameOptions to ParseReference in load command

### DIFF
--- a/cmd/cosign/cli/load.go
+++ b/cmd/cosign/cli/load.go
@@ -46,7 +46,7 @@ func Load() *cobra.Command {
 }
 
 func LoadCmd(ctx context.Context, opts options.LoadOptions, imageRef string) error {
-	ref, err := name.ParseReference(imageRef)
+	ref, err := name.ParseReference(imageRef, opts.Registry.NameOptions()...)
 	if err != nil {
 		return fmt.Errorf("parsing image name %s: %w", imageRef, err)
 	}


### PR DESCRIPTION
## Description

The `load` command was not passing `NameOptions()` to `name.ParseReference()`, causing the `--allow-http-registry` flag to be ignored when loading images to HTTP-only registries.

Every other command that parses image references (save, copy, attach, download, clean, tree, verify, generate) correctly passes `NameOptions()`. The load command was the only one missing this.

## Change

```go
// Before
ref, err := name.ParseReference(imageRef)

// After
ref, err := name.ParseReference(imageRef, opts.Registry.NameOptions()...)
```

## Testing

When `--allow-http-registry` is passed, `NameOptions()` returns `name.Insecure` which allows the reference parser to use HTTP URLs instead of forcing HTTPS.

Closes #4134