### PR TITLE
fix(verify): return error instead of panicking when no timestamps verify

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1400,6 +1400,9 @@ func VerifyRFC3161Timestamp(sig oci.Signature, co *CheckOpts) (*timestamp.Timest
 		if err != nil {
 			return nil, fmt.Errorf("unable to verify signed timestamps with trusted root: %w", err)
 		}
+		if len(verifiedTimestamps) == 0 {
+			return nil, fmt.Errorf("no signed timestamps verified: %v", verifyErrs)
+		}
 		if len(verifyErrs) > 0 {
 			log.Printf("Warning: subset of signed timestamps failed to verify: %v", verifyErrs)
 		}

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1843,6 +1843,55 @@ func TestVerifyRFC3161Timestamp(t *testing.T) {
 	}
 }
 
+// emptyTSATrustedMaterial is a TrustedMaterial whose TimestampingAuthorities()
+// returns an empty slice. Used to exercise the path where
+// verify.VerifySignedTimestamp returns (emptySlice, verifyErrs, nil) — i.e.
+// no top-level error, but no timestamps verified either.
+type emptyTSATrustedMaterial struct {
+	root.BaseTrustedMaterial
+}
+
+// Regression test for the panic where VerifyRFC3161Timestamp's TrustedMaterial
+// branch indexed verifiedTimestamps[0] without checking len(). When no
+// TimestampingAuthority in TrustedMaterial matches the timestamp under
+// verification, sigstore-go returns an empty slice with non-empty per-attempt
+// errors and a nil top-level error. The function should return that as a
+// regular verification error, not panic.
+func TestVerifyRFC3161Timestamp_NoMatchingTSAInTrustedMaterial(t *testing.T) {
+	rootCert, rootKey, _ := test.GenerateRootCa()
+	leafCert, privKey, _ := test.GenerateLeafCert("subject", "oidc-issuer", rootCert, rootKey)
+	pemRoot := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootCert.Raw})
+	pemLeaf := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCert.Raw})
+	payload := []byte{1, 2, 3, 4}
+	h := sha256.Sum256(payload)
+	signature, _ := privKey.Sign(rand.Reader, h[:], crypto.SHA256)
+
+	client, err := tsaMock.NewTSAClient(tsaMock.TSAClientOptions{Time: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsBytes, err := tsa.GetTimestampedSignature(signature, client)
+	if err != nil {
+		t.Fatalf("unexpected error creating timestamp: %v", err)
+	}
+	rfc3161TS := bundle.RFC3161Timestamp{SignedRFC3161Timestamp: tsBytes}
+
+	ociSig, _ := static.NewSignature(payload,
+		base64.StdEncoding.EncodeToString(signature),
+		static.WithCertChain(pemLeaf, appendSlices([][]byte{pemRoot})),
+		static.WithRFC3161Timestamp(&rfc3161TS))
+
+	_, err = VerifyRFC3161Timestamp(ociSig, &CheckOpts{
+		TrustedMaterial: &emptyTSATrustedMaterial{},
+	})
+	if err == nil {
+		t.Fatalf("expected error when TrustedMaterial has no matching TSA, got nil")
+	}
+	if !strings.Contains(err.Error(), "no signed timestamps verified") {
+		t.Fatalf("expected 'no signed timestamps verified' error, got: %v", err)
+	}
+}
+
 // This test verifies that artifact verification rejects signatures
 // where a CA certificate in the issuing chain is expired. This is a contrived
 // example because CAs shouldn't issue certificates where the leaf's validity


### PR DESCRIPTION
Closes #4846

#### Summary

`VerifyRFC3161Timestamp`'s `TrustedMaterial` branch indexes `verifiedTimestamps[0].Time`
after only logging `verifyErrs` as a warning. When `verify.VerifySignedTimestamp` returns an
empty slice with non-empty `verifyErrs` (i.e. all attempts failed but no top-level error), the
function panics with `runtime error: index out of range [0] with length 0` instead of
returning an error to the caller.

Three-line fix: guard on `len(verifiedTimestamps) == 0` and return an error wrapping
`verifyErrs`. Reviewers can verify by constructing a `CheckOpts` whose `TrustedMaterial`
contains no `TimestampingAuthority` matching the timestamp under verification — the same
shape that triggers the panic in the linked issue.

`go test ./pkg/cosign/...` passes with no regressions.

#### Release Note

```release-note
Fix a panic in `VerifyRFC3161Timestamp` that occurred when zero signed timestamps could be
verified against the provided `TrustedMaterial`. The function now returns an error wrapping
the per-attempt verification errors instead of indexing an empty slice.
```
