### PR TITLE
Treat Rekor v1 409 conflict as success in v2 bundle sign path

### DIFF
--- a/pkg/cosign/bundle/rekor_idempotent.go
+++ b/pkg/cosign/bundle/rekor_idempotent.go
@@ -1,0 +1,132 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	rekorclient "github.com/sigstore/rekor/pkg/client"
+	"github.com/sigstore/rekor/pkg/generated/client"
+	"github.com/sigstore/rekor/pkg/generated/client/entries"
+	"github.com/sigstore/rekor/pkg/generated/models"
+	"github.com/sigstore/rekor/pkg/tle"
+
+	"github.com/sigstore/cosign/v3/internal/ui"
+	"github.com/sigstore/sigstore-go/pkg/sign"
+)
+
+// rekorClientFactory builds a Rekor v1 read client lazily. Tests inject a stub.
+type rekorClientFactory func() (*client.Rekor, error)
+
+// rekorEntryFetcher abstracts the v1 GetLogEntryByUUID lookup so tests can stub it.
+type rekorEntryFetcher func(ctx context.Context, c *client.Rekor, uuid string) (*models.LogEntryAnon, error)
+
+// rekorTLEGenerator abstracts entry-to-TLE conversion so tests can stub it.
+type rekorTLEGenerator func(anon models.LogEntryAnon) (*protorekor.TransparencyLogEntry, error)
+
+// idempotentRekor wraps an upstream sigstore-go Transparency implementation and
+// treats a Rekor v1 409 conflict ("an equivalent entry already exists") as a
+// success by fetching the existing entry and appending it to the bundle, matching
+// the behavior of the v1 signing path in pkg/cosign/tlog.go (see issue #4851 and
+// the original fix tracked in #3356).
+//
+// Only the Rekor v1 path is covered here. Rekor v2 does not yet expose a
+// lookup-by-UUID API on its read client, so a 409 from a v2 endpoint will still
+// surface to the caller; that case must be addressed in rekor-tiles.
+type idempotentRekor struct {
+	inner       sign.Transparency
+	factory     rekorClientFactory
+	fetch       rekorEntryFetcher
+	generateTLE rekorTLEGenerator
+}
+
+func newIdempotentRekor(inner sign.Transparency, factory rekorClientFactory) *idempotentRekor {
+	return &idempotentRekor{
+		inner:       inner,
+		factory:     factory,
+		fetch:       defaultFetchEntry,
+		generateTLE: tle.GenerateTransparencyLogEntry,
+	}
+}
+
+func defaultFetchEntry(ctx context.Context, c *client.Rekor, uuid string) (*models.LogEntryAnon, error) {
+	params := entries.NewGetLogEntryByUUIDParamsWithContext(ctx)
+	params.SetEntryUUID(uuid)
+	resp, err := c.Entries.GetLogEntryByUUID(params)
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range resp.Payload {
+		e := e
+		return &e, nil
+	}
+	return nil, errors.New("empty response from rekor")
+}
+
+func (r *idempotentRekor) GetTransparencyLogEntry(ctx context.Context, keyOrCertPEM []byte, b *protobundle.Bundle) error {
+	err := r.inner.GetTransparencyLogEntry(ctx, keyOrCertPEM, b)
+	if err == nil {
+		return nil
+	}
+	var existsErr *entries.CreateLogEntryConflict
+	if !errors.As(err, &existsErr) {
+		return err
+	}
+	uuid := uuidFromLocation(existsErr.Location.String())
+	if uuid == "" {
+		return fmt.Errorf("rekor reported an existing entry but did not return a UUID: %w", err)
+	}
+	rekorClient, cerr := r.factory()
+	if cerr != nil {
+		return fmt.Errorf("constructing rekor client to fetch existing entry %s: %w", uuid, cerr)
+	}
+	entry, ferr := r.fetch(ctx, rekorClient, uuid)
+	if ferr != nil {
+		return fmt.Errorf("fetching existing rekor entry %s after 409 conflict: %w", uuid, ferr)
+	}
+	tlogEntry, terr := r.generateTLE(*entry)
+	if terr != nil {
+		return fmt.Errorf("generating transparency log entry from existing rekor entry %s: %w", uuid, terr)
+	}
+	if b.VerificationMaterial == nil {
+		b.VerificationMaterial = &protobundle.VerificationMaterial{}
+	}
+	if b.VerificationMaterial.TlogEntries == nil {
+		b.VerificationMaterial.TlogEntries = []*protorekor.TransparencyLogEntry{}
+	}
+	b.VerificationMaterial.TlogEntries = append(b.VerificationMaterial.TlogEntries, tlogEntry)
+	ui.Infof(ctx, "rekor entry already exists, reusing %s", uuid)
+	return nil
+}
+
+func uuidFromLocation(loc string) string {
+	loc = strings.TrimSpace(loc)
+	if loc == "" {
+		return ""
+	}
+	parts := strings.Split(loc, "/")
+	return parts[len(parts)-1]
+}
+
+func newRekorClientFactory(baseURL string) rekorClientFactory {
+	return func() (*client.Rekor, error) {
+		return rekorclient.GetRekorClient(baseURL)
+	}
+}

