### PR TITLE
docs: add digest-based verification example for verify-blob-attestation

### DIFF
--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -404,6 +404,10 @@ The blob may be specified as a path to a file.`,
   # Verify a simple blob attestation with a DSSE style signature
   cosign verify-blob-attestation --key cosign.pub (--signature <sig path>|<sig url>)[path to BLOB]
 
+  # Verify a bundle attestation by matching the in-toto subject digest instead of reading the blob.
+  # When the subject uses an alternative digest algorithm, pass it explicitly with --digestAlg.
+  cosign verify-blob-attestation --bundle <bundle path> --key cosign.pub --digest <hex digest> --digestAlg sha512
+
 `,
 
 		Args:             cobra.MaximumNArgs(1),

--- a/doc/cosign_verify-blob-attestation.md
+++ b/doc/cosign_verify-blob-attestation.md
@@ -22,6 +22,10 @@ cosign verify-blob-attestation [flags]
   # Verify a simple blob attestation with a DSSE style signature
   cosign verify-blob-attestation --key cosign.pub (--signature <sig path>|<sig url>)[path to BLOB]
 
+  # Verify a bundle attestation by matching the in-toto subject digest instead of reading the blob.
+  # When the subject uses an alternative digest algorithm, pass it explicitly with --digestAlg.
+  cosign verify-blob-attestation --bundle <bundle path> --key cosign.pub --digest <hex digest> --digestAlg sha512
+
 
 ```
 


### PR DESCRIPTION
## Summary
- add a concrete `verify-blob-attestation` example for digest-based subject verification
- show explicit usage of `--digest` together with `--digestAlg`
- refresh generated command docs

## Why
`verify-blob-attestation` already supports digest-based subject verification, but the generated command docs did not include a clear example showing alternative digest usage with an explicit `--digestAlg`.

## Scope
- docs/help text only
- no runtime logic changes
