### PR TITLE
Use the configured Target Repository more consistently.

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1688,9 +1688,15 @@ func GetBundles(_ context.Context, signedImgRef name.Reference, registryClientOp
 	if err != nil {
 		return nil, nil, err
 	}
+
+	bundleRepo := digest.Repository
+	if targetRepo := ociremote.TargetRepositoryFromOptions(registryClientOpts...); (targetRepo != name.Repository{}) {
+		bundleRepo = targetRepo
+	}
+
 	var bundles = make([]*sgbundle.Bundle, 0, len(index.Manifests))
 	for _, result := range index.Manifests {
-		st, err := name.ParseReference(fmt.Sprintf("%s@%s", digest.Repository, result.Digest.String()), nameOpts...)
+		st, err := name.ParseReference(fmt.Sprintf("%s@%s", bundleRepo, result.Digest.String()), nameOpts...)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/cosign/verify_oci_test.go
+++ b/pkg/cosign/verify_oci_test.go
@@ -125,6 +125,60 @@ func TestGetBundles_Valid(t *testing.T) {
 	}
 }
 
+func TestGetBundles_WithTargetRepository(t *testing.T) {
+	r := registry.New(registry.WithReferrersSupport(true))
+	s := httptest.NewServer(r)
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	assert.NoError(t, err)
+	host := u.Host
+
+	sourceRef, err := name.ParseReference(fmt.Sprintf("%s/source-repo:tag", host))
+	assert.NoError(t, err)
+
+	targetRepo, err := name.NewRepository(fmt.Sprintf("%s/target-repo", host))
+	assert.NoError(t, err)
+
+	// Write the source image.
+	assert.NoError(t, remote.Write(sourceRef, empty.Image))
+
+	// Get the source image digest.
+	desc, err := remote.Head(sourceRef)
+	assert.NoError(t, err)
+
+	// Write the attestation referrer into the target repo.
+	// Pass the source digest as subject (so WriteReferrer can HEAD it) and
+	// WithTargetRepository so the referrer manifest is stored in target-repo.
+	sourceDigestRef := sourceRef.Context().Digest(desc.Digest.String())
+	err = ociremote.WriteAttestationNewBundleFormat(sourceDigestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1",
+		ociremote.WithTargetRepository(targetRepo),
+	)
+	assert.NoError(t, err)
+
+	// Without WithTargetRepository, the bundle is not found in the source repo.
+	bundles, hash, err := GetBundles(context.Background(), sourceRef, []ociremote.Option{})
+	var noMatchErr *ErrNoMatchingAttestations
+	assert.ErrorAs(t, err, &noMatchErr)
+	assert.Len(t, bundles, 0)
+	assert.Nil(t, hash)
+
+	// With WithTargetRepository, the bundle is found in the target repo.
+	bundles, hash, err = GetBundles(context.Background(), sourceRef, []ociremote.Option{
+		ociremote.WithTargetRepository(targetRepo),
+	})
+	assert.NoError(t, err)
+	assert.Len(t, bundles, 1)
+	assert.NotNil(t, hash)
+
+	expected := sgbundle.Bundle{}
+	err = expected.UnmarshalJSON(testAttestation)
+	assert.NoError(t, err)
+	if !proto.Equal(bundles[0].Bundle, &expected) {
+		t.Errorf("got %v, want %v", bundles[0].Bundle, &expected)
+	}
+}
+
 // TODO: This test is getting long and maybe should be refactored into a
 // table-based test to exercise more permutations.
 func TestVerifyImageAttestationsSigstoreBundle(t *testing.T) {

--- a/pkg/oci/remote/options.go
+++ b/pkg/oci/remote/options.go
@@ -129,6 +129,13 @@ func WithTargetRepository(repo name.Repository) Option {
 	}
 }
 
+// TargetRepositoryFromOptions extracts the TargetRepository that a
+// WithTargetRepository option would have set in the provided options.
+// Returns the zero name.Repository if no override was provided.
+func TargetRepositoryFromOptions(opts ...Option) name.Repository {
+	return makeOptions(name.Repository{}, opts...).TargetRepository
+}
+
 // GetEnvTargetRepository returns the Repository specified by
 // `os.Getenv(RepoOverrideEnvKey)`, or the empty value if not set.
 // Returns an error if the value is set but cannot be parsed.

--- a/pkg/oci/remote/referrers.go
+++ b/pkg/oci/remote/referrers.go
@@ -21,14 +21,20 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
+var remoteReferrers = remote.Referrers
+
 // Referrers fetches references using registry options.
 func Referrers(d name.Digest, artifactType string, opts ...Option) (*v1.IndexManifest, error) {
 	o := makeOptions(name.Repository{}, opts...)
+	if (o.TargetRepository != name.Repository{}) {
+		d = o.TargetRepository.Digest(d.DigestStr())
+	}
+
 	rOpt := o.ROpt
 	if artifactType != "" {
 		rOpt = append(rOpt, remote.WithFilter("artifactType", artifactType))
 	}
-	idx, err := remote.Referrers(d, rOpt...)
+	idx, err := remoteReferrers(d, rOpt...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/remote/referrers_test.go
+++ b/pkg/oci/remote/referrers_test.go
@@ -1,0 +1,121 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+const testDigestStr = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+func TestReferrers_NoTargetRepository(t *testing.T) {
+	orig := remoteReferrers
+	t.Cleanup(func() { remoteReferrers = orig })
+
+	var capturedDigest name.Digest
+	remoteReferrers = func(d name.Digest, _ ...remote.Option) (v1.ImageIndex, error) {
+		capturedDigest = d
+		return empty.Index, nil
+	}
+
+	inputDigest, err := name.NewDigest("gcr.io/source-repo/image@" + testDigestStr)
+	if err != nil {
+		t.Fatalf("name.NewDigest: %v", err)
+	}
+
+	if _, err = Referrers(inputDigest, ""); err != nil {
+		t.Fatalf("Referrers() = %v", err)
+	}
+
+	if got, want := capturedDigest.Repository.String(), inputDigest.Repository.String(); got != want {
+		t.Errorf("repository = %q, want %q", got, want)
+	}
+	if got, want := capturedDigest.DigestStr(), testDigestStr; got != want {
+		t.Errorf("digest = %q, want %q", got, want)
+	}
+}
+
+func TestReferrers_WithTargetRepository(t *testing.T) {
+	orig := remoteReferrers
+	t.Cleanup(func() { remoteReferrers = orig })
+
+	var capturedDigest name.Digest
+	remoteReferrers = func(d name.Digest, _ ...remote.Option) (v1.ImageIndex, error) {
+		capturedDigest = d
+		return empty.Index, nil
+	}
+
+	inputDigest, err := name.NewDigest("gcr.io/source-repo/image@" + testDigestStr)
+	if err != nil {
+		t.Fatalf("name.NewDigest: %v", err)
+	}
+	targetRepo, err := name.NewRepository("gcr.io/target-repo/other")
+	if err != nil {
+		t.Fatalf("name.NewRepository: %v", err)
+	}
+
+	if _, err = Referrers(inputDigest, "", WithTargetRepository(targetRepo)); err != nil {
+		t.Fatalf("Referrers() = %v", err)
+	}
+
+	// The digest must be redirected to the target repository.
+	if got, want := capturedDigest.Repository.String(), targetRepo.String(); got != want {
+		t.Errorf("repository = %q, want %q", got, want)
+	}
+	// The digest hash itself must be preserved.
+	if got, want := capturedDigest.DigestStr(), testDigestStr; got != want {
+		t.Errorf("digest = %q, want %q", got, want)
+	}
+}
+
+func TestReferrers_ArtifactTypeFilter(t *testing.T) {
+	orig := remoteReferrers
+	t.Cleanup(func() { remoteReferrers = orig })
+
+	inputDigest, err := name.NewDigest("gcr.io/source-repo/image@" + testDigestStr)
+	if err != nil {
+		t.Fatalf("name.NewDigest: %v", err)
+	}
+
+	// Capture baseline option count (no artifact type filter).
+	var baselineOptCount int
+	remoteReferrers = func(_ name.Digest, opts ...remote.Option) (v1.ImageIndex, error) {
+		baselineOptCount = len(opts)
+		return empty.Index, nil
+	}
+	if _, err = Referrers(inputDigest, ""); err != nil {
+		t.Fatalf("Referrers() baseline = %v", err)
+	}
+
+	// Now with an artifact type filter — should add one extra option.
+	var capturedOptCount int
+	remoteReferrers = func(_ name.Digest, opts ...remote.Option) (v1.ImageIndex, error) {
+		capturedOptCount = len(opts)
+		return empty.Index, nil
+	}
+	if _, err = Referrers(inputDigest, "application/vnd.example.type"); err != nil {
+		t.Fatalf("Referrers() with filter = %v", err)
+	}
+
+	if capturedOptCount != baselineOptCount+1 {
+		t.Errorf("expected %d options (baseline %d + 1 filter), got %d", baselineOptCount+1, baselineOptCount, capturedOptCount)
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -4693,6 +4693,7 @@ func TestSignVerifyWithRepoOverride(t *testing.T) {
 		KeyRef:          pubKeyPath,
 		RekorURL:        rekorURL,
 		NewBundleFormat: true,
+		IgnoreTlog:      true,
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Resolves #4591 

#### Summary

`COSIGN_REPOSITORY=signature-repository cosign verify image-repository/my-image:latest` does not list referrers from the repository designated in the `COSIGN_REPOSITORY` environment variable. This also affects Kyverno's ImageValidatingPolicy when using the new bundle format in a separate signature repository. See https://github.com/kyverno/kyverno/issues/15950.

This can be verified by using cosign to create and attach a signature first, then trying to verify it.

```sh
$ export COSIGN_REPOSITORY=signature-repository
$ cosign sign image:tag ...
$ cosign verify image:tag
```

Note that there is an existing PR that also addresses #4591, but it's several months old, many commits behind, and inactive. I took a slightly different approach here, too. See https://github.com/sigstore/cosign/pull/4593

#### Release Note

Fixed `COSIGN_REPOSITORY` and `WithTargetRepository` to be respected when fetching OCI 1.1 referrer-based bundles during verification. Previously, `GetBundles` and `Referrers` ignored the configured target repository, causing verification to fail when bundles were stored in an alternate registry.