--- a/pkg/cosign/bundle/rekor_idempotent_test.go
+++ b/pkg/cosign/bundle/rekor_idempotent_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protorekor "github.com/sigstore/protobuf-specs/gen/pb-go/rekor/v1"
+	rekorclient "github.com/sigstore/rekor/pkg/generated/client"
+	"github.com/sigstore/rekor/pkg/generated/client/entries"
+	"github.com/sigstore/rekor/pkg/generated/models"
+)
+
+type fakeTransparency struct {
+	err error
+}
+
+func (f *fakeTransparency) GetTransparencyLogEntry(_ context.Context, _ []byte, _ *protobundle.Bundle) error {
+	return f.err
+}
+
+func newConflictErr(t *testing.T, location string) *entries.CreateLogEntryConflict {
+	t.Helper()
+	u, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("parse location: %v", err)
+	}
+	return &entries.CreateLogEntryConflict{Location: strfmt.URI(u.String())}
+}
+
+func TestIdempotentRekor_NoErrorPassesThrough(t *testing.T) {
+	t.Parallel()
+	inner := &fakeTransparency{err: nil}
+	r := newIdempotentRekor(inner, func() (*rekorclient.Rekor, error) {
+		t.Fatalf("factory should not be called when inner succeeds")
+		return nil, nil
+	})
+	r.fetch = func(_ context.Context, _ *rekorclient.Rekor, _ string) (*models.LogEntryAnon, error) {
+		t.Fatalf("fetch should not be called when inner succeeds")
+		return nil, nil
+	}
+	r.generateTLE = func(_ models.LogEntryAnon) (*protorekor.TransparencyLogEntry, error) {
+		t.Fatalf("generateTLE should not be called when inner succeeds")
+		return nil, nil
+	}
+	bundle := &protobundle.Bundle{}
+	if err := r.GetTransparencyLogEntry(context.Background(), nil, bundle); err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+}
+
+func TestIdempotentRekor_NonConflictErrorPropagates(t *testing.T) {
+	t.Parallel()
+	innerErr := errors.New("network broke")
+	r := newIdempotentRekor(&fakeTransparency{err: innerErr}, func() (*rekorclient.Rekor, error) {
+		t.Fatalf("factory should not be called for non-conflict errors")
+		return nil, nil
+	})
+	err := r.GetTransparencyLogEntry(context.Background(), nil, &protobundle.Bundle{})
+	if !errors.Is(err, innerErr) {
+		t.Fatalf("expected inner error to propagate, got: %v", err)
+	}
+}
+
+func TestIdempotentRekor_ConflictFetchesExistingEntry(t *testing.T) {
+	t.Parallel()
+	conflict := newConflictErr(t, "/api/v1/log/entries/108e9186e8c5677a")
+	wrappedInner := &fakeTransparency{err: conflict}
+
+	fetched := false
+	stubEntry := &models.LogEntryAnon{}
+	fakeTLE := &protorekor.TransparencyLogEntry{LogIndex: 42}
+
+	r := newIdempotentRekor(wrappedInner, func() (*rekorclient.Rekor, error) {
+		return &rekorclient.Rekor{}, nil
+	})
+	r.fetch = func(_ context.Context, _ *rekorclient.Rekor, uuid string) (*models.LogEntryAnon, error) {
+		fetched = true
+		if uuid != "108e9186e8c5677a" {
+			t.Fatalf("unexpected uuid: %q", uuid)
+		}
+		return stubEntry, nil
+	}
+	r.generateTLE = func(_ models.LogEntryAnon) (*protorekor.TransparencyLogEntry, error) {
+		return fakeTLE, nil
+	}
+
+	bundle := &protobundle.Bundle{}
+	if err := r.GetTransparencyLogEntry(context.Background(), nil, bundle); err != nil {
+		t.Fatalf("expected conflict to be treated as success, got: %v", err)
+	}
+	if !fetched {
+		t.Fatalf("expected fetch to be called for the existing entry")
+	}
+	if bundle.VerificationMaterial == nil {
+		t.Fatalf("expected VerificationMaterial to be initialized")
+	}
+	if got := len(bundle.VerificationMaterial.TlogEntries); got != 1 {
+		t.Fatalf("expected exactly one tlog entry, got %d", got)
+	}
+	if bundle.VerificationMaterial.TlogEntries[0] != fakeTLE {
+		t.Fatalf("expected the stub TLE to be appended to the bundle")
+	}
+}
+
+func TestIdempotentRekor_ConflictAppendsToExistingMaterial(t *testing.T) {
+	t.Parallel()
+	conflict := newConflictErr(t, "https://rekor.example.com/api/v1/log/entries/deadbeef")
+	wrappedInner := &fakeTransparency{err: conflict}
+
+	r := newIdempotentRekor(wrappedInner, func() (*rekorclient.Rekor, error) {
+		return &rekorclient.Rekor{}, nil
+	})
+	r.fetch = func(_ context.Context, _ *rekorclient.Rekor, _ string) (*models.LogEntryAnon, error) {
+		return &models.LogEntryAnon{}, nil
+	}
+	r.generateTLE = func(_ models.LogEntryAnon) (*protorekor.TransparencyLogEntry, error) {
+		return &protorekor.TransparencyLogEntry{LogIndex: 7}, nil
+	}
+
+	existing := &protorekor.TransparencyLogEntry{LogIndex: 1}
+	bundle := &protobundle.Bundle{
+		VerificationMaterial: &protobundle.VerificationMaterial{
+			TlogEntries: []*protorekor.TransparencyLogEntry{existing},
+		},
+	}
+	if err := r.GetTransparencyLogEntry(context.Background(), nil, bundle); err != nil {
+		t.Fatalf("expected conflict to be treated as success, got: %v", err)
+	}
+	if got := len(bundle.VerificationMaterial.TlogEntries); got != 2 {
+		t.Fatalf("expected two tlog entries, got %d", got)
+	}
+	if bundle.VerificationMaterial.TlogEntries[0] != existing {
+		t.Fatalf("expected pre-existing entry to be preserved at index 0")
+	}
+}
+
+func TestIdempotentRekor_ConflictFactoryError(t *testing.T) {
+	t.Parallel()
+	conflict := newConflictErr(t, "/api/v1/log/entries/abc123")
+	factoryErr := errors.New("cannot build client")
+	r := newIdempotentRekor(&fakeTransparency{err: conflict}, func() (*rekorclient.Rekor, error) {
+		return nil, factoryErr
+	})
+
+	err := r.GetTransparencyLogEntry(context.Background(), nil, &protobundle.Bundle{})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, factoryErr) {
+		t.Fatalf("expected factory error to be wrapped, got: %v", err)
+	}
+}
+
+func TestIdempotentRekor_ConflictFetchError(t *testing.T) {
+	t.Parallel()
+	conflict := newConflictErr(t, "/api/v1/log/entries/abc123")
+	fetchErr := errors.New("rekor unavailable")
+	r := newIdempotentRekor(&fakeTransparency{err: conflict}, func() (*rekorclient.Rekor, error) {
+		return &rekorclient.Rekor{}, nil
+	})
+	r.fetch = func(_ context.Context, _ *rekorclient.Rekor, _ string) (*models.LogEntryAnon, error) {
+		return nil, fetchErr
+	}
+
+	err := r.GetTransparencyLogEntry(context.Background(), nil, &protobundle.Bundle{})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, fetchErr) {
+		t.Fatalf("expected fetch error to be wrapped, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "abc123") {
+		t.Fatalf("expected error to mention the UUID, got: %v", err)
+	}
+}
+
+func TestIdempotentRekor_ConflictTLEError(t *testing.T) {
+	t.Parallel()
+	conflict := newConflictErr(t, "/api/v1/log/entries/zzz")
+	tleErr := errors.New("malformed body")
+	r := newIdempotentRekor(&fakeTransparency{err: conflict}, func() (*rekorclient.Rekor, error) {
+		return &rekorclient.Rekor{}, nil
+	})
+	r.fetch = func(_ context.Context, _ *rekorclient.Rekor, _ string) (*models.LogEntryAnon, error) {
+		return &models.LogEntryAnon{}, nil
+	}
+	r.generateTLE = func(_ models.LogEntryAnon) (*protorekor.TransparencyLogEntry, error) {
+		return nil, tleErr
+	}
+
+	err := r.GetTransparencyLogEntry(context.Background(), nil, &protobundle.Bundle{})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, tleErr) {
+		t.Fatalf("expected tle error to be wrapped, got: %v", err)
+	}
+}
+
+func TestUUIDFromLocation(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"absolute path", "/api/v1/log/entries/108e9186e8c5677a", "108e9186e8c5677a"},
+		{"full url", "https://rekor.example.com/api/v1/log/entries/deadbeef", "deadbeef"},
+		{"trailing whitespace", "  /api/v1/log/entries/abc  ", "abc"},
+		{"empty", "", ""},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := uuidFromLocation(tc.in); got != tc.want {
+				t.Fatalf("uuidFromLocation(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -125,7 +125,15 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 				Retries: 1,
 				Version: rekorSvc.MajorAPIVersion,
 			}
-			bundleOpts.TransparencyLogs = append(bundleOpts.TransparencyLogs, sign.NewRekor(rekorOpts))
+			var transparency sign.Transparency = sign.NewRekor(rekorOpts)
+			// On Rekor v1, a re-signed image+predicate triggers a 409 with the existing
+			// entry's UUID. Wrap the transparency log so the conflict is treated as success,
+			// mirroring the v1 signing path in pkg/cosign/tlog.go. See issue #4851 and the
+			// earlier fix tracked in #3356.
+			if rekorSvc.MajorAPIVersion == 1 {
+				transparency = newIdempotentRekor(transparency, newRekorClientFactory(rekorSvc.URL))
+			}
+			bundleOpts.TransparencyLogs = append(bundleOpts.TransparencyLogs, transparency)
 		}
 	}
 	// When requesting a short-lived Fulcio certificate, a timestamp must be provided during


