### PR TITLE
docs: add enterprise private-infrastructure guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This shows how to:
 * verify the container image
 * explore broader keyless blob signing/verification flows in the [Sigstore Cosign Quickstart](https://docs.sigstore.dev/quickstart/quickstart-cosign/)
 
-For private deployments that use an internal OIDC issuer, internal CA, RFC3161 TSA, and no Rekor dependency, see [Enterprise Private Infrastructure](./doc/enterprise-private-infrastructure.md).
+For private deployments that use an internal OIDC issuer, internal CA, RFC3161 TSA, and no Rekor dependency, see [Enterprise Private Infrastructure](./specs/PRIVATE_INFRASTRUCTURE_SPEC.md).
 
 ### Sign a container and store the signature in the registry
 
@@ -173,7 +173,7 @@ To verify in an air-gapped environment with a public key:
 cosign verify --key cosign.pub --local-image ./path/to/dir
 ```
 
-For private deployments that do not use Rekor, prefer a private trusted root and the workflows documented in [Enterprise Private Infrastructure](./doc/enterprise-private-infrastructure.md).
+For private deployments that do not use Rekor, prefer a private trusted root and the workflows documented in [Enterprise Private Infrastructure](./specs/PRIVATE_INFRASTRUCTURE_SPEC.md).
 
 ### Identity-based blob signing and verification
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ This shows how to:
 * verify the container image
 * explore broader keyless blob signing/verification flows in the [Sigstore Cosign Quickstart](https://docs.sigstore.dev/quickstart/quickstart-cosign/)
 
+For private deployments that use an internal OIDC issuer, internal CA, RFC3161 TSA, and no Rekor dependency, see [Enterprise Private Infrastructure](./doc/enterprise-private-infrastructure.md).
+
 ### Sign a container and store the signature in the registry
 
 Note that you should always sign images based on their digest (`@sha256:...`)
@@ -142,45 +144,36 @@ The following checks were performed on these signatures:
 
 ### Verify a container in an air-gapped environment
 
-**Note:** This section is out of date.
+Cosign's recommended air-gapped verification flow is bundle-first: move the artifact, its signatures, and a trusted root into the disconnected environment, then verify locally without depending on live Sigstore services.
 
-**Note:** Most verification workflows require periodically requesting service keys from a TUF repository.
-For airgapped verification of signatures using the public-good instance, you will need to retrieve the
-[trusted root](https://github.com/sigstore/root-signing/blob/main/targets/trusted_root.json) file from the production
-TUF repository. The contents of this file will change without notification. By not using TUF, you will need
-to build your own mechanism to keep your airgapped copy of this file up-to-date.
+There are two common trust models:
 
-Cosign can do completely offline verification by verifying a [bundle](./specs/SIGNATURE_SPEC.md#properties) which is typically distributed as an annotation on the image manifest.
-As long as this annotation is present, then offline verification can be done.
-This bundle annotation is always included by default for keyless signing, so the default `cosign sign` functionality will include all materials needed for offline verification.
+- Public-good Sigstore: mirror the current Sigstore trusted root and keep it updated with your own process.
+- Private infrastructure: distribute your own `trusted-root.json` that contains your internal CA, TSA, and any other verification material.
 
-To verify an image in an air-gapped environment, the image and signatures must be available locally on the filesystem.
+To prepare a local copy of an image and its signatures while connected:
 
-An image can be saved locally using `cosign save` (note, this step must be done with a network connection):
-
-```
-cosign initialize # This will pull in the latest TUF root
+```shell
 cosign save $IMAGE_NAME --dir ./path/to/dir
 ```
 
-Now, in an air-gapped environment, this local image can be verified:
+To verify in an air-gapped environment with keyless signatures and a trusted root:
 
 ```shell
 cosign verify \
   --certificate-identity $CERT_IDENTITY \
   --certificate-oidc-issuer $CERT_OIDC_ISSUER \
-  --offline=true \
-  --new-bundle-format=false \ # for artifacts signed without the new protobuf bundle format
-  --trusted-root ~/.sigstore/root/tuf-repo-cdn.sigstore.dev/targets/trusted_root.json \ # default location of trusted root
+  --trusted-root /path/to/trusted-root.json \
   --local-image ./path/to/dir
 ```
 
-You'll need to pass in expected values for `$CERT_IDENTITY` and `$CERT_OIDC_ISSUER` to correctly verify this image.
-If you signed with a keypair, the same command will work, assuming the public key material is present locally:
+To verify in an air-gapped environment with a public key:
 
+```shell
+cosign verify --key cosign.pub --local-image ./path/to/dir
 ```
-cosign verify --key cosign.pub --offline --local-image ./path/to/dir
-```
+
+For private deployments that do not use Rekor, prefer a private trusted root and the workflows documented in [Enterprise Private Infrastructure](./doc/enterprise-private-infrastructure.md).
 
 ### Identity-based blob signing and verification
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -82,6 +82,9 @@ race conditions or (worse) malicious tampering.
   # sign a container image and skip uploading to the transparency log
   cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
 
+  # sign a container image in private infrastructure with a custom signing config and TSA
+  cosign sign --key cosign.key --certificate cosign.crt --certificate-chain chain.crt --signing-config signing-config.json --timestamp-server-url https://tsa.internal.example.com/api/v1/timestamp <IMAGE DIGEST>
+
   # sign a container image by manually setting the container image identity
   cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -83,7 +83,7 @@ race conditions or (worse) malicious tampering.
   cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
 
   # sign a container image in private infrastructure with a custom signing config and TSA
-  cosign sign --key cosign.key --certificate cosign.crt --certificate-chain chain.crt --signing-config signing-config.json --timestamp-server-url https://tsa.internal.example.com/api/v1/timestamp <IMAGE DIGEST>
+  cosign sign --key cosign.key --certificate cosign.crt --certificate-chain chain.crt --signing-config signing-config.json --timestamp-server-url https://tsa.internal.example.com/api/v1/timestamp --timestamp-server-name tsa.internal.example.com <IMAGE DIGEST>
 
   # sign a container image by manually setting the container image identity
   cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>

--- a/cmd/cosign/cli/signingconfig.go
+++ b/cmd/cosign/cli/signingconfig.go
@@ -49,6 +49,13 @@ Each service is specified via a repeatable flag (--fulcio, --rekor, --oidc-provi
     --oidc-provider="url=https://oauth2.sigstore.dev/auth,api-version=1,start-time=2024-01-01T00:00:00Z,operator=sigstore.dev" \
     --tsa="url=https://timestamp.sigstore.dev/api/v1/timestamp,api-version=1,start-time=2024-01-01T00:00:00Z,operator=sigstore.dev" \
     --tsa-config="EXACT:1" \
+    --out signing-config.json
+
+cosign signing-config create \
+    --fulcio="url=https://ca.internal.example.com,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-pki" \
+    --oidc-provider="url=https://oidc.internal.example.com,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-identity" \
+    --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-pki" \
+    --tsa-config="EXACT:1" \
     --out signing-config.json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			scCreateCmd := &signingconfig.CreateCmd{

--- a/cmd/cosign/cli/trustedroot.go
+++ b/cmd/cosign/cli/trustedroot.go
@@ -49,6 +49,11 @@ Each service is specified via a repeatable flag (--fulcio, --rekor, --ctfe, --ts
     --rekor="url=https://rekor.sigstore.dev,public-key=/path/to/rekor.pub,start-time=2024-01-01T00:00:00Z" \
     --ctfe="url=https://ctfe.sigstore.dev,public-key=/path/to/ctfe.pub,start-time=2024-01-01T00:00:00Z" \
     --tsa="url=https://timestamp.sigstore.dev/api/v1/timestamp,certificate-chain=/path/to/tsa.pem" \
+    --out trusted-root.json
+
+cosign trusted-root create \
+    --fulcio="url=https://ca.internal.example.com,certificate-chain=/path/to/codesigning-chain.pem" \
+    --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,certificate-chain=/path/to/tsa-chain.pem" \
     --out trusted-root.json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			trCreateCmd := &trustedroot.CreateCmd{

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -68,6 +68,9 @@ against the transparency log.`,
   # chain and identity parameters, without Fulcio roots (for BYO PKI):
   cosign verify --cert-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com <IMAGE>
 
+  # verify an image in private infrastructure with a custom trusted root:
+  cosign verify --certificate-identity spiffe://example.internal/sa/build --certificate-oidc-issuer https://issuer.example.com --trusted-root trusted-root.json --private-infrastructure <IMAGE>
+
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
 

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -63,7 +63,7 @@ cosign sign [flags]
   cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
 
   # sign a container image in private infrastructure with a custom signing config and TSA
-  cosign sign --key cosign.key --certificate cosign.crt --certificate-chain chain.crt --signing-config signing-config.json --timestamp-server-url https://tsa.internal.example.com/api/v1/timestamp <IMAGE DIGEST>
+  cosign sign --key cosign.key --certificate cosign.crt --certificate-chain chain.crt --signing-config signing-config.json --timestamp-server-url https://tsa.internal.example.com/api/v1/timestamp --timestamp-server-name tsa.internal.example.com <IMAGE DIGEST>
 
   # sign a container image by manually setting the container image identity
   cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -62,6 +62,9 @@ cosign sign [flags]
   # sign a container image and skip uploading to the transparency log
   cosign sign --key cosign.key --tlog-upload=false <IMAGE DIGEST>
 
+  # sign a container image in private infrastructure with a custom signing config and TSA
+  cosign sign --key cosign.key --certificate cosign.crt --certificate-chain chain.crt --signing-config signing-config.json --timestamp-server-url https://tsa.internal.example.com/api/v1/timestamp <IMAGE DIGEST>
+
   # sign a container image by manually setting the container image identity
   cosign sign --sign-container-identity <NEW IMAGE DIGEST> <IMAGE DIGEST>
 

--- a/doc/cosign_signing-config_create.md
+++ b/doc/cosign_signing-config_create.md
@@ -22,6 +22,13 @@ cosign signing-config create \
     --tsa="url=https://timestamp.sigstore.dev/api/v1/timestamp,api-version=1,start-time=2024-01-01T00:00:00Z,operator=sigstore.dev" \
     --tsa-config="EXACT:1" \
     --out signing-config.json
+
+cosign signing-config create \
+    --fulcio="url=https://ca.internal.example.com,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-pki" \
+    --oidc-provider="url=https://oidc.internal.example.com,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-identity" \
+    --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-pki" \
+    --tsa-config="EXACT:1" \
+    --out signing-config.json
 ```
 
 ### Options

--- a/doc/cosign_trusted-root_create.md
+++ b/doc/cosign_trusted-root_create.md
@@ -21,6 +21,11 @@ cosign trusted-root create \
     --ctfe="url=https://ctfe.sigstore.dev,public-key=/path/to/ctfe.pub,start-time=2024-01-01T00:00:00Z" \
     --tsa="url=https://timestamp.sigstore.dev/api/v1/timestamp,certificate-chain=/path/to/tsa.pem" \
     --out trusted-root.json
+
+cosign trusted-root create \
+    --fulcio="url=https://ca.internal.example.com,certificate-chain=/path/to/codesigning-chain.pem" \
+    --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,certificate-chain=/path/to/tsa-chain.pem" \
+    --out trusted-root.json
 ```
 
 ### Options

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -46,6 +46,9 @@ cosign verify [flags]
   # chain and identity parameters, without Fulcio roots (for BYO PKI):
   cosign verify --cert-chain chain.crt --certificate-oidc-issuer https://issuer.example.com --certificate-identity foo@example.com <IMAGE>
 
+  # verify an image in private infrastructure with a custom trusted root:
+  cosign verify --certificate-identity spiffe://example.internal/sa/build --certificate-oidc-issuer https://issuer.example.com --trusted-root trusted-root.json --private-infrastructure <IMAGE>
+
   # verify image with public key provided by URL
   cosign verify --key https://host.for/[FILE] <IMAGE>
 

--- a/doc/enterprise-private-infrastructure.md
+++ b/doc/enterprise-private-infrastructure.md
@@ -1,0 +1,102 @@
+# Enterprise Private Infrastructure
+
+This guide shows how to use `cosign` in a private deployment that uses:
+
+- an internal OIDC issuer
+- an internal CA or other bring-your-own PKI chain
+- an RFC3161 timestamp authority
+- no Rekor dependency
+
+This model is useful when your trust and audit boundaries are private, and you want to verify signatures against internal trust roots instead of the public-good Sigstore services.
+
+## Recommended trust model
+
+For modern private deployments, prefer:
+
+- `cosign signing-config create` to define the service URLs used during signing
+- `cosign trusted-root create` to define the trust material used during verification
+- `--private-infrastructure` during verification when signatures are not uploaded to a public transparency log
+
+Avoid treating `--tlog-upload=false` as the long-term configuration mechanism by itself. It is better to make the "no Rekor" choice explicit in your `signing-config`.
+
+## 1. Create a trusted root
+
+Create a trusted root that contains your internal certificate authority chain and your TSA certificate chain.
+
+```shell
+cosign trusted-root create \
+  --fulcio="url=https://ca.internal.example.com,certificate-chain=/path/to/codesigning-chain.pem" \
+  --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,certificate-chain=/path/to/tsa-chain.pem" \
+  --out trusted-root.json
+```
+
+Notes:
+
+- The `--fulcio` field here models the certificate authority used for signing certificates. In a private deployment, this can represent your internal CA-backed certificate issuance path.
+- The `certificate-chain` should include the intermediate certificates needed for validation and end with the root certificate.
+
+## 2. Create a signing config
+
+Create a signing config that points signing to your internal services and omits Rekor.
+
+```shell
+cosign signing-config create \
+  --fulcio="url=https://ca.internal.example.com,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-pki" \
+  --oidc-provider="url=https://oidc.internal.example.com,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-identity" \
+  --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,api-version=1,start-time=2026-01-01T00:00:00Z,operator=internal-pki" \
+  --tsa-config="EXACT:1" \
+  --out signing-config.json
+```
+
+## 3. Sign with an internal certificate chain and TSA
+
+If your signing flow already has a key and a short-lived signing certificate, use them directly and timestamp the signature with your TSA.
+
+```shell
+cosign sign \
+  --key /path/to/codesigning.key \
+  --certificate /path/to/codesigning.crt \
+  --certificate-chain /path/to/codesigning-chain.pem \
+  --signing-config /path/to/signing-config.json \
+  --timestamp-server-url https://tsa.internal.example.com/api/v1/timestamp \
+  --timestamp-client-cacert /path/to/tsa-client-ca.pem \
+  --timestamp-client-cert /path/to/tsa-client.crt \
+  --timestamp-client-key /path/to/tsa-client.key \
+  --timestamp-server-name tsa.internal.example.com \
+  $IMAGE_DIGEST
+```
+
+If your private keyless flow mints an identity token outside of `cosign`, you can also pass it with `--identity-token`, or expose it through one of the ambient providers such as `filesystem`, `envvar`, or `spiffe`.
+
+## 4. Verify against your private trusted root
+
+Verify using the expected signer identity and your private trusted root.
+
+```shell
+cosign verify \
+  --certificate-identity "spiffe://example.internal/sa/build-job" \
+  --certificate-oidc-issuer "https://oidc.internal.example.com" \
+  --trusted-root /path/to/trusted-root.json \
+  --private-infrastructure \
+  $IMAGE_DIGEST
+```
+
+## Which trust input should I use?
+
+- Use `--trusted-root` when you want a single modern trust bundle that covers your private CA and TSA.
+- Use `--certificate-chain` when attaching or verifying the certificate chain embedded with a signature.
+- Use `--ca-roots` and `--ca-intermediates` when verification inputs are managed as separate PEM bundles instead of a Sigstore trusted root.
+
+## Air-gapped private verification
+
+In an air-gapped environment, move the image, signatures, and your private `trusted-root.json` into the disconnected network and verify locally:
+
+```shell
+cosign save $IMAGE_DIGEST --dir ./image-dir
+cosign verify \
+  --certificate-identity "spiffe://example.internal/sa/build-job" \
+  --certificate-oidc-issuer "https://oidc.internal.example.com" \
+  --trusted-root /path/to/trusted-root.json \
+  --private-infrastructure \
+  --local-image ./image-dir
+```

--- a/specs/PRIVATE_INFRASTRUCTURE_SPEC.md
+++ b/specs/PRIVATE_INFRASTRUCTURE_SPEC.md
@@ -1,21 +1,34 @@
 # Enterprise Private Infrastructure
 
-This guide shows how to use `cosign` in a private deployment that uses:
+This document describes how to use `cosign` in a private deployment that does not rely on public Sigstore services.
+The goal is to provide a consistent model for environments using:
 
-- an internal OIDC issuer
-- an internal CA or other bring-your-own PKI chain
-- an RFC3161 timestamp authority
-- no Rekor dependency
+- An internal OIDC issuer
+- An internal CA or other bring-your-own PKI chain
+- An RFC3161 timestamp authority
+- No Rekor dependency
 
-This model is useful when your trust and audit boundaries are private, and you want to verify signatures against internal trust roots instead of the public-good Sigstore services.
+This model is useful when your trust and audit boundaries are private, and you want to verify signatures against internal trust roots.
 
-## Recommended trust model
+## Sections
 
-For modern private deployments, prefer:
+- [Enterprise Private Infrastructure](#enterprise-private-infrastructure)
+  - [Sections](#sections)
+  - [Trust Model](#trust-model)
+  - [1. Create a trusted root](#1-create-a-trusted-root)
+  - [2. Create a signing config](#2-create-a-signing-config)
+  - [3. Sign with an internal certificate chain and TSA](#3-sign-with-an-internal-certificate-chain-and-tsa)
+  - [4. Verify against your private trusted root](#4-verify-against-your-private-trusted-root)
+  - [Which trust input should I use?](#which-trust-input-should-i-use)
+  - [Air-gapped private verification](#air-gapped-private-verification)
 
-- `cosign signing-config create` to define the service URLs used during signing
-- `cosign trusted-root create` to define the trust material used during verification
-- `--private-infrastructure` during verification when signatures are not uploaded to a public transparency log
+## Trust Model
+
+For private deployments, `cosign` supports a "Bring-Your-Own PKI" model. Prefer using:
+
+- `cosign signing-config create` to define the service URLs used during signing.
+- `cosign trusted-root create` to define the trust material used during verification.
+- `--private-infrastructure` during verification to explicitly skip public transparency log checks.
 
 Avoid treating `--tlog-upload=false` as the long-term configuration mechanism by itself. It is better to make the "no Rekor" choice explicit in your `signing-config`.
 
@@ -26,7 +39,7 @@ Create a trusted root that contains your internal certificate authority chain an
 ```shell
 cosign trusted-root create \
   --fulcio="url=https://ca.internal.example.com,certificate-chain=/path/to/codesigning-chain.pem" \
-  --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,certificate-chain=/path/to/tsa-chain.pem" \
+  --tsa="url=https://tsa.internal.example.com/api/v1/timestamp,certificate-chain=tsa-chain.pem" \
   --out trusted-root.json
 ```
 
@@ -63,7 +76,7 @@ cosign sign \
   --timestamp-client-cert /path/to/tsa-client.crt \
   --timestamp-client-key /path/to/tsa-client.key \
   --timestamp-server-name tsa.internal.example.com \
-  $IMAGE_DIGEST
+  <IMAGE DIGEST>
 ```
 
 If your private keyless flow mints an identity token outside of `cosign`, you can also pass it with `--identity-token`, or expose it through one of the ambient providers such as `filesystem`, `envvar`, or `spiffe`.
@@ -78,7 +91,7 @@ cosign verify \
   --certificate-oidc-issuer "https://oidc.internal.example.com" \
   --trusted-root /path/to/trusted-root.json \
   --private-infrastructure \
-  $IMAGE_DIGEST
+  <IMAGE DIGEST>
 ```
 
 ## Which trust input should I use?
@@ -92,7 +105,7 @@ cosign verify \
 In an air-gapped environment, move the image, signatures, and your private `trusted-root.json` into the disconnected network and verify locally:
 
 ```shell
-cosign save $IMAGE_DIGEST --dir ./image-dir
+cosign save <IMAGE DIGEST> --dir ./image-dir
 cosign verify \
   --certificate-identity "spiffe://example.internal/sa/build-job" \
   --certificate-oidc-issuer "https://oidc.internal.example.com" \


### PR DESCRIPTION
#### Summary
This is a docs-only PR. 

While `cosign` fully supports private deployments (e.g., using an internal OIDC issuer, internal CA / BYO PKI, an RFC3161 TSA, and no Rekor dependency), we didn't have a dedicated end-to-end guide for it. The air-gapped instructions in the `README.md` were also getting a bit stale.

This PR does the following:
- Adds `doc/enterprise-private-infrastructure.md` to serve as a comprehensive guide.
- Refreshes the air-gapped section in `README.md`.
- Adds private-infrastructure examples to the `cosign sign` and `cosign verify` commands (and ran `make docgen`).

There are no runtime behavior changes.

#### Release Note
NONE

#### Documentation
This PR itself is the documentation update. No further changes are needed.
