### PR TITLE
conformance: xfail rekor2-dsse-happy-path

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: sigstore/sigstore-conformance@main
         with:
           entrypoint: ${{ github.workspace }}/conformance
-          xfail: "test_verify*PATH-message-digest-mismatch_fail]"
+          xfail: "test_verify*PATH-message-digest-mismatch_fail] test_verify*rekor2-dsse-happy-path]"
 
       - name: Create Issue on Failure
         if: failure()

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -47,4 +47,4 @@ jobs:
       - uses: sigstore/sigstore-conformance@4d66ba3cb0c9c95f705c757c0f5e226d3f4d5151 # v0.0.27
         with:
           entrypoint: ${{ github.workspace }}/conformance
-          xfail: "test_verify*PATH-message-digest-mismatch_fail]"
+          xfail: "test_verify*PATH-message-digest-mismatch_fail] test_verify*rekor2-dsse-happy-path]"


### PR DESCRIPTION
## Summary

sigstore/sigstore-conformance#371 regenerates the `rekor2-dsse-*` bundle-verify fixtures to encode DSSE envelopes as `hashedrekord/0.0.2` entries per [rekor-v2-spec §6.1.4](https://github.com/sigstore/architecture-docs/pull/63), where `digest = Hash(PAE(payloadType, payload))` and `signature.content = envelope.signatures[0].sig`. Cosign does not yet recognize this encoding for DSSE bundles, so `rekor2-dsse-happy-path` will start failing once #371 lands.

xfails the happy-path case in both PR and nightly conformance workflows per @Hayden-IO's request on #371. The three `rekor2-dsse-*_fail` cases keep passing because cosign rejects the unrecognized entry, which is what those tests expect.

## Related

- Spec change: sigstore/architecture-docs#63
- Conformance tests: sigstore/sigstore-conformance#371