### PR TITLE
Honor COSIGN_REPOSITORY when verifying new-bundle attestations

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -150,7 +150,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	} else {
 		ref, err := name.ParseReference(images[0], c.NameOptions...)
 		if err == nil && c.NewBundleFormat {
-			newBundles, _, err := cosign.GetBundles(ctx, ref, co.RegistryClientOpts, c.NameOptions...)
+			newBundles, _, err := cosign.GetBundles(ctx, ref, co.RegistryClientOpts)
 			if len(newBundles) == 0 || err != nil {
 				co.NewBundleFormat = false
 			}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -134,7 +134,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	} else {
 		ref, err := name.ParseReference(images[0], c.NameOptions...)
 		if err == nil && c.NewBundleFormat {
-			newBundles, _, err := cosign.GetBundles(ctx, ref, co.RegistryClientOpts, c.NameOptions...)
+			newBundles, _, err := cosign.GetBundles(ctx, ref, co.RegistryClientOpts)
 			if len(newBundles) == 0 || err != nil {
 				co.NewBundleFormat = false
 			}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1029,13 +1029,13 @@ func loadSignatureFromFile(ctx context.Context, sigRef string, signedImgRef name
 
 // VerifyImageAttestations does all the main cosign checks in a loop, returning the verified attestations.
 // If there were no valid attestations, we return an error.
-func VerifyImageAttestations(ctx context.Context, signedImgRef name.Reference, co *CheckOpts, nameOpts ...name.Option) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
+func VerifyImageAttestations(ctx context.Context, signedImgRef name.Reference, co *CheckOpts, _ ...name.Option) (checkedAttestations []oci.Signature, bundleVerified bool, err error) {
 	// Enforce this up front.
 	if co.RootCerts == nil && co.SigVerifier == nil && co.TrustedMaterial == nil {
 		return nil, false, errors.New("one of verifier, root certs, or TrustedMaterial is required")
 	}
 	if co.NewBundleFormat {
-		return verifyImageAttestationsSigstoreBundle(ctx, signedImgRef, co, nameOpts...)
+		return verifyImageAttestationsSigstoreBundle(ctx, signedImgRef, co)
 	}
 
 	// This is a carefully optimized sequence for fetching the attestations of
@@ -1667,7 +1667,7 @@ func verifyImageSignaturesExperimentalOCI(ctx context.Context, signedImgRef name
 	return verifySignatures(ctx, sigs, h, co)
 }
 
-func GetBundles(_ context.Context, signedImgRef name.Reference, registryClientOpts []ociremote.Option, nameOpts ...name.Option) ([]*sgbundle.Bundle, *v1.Hash, error) {
+func GetBundles(_ context.Context, signedImgRef name.Reference, registryClientOpts []ociremote.Option) ([]*sgbundle.Bundle, *v1.Hash, error) {
 	// This is a carefully optimized sequence for fetching the signatures of the
 	// entity that minimizes registry requests when supplied with a digest input
 	digest, err := ociremote.ResolveDigest(signedImgRef, registryClientOpts...)
@@ -1684,16 +1684,14 @@ func GetBundles(_ context.Context, signedImgRef name.Reference, registryClientOp
 		return nil, nil, err
 	}
 
-	index, err := ociremote.Referrers(digest, "", registryClientOpts...)
+	target := ociremote.ResolveTargetDigest(digest, registryClientOpts...)
+	index, err := ociremote.Referrers(target, "", registryClientOpts...)
 	if err != nil {
 		return nil, nil, err
 	}
 	var bundles = make([]*sgbundle.Bundle, 0, len(index.Manifests))
 	for _, result := range index.Manifests {
-		st, err := name.ParseReference(fmt.Sprintf("%s@%s", digest.Repository, result.Digest.String()), nameOpts...)
-		if err != nil {
-			return nil, nil, err
-		}
+		st := target.Digest(result.Digest.String())
 		bundle, err := ociremote.Bundle(st, registryClientOpts...)
 		if err != nil {
 			// There may be non-Sigstore referrers in the index, so we can ignore them.
@@ -1853,8 +1851,8 @@ func getLocalBundleDescriptors(path string) ([]bundleDescriptor, *v1.Hash, error
 }
 
 // verifyImageAttestationsSigstoreBundle verifies attestations from attached sigstore bundles
-func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef name.Reference, co *CheckOpts, nameOpts ...name.Option) (checkedAttestations []oci.Signature, atLeastOneBundleVerified bool, err error) {
-	bundles, hash, err := GetBundles(ctx, signedImgRef, co.RegistryClientOpts, nameOpts...)
+func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef name.Reference, co *CheckOpts) (checkedAttestations []oci.Signature, atLeastOneBundleVerified bool, err error) {
+	bundles, hash, err := GetBundles(ctx, signedImgRef, co.RegistryClientOpts)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/cosign/verify_oci_test.go
+++ b/pkg/cosign/verify_oci_test.go
@@ -125,6 +125,43 @@ func TestGetBundles_Valid(t *testing.T) {
 	}
 }
 
+func TestGetBundles_WithTargetRepository(t *testing.T) {
+	r := registry.New(registry.WithReferrersSupport(true))
+	s := httptest.NewServer(r)
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	assert.NoError(t, err)
+
+	// Subject lives in repo-a; attestations live in repo-b.
+	subjectRef, err := name.ParseReference(fmt.Sprintf("%s/repo-a:tag", u.Host))
+	assert.NoError(t, err)
+	assert.NoError(t, remote.Write(subjectRef, empty.Image))
+	desc, err := remote.Head(subjectRef)
+	assert.NoError(t, err)
+	subjectDigest := subjectRef.Context().Digest(desc.Digest.String())
+
+	overrideRepo, err := name.NewRepository(fmt.Sprintf("%s/repo-b", u.Host))
+	assert.NoError(t, err)
+	opts := []ociremote.Option{ociremote.WithTargetRepository(overrideRepo)}
+
+	// Write attestation to the override repo with subject in repo-a.
+	err = ociremote.WriteAttestationNewBundleFormat(subjectDigest, testAttestation,
+		"https://cosign.sigstore.dev/attestation/v1", opts...)
+	assert.NoError(t, err)
+
+	// Read it back via GetBundles with the same override.
+	bundles, hash, err := GetBundles(context.Background(), subjectRef, opts)
+	assert.NoError(t, err)
+	assert.Len(t, bundles, 1)
+	assert.NotNil(t, hash)
+
+	// Sanity: without the override, GetBundles should not find anything in repo-a.
+	_, _, err = GetBundles(context.Background(), subjectRef, []ociremote.Option{})
+	var noMatchErr *ErrNoMatchingAttestations
+	assert.ErrorAs(t, err, &noMatchErr)
+}
+
 // TODO: This test is getting long and maybe should be refactored into a
 // table-based test to exercise more permutations.
 func TestVerifyImageAttestationsSigstoreBundle(t *testing.T) {

--- a/pkg/oci/remote/remote.go
+++ b/pkg/oci/remote/remote.go
@@ -151,6 +151,15 @@ func DockerContentDigest(ref name.Tag, opts ...Option) (name.Tag, error) {
 	return o.TargetRepository.Tag(normalizeWithSeparator(h, o.TagPrefix, "", ":")), nil
 }
 
+// ResolveTargetDigest returns d translated into the target repository
+// configured via WithTargetRepository (or COSIGN_REPOSITORY). If no
+// override is configured, the returned digest is in the same repository
+// as d.
+func ResolveTargetDigest(d name.Digest, opts ...Option) name.Digest {
+	o := makeOptions(d.Repository, opts...)
+	return o.TargetRepository.Digest(d.DigestStr())
+}
+
 func suffixTag(ref name.Reference, suffix string, algorithmSeparator string, o *options) (name.Tag, error) {
 	var h v1.Hash
 	if digest, ok := ref.(name.Digest); ok {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -4689,7 +4689,11 @@ func TestSignVerifyWithRepoOverride(t *testing.T) {
 	assert.Equal(t, tags[0], "latest", "expected tag name to be 'latest'")
 
 	// Verify should work with new bundle format
+	trustedRootPath := prepareTrustedRoot(t, "")
 	cmd := cliverify.VerifyCommand{
+		CommonVerifyOptions: options.CommonVerifyOptions{
+			TrustedRootPath: trustedRootPath,
+		},
 		KeyRef:          pubKeyPath,
 		RekorURL:        rekorURL,
 		NewBundleFormat: true,


### PR DESCRIPTION
## Summary

`COSIGN_REPOSITORY` is silently ignored on verify when `--new-bundle-format=true`.
`cosign attest` writes to the override repo, but `cosign verify-attestation`
reads referrers from the *subject's* repo, so verification always fails.

The legacy `.att` tag path honors the override (via `ociremote.AttestationTag`).
The new-bundle path bypassed that and was never wired up.

## Fix

- New `ociremote.ResolveTargetDigest` helper translates a `name.Digest` into the
  target repository configured by `WithTargetRepository` (set from
  `COSIGN_REPOSITORY`), mirroring `AttestationTag`.
- `GetBundles` resolves once and uses that target for both the `Referrers`
  query and the per-bundle fetch.
- Drop the now-unused `nameOpts` parameter from `GetBundles`. The old code
  passed it to `name.ParseReference` to reapply `name.Insecure` across a
  string round-trip; `target.Digest(...)` reuses the existing `Repository`
  directly, so the insecure flag is preserved without it. Exported
  `VerifyImageAttestations` keeps its variadic signature for backwards
  compatibility.

## Tests

- Unit test in `pkg/cosign/verify_oci_test.go` pushes an attestation to a
  separate repo on the in-process registry and asserts `GetBundles` finds it
  only when the same `WithTargetRepository` option is passed on read.
- Pass `TrustedRootPath` via `CommonVerifyOptions` in
  `TestSignVerifyWithRepoOverride`; the new-bundle verify path requires
  trusted material.

Fixes https://github.com/sigstore/cosign/issues/4872