### PR TITLE
Update conformance to latest

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -44,7 +44,7 @@ jobs:
 
       - run: make cosign conformance
 
-      - uses: sigstore/sigstore-conformance@9611941d54398f2e3f6383b6f744442a56d2fb2a # v0.0.26
+      - uses: sigstore/sigstore-conformance@4d66ba3cb0c9c95f705c757c0f5e226d3f4d5151 # v0.0.27
         with:
           entrypoint: ${{ github.workspace }}/conformance
           xfail: "test_verify*PATH-message-digest-mismatch_fail]"


### PR DESCRIPTION
#### Summary

This change updates the `Conformance Tests` workflow to use the latest version of `sigstore/sigstore-conformance`, [v0.0.27](https://github.com/sigstore/sigstore-conformance/releases/tag/v0.0.27), which more reliably provides a valid identity token.