### PR TITLE
fix(verify): honour user-provided TSA chain when TrustedMaterial is set

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1391,6 +1391,17 @@ func VerifyRFC3161Timestamp(sig oci.Signature, co *CheckOpts) (*timestamp.Timest
 		tsBytes = rawSig
 	}
 
+	// Honour the explicit TSA chain when set — TrustedMaterial may not
+	// contain the TSA used to sign this timestamp.
+	if co.TSARootCertificates != nil {
+		return tsaverification.VerifyTimestampResponse(ts.SignedRFC3161Timestamp, bytes.NewReader(tsBytes),
+			tsaverification.VerifyOpts{
+				TSACertificate: co.TSACertificate,
+				Intermediates:  co.TSAIntermediateCertificates,
+				Roots:          co.TSARootCertificates,
+			})
+	}
+
 	if co.TrustedMaterial != nil {
 		entity := &signedEntityForTimestamp{
 			timestamp:  ts,

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1843,6 +1843,65 @@ func TestVerifyRFC3161Timestamp(t *testing.T) {
 	}
 }
 
+// TrustedMaterial with no TSAs — exercises the case where the caller's
+// TSA chain is the only place the signing TSA is configured.
+type noMatchingTSAsMaterial struct {
+	root.BaseTrustedMaterial
+}
+
+func TestVerifyRFC3161Timestamp_LegacyChainHonouredWithTrustedMaterial(t *testing.T) {
+	rootCert, rootKey, _ := test.GenerateRootCa()
+	leafCert, privKey, _ := test.GenerateLeafCert("subject", "oidc-issuer", rootCert, rootKey)
+	pemRoot := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: rootCert.Raw})
+	pemLeaf := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: leafCert.Raw})
+	payload := []byte{1, 2, 3, 4}
+	h := sha256.Sum256(payload)
+	signature, _ := privKey.Sign(rand.Reader, h[:], crypto.SHA256)
+
+	client, err := tsaMock.NewTSAClient(tsaMock.TSAClientOptions{Time: time.Now()})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsBytes, err := tsa.GetTimestampedSignature(signature, client)
+	if err != nil {
+		t.Fatalf("unexpected error creating timestamp: %v", err)
+	}
+	rfc3161TS := bundle.RFC3161Timestamp{SignedRFC3161Timestamp: tsBytes}
+
+	certChainPEM, err := cryptoutils.MarshalCertificatesToPEM(client.CertChain)
+	if err != nil {
+		t.Fatalf("unexpected error marshalling cert chain: %v", err)
+	}
+	leaves, intermediates, roots, err := tsa.SplitPEMCertificateChain(certChainPEM)
+	if err != nil {
+		t.Fatal("error splitting response into certificate chain")
+	}
+
+	ociSig, _ := static.NewSignature(payload,
+		base64.StdEncoding.EncodeToString(signature),
+		static.WithCertChain(pemLeaf, appendSlices([][]byte{pemRoot})),
+		static.WithRFC3161Timestamp(&rfc3161TS))
+
+	// Both TrustedMaterial AND the legacy TSA fields are set. TrustedMaterial
+	// has no matching TSA; the legacy fields contain the chain that actually
+	// signed the timestamp. Verification must use the legacy chain.
+	ts, err := VerifyRFC3161Timestamp(ociSig, &CheckOpts{
+		TrustedMaterial:             &noMatchingTSAsMaterial{},
+		TSACertificate:              leaves[0],
+		TSAIntermediateCertificates: intermediates,
+		TSARootCertificates:         roots,
+	})
+	if err != nil {
+		t.Fatalf("expected verification to succeed when legacy TSA chain is set alongside TrustedMaterial, got: %v", err)
+	}
+	if ts == nil {
+		t.Fatalf("expected non-nil verified timestamp")
+	}
+	if err := CheckExpiry(leafCert, nil, ts.Time); err != nil {
+		t.Fatalf("unexpected error using time from timestamp to verify certificate: %v", err)
+	}
+}
+
 // This test verifies that artifact verification rejects signatures
 // where a CA certificate in the issuing chain is expired. This is a contrived
 // example because CAs shouldn't issue certificates where the leaf's validity


### PR DESCRIPTION
Closes #4847

#### Summary

`VerifyRFC3161Timestamp` silently dropped `co.TSACertificate` /
`co.TSAIntermediateCertificates` / `co.TSARootCertificates` whenever `co.TrustedMaterial`
was non-nil — a regression from cosign v2 that breaks the use case where a caller legitimately
wants to combine `TrustedMaterial` (Fulcio CA / Rekor pubkeys from a public sigstore TUF root)
with a TSA chain for an out-of-tree TSA not present in any TUF root (e.g. GitHub's private TSA
used by `actions/attest-build-provenance` on private repositories). See #4847 for the full
diagnosis, including reproduction toggling between fail and pass on the single bit
`co.TrustedMaterial == nil`.

This PR implements **Option A** from the issue: when `co.TSARootCertificates` is set, treat
it as an explicit directive and use the legacy `tsaverification.VerifyTimestampResponse` path,
even when `TrustedMaterial` is also set. The `TrustedMaterial` branch is unchanged for
callers who don't set the legacy fields. Net effect: any v2 CheckOpts shape that previously
worked continues to work; new CheckOpts that carry both fields now work as the caller
clearly intends.

Option B in the issue (merge the legacy fields into `TrustedMaterial` as a
`SigstoreTimestampingAuthority`) is also viable; happy to switch to that shape if you'd
prefer the v3-architectural direction. Option A picked here because it's strictly additive
(16 lines, no deletions, no new types) and easier to backport.

Reviewers can verify with the reproduction program in #4847: it should output
`✓ verified` for both Case 1 and Case 2 with this patch applied. `go test ./pkg/cosign/...`
passes with no regressions.

#### Release Note

```release-note
Fix `VerifyRFC3161Timestamp` silently dropping the user-provided TSA chain
(`TSACertificate` / `TSAIntermediateCertificates` / `TSARootCertificates`) when
`TrustedMaterial` is also set on `CheckOpts`. This restores the v2 contract for callers
who combine a public sigstore trusted root with a TSA chain for an out-of-tree timestamp
authority (e.g. GitHub's private TSA used by Artifact Attestations on private
repositories).
```
