### PR TITLE
Return error instead of panicking when no signed timestamps verify

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1403,6 +1403,9 @@ func VerifyRFC3161Timestamp(sig oci.Signature, co *CheckOpts) (*timestamp.Timest
 		if len(verifyErrs) > 0 {
 			log.Printf("Warning: subset of signed timestamps failed to verify: %v", verifyErrs)
 		}
+		if len(verifiedTimestamps) == 0 {
+			return nil, fmt.Errorf("no signed timestamps could be verified with the trusted root: %v", verifyErrs)
+		}
 		return &timestamp.Timestamp{Time: verifiedTimestamps[0].Time}, nil
 	}
 

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1841,6 +1841,28 @@ func TestVerifyRFC3161Timestamp(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "no TSA root certificate(s) provided to verify timestamp") {
 		t.Fatalf("expected error verifying without a root certificate, got: %v", err)
 	}
+
+	// failure with a trusted root that has no matching timestamping authority:
+	// verify.VerifySignedTimestamp returns zero verified timestamps without a
+	// top-level error, which must surface as an error rather than panic on
+	// indexing an empty slice (see issue #4846).
+	tsBytes, err = tsa.GetTimestampedSignature(signature, client)
+	if err != nil {
+		t.Fatalf("unexpected error creating timestamp: %v", err)
+	}
+	rfc3161TS = bundle.RFC3161Timestamp{SignedRFC3161Timestamp: tsBytes}
+	ociSig, _ = static.NewSignature(payload,
+		base64.StdEncoding.EncodeToString(signature),
+		static.WithCertChain(pemLeaf, appendSlices([][]byte{pemRoot})),
+		static.WithRFC3161Timestamp(&rfc3161TS))
+	emptyTrustedRoot, err := root.NewTrustedRoot(root.TrustedRootMediaType01, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = VerifyRFC3161Timestamp(ociSig, &CheckOpts{TrustedMaterial: emptyTrustedRoot})
+	if err == nil || !strings.Contains(err.Error(), "no signed timestamps could be verified") {
+		t.Fatalf("expected error verifying timestamp with empty trusted root, got: %v", err)
+	}
 }
 
 // This test verifies that artifact verification rejects signatures


### PR DESCRIPTION
## Summary

`VerifyRFC3161Timestamp` indexes `verifiedTimestamps[0].Time` without checking that the slice is non-empty. When `verify.VerifySignedTimestamp` returns zero verified timestamps along with only per-attempt errors (no top-level error), the function falls through and panics with `index out of range [0] with length 0`.

This adds a length check that returns a descriptive error instead.

Fixes #4846

## Testing

Extended `TestVerifyRFC3161Timestamp` with a case that passes a trusted root containing no timestamping authorities; it fails (panics) without the fix and passes with it. `go test ./pkg/cosign/` and `go vet` pass.