### PR TITLE
fix: use Header.Set to prevent duplicate Authorization on retry

### DIFF
--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -68,7 +68,7 @@ func (ga *githubActions) Provide(ctx context.Context, audience string) (string, 
 
 	// Retry up to 3 times.
 	for i := 0; ; i++ {
-		req.Header.Add("Authorization", "bearer "+env.Getenv(env.VariableGitHubRequestToken))
+		req.Header.Set("Authorization", "bearer "+env.Getenv(env.VariableGitHubRequestToken))
 		resp, err := client.Do(req)
 		if err != nil {
 			if i == 2 {

--- a/pkg/providers/github/github_test.go
+++ b/pkg/providers/github/github_test.go
@@ -1,0 +1,75 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sigstore/cosign/v3/pkg/cosign/env"
+)
+
+func TestProvide_NoDuplicateAuthHeaders(t *testing.T) {
+	var attempts atomic.Int32
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+
+		// Verify exactly one Authorization header on every attempt.
+		authHeaders := r.Header.Values("Authorization")
+		if len(authHeaders) != 1 {
+			t.Errorf("attempt %d: want 1 Authorization header, got %d: %v", n, len(authHeaders), authHeaders)
+		}
+
+		if n < 3 {
+			// Force retries by closing the connection.
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				t.Fatal("server does not support hijacking")
+			}
+			conn, _, err := hj.Hijack()
+			if err != nil {
+				t.Fatal(err)
+			}
+			conn.Close()
+			return
+		}
+
+		// Succeed on the 3rd attempt.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"value":"test-token"}`)) //nolint:errcheck
+	}))
+	defer ts.Close()
+
+	t.Setenv(env.VariableGitHubRequestToken.String(), "fake-token")
+	// The provider appends "&audience=..." so the base URL needs a query param.
+	t.Setenv(env.VariableGitHubRequestURL.String(), ts.URL+"?test=1")
+
+	ga := &githubActions{}
+	token, err := ga.Provide(context.Background(), "sigstore")
+	if err != nil {
+		t.Fatalf("Provide: %v", err)
+	}
+	if token != "test-token" {
+		t.Errorf("want token %q, got %q", "test-token", token)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Errorf("want 3 attempts, got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

The GitHub Actions OIDC token provider (`pkg/providers/github/github.go`) uses `Header.Add` inside a retry loop. On each retry iteration, an additional `Authorization` header is appended to the request. By the third attempt, three identical headers are sent. Some servers and proxies reject requests with duplicate `Authorization` headers, causing retries to fail when they should succeed.

## Fix

Replace `Header.Add` with `Header.Set` so only one `Authorization` header is ever present, regardless of how many retries occur.

## Testing

Added `TestProvide_NoDuplicateAuthHeaders` which uses `httptest` to force two retries via connection hijack and asserts exactly one `Authorization` header is received on every attempt. The test fails on the old code (2 headers on attempt 2, 3 on attempt 3) and passes with the fix.