### PR TITLE
Add bundle inspect command

### DIFF
--- a/cmd/cosign/cli/bundle.go
+++ b/cmd/cosign/cli/bundle.go
@@ -32,6 +32,7 @@ func Bundle() *cobra.Command {
 
 	cmd.AddCommand(bundleCreate())
 	cmd.AddCommand(bundleUpgrade())
+	cmd.AddCommand(bundleInspect())
 
 	return cmd
 }
@@ -92,5 +93,22 @@ func bundleUpgrade() *cobra.Command {
 	}
 
 	o.AddFlags(cmd)
+	return cmd
+}
+
+func bundleInspect() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inspect BUNDLE",
+		Short: "Inspect a Sigstore protobuf bundle",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			bundleInspectCmd := &bundle.InspectCmd{
+				BundlePath: args[0],
+			}
+
+			return bundleInspectCmd.Exec()
+		},
+	}
+
 	return cmd
 }

--- a/cmd/cosign/cli/bundle/inspect.go
+++ b/cmd/cosign/cli/bundle/inspect.go
@@ -177,16 +177,6 @@ func (c *InspectCmd) Exec() error {
 	return nil
 }
 
-type pkiStatusInfo struct {
-	Status int
-	Rest   []asn1.RawValue `asn1:"optional"`
-}
-
-type timeStampResp struct {
-	Status         pkiStatusInfo
-	TimeStampToken asn1.RawValue `asn1:"optional"`
-}
-
 type node struct {
 	Label    string
 	Value    string
@@ -537,15 +527,12 @@ func populateTimestampSummary(n *node, tsData *protobundle.TimestampVerification
 	for i, ts := range tsData.GetRfc3161Timestamps() {
 		singleTsNode := n.addChild(fmt.Sprintf("Timestamp [%d]", i), "")
 
-		var resp timeStampResp
-		if _, err := asn1.Unmarshal(ts.SignedTimestamp, &resp); err == nil {
-			if parsedTs, err := timestamp.Parse(resp.TimeStampToken.FullBytes); err == nil {
-				singleTsNode.addChild("Time", parsedTs.Time.Format(time.RFC3339))
-				singleTsNode.addChild("Hash Algorithm", parsedTs.HashAlgorithm.String())
-				singleTsNode.addChild("Message Imprint", fmt.Sprintf("Present (%d bytes)", len(parsedTs.HashedMessage)))
-				singleTsNode.addChild("Serial Number", fmt.Sprintf("%s", parsedTs.SerialNumber))
-				singleTsNode.addChild("Policy", parsedTs.Policy.String())
-			}
+		if parsedTs, err := timestamp.ParseResponse(ts.SignedTimestamp); err == nil {
+			singleTsNode.addChild("Time", parsedTs.Time.Format(time.RFC3339))
+			singleTsNode.addChild("Hash Algorithm", parsedTs.HashAlgorithm.String())
+			singleTsNode.addChild("Message Imprint", fmt.Sprintf("Present (%d bytes)", len(parsedTs.HashedMessage)))
+			singleTsNode.addChild("Serial Number", fmt.Sprintf("%s", parsedTs.SerialNumber))
+			singleTsNode.addChild("Policy", parsedTs.Policy.String())
 		}
 	}
 }

--- a/cmd/cosign/cli/bundle/inspect.go
+++ b/cmd/cosign/cli/bundle/inspect.go
@@ -122,7 +122,7 @@ type InspectCmd struct {
 
 func (c *InspectCmd) Exec() error {
 	fmt.Fprintln(os.Stderr, "WARNING: This command only inspects the contents of the bundle.")
-	fmt.Fprintln(os.Stderr, "It does not perform cryptographic verification or check against the transparency log.")
+	fmt.Fprintln(os.Stderr, "It does not perform cryptographic verification or verify log inclusion.")
 	fmt.Fprintln(os.Stderr, "")
 
 	tr, err := cosign.TrustedRoot()

--- a/cmd/cosign/cli/bundle/inspect.go
+++ b/cmd/cosign/cli/bundle/inspect.go
@@ -1,0 +1,656 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/digitorus/timestamp"
+	"github.com/google/certificate-transparency-go/x509util"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	rekorv1 "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/rekor/pkg/util"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// OIDs that are explicitly handled earlier in certificate population
+// and should be skipped in the "Other Extensions" loop
+var handledOIDs = map[string]bool{
+	"2.5.29.15": true, // Key Usage
+	"2.5.29.37": true, // Extended Key Usage
+	"2.5.29.14": true, // Subject Key Identifier
+	"2.5.29.35": true, // Authority Key Identifier
+	"2.5.29.17": true, // Subject Alternative Name
+}
+
+var keyUsageNames = []struct {
+	usage x509.KeyUsage
+	name  string
+}{
+	{x509.KeyUsageDigitalSignature, "Digital Signature"},
+	{x509.KeyUsageContentCommitment, "Content Commitment"},
+	{x509.KeyUsageKeyEncipherment, "Key Encipherment"},
+	{x509.KeyUsageDataEncipherment, "Data Encipherment"},
+	{x509.KeyUsageKeyAgreement, "Key Agreement"},
+	{x509.KeyUsageCertSign, "Cert Sign"},
+	{x509.KeyUsageCRLSign, "CRL Sign"},
+	{x509.KeyUsageEncipherOnly, "Encipher Only"},
+	{x509.KeyUsageDecipherOnly, "Decipher Only"},
+}
+
+var extKeyUsageNames = map[x509.ExtKeyUsage]string{
+	x509.ExtKeyUsageAny:             "Any",
+	x509.ExtKeyUsageServerAuth:      "Server Auth",
+	x509.ExtKeyUsageClientAuth:      "Client Auth",
+	x509.ExtKeyUsageCodeSigning:     "Code Signing",
+	x509.ExtKeyUsageEmailProtection: "Email Protection",
+	x509.ExtKeyUsageIPSECEndSystem:  "IPSEC End System",
+	x509.ExtKeyUsageIPSECTunnel:     "IPSEC Tunnel",
+	x509.ExtKeyUsageIPSECUser:       "IPSEC User",
+	x509.ExtKeyUsageTimeStamping:    "Time Stamping",
+	x509.ExtKeyUsageOCSPSigning:     "OCSP Signing",
+}
+
+// Fulcio cert-extensions, documented here: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
+var certExtensionMap = map[string]string{
+	"1.3.6.1.4.1.57264.1.1":  "OIDC Issuer",
+	"1.3.6.1.4.1.57264.1.2":  "GitHub Workflow Trigger",
+	"1.3.6.1.4.1.57264.1.3":  "GitHub Workflow SHA",
+	"1.3.6.1.4.1.57264.1.4":  "GitHub Workflow Name",
+	"1.3.6.1.4.1.57264.1.5":  "GitHub Workflow Repository",
+	"1.3.6.1.4.1.57264.1.6":  "GitHub Workflow Ref",
+	"1.3.6.1.4.1.57264.1.7":  "OtherName SAN",
+	"1.3.6.1.4.1.57264.1.8":  "Issuer (V2)",
+	"1.3.6.1.4.1.57264.1.9":  "Build Signer URI",
+	"1.3.6.1.4.1.57264.1.10": "Build Signer Digest",
+	"1.3.6.1.4.1.57264.1.11": "Runner Environment",
+	"1.3.6.1.4.1.57264.1.12": "Source Repository URI",
+	"1.3.6.1.4.1.57264.1.13": "Source Repository Digest",
+	"1.3.6.1.4.1.57264.1.14": "Source Repository Ref",
+	"1.3.6.1.4.1.57264.1.15": "Source Repository Identifier",
+	"1.3.6.1.4.1.57264.1.16": "Source Repository Owner URI",
+	"1.3.6.1.4.1.57264.1.17": "Source Repository Owner Identifier",
+	"1.3.6.1.4.1.57264.1.18": "Build Config URI",
+	"1.3.6.1.4.1.57264.1.19": "Build Config Digest",
+	"1.3.6.1.4.1.57264.1.20": "Build Trigger",
+	"1.3.6.1.4.1.57264.1.21": "Run Invocation URI",
+	"1.3.6.1.4.1.57264.1.22": "Source Repository Visibility At Signing",
+	"1.3.6.1.4.1.57264.1.23": "Deployment Environment",
+	"1.3.6.1.4.1.57264.1.24": "Token Subject",
+}
+
+const sctExtensionOid = "1.3.6.1.4.1.11129.2.4.2"
+
+var recognizedMediaTypes = map[string]int{
+	"application/vnd.dev.sigstore.bundle+json;version=0.1": 1,
+	"application/vnd.dev.sigstore.bundle+json;version=0.2": 2,
+	"application/vnd.dev.sigstore.bundle+json;version=0.3": 3,
+	"application/vnd.dev.sigstore.bundle.v0.3+json":        3,
+}
+
+type InspectCmd struct {
+	BundlePath string
+	Out        io.Writer
+}
+
+func (c *InspectCmd) Exec() error {
+	fmt.Fprintln(os.Stderr, "WARNING: This command only inspects the contents of the bundle.")
+	fmt.Fprintln(os.Stderr, "It does not perform cryptographic verification or check against the transparency log.")
+	fmt.Fprintln(os.Stderr, "")
+
+	tr, err := cosign.TrustedRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "WARNING: Could not initialize trusted root: %v\n", err)
+	}
+
+	f, err := os.Open(c.BundlePath)
+	if err != nil {
+		return fmt.Errorf("opening bundle file: %w", err)
+	}
+	defer f.Close()
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return fmt.Errorf("reading bundle: %w", err)
+	}
+
+	var b protobundle.Bundle
+	err = protojson.Unmarshal(data, &b)
+	if err != nil {
+		return fmt.Errorf("unmarshaling bundle JSON: %w", err)
+	}
+
+	rootNode := &node{}
+
+	rootNode.addChild("Bundle Media Type", b.MediaType)
+	version, ok := recognizedMediaTypes[b.MediaType]
+	if b.MediaType == "" {
+		rootNode.addChild("[!] WARNING", "Missing Bundle Media Type")
+	} else if !ok {
+		rootNode.addChild("[!] WARNING", "Unrecognized Media Type")
+	}
+
+	if b.VerificationMaterial != nil {
+		populateVerificationMaterialSummary(rootNode, b.VerificationMaterial, tr, version)
+	} else {
+		rootNode.addChild("[!] WARNING", "Missing Verification Material")
+	}
+
+	if b.Content != nil {
+		populateContentSummary(rootNode, &b)
+	} else {
+		rootNode.addChild("[!] WARNING", "Missing Content")
+	}
+
+	out := c.Out
+	if out == nil {
+		out = os.Stdout
+	}
+	rootNode.print(out, 0)
+
+	return nil
+}
+
+type pkiStatusInfo struct {
+	Status int
+	Rest   []asn1.RawValue `asn1:"optional"`
+}
+
+type timeStampResp struct {
+	Status         pkiStatusInfo
+	TimeStampToken asn1.RawValue `asn1:"optional"`
+}
+
+type node struct {
+	Label    string
+	Value    string
+	Children []node
+}
+
+func (n *node) addChild(label, value string) *node {
+	n.Children = append(n.Children, node{Label: label, Value: value})
+	return &n.Children[len(n.Children)-1]
+}
+
+func (n *node) print(w io.Writer, depth int) {
+	if n.Label != "" {
+		indent := strings.Repeat("  ", depth)
+		if n.Value != "" {
+			fmt.Fprintf(w, "%s- %s: %s\n", indent, n.Label, n.Value)
+		} else {
+			fmt.Fprintf(w, "%s- %s:\n", indent, n.Label)
+		}
+		depth++
+	}
+	for _, child := range n.Children {
+		child.print(w, depth)
+	}
+}
+
+func populateVerificationMaterialSummary(n *node, vm *protobundle.VerificationMaterial, tr root.TrustedMaterial, version int) {
+	vmNode := n.addChild("Verification Material", "")
+
+	switch content := vm.Content.(type) {
+	case *protobundle.VerificationMaterial_Certificate:
+		certNode := vmNode.addChild("Content", "X.509 Certificate")
+		if len(content.Certificate.RawBytes) > 0 {
+			populateCertificateSummary(certNode, content.Certificate.RawBytes, tr)
+		} else {
+			certNode.addChild("[!] WARNING", "Certificate raw_bytes is empty")
+		}
+
+		if version > 0 && version < 3 {
+			certNode.addChild("[!] WARNING", "v0.1/v0.2 bundle should use certificate chain, not single certificate")
+		}
+
+	case *protobundle.VerificationMaterial_X509CertificateChain:
+		chainNode := vmNode.addChild("Content", "X.509 Certificate Chain")
+		if len(content.X509CertificateChain.Certificates) > 0 {
+			chainNode.addChild("Certificates", fmt.Sprintf("%d", len(content.X509CertificateChain.Certificates)))
+			for i, cert := range content.X509CertificateChain.Certificates {
+				certNode := chainNode.addChild(fmt.Sprintf("Certificate [%d]", i), "")
+				populateCertificateSummary(certNode, cert.RawBytes, tr)
+			}
+		} else {
+			chainNode.addChild("[!] WARNING", "Certificate chain is empty")
+		}
+
+		if version >= 3 {
+			chainNode.addChild("[!] WARNING", "v0.3 bundle should use single certificate, not chain")
+		}
+
+	case *protobundle.VerificationMaterial_PublicKey:
+		pkNode := vmNode.addChild("Content", "Public Key Identifier")
+		hint := content.PublicKey.GetHint()
+		if hint != "" {
+			if decoded, err := base64.StdEncoding.DecodeString(hint); err == nil {
+				pkNode.addChild("Hint", hex.EncodeToString(decoded))
+			} else {
+				pkNode.addChild("Hint", hint)
+			}
+		} else {
+			pkNode.addChild("[!] WARNING", "Public key hint is empty")
+		}
+
+	case nil:
+		vmNode.addChild("[!] WARNING", "Missing Verification Material Content (must be certificate, chain, or public key)")
+	}
+
+	if len(vm.TlogEntries) > 0 {
+		tlogNode := vmNode.addChild("Transparency Log Entries", fmt.Sprintf("%d", len(vm.TlogEntries)))
+		for i, entry := range vm.TlogEntries {
+			entryNode := tlogNode.addChild(fmt.Sprintf("Entry [%d]", i), "")
+			populateTlogEntrySummary(entryNode, entry, tr)
+
+			if version == 1 && entry.GetInclusionPromise() == nil {
+				entryNode.addChild("[!] WARNING", "v0.1 bundle tlog entry MUST contain an inclusion promise")
+			}
+
+			if version >= 2 && entry.GetInclusionProof() == nil {
+				entryNode.addChild("[!] WARNING", fmt.Sprintf("v0.%d bundle tlog entry MUST contain an inclusion proof", version))
+			}
+		}
+	}
+
+	tsData := vm.TimestampVerificationData
+	if tsData != nil {
+		tsNode := vmNode.addChild("Timestamp Verification Data", "")
+		populateTimestampSummary(tsNode, tsData)
+	}
+}
+
+func populateCertificateSummary(n *node, rawBytes []byte, tr root.TrustedMaterial) {
+	cert, err := x509.ParseCertificate(rawBytes)
+	if err != nil {
+		n.addChild("Error", fmt.Sprintf("parsing certificate: %v", err))
+		return
+	}
+
+	n.addChild("Signature Algorithm", cert.SignatureAlgorithm.String())
+
+	if cert.Subject.String() != "" {
+		n.addChild("Subject", cert.Subject.String())
+	}
+
+	hasIssuer := cert.Issuer.CommonName != "" || len(cert.Issuer.Organization) > 0 || len(cert.Issuer.Country) > 0
+	if hasIssuer {
+		issuerNode := n.addChild("Issuer", "")
+		if cert.Issuer.CommonName != "" {
+			issuerNode.addChild("Common Name", cert.Issuer.CommonName)
+		}
+		if len(cert.Issuer.Organization) > 0 {
+			issuerNode.addChild("Organization", cert.Issuer.Organization[0])
+		}
+		if len(cert.Issuer.Country) > 0 {
+			issuerNode.addChild("Country", cert.Issuer.Country[0])
+		}
+	}
+
+	validityNode := n.addChild("Validity", "")
+	validityNode.addChild("Not Before", cert.NotBefore.Format(time.RFC3339))
+	validityNode.addChild("Not After", cert.NotAfter.Format(time.RFC3339))
+
+	spkiNode := n.addChild("Subject Public Key Info", "")
+	switch pub := cert.PublicKey.(type) {
+	case *ecdsa.PublicKey:
+		spkiNode.addChild("Algorithm", "ECDSA")
+		spkiNode.addChild("Curve", pub.Curve.Params().Name)
+		if ecdhPub, err := pub.ECDH(); err == nil {
+			pubBytes := ecdhPub.Bytes()
+			pubHex := hex.EncodeToString(pubBytes)
+			if len(pubHex) > 20 {
+				spkiNode.addChild("Public Key", fmt.Sprintf("%s...%s (%d bytes)", pubHex[:8], pubHex[len(pubHex)-8:], len(pubBytes)))
+			} else {
+				spkiNode.addChild("Public Key", pubHex)
+			}
+		} else {
+			spkiNode.addChild("Public Key", fmt.Sprintf("Error extracting key: %v", err))
+		}
+
+	case ed25519.PublicKey:
+		spkiNode.addChild("Algorithm", "Ed25519")
+		pubHex := hex.EncodeToString(pub)
+		if len(pubHex) > 20 {
+			spkiNode.addChild("Public Key", fmt.Sprintf("%s...%s (%d bytes)", pubHex[:8], pubHex[len(pubHex)-8:], len(pub)))
+		} else {
+			spkiNode.addChild("Public Key", pubHex)
+		}
+
+	case *rsa.PublicKey:
+		spkiNode.addChild("Algorithm", "RSA")
+		spkiNode.addChild("Key Size", fmt.Sprintf("%d bits", pub.N.BitLen()))
+
+	default:
+		spkiNode.addChild("Algorithm", "Unknown")
+	}
+
+	extsNode := n.addChild("Extensions", "")
+
+	if cert.Subject.CommonName != "" || len(cert.EmailAddresses) > 0 || len(cert.URIs) > 0 {
+		identityNode := extsNode.addChild("Identity (Subject Alternative Name)", "")
+		if cert.Subject.CommonName != "" {
+			identityNode.addChild("Common Name", cert.Subject.CommonName)
+		}
+		for _, email := range cert.EmailAddresses {
+			identityNode.addChild("Email", email)
+		}
+		for _, uri := range cert.URIs {
+			identityNode.addChild("URI", uri.String())
+		}
+	}
+
+	var usages []string
+	for _, ku := range keyUsageNames {
+		if cert.KeyUsage&ku.usage != 0 {
+			usages = append(usages, ku.name)
+		}
+	}
+	if len(usages) > 0 {
+		extsNode.addChild("Key Usage", strings.Join(usages, ", "))
+	}
+
+	var extUsages []string
+	for _, u := range cert.ExtKeyUsage {
+		if name, ok := extKeyUsageNames[u]; ok {
+			extUsages = append(extUsages, name)
+		}
+	}
+	if len(extUsages) > 0 {
+		extsNode.addChild("Extended Key Usage", strings.Join(extUsages, ", "))
+	}
+
+	var unknownExtUsages []string
+	for _, u := range cert.UnknownExtKeyUsage {
+		unknownExtUsages = append(unknownExtUsages, u.String())
+	}
+	if len(unknownExtUsages) > 0 {
+		extsNode.addChild("Unknown Extended Key Usage", strings.Join(unknownExtUsages, ", "))
+	}
+
+	if len(cert.SubjectKeyId) > 0 {
+		extsNode.addChild("Subject Key ID", hex.EncodeToString(cert.SubjectKeyId))
+	}
+	if len(cert.AuthorityKeyId) > 0 {
+		keyID := hex.EncodeToString(cert.AuthorityKeyId)
+		url := findFulcioURL(tr, keyID)
+		if url != "" {
+			extsNode.addChild("Authority URL", url)
+		} else {
+			extsNode.addChild("Authority Key ID", keyID)
+		}
+	}
+
+	// Other Extensions
+	for _, ext := range cert.Extensions {
+		oidStr := ext.Id.String()
+		if handledOIDs[oidStr] {
+			continue
+		}
+
+		if oidStr == sctExtensionOid {
+			embeddedSCTs, err := x509util.ParseSCTsFromCertificate(cert.Raw)
+			if err == nil && len(embeddedSCTs) > 0 {
+				sctsNode := extsNode.addChild("Signed Certificate Timestamps", fmt.Sprintf("%d", len(embeddedSCTs)))
+				for i, sct := range embeddedSCTs {
+					sctNode := sctsNode.addChild(fmt.Sprintf("Signed Certificate Timestamp [%d]", i), "")
+					sctNode.addChild("Version", fmt.Sprintf("v%d", sct.SCTVersion+1))
+
+					logID := hex.EncodeToString(sct.LogID.KeyID[:])
+					url := findCTLogURL(tr, logID)
+					if url != "" {
+						sctNode.addChild("Log URL", url)
+					} else {
+						sctNode.addChild("Log ID", logID)
+					}
+
+					sctNode.addChild("Timestamp", time.Unix(0, int64(sct.Timestamp)*1000000).Format(time.RFC3339))
+
+					extStr := "none"
+					if len(sct.Extensions) > 0 {
+						extStr = fmt.Sprintf("%d bytes", len(sct.Extensions))
+					}
+					sctNode.addChild("Extensions", extStr)
+
+					sctNode.addChild("Signature", fmt.Sprintf("Present (%d bytes)", len(sct.Signature.Signature)))
+				}
+				continue
+			}
+		}
+
+		if readableName, ok := certExtensionMap[oidStr]; ok {
+			valStr := string(ext.Value)
+			var decodedStr string
+			_, err := asn1.Unmarshal(ext.Value, &decodedStr)
+			if err == nil {
+				valStr = decodedStr
+			}
+			extsNode.addChild(readableName, valStr)
+		} else {
+			extsNode.addChild(fmt.Sprintf("OID: %s", oidStr), fmt.Sprintf("(Critical: %t) [%d bytes]", ext.Critical, len(ext.Value)))
+		}
+	}
+
+	n.addChild("Signature", fmt.Sprintf("Present (%d bytes)", len(cert.Signature)))
+}
+
+func populateTlogEntrySummary(n *node, entry *rekorv1.TransparencyLogEntry, tr root.TrustedMaterial) {
+	n.addChild("Log Index", fmt.Sprintf("%d", entry.LogIndex))
+
+	if entry.LogId != nil {
+		logID := hex.EncodeToString(entry.LogId.KeyId)
+		url := findRekorURL(tr, logID)
+		if url != "" {
+			n.addChild("Log URL", url)
+		} else {
+			n.addChild("Log ID", logID)
+		}
+	}
+
+	if entry.KindVersion != nil {
+		n.addChild("Kind", entry.KindVersion.Kind)
+		n.addChild("Version", entry.KindVersion.Version)
+	}
+
+	if entry.IntegratedTime == 0 {
+		n.addChild("Integrated Time", "0 (Not set)")
+	} else {
+		t := time.Unix(entry.IntegratedTime, 0).UTC()
+		n.addChild("Integrated Time", t.Format(time.RFC3339))
+	}
+
+	if entry.GetInclusionPromise() != nil {
+		promise := entry.GetInclusionPromise()
+		promiseNode := n.addChild("Inclusion Promise", "")
+		promiseNode.addChild("Signed Entry Timestamp", fmt.Sprintf("Present (%d bytes)", len(promise.SignedEntryTimestamp)))
+	}
+
+	if entry.GetInclusionProof() != nil {
+		proof := entry.GetInclusionProof()
+		proofNode := n.addChild("Inclusion Proof", "")
+		proofNode.addChild("Log Index", fmt.Sprintf("%d", proof.LogIndex))
+		proofNode.addChild("Tree Size", fmt.Sprintf("%d", proof.TreeSize))
+		proofNode.addChild("Hashes", fmt.Sprintf("%d", len(proof.Hashes)))
+
+		if proof.Checkpoint != nil {
+			checkpointNode := proofNode.addChild("Checkpoint", "")
+			var sc util.SignedCheckpoint
+			if err := sc.UnmarshalText([]byte(proof.Checkpoint.Envelope)); err == nil {
+				checkpointNode.addChild("Origin", sc.Origin)
+				checkpointNode.addChild("Tree Size", fmt.Sprintf("%d", sc.Size))
+
+				if len(sc.OtherContent) > 0 {
+					otherNode := checkpointNode.addChild("Other Content", fmt.Sprintf("%d lines", len(sc.OtherContent)))
+					for i, line := range sc.OtherContent {
+						otherNode.addChild(fmt.Sprintf("[%d]", i), line)
+					}
+				}
+
+				if len(sc.Signatures) > 0 {
+					witnessesNode := checkpointNode.addChild("Witnesses", fmt.Sprintf("%d", len(sc.Signatures)))
+					for _, sig := range sc.Signatures {
+						sigBytes, err := base64.StdEncoding.DecodeString(sig.Base64)
+						sigNode := witnessesNode.addChild(sig.Name, fmt.Sprintf("Signature Present (%d bytes)", len(sigBytes)))
+						if err != nil {
+							sigNode.addChild("[!] WARNING", "Malformed Base64")
+						}
+					}
+				}
+			} else {
+				checkpointNode.addChild("Envelope", fmt.Sprintf("Present (%d bytes)", len(proof.Checkpoint.Envelope)))
+			}
+		}
+	}
+
+	if len(entry.CanonicalizedBody) > 0 {
+		n.addChild("Canonicalized Body", fmt.Sprintf("Present (%d bytes)", len(entry.CanonicalizedBody)))
+	}
+}
+
+func populateTimestampSummary(n *node, tsData *protobundle.TimestampVerificationData) {
+	n.addChild("RFC3161 Timestamps", fmt.Sprintf("%d", len(tsData.GetRfc3161Timestamps())))
+	for i, ts := range tsData.GetRfc3161Timestamps() {
+		singleTsNode := n.addChild(fmt.Sprintf("Timestamp [%d]", i), "")
+
+		var resp timeStampResp
+		if _, err := asn1.Unmarshal(ts.SignedTimestamp, &resp); err == nil {
+			if parsedTs, err := timestamp.Parse(resp.TimeStampToken.FullBytes); err == nil {
+				singleTsNode.addChild("Time", parsedTs.Time.Format(time.RFC3339))
+				singleTsNode.addChild("Hash Algorithm", parsedTs.HashAlgorithm.String())
+				singleTsNode.addChild("Message Imprint", fmt.Sprintf("Present (%d bytes)", len(parsedTs.HashedMessage)))
+				singleTsNode.addChild("Serial Number", fmt.Sprintf("%s", parsedTs.SerialNumber))
+				singleTsNode.addChild("Policy", parsedTs.Policy.String())
+			}
+		}
+	}
+}
+
+func populateContentSummary(n *node, b *protobundle.Bundle) {
+	contentNode := n.addChild("Content", "")
+	switch content := b.Content.(type) {
+	case *protobundle.Bundle_DsseEnvelope:
+		contentNode.addChild("Type", "DSSE Envelope")
+		contentNode.addChild("Payload Type", content.DsseEnvelope.PayloadType)
+		contentNode.addChild("Payload", fmt.Sprintf("Present (%d bytes)", len(content.DsseEnvelope.Payload)))
+
+		if content.DsseEnvelope.PayloadType == "application/vnd.in-toto+json" {
+			var statement map[string]interface{}
+			if err := json.Unmarshal(content.DsseEnvelope.Payload, &statement); err == nil {
+				payloadNode := contentNode.addChild("Payload Content (in-toto)", "")
+				if predicateType, ok := statement["predicateType"].(string); ok {
+					payloadNode.addChild("Predicate Type", predicateType)
+				}
+				if subjects, ok := statement["subject"].([]interface{}); ok {
+					subjectsNode := payloadNode.addChild("Subjects", fmt.Sprintf("%d", len(subjects)))
+					for _, s := range subjects {
+						if subMap, ok := s.(map[string]interface{}); ok {
+							if name, ok := subMap["name"].(string); ok {
+								subjectsNode.addChild("Name", name)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		sigsNode := contentNode.addChild("Signatures", fmt.Sprintf("%d", len(content.DsseEnvelope.Signatures)))
+		if len(content.DsseEnvelope.Signatures) != 1 {
+			contentNode.addChild("[!] WARNING", "DSSE envelope MUST contain only one signature")
+		}
+
+		for i, sig := range content.DsseEnvelope.Signatures {
+			sigNode := sigsNode.addChild(fmt.Sprintf("Signature [%d]", i), "")
+			sigNode.addChild("Signature", fmt.Sprintf("Present (%d bytes)", len(sig.Sig)))
+			if sig.Keyid != "" {
+				if decoded, err := base64.StdEncoding.DecodeString(sig.Keyid); err == nil {
+					sigNode.addChild("Key Hint", hex.EncodeToString(decoded))
+				} else {
+					sigNode.addChild("Key Hint", sig.Keyid)
+				}
+
+				if b.VerificationMaterial != nil && b.VerificationMaterial.GetPublicKey() != nil {
+					vmHint := b.VerificationMaterial.GetPublicKey().GetHint()
+					if vmHint != sig.Keyid {
+						sigNode.addChild("[!] WARNING", "Key hint mismatch with Verification Material")
+					}
+				}
+			}
+		}
+
+	case *protobundle.Bundle_MessageSignature:
+		contentNode.addChild("Type", "Message Signature")
+		if content.MessageSignature.MessageDigest != nil {
+			digestNode := contentNode.addChild("Message Digest", "")
+			digestNode.addChild("Algorithm", content.MessageSignature.MessageDigest.Algorithm.String())
+			digestNode.addChild("Digest", fmt.Sprintf("Present (%d bytes)", len(content.MessageSignature.MessageDigest.Digest)))
+		}
+		contentNode.addChild("Signature", fmt.Sprintf("Present (%d bytes)", len(content.MessageSignature.Signature)))
+	}
+}
+
+func findFulcioURL(tr root.TrustedMaterial, authorityKeyID string) string {
+	if tr == nil {
+		return ""
+	}
+	for _, ca := range tr.FulcioCertificateAuthorities() {
+		if fca, ok := ca.(*root.FulcioCertificateAuthority); ok {
+			if hex.EncodeToString(fca.Root.SubjectKeyId) == authorityKeyID {
+				return fca.URI
+			}
+			for _, incert := range fca.Intermediates {
+				if hex.EncodeToString(incert.SubjectKeyId) == authorityKeyID {
+					return fca.URI
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func findCTLogURL(tr root.TrustedMaterial, logID string) string {
+	if tr == nil {
+		return ""
+	}
+	ctlogs := tr.CTLogs()
+	if log, ok := ctlogs[logID]; ok {
+		return log.BaseURL
+	}
+	return ""
+}
+
+func findRekorURL(tr root.TrustedMaterial, logID string) string {
+	if tr == nil {
+		return ""
+	}
+	tlogs := tr.RekorLogs()
+	if log, ok := tlogs[logID]; ok {
+		return log.BaseURL
+	}
+	return ""
+}

--- a/cmd/cosign/cli/bundle/inspect.go
+++ b/cmd/cosign/cli/bundle/inspect.go
@@ -142,9 +142,8 @@ func (c *InspectCmd) Exec() error {
 	}
 
 	var b protobundle.Bundle
-	err = protojson.Unmarshal(data, &b)
-	if err != nil {
-		return fmt.Errorf("unmarshaling bundle JSON: %w", err)
+	if err := protojson.Unmarshal(data, &b); err != nil {
+		return fmt.Errorf("unmarshaling bundle: %w", err)
 	}
 
 	rootNode := &node{}

--- a/cmd/cosign/cli/bundle/inspect.go
+++ b/cmd/cosign/cli/bundle/inspect.go
@@ -127,7 +127,7 @@ func (c *InspectCmd) Exec() error {
 
 	tr, err := cosign.TrustedRoot()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "WARNING: Could not initialize trusted root: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Local TUF environment not initialized, some details will be omitted: %v\n", err)
 	}
 
 	f, err := os.Open(c.BundlePath)

--- a/cmd/cosign/cli/bundle/inspect_test.go
+++ b/cmd/cosign/cli/bundle/inspect_test.go
@@ -1,0 +1,928 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"math/big"
+	"net/url"
+	"time"
+
+	"github.com/sigstore/cosign/v3/internal/pkg/cosign/tsa"
+	tsaMock "github.com/sigstore/cosign/v3/internal/pkg/cosign/tsa/mock"
+	"github.com/sigstore/cosign/v3/internal/test"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	protodsse "github.com/sigstore/protobuf-specs/gen/pb-go/dsse"
+	rekorv1 "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	"github.com/sigstore/sigstore-go/pkg/root"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func TestInspectCmd(t *testing.T) {
+	rootCert, rootKey, err := test.GenerateRootCa()
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafCert, _, err := test.GenerateLeafCert("subject@mail.com", "oidc-issuer", rootCert, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name            string
+		bundle          *protobundle.Bundle
+		expectedOutputs []string
+	}{
+		{
+			name: "v0.3 bundle with single cert",
+			bundle: &protobundle.Bundle{
+				MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_Certificate{
+						Certificate: &protocommon.X509Certificate{RawBytes: leafCert.Raw},
+					},
+				},
+				Content: &protobundle.Bundle_MessageSignature{
+					MessageSignature: &protocommon.MessageSignature{
+						Signature: []byte("sig"),
+					},
+				},
+			},
+			expectedOutputs: []string{"Bundle Media Type", "Verification Material", "X.509 Certificate", "Message Signature"},
+		},
+
+		{
+			name: "Bundle with missing media type",
+			bundle: &protobundle.Bundle{
+				MediaType: "",
+			},
+			expectedOutputs: []string{"Missing Bundle Media Type"},
+		},
+		{
+			name: "Bundle with unrecognized media type",
+			bundle: &protobundle.Bundle{
+				MediaType: "application/garbage",
+			},
+			expectedOutputs: []string{"Unrecognized Media Type"},
+		},
+		{
+			name: "Bundle with missing verification material",
+			bundle: &protobundle.Bundle{
+				MediaType:            "application/vnd.dev.sigstore.bundle.v0.3+json",
+				VerificationMaterial: nil,
+			},
+			expectedOutputs: []string{"Missing Verification Material"},
+		},
+		{
+			name: "Bundle with missing content",
+			bundle: &protobundle.Bundle{
+				MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_Certificate{
+						Certificate: &protocommon.X509Certificate{RawBytes: leafCert.Raw},
+					},
+				},
+				Content: nil,
+			},
+			expectedOutputs: []string{"Missing Content"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jsonData, err := protojson.Marshal(tc.bundle)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			tmpDir := t.TempDir()
+			bundleFile := filepath.Join(tmpDir, "bundle.json")
+			err = os.WriteFile(bundleFile, jsonData, 0600)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var buf bytes.Buffer
+			cmd := &InspectCmd{
+				BundlePath: bundleFile,
+				Out:        &buf,
+			}
+
+			err = cmd.Exec()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			output := buf.String()
+
+			for _, expected := range tc.expectedOutputs {
+				if !strings.Contains(output, expected) {
+					t.Errorf("expected output to contain %q, got:\n%s", expected, output)
+				}
+			}
+		})
+	}
+}
+
+func TestPopulateVerificationMaterialSummary(t *testing.T) {
+	rootCert, rootKey, err := test.GenerateRootCa()
+	if err != nil {
+		t.Fatal(err)
+	}
+	leafCert, _, err := test.GenerateLeafCert("subject@mail.com", "oidc-issuer", rootCert, rootKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name            string
+		version         int
+		vm              *protobundle.VerificationMaterial
+		expectedOutputs []string
+	}{
+		{
+			name:    "v0.3 bundle with public key",
+			version: 3,
+			vm: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_PublicKey{
+					PublicKey: &protocommon.PublicKeyIdentifier{Hint: "amtiZEdWemRDaz0="},
+				},
+			},
+			expectedOutputs: []string{"Public Key Identifier", "Hint"},
+		},
+		{
+			name:    "v0.1 bundle with single cert (expects warning)",
+			version: 1,
+			vm: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_Certificate{
+					Certificate: &protocommon.X509Certificate{RawBytes: leafCert.Raw},
+				},
+			},
+			expectedOutputs: []string{"v0.1/v0.2 bundle should use certificate chain, not single certificate"},
+		},
+		{
+			name:    "v0.3 bundle with certificate chain (expects warning)",
+			version: 3,
+			vm: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_X509CertificateChain{
+					X509CertificateChain: &protocommon.X509CertificateChain{
+						Certificates: []*protocommon.X509Certificate{{RawBytes: leafCert.Raw}},
+					},
+				},
+			},
+			expectedOutputs: []string{"v0.3 bundle should use single certificate, not chain"},
+		},
+		{
+			name:    "v0.1 bundle with tlog entry missing promise",
+			version: 1,
+			vm: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_Certificate{
+					Certificate: &protocommon.X509Certificate{RawBytes: leafCert.Raw},
+				},
+				TlogEntries: []*rekorv1.TransparencyLogEntry{
+					{LogIndex: 123},
+				},
+			},
+			expectedOutputs: []string{"v0.1 bundle tlog entry MUST contain an inclusion promise"},
+		},
+		{
+			name:    "v0.3 bundle with tlog entry missing proof",
+			version: 3,
+			vm: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_Certificate{
+					Certificate: &protocommon.X509Certificate{RawBytes: leafCert.Raw},
+				},
+				TlogEntries: []*rekorv1.TransparencyLogEntry{
+					{LogIndex: 456},
+				},
+			},
+			expectedOutputs: []string{"v0.3 bundle tlog entry MUST contain an inclusion proof"},
+		},
+		{
+			name:    "v0.3 bundle with empty certificate raw_bytes",
+			version: 3,
+			vm: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_Certificate{
+					Certificate: &protocommon.X509Certificate{RawBytes: []byte{}},
+				},
+			},
+			expectedOutputs: []string{"Certificate raw_bytes is empty"},
+		},
+		{
+			name:    "v0.3 bundle with empty certificate chain",
+			version: 3,
+			vm: &protobundle.VerificationMaterial{
+				Content: &protobundle.VerificationMaterial_X509CertificateChain{
+					X509CertificateChain: &protocommon.X509CertificateChain{
+						Certificates: []*protocommon.X509Certificate{},
+					},
+				},
+			},
+			expectedOutputs: []string{"Certificate chain is empty"},
+		},
+		{
+			name:    "v0.3 bundle with missing verification material content",
+			version: 3,
+			vm: &protobundle.VerificationMaterial{
+				Content: nil,
+			},
+			expectedOutputs: []string{"Missing Verification Material Content (must be certificate, chain, or public key)"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &node{}
+			populateVerificationMaterialSummary(n, tc.vm, nil, tc.version)
+
+			for _, expected := range tc.expectedOutputs {
+				if !nodeTreeContains(n, expected) {
+					t.Errorf("expected node tree to contain %q", expected)
+				}
+			}
+		})
+	}
+}
+
+func nodeTreeContains(n *node, str string) bool {
+	if strings.Contains(n.Label, str) || strings.Contains(n.Value, str) {
+		return true
+	}
+	for i := range n.Children {
+		if nodeTreeContains(&n.Children[i], str) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPopulateCertificateSummary(t *testing.T) {
+	genCert := func(t *testing.T, pub any, priv any) []byte {
+		parsedURL, _ := url.Parse("https://example.com")
+		oidcIssuerOID := asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 57264, 1, 1}
+		issuerBytes, _ := asn1.Marshal("https://issuer.example.com")
+
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				CommonName: "test",
+			},
+			NotBefore:      time.Now(),
+			NotAfter:       time.Now().Add(time.Hour),
+			EmailAddresses: []string{"test@example.com"},
+			URIs:           []*url.URL{parsedURL},
+			KeyUsage:       x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+			SubjectKeyId:   []byte{1, 2, 3, 4},
+			AuthorityKeyId: []byte{5, 6, 7, 8},
+			ExtraExtensions: []pkix.Extension{
+				{
+					Id:       oidcIssuerOID,
+					Critical: false,
+					Value:    issuerBytes,
+				},
+			},
+		}
+		certBytes, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return certBytes
+	}
+
+	ecdsaPriv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	ecdsaCert := genCert(t, &ecdsaPriv.PublicKey, ecdsaPriv)
+
+	edPub, edPriv, _ := ed25519.GenerateKey(rand.Reader)
+	edCert := genCert(t, edPub, edPriv)
+
+	rsaPriv, _ := rsa.GenerateKey(rand.Reader, 2048)
+	rsaCert := genCert(t, &rsaPriv.PublicKey, rsaPriv)
+
+	tests := []struct {
+		name          string
+		certBytes     []byte
+		expectedLabel string
+		expectedValue string
+	}{
+		{
+			name:          "ECDSA",
+			certBytes:     ecdsaCert,
+			expectedLabel: "Algorithm",
+			expectedValue: "ECDSA",
+		},
+		{
+			name:          "Ed25519",
+			certBytes:     edCert,
+			expectedLabel: "Algorithm",
+			expectedValue: "Ed25519",
+		},
+		{
+			name:          "RSA",
+			certBytes:     rsaCert,
+			expectedLabel: "Algorithm",
+			expectedValue: "RSA",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &node{}
+			populateCertificateSummary(n, tc.certBytes, nil)
+
+			found := false
+			for _, child := range n.Children {
+				if child.Label == "Subject Public Key Info" {
+					for _, grandChild := range child.Children {
+						if grandChild.Label == tc.expectedLabel && grandChild.Value == tc.expectedValue {
+							found = true
+							break
+						}
+					}
+				}
+			}
+			if !found {
+				t.Errorf("expected child with label %s and value %s under 'Subject Public Key Info'", tc.expectedLabel, tc.expectedValue)
+			}
+		})
+	}
+}
+
+func TestPopulateCertificateSummary_Authority(t *testing.T) {
+	trBytes, err := os.ReadFile("../../../../pkg/cosign/testdata/trusted_root_pgi.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr, err := root.NewTrustedRootFromJSON(trBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	genCert := func(t *testing.T, authKeyID []byte) []byte {
+		priv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			Subject: pkix.Name{
+				CommonName: "test",
+			},
+			NotBefore:      time.Now(),
+			NotAfter:       time.Now().Add(time.Hour),
+			KeyUsage:       x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:    []x509.ExtKeyUsage{x509.ExtKeyUsageCodeSigning},
+			AuthorityKeyId: authKeyID,
+		}
+		certBytes, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return certBytes
+	}
+
+	fulcioCAs := tr.FulcioCertificateAuthorities()
+	if len(fulcioCAs) == 0 {
+		t.Fatal("expected Fulcio CAs in trusted root")
+	}
+	fca, ok := fulcioCAs[0].(*root.FulcioCertificateAuthority)
+	if !ok {
+		t.Fatal("expected *root.FulcioCertificateAuthority")
+	}
+
+	foundCert := genCert(t, fca.Root.SubjectKeyId)
+	notFoundCert := genCert(t, []byte{5, 6, 7, 8})
+
+	t.Run("Found in initialized trusted root", func(t *testing.T) {
+		n := &node{}
+		populateCertificateSummary(n, foundCert, tr)
+
+		var extensionsNode *node
+		for i := range n.Children {
+			if n.Children[i].Label == "Extensions" {
+				extensionsNode = &n.Children[i]
+				break
+			}
+		}
+		if extensionsNode == nil {
+			t.Fatal("expected 'Extensions' node")
+		}
+
+		found := false
+		for _, child := range extensionsNode.Children {
+			if child.Label == "Authority URL" && child.Value == "https://fulcio.sigstore.dev" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected 'Authority URL' with value 'https://fulcio.sigstore.dev'")
+		}
+	})
+
+	t.Run("Not found in initialized trusted root", func(t *testing.T) {
+		n := &node{}
+		populateCertificateSummary(n, notFoundCert, tr)
+
+		var extensionsNode *node
+		for i := range n.Children {
+			if n.Children[i].Label == "Extensions" {
+				extensionsNode = &n.Children[i]
+				break
+			}
+		}
+		if extensionsNode == nil {
+			t.Fatal("expected 'Extensions' node")
+		}
+
+		found := false
+		for _, child := range extensionsNode.Children {
+			if child.Label == "Authority Key ID" && child.Value == "05060708" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Error("expected 'Authority Key ID' with value '05060708'")
+		}
+	})
+}
+
+func TestPopulateTlogEntrySummary(t *testing.T) {
+	trBytes, err := os.ReadFile("../../../../pkg/cosign/testdata/trusted_root_pgi.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr, err := root.NewTrustedRootFromJSON(trBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name          string
+		entry         *rekorv1.TransparencyLogEntry
+		expectedPairs map[string]string
+	}{
+		{
+			name: "Not found in initialized trusted root",
+			entry: &rekorv1.TransparencyLogEntry{
+				LogIndex: 123,
+				LogId: &protocommon.LogId{
+					KeyId: []byte("log-id"),
+				},
+			},
+			expectedPairs: map[string]string{
+				"Log Index": "123",
+				"Log ID":    "6c6f672d6964",
+			},
+		},
+		{
+			name: "Found in initialized trusted root",
+			entry: &rekorv1.TransparencyLogEntry{
+				LogIndex: 456,
+				LogId: &protocommon.LogId{
+					KeyId: func() []byte {
+						b, _ := hex.DecodeString("c0d23d6ad406973f9559f3ba2d1ca01f84147d8ffc5b8445c224f98b9591801d")
+						return b
+					}(),
+				},
+			},
+			expectedPairs: map[string]string{
+				"Log Index": "456",
+				"Log URL":   "https://rekor.sigstore.dev",
+			},
+		},
+		{
+			name: "with kind/version",
+			entry: &rekorv1.TransparencyLogEntry{
+				LogIndex: 777,
+				KindVersion: &rekorv1.KindVersion{
+					Kind:    "hashedrekord",
+					Version: "0.0.1",
+				},
+			},
+			expectedPairs: map[string]string{
+				"Log Index": "777",
+				"Kind":      "hashedrekord",
+				"Version":   "0.0.1",
+			},
+		},
+		{
+			name: "with canonicalized body",
+			entry: &rekorv1.TransparencyLogEntry{
+				LogIndex:          888,
+				CanonicalizedBody: []byte(`{"body":"json"}`),
+			},
+			expectedPairs: map[string]string{
+				"Log Index":          "888",
+				"Canonicalized Body": "Present (15 bytes)",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &node{}
+			populateTlogEntrySummary(n, tc.entry, tr)
+
+			for expectedLabel, expectedValue := range tc.expectedPairs {
+				found := false
+				for _, child := range n.Children {
+					if child.Label == expectedLabel && child.Value == expectedValue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected child with label %s and value %s", expectedLabel, expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestPopulateContentSummary(t *testing.T) {
+	tests := []struct {
+		name          string
+		bundleContent *protobundle.Bundle
+		expectedLabel string
+		expectedValue string
+	}{
+		{
+			name: "DSSE Envelope",
+			bundleContent: &protobundle.Bundle{
+				Content: &protobundle.Bundle_DsseEnvelope{
+					DsseEnvelope: &protodsse.Envelope{
+						PayloadType: "application/vnd.in-toto+json",
+						Payload:     []byte(`{"predicateType":"https://in-toto.io/Attestation/GitHubWorkflow/v0.1","subject":[{"name":"foo"}]}`),
+					},
+				},
+			},
+			expectedLabel: "Type",
+			expectedValue: "DSSE Envelope",
+		},
+		{
+			name: "Message Signature",
+			bundleContent: &protobundle.Bundle{
+				Content: &protobundle.Bundle_MessageSignature{
+					MessageSignature: &protocommon.MessageSignature{
+						MessageDigest: &protocommon.HashOutput{
+							Algorithm: protocommon.HashAlgorithm_SHA2_256,
+							Digest:    []byte("digest"),
+						},
+						Signature: []byte("signature"),
+					},
+				},
+			},
+			expectedLabel: "Type",
+			expectedValue: "Message Signature",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &node{}
+			populateContentSummary(n, tc.bundleContent)
+
+			found := false
+			for _, child := range n.Children {
+				if child.Label == "Content" {
+					for _, grandChild := range child.Children {
+						if grandChild.Label == tc.expectedLabel && grandChild.Value == tc.expectedValue {
+							found = true
+							break
+						}
+					}
+				}
+			}
+			if !found {
+				t.Errorf("expected child with label %s and value %s", tc.expectedLabel, tc.expectedValue)
+			}
+		})
+	}
+}
+
+func TestPopulateTimestampSummary(t *testing.T) {
+	payload := []byte{1, 2, 3, 4}
+	h := sha256.Sum256(payload)
+
+	ecdsaPriv, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	signature, err := ecdsaPriv.Sign(rand.Reader, h[:], crypto.SHA256)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	client, err := tsaMock.NewTSAClient(tsaMock.TSAClientOptions{Time: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tsBytes, err := tsa.GetTimestampedSignature(signature, client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	n := &node{}
+	tsData := &protobundle.TimestampVerificationData{
+		Rfc3161Timestamps: []*protocommon.RFC3161SignedTimestamp{
+			{SignedTimestamp: tsBytes},
+		},
+	}
+
+	populateTimestampSummary(n, tsData)
+
+	if len(n.Children) == 0 {
+		t.Error("expected children, got none")
+	}
+
+	found := false
+	for _, child := range n.Children {
+		if child.Label == "RFC3161 Timestamps" && child.Value == "1" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'RFC3161 Timestamps' with value '1'")
+	}
+}
+
+func TestPopulateContentSummary_DsseSignatures(t *testing.T) {
+	tests := []struct {
+		name           string
+		bundle         *protobundle.Bundle
+		expectedLabels []string
+		expectedValues []string
+	}{
+		{
+			name: "Valid Base64 Key Hint",
+			bundle: &protobundle.Bundle{
+				Content: &protobundle.Bundle_DsseEnvelope{
+					DsseEnvelope: &protodsse.Envelope{
+						Signatures: []*protodsse.Signature{
+							{
+								Sig:   []byte("sig1"),
+								Keyid: "dGVzdC1oaW50",
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: []string{"Key Hint"},
+			expectedValues: []string{"746573742d68696e74"},
+		},
+		{
+			name: "Invalid Base64 Key Hint",
+			bundle: &protobundle.Bundle{
+				Content: &protobundle.Bundle_DsseEnvelope{
+					DsseEnvelope: &protodsse.Envelope{
+						Signatures: []*protodsse.Signature{
+							{
+								Sig:   []byte("sig2"),
+								Keyid: "not-base64-!",
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: []string{"Key Hint"},
+			expectedValues: []string{"not-base64-!"},
+		},
+		{
+			name: "Key Hint Mismatch",
+			bundle: &protobundle.Bundle{
+				VerificationMaterial: &protobundle.VerificationMaterial{
+					Content: &protobundle.VerificationMaterial_PublicKey{
+						PublicKey: &protocommon.PublicKeyIdentifier{
+							Hint: "different-hint",
+						},
+					},
+				},
+				Content: &protobundle.Bundle_DsseEnvelope{
+					DsseEnvelope: &protodsse.Envelope{
+						Signatures: []*protodsse.Signature{
+							{
+								Sig:   []byte("sig3"),
+								Keyid: "hint-1",
+							},
+						},
+					},
+				},
+			},
+			expectedLabels: []string{"Key Hint", "[!] WARNING"},
+			expectedValues: []string{"hint-1", "Key hint mismatch with Verification Material"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			n := &node{}
+			populateContentSummary(n, tc.bundle)
+
+			// Helper function to recursively find nodes in the tree
+			var findNodes func(n *node, label string) []*node
+			findNodes = func(n *node, label string) []*node {
+				var res []*node
+				if n.Label == label {
+					res = append(res, n)
+				}
+				for i := range n.Children {
+					res = append(res, findNodes(&n.Children[i], label)...)
+				}
+				return res
+			}
+
+			for i, expectedLabel := range tc.expectedLabels {
+				expectedValue := tc.expectedValues[i]
+				nodes := findNodes(n, expectedLabel)
+				found := false
+				for _, matchingNode := range nodes {
+					if matchingNode.Value == expectedValue {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected node with label %q and value %q to be present in tree", expectedLabel, expectedValue)
+				}
+			}
+		})
+	}
+}
+
+func TestPopulateTlogEntrySummary_Inclusion(t *testing.T) {
+	t.Run("Inclusion promise", func(t *testing.T) {
+		n := &node{}
+		entry := &rekorv1.TransparencyLogEntry{
+			InclusionPromise: &rekorv1.InclusionPromise{
+				SignedEntryTimestamp: []byte("promise"),
+			},
+		}
+		populateTlogEntrySummary(n, entry, nil)
+
+		var promiseNode *node
+		for i := range n.Children {
+			if n.Children[i].Label == "Inclusion Promise" {
+				promiseNode = &n.Children[i]
+				break
+			}
+		}
+		if promiseNode == nil {
+			t.Fatal("expected 'Inclusion Promise' node")
+		}
+		if len(promiseNode.Children) != 1 || promiseNode.Children[0].Label != "Signed Entry Timestamp" || promiseNode.Children[0].Value != "Present (7 bytes)" {
+			t.Errorf("unexpected Inclusion Promise children: %v", promiseNode.Children)
+		}
+	})
+
+	t.Run("Inclusion proof with invalid checkpoint", func(t *testing.T) {
+		n := &node{}
+		entry := &rekorv1.TransparencyLogEntry{
+			InclusionProof: &rekorv1.InclusionProof{
+				LogIndex: 123,
+				TreeSize: 456,
+				Hashes:   [][]byte{[]byte("h1")},
+				Checkpoint: &rekorv1.Checkpoint{
+					Envelope: "invalid",
+				},
+			},
+		}
+		populateTlogEntrySummary(n, entry, nil)
+
+		var proofNode *node
+		for i := range n.Children {
+			if n.Children[i].Label == "Inclusion Proof" {
+				proofNode = &n.Children[i]
+				break
+			}
+		}
+		if proofNode == nil {
+			t.Fatal("expected 'Inclusion Proof' node")
+		}
+
+		expectedProofFields := map[string]string{
+			"Log Index": "123",
+			"Tree Size": "456",
+			"Hashes":    "1",
+		}
+		for _, child := range proofNode.Children {
+			if val, ok := expectedProofFields[child.Label]; ok {
+				if child.Value != val {
+					t.Errorf("expected proof field %s to be %s, got %s", child.Label, val, child.Value)
+				}
+			}
+		}
+
+		var checkpointNode *node
+		for i := range proofNode.Children {
+			if proofNode.Children[i].Label == "Checkpoint" {
+				checkpointNode = &proofNode.Children[i]
+				break
+			}
+		}
+		if checkpointNode == nil {
+			t.Fatal("expected 'Checkpoint' node under proof")
+		}
+		if len(checkpointNode.Children) != 1 || checkpointNode.Children[0].Label != "Envelope" || checkpointNode.Children[0].Value != "Present (7 bytes)" {
+			t.Errorf("unexpected Checkpoint children: %v", checkpointNode.Children)
+		}
+	})
+
+	t.Run("Inclusion proof with valid checkpoint", func(t *testing.T) {
+		n := &node{}
+		validEnvelope := "rekor.sigstore.dev\n123\n47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n\n— witness1 dGVzdC1zaWc=\n"
+		entry := &rekorv1.TransparencyLogEntry{
+			InclusionProof: &rekorv1.InclusionProof{
+				LogIndex: 123,
+				TreeSize: 456,
+				Hashes:   [][]byte{[]byte("h1")},
+				Checkpoint: &rekorv1.Checkpoint{
+					Envelope: validEnvelope,
+				},
+			},
+		}
+		populateTlogEntrySummary(n, entry, nil)
+
+		var proofNode *node
+		for i := range n.Children {
+			if n.Children[i].Label == "Inclusion Proof" {
+				proofNode = &n.Children[i]
+				break
+			}
+		}
+		if proofNode == nil {
+			t.Fatal("expected 'Inclusion Proof' node")
+		}
+
+		var checkpointNode *node
+		for i := range proofNode.Children {
+			if proofNode.Children[i].Label == "Checkpoint" {
+				checkpointNode = &proofNode.Children[i]
+				break
+			}
+		}
+		if checkpointNode == nil {
+			t.Fatal("expected 'Checkpoint' node under proof")
+		}
+
+		hasOrigin := false
+		expectedCheckpointFields := map[string]string{
+			"Origin":    "rekor.sigstore.dev",
+			"Tree Size": "123",
+		}
+		for _, child := range checkpointNode.Children {
+			if child.Label == "Origin" {
+				hasOrigin = true
+			}
+			if val, ok := expectedCheckpointFields[child.Label]; ok {
+				if child.Value != val {
+					t.Errorf("expected checkpoint field %s to be %s, got %s", child.Label, val, child.Value)
+				}
+			}
+		}
+		if !hasOrigin {
+			t.Error("expected 'Origin' node, meaning checkpoint unmarshaling failed and hit fallback")
+		}
+
+		var witnessesNode *node
+		for i := range checkpointNode.Children {
+			if checkpointNode.Children[i].Label == "Witnesses" {
+				witnessesNode = &checkpointNode.Children[i]
+				break
+			}
+		}
+		if witnessesNode == nil {
+			t.Fatal("expected 'Witnesses' node under checkpoint")
+		}
+		if len(witnessesNode.Children) != 1 || witnessesNode.Children[0].Label != "witness1" || !strings.Contains(witnessesNode.Children[0].Value, "Signature Present") {
+			t.Errorf("unexpected Witnesses children: %v", witnessesNode.Children)
+		}
+	})
+}

--- a/doc/cosign_bundle.md
+++ b/doc/cosign_bundle.md
@@ -24,5 +24,6 @@ Tools for interacting with a Sigstore protobuf bundle
 
 * [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign bundle create](cosign_bundle_create.md)	 - Create a Sigstore protobuf bundle
+* [cosign bundle inspect](cosign_bundle_inspect.md)	 - Inspect a Sigstore protobuf bundle
 * [cosign bundle upgrade](cosign_bundle_upgrade.md)	 - Upgrade a Sigstore protobuf bundle
 

--- a/doc/cosign_bundle_inspect.md
+++ b/doc/cosign_bundle_inspect.md
@@ -1,0 +1,26 @@
+## cosign bundle inspect
+
+Inspect a Sigstore protobuf bundle
+
+```
+cosign bundle inspect BUNDLE [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for inspect
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign bundle](cosign_bundle.md)	 - Interact with a Sigstore protobuf bundle
+


### PR DESCRIPTION
Partially addresses #3794 

#### Summary

This change adds a `bundle inspect` command which provides a diagnostic display of a bundle's contents.