### PR TITLE
fix: close file descriptor leaked in WriteSignedImageIndexImages loop

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -118,6 +118,7 @@ func WriteSignedImageIndexImages(ref name.Reference, sii oci.SignedImageIndex, d
 			return err
 		}
 		manifest, err := v1.ParseManifest(fd)
+		fd.Close()
 		if err != nil || manifest.Subject == nil {
 			continue
 		}


### PR DESCRIPTION
In `WriteSignedImageIndexImages`, `os.Open` is called inside a loop to parse each blob manifest, but the returned file descriptor is never closed. This leaks one fd per iteration, on every `continue` (parse error or nil Subject) and on the normal path alike.

Close `fd` immediately after `v1.ParseManifest` since the parsed manifest is the only value needed from the file. A plain `Close()` rather than `defer` is used because `defer` inside a loop would accumulate closers until the function returns, defeating the purpose.

**Impact:** In OCI image layouts with many blob files (e.g. multi-arch images with attestations), this can exhaust process file descriptors during `cosign load` followed by remote push workflows.
