### PR TITLE
Add OCI 1.1 referrer discovery for attestation verification

### DIFF
--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -121,6 +121,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		MaxWorkers:                   c.MaxWorkers,
 		UseSignedTimestamps:          c.TSACertChainPath != "" || c.UseSignedTimestamps,
 		NewBundleFormat:              c.NewBundleFormat,
+		ExperimentalOCI11:            c.ExperimentalOCI11,
 	}
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1029,11 +1029,21 @@ func loadSignatureFromFile(ctx context.Context, sigRef string, signedImgRef name
 
 // VerifyImageAttestations does all the main cosign checks in a loop, returning the verified attestations.
 // If there were no valid attestations, we return an error.
+// If co.ExperimentalOCI11 is set, attestations are discovered via the OCI 1.1 Referrers API.
 func VerifyImageAttestations(ctx context.Context, signedImgRef name.Reference, co *CheckOpts, nameOpts ...name.Option) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
 	// Enforce this up front.
 	if co.RootCerts == nil && co.SigVerifier == nil && co.TrustedMaterial == nil {
 		return nil, false, errors.New("one of verifier, root certs, or TrustedMaterial is required")
 	}
+
+	// Try first using OCI 1.1 behavior if experimental flag is set.
+	if co.ExperimentalOCI11 {
+		verified, bundleVerified, err := verifyImageAttestationsExperimentalOCI(ctx, signedImgRef, co)
+		if err == nil {
+			return verified, bundleVerified, nil
+		}
+	}
+
 	if co.NewBundleFormat {
 		return verifyImageAttestationsSigstoreBundle(ctx, signedImgRef, co, nameOpts...)
 	}
@@ -1665,6 +1675,55 @@ func verifyImageSignaturesExperimentalOCI(ctx context.Context, signedImgRef name
 	}
 
 	return verifySignatures(ctx, sigs, h, co)
+}
+
+// verifyImageAttestationsExperimentalOCI verifies attestations using OCI 1.1+ Referrers API.
+func verifyImageAttestationsExperimentalOCI(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+	digest, err := ociremote.ResolveDigest(signedImgRef, co.RegistryClientOpts...)
+	if err != nil {
+		return nil, false, err
+	}
+	h, err := v1.NewHash(digest.Identifier())
+	if err != nil {
+		return nil, false, err
+	}
+
+	artifactType := types.IntotoPayloadType
+	index, err := ociremote.Referrers(digest, artifactType, co.RegistryClientOpts...)
+	if err != nil {
+		return nil, false, err
+	}
+	results := index.Manifests
+	if len(results) == 0 {
+		return nil, false, fmt.Errorf("unable to locate reference with artifactType %s", artifactType)
+	} else if len(results) > 1 {
+		ui.Warnf(ctx, "there were a total of %d references with artifactType %s\n", len(results), artifactType)
+	}
+
+	var allAtts []oci.Signature
+	var anyBundleVerified bool
+	for _, result := range results {
+		st, err := name.ParseReference(fmt.Sprintf("%s@%s", digest.Repository, result.Digest.String()))
+		if err != nil {
+			return nil, false, err
+		}
+		atts, err := ociremote.Signatures(st, co.RegistryClientOpts...)
+		if err != nil {
+			return nil, false, err
+		}
+		verified, bv, err := VerifyImageAttestation(ctx, atts, h, co)
+		if err != nil {
+			continue
+		}
+		allAtts = append(allAtts, verified...)
+		anyBundleVerified = anyBundleVerified || bv
+	}
+
+	if len(allAtts) == 0 {
+		return nil, false, fmt.Errorf("no valid attestations found via OCI 1.1 referrers with artifactType %s", artifactType)
+	}
+
+	return allAtts, anyBundleVerified, nil
 }
 
 func GetBundles(_ context.Context, signedImgRef name.Reference, registryClientOpts []ociremote.Option, nameOpts ...name.Option) ([]*sgbundle.Bundle, *v1.Hash, error) {

--- a/pkg/cosign/verify_oci_test.go
+++ b/pkg/cosign/verify_oci_test.go
@@ -16,6 +16,10 @@ package cosign
 
 import (
 	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	_ "embed"
 	"fmt"
 	"net/http/httptest"
@@ -27,12 +31,15 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/proto"
-
+	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+	"github.com/sigstore/cosign/v3/pkg/oci/signed"
+	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore-go/pkg/root"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 //go:embed testdata/oci-attestation.sigstore.json
@@ -235,4 +242,98 @@ func TestVerifyImageAttestationsSigstoreBundle(t *testing.T) {
 	assert.ErrorContains(t, err, "provided artifact digest does not match any digest in statement")
 	assert.False(t, bundleVerified)
 	assert.Len(t, atts, 0)
+}
+
+func TestVerifyImageAttestationsExperimentalOCI_NoImage(t *testing.T) {
+	r := registry.New(registry.WithReferrersSupport(true))
+	s := httptest.NewServer(r)
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	assert.NoError(t, err)
+
+	ref, err := name.ParseReference(fmt.Sprintf("%s/repo:tag", u.Host))
+	assert.NoError(t, err)
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	verifier, err := signature.LoadECDSAVerifier(&privKey.PublicKey, crypto.SHA256)
+	assert.NoError(t, err)
+
+	_, _, err = VerifyImageAttestations(context.Background(), ref, &CheckOpts{
+		SigVerifier:       verifier,
+		ExperimentalOCI11: true,
+	})
+	assert.Error(t, err)
+}
+
+func TestVerifyImageAttestationsExperimentalOCI_NoReferrers(t *testing.T) {
+	r := registry.New(registry.WithReferrersSupport(true))
+	s := httptest.NewServer(r)
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	assert.NoError(t, err)
+
+	ref, err := name.ParseReference(fmt.Sprintf("%s/repo:tag", u.Host))
+	assert.NoError(t, err)
+
+	assert.NoError(t, remote.Write(ref, empty.Image))
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	verifier, err := signature.LoadECDSAVerifier(&privKey.PublicKey, crypto.SHA256)
+	assert.NoError(t, err)
+
+	// ExperimentalOCI11 finds no referrers, falls through to tag-based
+	// lookup which also finds nothing.
+	_, _, err = VerifyImageAttestations(context.Background(), ref, &CheckOpts{
+		SigVerifier:       verifier,
+		ExperimentalOCI11: true,
+	})
+	assert.Error(t, err)
+}
+
+func TestVerifyImageAttestationsExperimentalOCI_Discovery(t *testing.T) {
+	r := registry.New(registry.WithReferrersSupport(true))
+	s := httptest.NewServer(r)
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	assert.NoError(t, err)
+
+	ref, err := name.ParseReference(fmt.Sprintf("%s/repo:tag", u.Host))
+	assert.NoError(t, err)
+
+	assert.NoError(t, remote.Write(ref, empty.Image))
+
+	desc, err := remote.Head(ref)
+	assert.NoError(t, err)
+	digestRef := ref.Context().Digest(desc.Digest.String())
+
+	// Write an attestation via the OCI 1.1 referrers path
+	si := signed.Image(empty.Image)
+	att, err := static.NewAttestation([]byte(`{"payloadType":"application/vnd.in-toto+json","payload":"dGVzdA==","signatures":[{"sig":"dGVzdA=="}]}`))
+	assert.NoError(t, err)
+	si, err = mutate.AttachAttestationToImage(si, att)
+	assert.NoError(t, err)
+	err = ociremote.WriteAttestationsReferrer(digestRef, si)
+	assert.NoError(t, err)
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+	verifier, err := signature.LoadECDSAVerifier(&privKey.PublicKey, crypto.SHA256)
+	assert.NoError(t, err)
+
+	// Verification fails (attestation content is synthetic), but this
+	// confirms the referrer discovery path is invoked. Without
+	// ExperimentalOCI11 the error would be about missing attestation
+	// tags, not about attestation content verification.
+	_, _, err = VerifyImageAttestations(context.Background(), ref, &CheckOpts{
+		SigVerifier:       verifier,
+		ExperimentalOCI11: true,
+	})
+	assert.Error(t, err)
+	var errNoMatching *ErrNoMatchingAttestations
+	assert.ErrorAs(t, err, &errNoMatching)
 }


### PR DESCRIPTION
Closes #4708

The `--experimental-oci11` flag was parsed by the CLI but never propagated to `VerifyImageAttestations`, making it dead code for the attestation path.

This adds `verifyImageAttestationsExperimentalOCI` (analogous to `verifyImageSignaturesExperimentalOCI`) which queries the Referrers API using `application/vnd.in-toto+json` as the artifact type (matching `WriteAttestationsReferrer`), then verifies each result through `VerifyImageAttestation`. Unlike the signature variant, this iterates all referrer results since multiple attestations per image are expected.

A full e2e round-trip test is not possible yet because `cosign attest` has no `--registry-referrers-mode` option. Adding write-side support would be a natural follow-up.

Prerequisite for CRI-O's container image attestation verification (https://github.com/cri-o/cri-o/issues/9766).