### PR DESCRIPTION
## Summary

When `cosign attest --yes` is re-run against the same image and predicate (a common CI retry pattern), Rekor v1 returns `409 createLogEntryConflict` with the existing entry's UUID. The v1 signing path in `pkg/cosign/tlog.go` (see `doUpload`) has handled this for a long time by fetching the existing entry and continuing. The newer v2 bundle path in `pkg/cosign/bundle/sign.go` does not, and surfaces the error verbatim:

```
Error: signing ...: signing bundle: error signing bundle: [POST /api/v1/log/entries][409] createLogEntryConflict {"code":409,"message":"an equivalent entry already exists in the transparency log with UUID 108e9186e8c5677a..."}
```

This wraps the `sign.Transparency` returned by `sigstore-go`'s `sign.NewRekor` with an idempotent variant. The wrapper:

1. Calls the inner Transparency normally.
2. If the returned error is `*entries.CreateLogEntryConflict`, parses the UUID out of the `Location` header.
3. Builds a Rekor v1 read client, calls `GetLogEntryByUUID`, converts the existing entry into a `TransparencyLogEntry` via `tle.GenerateTransparencyLogEntry`, and appends it to the bundle.
4. Any non-conflict error propagates untouched.

The wrapper is only installed when `MajorAPIVersion == 1`. Rekor v2 (`rekor-tiles`) has no lookup-by-UUID API on its read client today, so fixing the v2 case requires upstream support and is out of scope for this PR.

Fixes #4851
Refs #3356

## Test plan

- [x] Unit tests added in `pkg/cosign/bundle/rekor_idempotent_test.go` covering: pass-through on no error, non-conflict error propagation, 409 with successful fetch (entry appended to a fresh and an existing `TlogEntries`), factory error, fetch error, TLE conversion error, and the `Location`-to-UUID parser.
- [x] `go test ./pkg/cosign/bundle/...`
- [x] `go test ./pkg/cosign/...`
- [x] `go vet` and `golangci-lint run ./pkg/cosign/bundle/...` clean.