### PR TITLE
feat(cli): add first-class WebAssembly signing and embedded signature management

### DIFF
--- a/cmd/cosign/cli/commands.go
+++ b/cmd/cosign/cli/commands.go
@@ -114,6 +114,7 @@ func New() *cobra.Command {
 	cmd.AddCommand(Save())
 	cmd.AddCommand(Sign())
 	cmd.AddCommand(SignBlob())
+	cmd.AddCommand(Wasm())
 	cmd.AddCommand(Upload())
 	cmd.AddCommand(Verify())
 	cmd.AddCommand(VerifyAttestation())

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -35,6 +35,8 @@ type SignBlobOptions struct {
 	Output               string // deprecated: TODO remove when the output flag is fully deprecated
 	OutputSignature      string // TODO: this should be the root output file arg.
 	OutputCertificate    string
+	Wasm                 bool
+	WasmOutput           string
 	SecurityKey          SecurityKeyOptions
 	Fulcio               FulcioOptions
 	Rekor                RekorOptions
@@ -105,15 +107,22 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 		"write everything required to verify the blob to a FILE")
 	_ = cmd.MarkFlagFilename("bundle", bundleExts...)
 
+	cmd.Flags().BoolVar(&o.Wasm, "wasm", false,
+		"treat the blob as a WebAssembly module and sign bytes with existing wasm-cosign custom sections removed")
+
+	cmd.Flags().StringVar(&o.WasmOutput, "wasm-output", "",
+		"write a signed WebAssembly module to FILE with the Sigstore bundle appended in a wasm-cosign custom section")
+	_ = cmd.MarkFlagFilename("wasm-output", wasmExts...)
+
 	cmd.Flags().BoolVar(&o.NewBundleFormat, "new-bundle-format", true,
 		"output bundle in new format that contains all verification material")
 	_ = cmd.Flags().MarkDeprecated("new-bundle-format", "this will be the only supported format in future versions")
 
 	cmd.Flags().BoolVar(&o.UseSigningConfig, "use-signing-config", true,
-		"whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format")
+		"whether to use a TUF-provided signing config for the service URLs. Must provide --bundle or --wasm-output, which will output verification material in the new format")
 
 	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config", "",
-		"path to a signing config file. Must provide --bundle, which will output verification material in the new format")
+		"path to a signing config file. Must provide --bundle or --wasm-output, which will output verification material in the new format")
 
 	cmd.MarkFlagsMutuallyExclusive("use-signing-config", "signing-config")
 

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -183,6 +183,7 @@ type VerifyBlobOptions struct {
 	Key        string
 	Signature  string
 	BundlePath string
+	Wasm       bool
 
 	SecurityKey         SecurityKeyOptions
 	CertVerify          CertVerifyOptions
@@ -214,6 +215,9 @@ func (o *VerifyBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.BundlePath, "bundle", "",
 		"path to bundle FILE")
+
+	cmd.Flags().BoolVar(&o.Wasm, "wasm", false,
+		"treat the blob as a WebAssembly module and verify bytes with wasm-cosign custom sections removed")
 
 	cmd.Flags().StringVar(&o.RFC3161TimestampPath, "rfc3161-timestamp", "",
 		"path to RFC3161 timestamp FILE")

--- a/cmd/cosign/cli/options/wasm.go
+++ b/cmd/cosign/cli/options/wasm.go
@@ -1,0 +1,41 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import "github.com/spf13/cobra"
+
+type WasmStripSignaturesOptions struct {
+	Output string
+}
+
+type WasmListSignaturesOptions struct {
+	Output string
+}
+
+var _ Interface = (*WasmStripSignaturesOptions)(nil)
+var _ Interface = (*WasmListSignaturesOptions)(nil)
+
+func (o *WasmStripSignaturesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "",
+		"write the unsigned WebAssembly module to FILE")
+	_ = cmd.MarkFlagFilename("output", wasmExts...)
+	_ = cmd.MarkFlagRequired("output")
+}
+
+func (o *WasmListSignaturesOptions) AddFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.Output, "output", "o", "text",
+		"output format for embedded signatures (json|text)")
+}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -292,6 +292,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	cbundleOpts := cbundle.SignOptions{
 		TSAClientTransport:  tsaClientTransport,
 		CertificateProvider: certProvider,
+		VerifierOptions:     cbundle.VerifierOptionsForKeypair(keypair),
 	}
 
 	ociSigs := make([]oci.Signature, len(payloads))

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -121,7 +121,10 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 			return nil, fmt.Errorf("getting TSA client transport: %w", err)
 		}
 	}
-	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
+	signOpts := cbundle.SignOptions{
+		TSAClientTransport: tsaClientTransport,
+		VerifierOptions:    cbundle.VerifierOptionsForKeypair(keypair),
+	}
 	bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -16,15 +16,20 @@
 package cli
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon"
+	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/wasm"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,15 +59,27 @@ func SignBlob() *cobra.Command {
   cosign sign-blob --key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <FILE>
 
   # sign a blob with a key pair stored in Hashicorp Vault
-  cosign sign-blob --key hashivault://[KEY] <FILE>`,
+  cosign sign-blob --key hashivault://[KEY] <FILE>
+
+  # sign a WebAssembly module, appending the Sigstore bundle in a new wasm-cosign custom section
+  cosign sign-blob --wasm --wasm-output signed.wasm --key cosign.key module.wasm`,
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
-		PreRunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if options.NOf(o.Key, o.SecurityKey.Use) > 1 {
 				return &options.KeyParseError{}
 			}
 
-			if o.NewBundleFormat && o.BundlePath == "" {
+			if o.WasmOutput != "" {
+				o.Wasm = true
+			}
+			if o.WasmOutput != "" && len(args) != 1 {
+				return fmt.Errorf("--wasm-output can only be used when signing exactly one wasm module")
+			}
+			if o.WasmOutput != "" && !o.NewBundleFormat {
+				return fmt.Errorf("--wasm-output requires --new-bundle-format")
+			}
+			if o.NewBundleFormat && o.BundlePath == "" && o.WasmOutput == "" {
 				return fmt.Errorf("must specify --bundle with --new-bundle-format")
 			}
 
@@ -129,6 +146,13 @@ func SignBlob() *cobra.Command {
 					o.OutputSignature = o.Output
 				}
 
+				if o.Wasm {
+					if err := signWasmBlob(cmd.Context(), ko, blob, o.Cert, o.CertChain, o.Base64Output, o.OutputSignature, o.OutputCertificate, o.TlogUpload, o.WasmOutput); err != nil {
+						return fmt.Errorf("signing wasm %s: %w", blob, err)
+					}
+					continue
+				}
+
 				if _, err := sign.SignBlobCmd(cmd.Context(), ro, ko, blob, o.Cert, o.CertChain, o.Base64Output, o.OutputSignature, o.OutputCertificate, o.TlogUpload); err != nil {
 					return fmt.Errorf("signing %s: %w", blob, err)
 				}
@@ -139,4 +163,87 @@ func SignBlob() *cobra.Command {
 
 	o.AddFlags(cmd)
 	return cmd
+}
+
+func signWasmBlob(ctx context.Context, ko options.KeyOpts, blobPath, certPath, certChainPath string, b64 bool, outputSignature, outputCertificate string, tlogUpload bool, wasmOutput string) error {
+	module, err := readWasmModule(blobPath)
+	if err != nil {
+		return err
+	}
+
+	unsignedModule, err := wasm.StripSignatureSections(module)
+	if err != nil {
+		return err
+	}
+
+	payloadPath, cleanupPayload, err := writeTempFile("cosign-wasm-payload-*", unsignedModule)
+	if err != nil {
+		return err
+	}
+	defer cleanupPayload()
+
+	bundlePath := ko.BundlePath
+	var cleanupBundle func()
+	if wasmOutput != "" && bundlePath == "" {
+		bundlePath, cleanupBundle, err = writeTempFile("cosign-wasm-bundle-*.json", nil)
+		if err != nil {
+			return err
+		}
+		defer cleanupBundle()
+		ko.BundlePath = bundlePath
+	}
+
+	if _, err := sign.SignBlobCmd(ctx, ro, ko, payloadPath, certPath, certChainPath, b64, outputSignature, outputCertificate, tlogUpload); err != nil {
+		return err
+	}
+
+	if wasmOutput == "" {
+		return nil
+	}
+
+	bundleBytes, err := os.ReadFile(filepath.Clean(bundlePath))
+	if err != nil {
+		return fmt.Errorf("reading bundle for wasm custom section: %w", err)
+	}
+	signedModule, err := wasm.AppendSignatureSection(module, bundleBytes)
+	if err != nil {
+		return err
+	}
+	if wasmOutput == "-" {
+		_, err = os.Stdout.Write(signedModule)
+		return err
+	}
+	if err := os.WriteFile(filepath.Clean(wasmOutput), signedModule, 0600); err != nil {
+		return fmt.Errorf("writing signed wasm module: %w", err)
+	}
+	ui.Infof(ctx, "Wrote signed wasm module to file %s", wasmOutput)
+	return nil
+}
+
+func readWasmModule(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	return os.ReadFile(filepath.Clean(path))
+}
+
+func writeTempFile(pattern string, contents []byte) (string, func(), error) {
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", nil, err
+	}
+	name := f.Name()
+	cleanup := func() {
+		_ = os.Remove(name)
+	}
+	if _, err := f.Write(contents); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, err
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return name, cleanup, nil
 }

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -100,6 +100,10 @@ func SignBlob() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			signingAlgorithm := ""
+			if cmd.Flags().Changed("signing-algorithm") {
+				signingAlgorithm = o.SigningAlgorithm
+			}
 			oidcClientSecret, err := o.OIDC.ClientSecret()
 			if err != nil {
 				return err
@@ -130,7 +134,7 @@ func SignBlob() *cobra.Command {
 				TSAServerURL:                   o.TSAServerURL,
 				RFC3161TimestampPath:           o.RFC3161TimestampPath,
 				IssueCertificateForExistingKey: o.IssueCertificate,
-				SigningAlgorithm:               o.SigningAlgorithm,
+				SigningAlgorithm:               signingAlgorithm,
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -85,13 +85,18 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 	var idToken string
 	var sv *SignerVerifier
 	var certBytes []byte
+	var algo *signature.AlgorithmDetails
 	var err error
 
-	sv, ephemeralKeypair, err = signerFromKeyOpts(ctx, cert, certChain, ko)
+	sv, ephemeralKeypair, algo, err = signerFromKeyOpts(ctx, cert, certChain, ko)
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("getting signer: %w", err)
 	}
-	keypair, err = key.NewSignerVerifierKeypair(sv, ko.DefaultLoadOptions)
+	if algo != nil {
+		keypair, err = key.NewSignerVerifierKeypairWithAlgorithm(sv, *algo)
+	} else {
+		keypair, err = key.NewSignerVerifierKeypair(sv, ko.DefaultLoadOptions)
+	}
 	if err != nil {
 		sv.Close()
 		return nil, nil, "", fmt.Errorf("creating signerverifier keypair: %w", err)
@@ -163,24 +168,39 @@ func shouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 	return true
 }
 
-func signerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, bool, error) {
+func signerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, bool, *signature.AlgorithmDetails, error) {
 	var sv *SignerVerifier
 	var err error
 	genKey := false
+	var algo *signature.AlgorithmDetails
+	if ko.SigningAlgorithm != "" {
+		keyDetails, err := ParseSignatureAlgorithmFlag(ko.SigningAlgorithm)
+		if err != nil {
+			return nil, false, nil, fmt.Errorf("parsing signature algorithm: %w", err)
+		}
+		algorithmDetails, err := signature.GetAlgorithmDetails(keyDetails)
+		if err != nil {
+			return nil, false, nil, fmt.Errorf("getting algorithm details: %w", err)
+		}
+		algo = &algorithmDetails
+	}
 	switch {
 	case ko.Sk:
+		if algo != nil {
+			return nil, false, nil, errors.New("--signing-algorithm is not supported with --sk")
+		}
 		sv, err = signerFromSecurityKey(ctx, ko.Slot)
 	case ko.KeyRef != "":
-		sv, err = signerFromKeyRef(ctx, certPath, certChainPath, ko.KeyRef, ko.PassFunc, ko.DefaultLoadOptions)
+		sv, err = signerFromKeyRef(ctx, certPath, certChainPath, ko.KeyRef, ko.PassFunc, ko.DefaultLoadOptions, algo)
 	default:
 		genKey = true
 		ui.Infof(ctx, "Generating ephemeral keys...")
 		sv, err = signerFromNewKey(ko.SigningAlgorithm, ko.DefaultLoadOptions)
 	}
 	if err != nil {
-		return nil, false, err
+		return nil, false, nil, err
 	}
-	return sv, genKey, nil
+	return sv, genKey, algo, nil
 }
 
 func signerFromSecurityKey(ctx context.Context, keySlot string) (*SignerVerifier, error) {
@@ -217,8 +237,14 @@ func signerFromSecurityKey(ctx context.Context, keySlot string) (*SignerVerifier
 	}, nil
 }
 
-func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef string, passFunc cosign.PassFunc, defaultLoadOptions *[]signature.LoadOption) (*SignerVerifier, error) {
-	k, err := sigs.SignerVerifierFromKeyRef(ctx, keyRef, passFunc, defaultLoadOptions)
+func signerFromKeyRef(ctx context.Context, certPath, certChainPath, keyRef string, passFunc cosign.PassFunc, defaultLoadOptions *[]signature.LoadOption, algo *signature.AlgorithmDetails) (*SignerVerifier, error) {
+	var k signature.SignerVerifier
+	var err error
+	if algo != nil {
+		k, err = sigs.SignerVerifierFromKeyRefWithAlgorithm(ctx, keyRef, passFunc, *algo)
+	} else {
+		k, err = sigs.SignerVerifierFromKeyRef(ctx, keyRef, passFunc, defaultLoadOptions)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("reading key: %w", err)
 	}
@@ -474,7 +500,10 @@ func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certCha
 			return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting TSA client transport: %w", err)
 		}
 	}
-	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
+	signOpts := cbundle.SignOptions{
+		TSAClientTransport: tsaClientTransport,
+		VerifierOptions:    cbundle.VerifierOptionsForKeypair(keypair),
+	}
 
 	bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, signingConfig, trustedMaterial, signOpts)
 	if err != nil {

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -108,7 +108,7 @@ func Test_signerFromKeyRefSuccess(t *testing.T) {
 	ctx := context.Background()
 	keyFile, certFile, chainFile, privKey, cert, chain := generateCertificateFiles(t, tmpDir, pass("foo"))
 
-	signer, err := signerFromKeyRef(ctx, certFile, chainFile, keyFile, pass("foo"), nil)
+	signer, err := signerFromKeyRef(ctx, certFile, chainFile, keyFile, pass("foo"), nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error generating signer: %v", err)
 	}
@@ -147,17 +147,17 @@ func Test_signerFromKeyRefFailure(t *testing.T) {
 	_, certFile2, chainFile2, _, _, _ := generateCertificateFiles(t, tmpDir2, pass("bar"))
 
 	// Public keys don't match
-	_, err := signerFromKeyRef(ctx, certFile2, chainFile2, keyFile, pass("foo"), nil)
+	_, err := signerFromKeyRef(ctx, certFile2, chainFile2, keyFile, pass("foo"), nil, nil)
 	if err == nil || err.Error() != "public key in certificate does not match the provided public key" {
 		t.Fatalf("expected mismatched keys error, got %v", err)
 	}
 	// Certificate chain cannot be verified
-	_, err = signerFromKeyRef(ctx, certFile, chainFile2, keyFile, pass("foo"), nil)
+	_, err = signerFromKeyRef(ctx, certFile, chainFile2, keyFile, pass("foo"), nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "unable to validate certificate chain") {
 		t.Fatalf("expected chain verification error, got %v", err)
 	}
 	// Certificate chain specified without certificate
-	_, err = signerFromKeyRef(ctx, "", chainFile2, keyFile, pass("foo"), nil)
+	_, err = signerFromKeyRef(ctx, "", chainFile2, keyFile, pass("foo"), nil, nil)
 	if err == nil || !strings.Contains(err.Error(), "no leaf certificate found or provided while specifying chain") {
 		t.Fatalf("expected no leaf error, got %v", err)
 	}
@@ -177,7 +177,7 @@ func Test_signerFromKeyRefFailureEmptyChainFile(t *testing.T) {
 		t.Fatalf("failed to write chain file: %v", err)
 	}
 
-	_, err = signerFromKeyRef(ctx, certFile, tmpChainFile.Name(), keyFile, pass("foo"), nil)
+	_, err = signerFromKeyRef(ctx, certFile, tmpChainFile.Name(), keyFile, pass("foo"), nil, nil)
 	if err == nil || err.Error() != "no certificates in certificate chain" {
 		t.Fatalf("expected empty chain error, got %v", err)
 	}

--- a/cmd/cosign/cli/verify.go
+++ b/cmd/cosign/cli/verify.go
@@ -17,6 +17,7 @@ package cli
 
 import (
 	"context"
+	"crypto"
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -304,6 +305,9 @@ The blob may be specified as a path to a file or - for stdin.`,
 
   # Verify a blob against GitLab with project id
   cosign verify-blob --bundle artifact.sigstore.json --key gitlab://[PROJECT_ID] <blob>
+
+  # Verify a WebAssembly module with embedded wasm-cosign Sigstore bundle(s)
+  cosign verify-blob --wasm --key cosign.pub module.wasm
 `,
 
 		Args:             cobra.ExactArgs(1),
@@ -318,37 +322,7 @@ The blob may be specified as a path to a file or - for stdin.`,
 				return err
 			}
 
-			ko := options.KeyOpts{
-				KeyRef:               o.Key,
-				Sk:                   o.SecurityKey.Use,
-				Slot:                 o.SecurityKey.Slot,
-				RekorURL:             o.Rekor.URL,
-				BundlePath:           o.BundlePath,
-				RFC3161TimestampPath: o.RFC3161TimestampPath,
-				TSACertChainPath:     o.CommonVerifyOptions.TSACertChainPath,
-				NewBundleFormat:      o.CommonVerifyOptions.NewBundleFormat,
-			}
-			verifyBlobCmd := &verify.VerifyBlobCmd{
-				KeyOpts:                      ko,
-				CertVerifyOptions:            o.CertVerify,
-				CertRef:                      o.CertVerify.Cert,
-				CertChain:                    o.CertVerify.CertChain,
-				CARoots:                      o.CertVerify.CARoots,
-				CAIntermediates:              o.CertVerify.CAIntermediates,
-				SigRef:                       o.Signature,
-				CertGithubWorkflowTrigger:    o.CertVerify.CertGithubWorkflowTrigger,
-				CertGithubWorkflowSHA:        o.CertVerify.CertGithubWorkflowSha,
-				CertGithubWorkflowName:       o.CertVerify.CertGithubWorkflowName,
-				CertGithubWorkflowRepository: o.CertVerify.CertGithubWorkflowRepository,
-				CertGithubWorkflowRef:        o.CertVerify.CertGithubWorkflowRef,
-				IgnoreSCT:                    o.CertVerify.IgnoreSCT,
-				SCTRef:                       o.CertVerify.SCT,
-				Offline:                      o.CommonVerifyOptions.Offline,
-				IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
-				UseSignedTimestamps:          o.CommonVerifyOptions.UseSignedTimestamps,
-				TrustedRootPath:              o.CommonVerifyOptions.TrustedRootPath,
-				HashAlgorithm:                hashAlgorithm,
-			}
+			verifyBlobCmd := newVerifyBlobCmd(o, hashAlgorithm)
 
 			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
 			defer cancel()
@@ -363,6 +337,41 @@ The blob may be specified as a path to a file or - for stdin.`,
 
 	o.AddFlags(cmd)
 	return cmd
+}
+
+func newVerifyBlobCmd(o *options.VerifyBlobOptions, hashAlgorithm crypto.Hash) *verify.VerifyBlobCmd {
+	ko := options.KeyOpts{
+		KeyRef:               o.Key,
+		Sk:                   o.SecurityKey.Use,
+		Slot:                 o.SecurityKey.Slot,
+		RekorURL:             o.Rekor.URL,
+		BundlePath:           o.BundlePath,
+		RFC3161TimestampPath: o.RFC3161TimestampPath,
+		TSACertChainPath:     o.CommonVerifyOptions.TSACertChainPath,
+		NewBundleFormat:      o.CommonVerifyOptions.NewBundleFormat,
+	}
+	return &verify.VerifyBlobCmd{
+		KeyOpts:                      ko,
+		CertVerifyOptions:            o.CertVerify,
+		CertRef:                      o.CertVerify.Cert,
+		CertChain:                    o.CertVerify.CertChain,
+		CARoots:                      o.CertVerify.CARoots,
+		CAIntermediates:              o.CertVerify.CAIntermediates,
+		SigRef:                       o.Signature,
+		CertGithubWorkflowTrigger:    o.CertVerify.CertGithubWorkflowTrigger,
+		CertGithubWorkflowSHA:        o.CertVerify.CertGithubWorkflowSha,
+		CertGithubWorkflowName:       o.CertVerify.CertGithubWorkflowName,
+		CertGithubWorkflowRepository: o.CertVerify.CertGithubWorkflowRepository,
+		CertGithubWorkflowRef:        o.CertVerify.CertGithubWorkflowRef,
+		IgnoreSCT:                    o.CertVerify.IgnoreSCT,
+		SCTRef:                       o.CertVerify.SCT,
+		Offline:                      o.CommonVerifyOptions.Offline,
+		IgnoreTlog:                   o.CommonVerifyOptions.IgnoreTlog,
+		UseSignedTimestamps:          o.CommonVerifyOptions.UseSignedTimestamps,
+		TrustedRootPath:              o.CommonVerifyOptions.TrustedRootPath,
+		HashAlgorithm:                hashAlgorithm,
+		Wasm:                         o.Wasm,
+	}
 }
 
 func VerifyBlobAttestation() *cobra.Command {

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	sigs "github.com/sigstore/cosign/v3/pkg/signature"
+	"github.com/sigstore/cosign/v3/pkg/wasm"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	sgverify "github.com/sigstore/sigstore-go/pkg/verify"
 
@@ -70,6 +71,7 @@ type VerifyBlobCmd struct {
 	UseSignedTimestamps          bool
 	IgnoreTlog                   bool
 	HashAlgorithm                crypto.Hash
+	Wasm                         bool
 }
 
 // nolint
@@ -79,6 +81,46 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		c.HashAlgorithm = crypto.SHA256
 	}
 
+	if c.Wasm {
+		var cleanup func()
+		var embeddedBundlePaths []string
+		var err error
+		blobRef, embeddedBundlePaths, cleanup, err = c.prepareWasmBlob(ctx, blobRef)
+		if err != nil {
+			return err
+		}
+		defer cleanup()
+
+		if len(embeddedBundlePaths) > 0 {
+			originalBundlePath := c.BundlePath
+			originalKeyOptsBundlePath := c.KeyOpts.BundlePath
+			defer func() {
+				c.BundlePath = originalBundlePath
+				c.KeyOpts.BundlePath = originalKeyOptsBundlePath
+			}()
+
+			for i, bundlePath := range embeddedBundlePaths {
+				c.BundlePath = bundlePath
+				c.KeyOpts.BundlePath = bundlePath
+				if err := c.verify(ctx, blobRef); err != nil {
+					return fmt.Errorf("verifying embedded %q custom section %d of %d: %w", wasm.SignatureSectionName, i+1, len(embeddedBundlePaths), err)
+				}
+			}
+
+			ui.Infof(ctx, "Verified OK")
+			return nil
+		}
+	}
+
+	if err := c.verify(ctx, blobRef); err != nil {
+		return err
+	}
+
+	ui.Infof(ctx, "Verified OK")
+	return nil
+}
+
+func (c *VerifyBlobCmd) verify(ctx context.Context, blobRef string) error {
 	// Require a certificate/key OR a local bundle file that has the cert.
 	if options.NOf(c.KeyRef, c.CertRef, c.Sk, c.BundlePath) == 0 {
 		return fmt.Errorf("provide a key with --key or --sk, a certificate to verify against with --certificate, or a bundle with --bundle")
@@ -160,7 +202,6 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			return err
 		}
 
-		ui.Infof(ctx, "Verified OK")
 		return nil
 	}
 
@@ -288,7 +329,6 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		return err
 	}
 
-	ui.Infof(ctx, "Verified OK")
 	return nil
 }
 
@@ -320,6 +360,79 @@ func base64signature(sigRef, bundlePath string) (string, error) {
 		return string(targetSig), nil
 	}
 	return base64.StdEncoding.EncodeToString(targetSig), nil
+}
+
+func (c *VerifyBlobCmd) prepareWasmBlob(ctx context.Context, blobRef string) (string, []string, func(), error) {
+	module, err := payloadBytes(blobRef)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	unsignedModule, embeddedBundles, err := wasm.StripAndExtractSignatureSections(module)
+	if err != nil {
+		return "", nil, nil, err
+	}
+
+	payloadPath, cleanupPayload, err := writeTempFile("cosign-wasm-payload-*", unsignedModule)
+	if err != nil {
+		return "", nil, nil, err
+	}
+	cleanupPaths := []func(){cleanupPayload}
+	embeddedBundlePaths := make([]string, 0, len(embeddedBundles))
+
+	if c.BundlePath == "" && c.SigRef == "" {
+		if !c.KeyOpts.NewBundleFormat {
+			cleanupAll(cleanupPaths)
+			return "", nil, nil, fmt.Errorf("--wasm embedded verification requires --new-bundle-format")
+		}
+		if len(embeddedBundles) == 0 {
+			cleanupAll(cleanupPaths)
+			return "", nil, nil, fmt.Errorf("wasm module does not contain a %q custom section; provide --bundle or --signature", wasm.SignatureSectionName)
+		}
+		if len(embeddedBundles) > 1 {
+			ui.Infof(ctx, "Found %d embedded %q custom sections; verifying all of them", len(embeddedBundles), wasm.SignatureSectionName)
+		}
+		for _, embeddedBundle := range embeddedBundles {
+			bundlePath, cleanupBundle, err := writeTempFile("cosign-wasm-bundle-*.json", embeddedBundle)
+			if err != nil {
+				cleanupAll(cleanupPaths)
+				return "", nil, nil, err
+			}
+			cleanupPaths = append(cleanupPaths, cleanupBundle)
+			embeddedBundlePaths = append(embeddedBundlePaths, bundlePath)
+		}
+	}
+
+	return payloadPath, embeddedBundlePaths, func() {
+		cleanupAll(cleanupPaths)
+	}, nil
+}
+
+func cleanupAll(cleanups []func()) {
+	for _, cleanup := range cleanups {
+		cleanup()
+	}
+}
+
+func writeTempFile(pattern string, contents []byte) (string, func(), error) {
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", nil, err
+	}
+	name := f.Name()
+	cleanup := func() {
+		_ = os.Remove(name)
+	}
+	if _, err := f.Write(contents); err != nil {
+		_ = f.Close()
+		cleanup()
+		return "", nil, err
+	}
+	if err := f.Close(); err != nil {
+		cleanup()
+		return "", nil, err
+	}
+	return name, cleanup, nil
 }
 
 func payloadBytes(blobRef string) ([]byte, error) {

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	ctypes "github.com/sigstore/cosign/v3/pkg/types"
+	"github.com/sigstore/cosign/v3/pkg/wasm"
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
 	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/rekor/pkg/generated/models"
@@ -124,6 +125,62 @@ func TestSignaturesBundle(t *testing.T) {
 	}
 	if gotSig != b64sig {
 		t.Fatalf("unexpected signature, expected: %s got: %s", b64sig, gotSig)
+	}
+}
+
+func TestPrepareWasmBlobExtractsAllEmbeddedBundles(t *testing.T) {
+	td := t.TempDir()
+	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+
+	module, err := wasm.AppendSignatureSection(module, []byte("first-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module, err = wasm.AppendSignatureSection(module, []byte("second-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modulePath := filepath.Join(td, "module.wasm")
+	if err := os.WriteFile(modulePath, module, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := VerifyBlobCmd{
+		KeyOpts: options.KeyOpts{
+			NewBundleFormat: true,
+		},
+	}
+	payloadPath, bundlePaths, cleanup, err := cmd.prepareWasmBlob(context.Background(), modulePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+
+	payloadBytes, err := os.ReadFile(payloadPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(payloadBytes, []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}) {
+		t.Fatalf("payload = %x, want minimal wasm module", payloadBytes)
+	}
+	if got, want := len(bundlePaths), 2; got != want {
+		t.Fatalf("len(bundlePaths) = %d, want %d", got, want)
+	}
+
+	firstBundle, err := os.ReadFile(bundlePaths[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBundle, err := os.ReadFile(bundlePaths[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstBundle, []byte("first-bundle")) {
+		t.Fatalf("first bundle = %q, want first-bundle", firstBundle)
+	}
+	if !bytes.Equal(secondBundle, []byte("second-bundle")) {
+		t.Fatalf("second bundle = %q, want second-bundle", secondBundle)
 	}
 }
 

--- a/cmd/cosign/cli/wasm.go
+++ b/cmd/cosign/cli/wasm.go
@@ -1,0 +1,340 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/generate"
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/signcommon"
+	"github.com/sigstore/cosign/v3/internal/ui"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/wasm"
+	"github.com/spf13/cobra"
+)
+
+func Wasm() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "wasm",
+		Short: "Utilities for working with WebAssembly modules and embedded wasm-cosign signatures",
+	}
+
+	cmd.AddCommand(wasmSign())
+	cmd.AddCommand(wasmVerify())
+	cmd.AddCommand(wasmListSignatures())
+	cmd.AddCommand(wasmExtractSignatures())
+	cmd.AddCommand(wasmStripSignatures())
+	return cmd
+}
+
+func wasmSign() *cobra.Command {
+	o := &options.SignBlobOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "sign <module>",
+		Short: "Sign a WebAssembly module with an embedded wasm-cosign custom section",
+		Example: `  cosign wasm sign --wasm-output signed.wasm --key cosign.key module.wasm
+
+  # append another wasm-cosign custom section to an already signed module
+  cosign wasm sign --wasm-output resigned.wasm --key cosign.key module.wasm`,
+		Args:             cobra.ExactArgs(1),
+		PersistentPreRun: options.BindViper,
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			if options.NOf(o.Key, o.SecurityKey.Use) > 1 {
+				return &options.KeyParseError{}
+			}
+			if o.WasmOutput == "" {
+				return fmt.Errorf("--wasm-output is required")
+			}
+			if o.WasmOutput != "" && !o.NewBundleFormat {
+				return fmt.Errorf("--wasm-output requires --new-bundle-format")
+			}
+
+			supportedAlgorithms := cosign.GetSupportedAlgorithms()
+			isValid := false
+			for _, algo := range supportedAlgorithms {
+				if algo == o.SigningAlgorithm {
+					isValid = true
+					break
+				}
+			}
+			if !isValid {
+				return fmt.Errorf("invalid signing algorithm: %s. Supported algorithms are: %s",
+					o.SigningAlgorithm, strings.Join(supportedAlgorithms, ", "))
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			oidcClientSecret, err := o.OIDC.ClientSecret()
+			if err != nil {
+				return err
+			}
+
+			ko := options.KeyOpts{
+				KeyRef:                         o.Key,
+				PassFunc:                       generate.GetPass,
+				Sk:                             o.SecurityKey.Use,
+				Slot:                           o.SecurityKey.Slot,
+				FulcioURL:                      o.Fulcio.URL,
+				IDToken:                        o.Fulcio.IdentityToken,
+				FulcioAuthFlow:                 o.Fulcio.AuthFlow,
+				InsecureSkipFulcioVerify:       o.Fulcio.InsecureSkipFulcioVerify,
+				RekorURL:                       o.Rekor.URL,
+				OIDCIssuer:                     o.OIDC.Issuer,
+				OIDCClientID:                   o.OIDC.ClientID,
+				OIDCClientSecret:               oidcClientSecret,
+				OIDCRedirectURL:                o.OIDC.RedirectURL,
+				OIDCDisableProviders:           o.OIDC.DisableAmbientProviders,
+				BundlePath:                     o.BundlePath,
+				NewBundleFormat:                o.NewBundleFormat,
+				SkipConfirmation:               o.SkipConfirmation,
+				TSAClientCACert:                o.TSAClientCACert,
+				TSAClientCert:                  o.TSAClientCert,
+				TSAClientKey:                   o.TSAClientKey,
+				TSAServerName:                  o.TSAServerName,
+				TSAServerURL:                   o.TSAServerURL,
+				RFC3161TimestampPath:           o.RFC3161TimestampPath,
+				IssueCertificateForExistingKey: o.IssueCertificate,
+				SigningAlgorithm:               o.SigningAlgorithm,
+			}
+			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
+				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
+				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate,
+				o.Output, "", o.OutputCertificate, "", o.OutputSignature, o.RFC3161TimestampPath); err != nil {
+				return err
+			}
+
+			if err := signWasmBlob(cmd.Context(), ko, args[0], o.Cert, o.CertChain, o.Base64Output, o.OutputSignature, o.OutputCertificate, o.TlogUpload, o.WasmOutput); err != nil {
+				return fmt.Errorf("signing wasm %s: %w", args[0], err)
+			}
+			return nil
+		},
+	}
+
+	o.AddFlags(cmd)
+	_ = cmd.Flags().MarkHidden("wasm")
+	_ = cmd.MarkFlagRequired("wasm-output")
+	return cmd
+}
+
+func wasmVerify() *cobra.Command {
+	o := &options.VerifyBlobOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "verify <module>",
+		Short: "Verify a WebAssembly module with embedded wasm-cosign signatures",
+		Example: `  cosign wasm verify --key cosign.pub module.wasm
+
+  # verify all embedded wasm-cosign signatures in a module
+  cosign wasm verify --key cosign.pub module.wasm`,
+		Args:             cobra.ExactArgs(1),
+		PersistentPreRun: options.BindViper,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if o.CommonVerifyOptions.PrivateInfrastructure {
+				o.CommonVerifyOptions.IgnoreTlog = true
+			}
+
+			hashAlgorithm, err := o.SignatureDigest.HashAlgorithm()
+			if err != nil {
+				return err
+			}
+			verifyBlobCmd := newVerifyBlobCmd(o, hashAlgorithm)
+			verifyBlobCmd.Wasm = true
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), ro.Timeout)
+			defer cancel()
+
+			if o.CommonVerifyOptions.IgnoreTlog && !o.CommonVerifyOptions.PrivateInfrastructure {
+				ui.Warnf(ctx, ignoreTLogMessage, "blob")
+			}
+
+			return verifyBlobCmd.Exec(ctx, args[0])
+		},
+	}
+
+	o.AddFlags(cmd)
+	_ = cmd.Flags().MarkHidden("wasm")
+	return cmd
+}
+
+func wasmExtractSignatures() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:              "extract-signatures <module>",
+		Short:            "Print embedded wasm-cosign bundle payloads from a WebAssembly module",
+		Example:          `  cosign wasm extract-signatures module.wasm`,
+		Args:             cobra.ExactArgs(1),
+		PersistentPreRun: options.BindViper,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return extractWasmSignatures(args[0])
+		},
+	}
+	return cmd
+}
+
+func wasmListSignatures() *cobra.Command {
+	o := &options.WasmListSignaturesOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list-signatures <module>",
+		Short: "List embedded wasm-cosign signatures in a WebAssembly module",
+		Example: `  cosign wasm list-signatures module.wasm
+
+  # emit machine-readable signature metadata
+  cosign wasm list-signatures -o json module.wasm`,
+		Args:             cobra.ExactArgs(1),
+		PersistentPreRun: options.BindViper,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return listWasmSignatures(args[0], o.Output)
+		},
+	}
+
+	o.AddFlags(cmd)
+	return cmd
+}
+
+func wasmStripSignatures() *cobra.Command {
+	o := &options.WasmStripSignaturesOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "strip-signatures <module>",
+		Short: "Remove embedded wasm-cosign custom sections from a WebAssembly module",
+		Example: `  cosign wasm strip-signatures -o unsigned.wasm signed.wasm
+
+  # read from stdin and write the stripped module to stdout
+  cosign wasm strip-signatures -o - < signed.wasm`,
+		Args:             cobra.ExactArgs(1),
+		PersistentPreRun: options.BindViper,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := stripWasmSignatures(args[0], o.Output); err != nil {
+				return err
+			}
+			if o.Output != "-" {
+				ui.Infof(cmd.Context(), "Wrote unsigned wasm module to file %s", o.Output)
+			}
+			return nil
+		},
+	}
+
+	o.AddFlags(cmd)
+	return cmd
+}
+
+func extractWasmSignatures(inPath string) error {
+	module, err := readWasmModule(inPath)
+	if err != nil {
+		return err
+	}
+
+	_, sections, err := wasm.StripAndExtractSignatureSections(module)
+	if err != nil {
+		return err
+	}
+
+	for i, section := range sections {
+		if i > 0 {
+			if _, err := os.Stdout.Write([]byte("\n")); err != nil {
+				return err
+			}
+		}
+		if _, err := os.Stdout.Write(section); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type wasmSignatureInfo struct {
+	Index       int    `json:"index"`
+	Offset      int    `json:"offset"`
+	SectionSize uint32 `json:"sectionSize"`
+	PayloadSize int    `json:"payloadSize"`
+	SHA256      string `json:"sha256"`
+}
+
+func listWasmSignatures(inPath, output string) error {
+	module, err := readWasmModule(inPath)
+	if err != nil {
+		return err
+	}
+
+	sections, err := wasm.InspectSignatureSections(module)
+	if err != nil {
+		return err
+	}
+
+	infos := make([]wasmSignatureInfo, 0, len(sections))
+	for _, section := range sections {
+		digest := sha256.Sum256(section.Payload)
+		infos = append(infos, wasmSignatureInfo{
+			Index:       section.Index,
+			Offset:      section.Offset,
+			SectionSize: section.SectionSize,
+			PayloadSize: section.PayloadSize,
+			SHA256:      hex.EncodeToString(digest[:]),
+		})
+	}
+
+	switch output {
+	case "", "text":
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		if _, err := fmt.Fprintln(w, "INDEX\tOFFSET\tSECTION SIZE\tPAYLOAD SIZE\tSHA256"); err != nil {
+			return err
+		}
+		for _, info := range infos {
+			if _, err := fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%s\n", info.Index, info.Offset, info.SectionSize, info.PayloadSize, info.SHA256); err != nil {
+				return err
+			}
+		}
+		return w.Flush()
+	case "json":
+		encoder := json.NewEncoder(os.Stdout)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(infos)
+	default:
+		return fmt.Errorf("unknown output format %q, expected json or text", output)
+	}
+}
+
+func stripWasmSignatures(inPath, outPath string) error {
+	module, err := readWasmModule(inPath)
+	if err != nil {
+		return err
+	}
+
+	stripped, err := wasm.StripSignatureSections(module)
+	if err != nil {
+		return err
+	}
+
+	if outPath == "-" {
+		_, err = os.Stdout.Write(stripped)
+		return err
+	}
+
+	if err := os.WriteFile(filepath.Clean(outPath), stripped, 0600); err != nil {
+		return fmt.Errorf("writing unsigned wasm module: %w", err)
+	}
+	return nil
+}

--- a/cmd/cosign/cli/wasm.go
+++ b/cmd/cosign/cli/wasm.go
@@ -87,6 +87,10 @@ func wasmSign() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			signingAlgorithm := ""
+			if cmd.Flags().Changed("signing-algorithm") {
+				signingAlgorithm = o.SigningAlgorithm
+			}
 			oidcClientSecret, err := o.OIDC.ClientSecret()
 			if err != nil {
 				return err
@@ -117,7 +121,7 @@ func wasmSign() *cobra.Command {
 				TSAServerURL:                   o.TSAServerURL,
 				RFC3161TimestampPath:           o.RFC3161TimestampPath,
 				IssueCertificateForExistingKey: o.IssueCertificate,
-				SigningAlgorithm:               o.SigningAlgorithm,
+				SigningAlgorithm:               signingAlgorithm,
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,

--- a/cmd/cosign/cli/wasm_test.go
+++ b/cmd/cosign/cli/wasm_test.go
@@ -28,6 +28,10 @@ import (
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/wasm"
+	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore/pkg/signature"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 func TestStripWasmSignatures(t *testing.T) {
@@ -156,6 +160,144 @@ func TestSignWasmBlobAppendsSignatureSection(t *testing.T) {
 	want := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
 	if !bytes.Equal(stripped, want) {
 		t.Fatalf("stripped module = %x, want %x", stripped, want)
+	}
+}
+
+func TestSignWasmBlobWithSigningAlgorithm(t *testing.T) {
+	oldTimeout := ro.Timeout
+	ro.Timeout = time.Minute
+	defer func() { ro.Timeout = oldTimeout }()
+
+	tests := []struct {
+		name              string
+		signingAlgorithm  protocommon.PublicKeyDetails
+		wantHashAlgorithm protocommon.HashAlgorithm
+	}{
+		{
+			name:              "ed25519",
+			signingAlgorithm:  protocommon.PublicKeyDetails_PKIX_ED25519,
+			wantHashAlgorithm: protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED,
+		},
+		{
+			name:              "ed25519ph",
+			signingAlgorithm:  protocommon.PublicKeyDetails_PKIX_ED25519_PH,
+			wantHashAlgorithm: protocommon.HashAlgorithm_SHA2_512,
+		},
+		{
+			name:              "rsa-pss",
+			signingAlgorithm:  protocommon.PublicKeyDetails_PKIX_RSA_PSS_2048_SHA256,
+			wantHashAlgorithm: protocommon.HashAlgorithm_SHA2_256,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := t.TempDir()
+
+			algo, err := signature.GetAlgorithmDetails(tt.signingAlgorithm)
+			if err != nil {
+				t.Fatal(err)
+			}
+			keys, err := cosign.GenerateKeyPairWithAlgorithm(&algo, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			keyPath := filepath.Join(td, "key.pem")
+			if err := os.WriteFile(keyPath, keys.PrivateBytes, 0o600); err != nil {
+				t.Fatal(err)
+			}
+
+			inputPath := filepath.Join(td, "input.wasm")
+			if err := os.WriteFile(inputPath, []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			outputPath := filepath.Join(td, "signed.wasm")
+			signingAlgorithm, err := signature.FormatSignatureAlgorithmFlag(tt.signingAlgorithm)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			ko := options.KeyOpts{
+				KeyRef:           keyPath,
+				NewBundleFormat:  true,
+				SigningAlgorithm: signingAlgorithm,
+			}
+
+			if err := signWasmBlob(t.Context(), ko, inputPath, "", "", false, "", "", false, outputPath); err != nil {
+				t.Fatal(err)
+			}
+
+			signed, err := os.ReadFile(outputPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, sections, err := wasm.StripAndExtractSignatureSections(signed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(sections), 1; got != want {
+				t.Fatalf("len(sections) = %d, want %d", got, want)
+			}
+			var bundle protobundle.Bundle
+			if err := protojson.Unmarshal(sections[0], &bundle); err != nil {
+				t.Fatal(err)
+			}
+			gotHashAlgorithm := bundle.GetMessageSignature().GetMessageDigest().GetAlgorithm()
+			if gotHashAlgorithm != tt.wantHashAlgorithm {
+				t.Fatalf("message digest algorithm = %v, want %v", gotHashAlgorithm, tt.wantHashAlgorithm)
+			}
+		})
+	}
+}
+
+func TestWasmSignDoesNotForceDefaultSigningAlgorithmForKey(t *testing.T) {
+	td := t.TempDir()
+
+	algo, err := signature.GetAlgorithmDetails(protocommon.PublicKeyDetails_PKIX_ED25519_PH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys, err := cosign.GenerateKeyPairWithAlgorithm(&algo, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(td, "key.pem")
+	if err := os.WriteFile(keyPath, keys.PrivateBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	inputPath := filepath.Join(td, "input.wasm")
+	if err := os.WriteFile(inputPath, []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(td, "signed.wasm")
+
+	ko := options.KeyOpts{
+		KeyRef:          keyPath,
+		NewBundleFormat: true,
+	}
+
+	if err := signWasmBlob(t.Context(), ko, inputPath, "", "", false, "", "", false, outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	signed, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, sections, err := wasm.StripAndExtractSignatureSections(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(sections), 1; got != want {
+		t.Fatalf("len(sections) = %d, want %d", got, want)
+	}
+	var bundle protobundle.Bundle
+	if err := protojson.Unmarshal(sections[0], &bundle); err != nil {
+		t.Fatal(err)
+	}
+	gotHashAlgorithm := bundle.GetMessageSignature().GetMessageDigest().GetAlgorithm()
+	if gotHashAlgorithm != protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED {
+		t.Fatalf("message digest algorithm = %v, want %v", gotHashAlgorithm, protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED)
 	}
 }
 

--- a/cmd/cosign/cli/wasm_test.go
+++ b/cmd/cosign/cli/wasm_test.go
@@ -1,0 +1,184 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/wasm"
+)
+
+func TestStripWasmSignatures(t *testing.T) {
+	td := t.TempDir()
+	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+
+	var err error
+	module, err = wasm.AppendSignatureSection(module, []byte("first-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module, err = wasm.AppendSignatureSection(module, []byte("second-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputPath := filepath.Join(td, "signed.wasm")
+	if err := os.WriteFile(inputPath, module, 0644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(td, "unsigned.wasm")
+
+	if err := stripWasmSignatures(inputPath, outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	stripped, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+	if !bytes.Equal(stripped, want) {
+		t.Fatalf("stripped module = %x, want %x", stripped, want)
+	}
+}
+
+func TestListWasmSignatures(t *testing.T) {
+	td := t.TempDir()
+	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+
+	var err error
+	module, err = wasm.AppendSignatureSection(module, []byte("first-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	module, err = wasm.AppendSignatureSection(module, []byte("second-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputPath := filepath.Join(td, "signed.wasm")
+	if err := os.WriteFile(inputPath, module, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output := captureStdout(t, func() error {
+		return listWasmSignatures(inputPath, "text")
+	})
+
+	firstDigest := sha256.Sum256([]byte("first-bundle"))
+	secondDigest := sha256.Sum256([]byte("second-bundle"))
+	if !strings.Contains(output, "INDEX") || !strings.Contains(output, hex.EncodeToString(firstDigest[:])) || !strings.Contains(output, hex.EncodeToString(secondDigest[:])) {
+		t.Fatalf("text output = %q, want header and both signature digests", output)
+	}
+
+	output = captureStdout(t, func() error {
+		return listWasmSignatures(inputPath, "json")
+	})
+	if !strings.Contains(output, `"index": 0`) || !strings.Contains(output, `"payloadSize": 12`) || !strings.Contains(output, hex.EncodeToString(secondDigest[:])) {
+		t.Fatalf("json output = %q, want signature metadata", output)
+	}
+}
+
+func TestSignWasmBlobAppendsSignatureSection(t *testing.T) {
+	oldTimeout := ro.Timeout
+	ro.Timeout = time.Minute
+	defer func() { ro.Timeout = oldTimeout }()
+
+	td := t.TempDir()
+
+	keys, _ := cosign.GenerateKeyPair(nil)
+	keyPath := filepath.Join(td, "key.pem")
+	if err := os.WriteFile(keyPath, keys.PrivateBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	module := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+	module, err := wasm.AppendSignatureSection(module, []byte("first-bundle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inputPath := filepath.Join(td, "input.wasm")
+	if err := os.WriteFile(inputPath, module, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outputPath := filepath.Join(td, "signed.wasm")
+
+	ko := options.KeyOpts{
+		KeyRef:          keyPath,
+		NewBundleFormat: true,
+	}
+
+	if err := signWasmBlob(t.Context(), ko, inputPath, "", "", false, "", "", false, outputPath); err != nil {
+		t.Fatal(err)
+	}
+
+	signed, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stripped, sections, err := wasm.StripAndExtractSignatureSections(signed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(sections), 2; got != want {
+		t.Fatalf("len(sections) = %d, want %d", got, want)
+	}
+	if !bytes.Equal(sections[0], []byte("first-bundle")) {
+		t.Fatalf("sections[0] = %q, want first-bundle", sections[0])
+	}
+	if len(sections[1]) == 0 {
+		t.Fatal("sections[1] is empty")
+	}
+	want := []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+	if !bytes.Equal(stripped, want) {
+		t.Fatalf("stripped module = %x, want %x", stripped, want)
+	}
+}
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+
+	originalStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	err = fn()
+	_ = w.Close()
+	os.Stdout = originalStdout
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}

--- a/doc/cosign.md
+++ b/doc/cosign.md
@@ -44,4 +44,5 @@ A tool for Container Signing, Verification and Storage in an OCI registry.
 * [cosign verify-blob](cosign_verify-blob.md)	 - Verify a signature on the supplied blob
 * [cosign verify-blob-attestation](cosign_verify-blob-attestation.md)	 - Verify an attestation on the supplied blob
 * [cosign version](cosign_version.md)	 - Prints the version
+* [cosign wasm](cosign_wasm.md)	 - Utilities for working with WebAssembly modules and embedded wasm-cosign signatures
 

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -48,7 +48,7 @@ cosign sign-blob [flags]
       --oidc-disable-ambient-providers   Disable ambient OIDC providers. When true, ambient credentials will not be read
       --oidc-provider string             Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
       --oidc-redirect-url string         OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
-      --signing-algorithm string         signing algorithm to use for signing/hashing (allowed ecdsa-sha2-256-nistp256, ecdsa-sha2-384-nistp384, ecdsa-sha2-512-nistp521, rsa-sign-pkcs1-2048-sha256, rsa-sign-pkcs1-3072-sha256, rsa-sign-pkcs1-4096-sha256) (default "ecdsa-sha2-256-nistp256")
+      --signing-algorithm string         signing algorithm to use for signing/hashing (allowed ecdsa-sha2-256-nistp256, ecdsa-sha2-256-nistp384, ecdsa-sha2-256-nistp521, ecdsa-sha2-384-nistp384, ecdsa-sha2-512-nistp521, ed25519, ed25519-ph, rsa-sign-pkcs1-2048-sha256, rsa-sign-pkcs1-3072-sha256, rsa-sign-pkcs1-4096-sha256, rsa-sign-pss-2048-sha256, rsa-sign-pss-3072-sha256, rsa-sign-pss-4096-sha256) (default "ecdsa-sha2-256-nistp256")
       --signing-config string            path to a signing config file. Must provide --bundle or --wasm-output, which will output verification material in the new format
       --sk                               whether to use a hardware security key
       --slot string                      security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)

--- a/doc/cosign_wasm.md
+++ b/doc/cosign_wasm.md
@@ -1,0 +1,27 @@
+## cosign wasm
+
+Utilities for working with WebAssembly modules and embedded wasm-cosign signatures
+
+### Options
+
+```
+  -h, --help   help for wasm
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
+* [cosign wasm extract-signatures](cosign_wasm_extract-signatures.md)	 - Print embedded wasm-cosign bundle payloads from a WebAssembly module
+* [cosign wasm list-signatures](cosign_wasm_list-signatures.md)	 - List embedded wasm-cosign signatures in a WebAssembly module
+* [cosign wasm sign](cosign_wasm_sign.md)	 - Sign a WebAssembly module with an embedded wasm-cosign custom section
+* [cosign wasm strip-signatures](cosign_wasm_strip-signatures.md)	 - Remove embedded wasm-cosign custom sections from a WebAssembly module
+* [cosign wasm verify](cosign_wasm_verify.md)	 - Verify a WebAssembly module with embedded wasm-cosign signatures
+

--- a/doc/cosign_wasm_extract-signatures.md
+++ b/doc/cosign_wasm_extract-signatures.md
@@ -1,0 +1,32 @@
+## cosign wasm extract-signatures
+
+Print embedded wasm-cosign bundle payloads from a WebAssembly module
+
+```
+cosign wasm extract-signatures <module> [flags]
+```
+
+### Examples
+
+```
+  cosign wasm extract-signatures module.wasm
+```
+
+### Options
+
+```
+  -h, --help   help for extract-signatures
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign wasm](cosign_wasm.md)	 - Utilities for working with WebAssembly modules and embedded wasm-cosign signatures
+

--- a/doc/cosign_wasm_list-signatures.md
+++ b/doc/cosign_wasm_list-signatures.md
@@ -1,0 +1,36 @@
+## cosign wasm list-signatures
+
+List embedded wasm-cosign signatures in a WebAssembly module
+
+```
+cosign wasm list-signatures <module> [flags]
+```
+
+### Examples
+
+```
+  cosign wasm list-signatures module.wasm
+
+  # emit machine-readable signature metadata
+  cosign wasm list-signatures -o json module.wasm
+```
+
+### Options
+
+```
+  -h, --help            help for list-signatures
+  -o, --output string   output format for embedded signatures (json|text) (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign wasm](cosign_wasm.md)	 - Utilities for working with WebAssembly modules and embedded wasm-cosign signatures
+

--- a/doc/cosign_wasm_sign.md
+++ b/doc/cosign_wasm_sign.md
@@ -30,7 +30,7 @@ cosign wasm sign <module> [flags]
       --oidc-disable-ambient-providers   Disable ambient OIDC providers. When true, ambient credentials will not be read
       --oidc-provider string             Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
       --oidc-redirect-url string         OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
-      --signing-algorithm string         signing algorithm to use for signing/hashing (allowed ecdsa-sha2-256-nistp256, ecdsa-sha2-384-nistp384, ecdsa-sha2-512-nistp521, rsa-sign-pkcs1-2048-sha256, rsa-sign-pkcs1-3072-sha256, rsa-sign-pkcs1-4096-sha256) (default "ecdsa-sha2-256-nistp256")
+      --signing-algorithm string         signing algorithm to use for signing/hashing (allowed ecdsa-sha2-256-nistp256, ecdsa-sha2-256-nistp384, ecdsa-sha2-256-nistp521, ecdsa-sha2-384-nistp384, ecdsa-sha2-512-nistp521, ed25519, ed25519-ph, rsa-sign-pkcs1-2048-sha256, rsa-sign-pkcs1-3072-sha256, rsa-sign-pkcs1-4096-sha256, rsa-sign-pss-2048-sha256, rsa-sign-pss-3072-sha256, rsa-sign-pss-4096-sha256) (default "ecdsa-sha2-256-nistp256")
       --signing-config string            path to a signing config file. Must provide --bundle or --wasm-output, which will output verification material in the new format
       --sk                               whether to use a hardware security key
       --slot string                      security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)

--- a/doc/cosign_wasm_sign.md
+++ b/doc/cosign_wasm_sign.md
@@ -1,36 +1,18 @@
-## cosign sign-blob
+## cosign wasm sign
 
-Sign the supplied blob, outputting the base64-encoded signature to stdout.
+Sign a WebAssembly module with an embedded wasm-cosign custom section
 
 ```
-cosign sign-blob [flags]
+cosign wasm sign <module> [flags]
 ```
 
 ### Examples
 
 ```
-  cosign sign-blob --key <key path>|<kms uri> <blob>
+  cosign wasm sign --wasm-output signed.wasm --key cosign.key module.wasm
 
-  # sign a blob with a local key pair file
-  cosign sign-blob --key cosign.key <FILE>
-
-  # sign a blob with a key stored in an environment variable
-  cosign sign-blob --key env://[ENV_VAR] <FILE>
-
-  # sign a blob with a key pair stored in Azure Key Vault
-  cosign sign-blob --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <FILE>
-
-  # sign a blob with a key pair stored in AWS KMS
-  cosign sign-blob --key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <FILE>
-
-  # sign a blob with a key pair stored in Google Cloud KMS
-  cosign sign-blob --key gcpkms://projects/[PROJECT]/locations/global/keyRings/[KEYRING]/cryptoKeys/[KEY] <FILE>
-
-  # sign a blob with a key pair stored in Hashicorp Vault
-  cosign sign-blob --key hashivault://[KEY] <FILE>
-
-  # sign a WebAssembly module, appending the Sigstore bundle in a new wasm-cosign custom section
-  cosign sign-blob --wasm --wasm-output signed.wasm --key cosign.key module.wasm
+  # append another wasm-cosign custom section to an already signed module
+  cosign wasm sign --wasm-output resigned.wasm --key cosign.key module.wasm
 ```
 
 ### Options
@@ -40,7 +22,7 @@ cosign sign-blob [flags]
       --certificate string               path to the X.509 certificate for signing attestation
       --certificate-chain string         path to a list of CA X.509 certificates in PEM format which will be needed when building the certificate chain for the signed attestation. Must start with the parent intermediate CA certificate of the signing certificate and end with the root certificate.
       --fulcio-auth-flow string          fulcio interactive oauth2 flow to use for certificate from fulcio. Defaults to determining the flow based on the runtime environment. (options) normal|device|token|client_credentials
-  -h, --help                             help for sign-blob
+  -h, --help                             help for sign
       --identity-token string            identity token to use for certificate from fulcio. the token or a path to a file containing the token is accepted.
       --key string                       path to the private key file, KMS URI or Kubernetes Secret
       --oidc-client-id string            OIDC client ID for application (default "sigstore")
@@ -58,7 +40,6 @@ cosign sign-blob [flags]
       --timestamp-server-name string     SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
       --trusted-root string              optional path to a TrustedRoot JSON file to verify a signature after signing
       --use-signing-config               whether to use a TUF-provided signing config for the service URLs. Must provide --bundle or --wasm-output, which will output verification material in the new format (default true)
-      --wasm                             treat the blob as a WebAssembly module and sign bytes with existing wasm-cosign custom sections removed
       --wasm-output string               write a signed WebAssembly module to FILE with the Sigstore bundle appended in a wasm-cosign custom section
   -y, --yes                              skip confirmation prompts for non-destructive operations
 ```
@@ -73,5 +54,5 @@ cosign sign-blob [flags]
 
 ### SEE ALSO
 
-* [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
+* [cosign wasm](cosign_wasm.md)	 - Utilities for working with WebAssembly modules and embedded wasm-cosign signatures
 

--- a/doc/cosign_wasm_strip-signatures.md
+++ b/doc/cosign_wasm_strip-signatures.md
@@ -1,0 +1,36 @@
+## cosign wasm strip-signatures
+
+Remove embedded wasm-cosign custom sections from a WebAssembly module
+
+```
+cosign wasm strip-signatures <module> [flags]
+```
+
+### Examples
+
+```
+  cosign wasm strip-signatures -o unsigned.wasm signed.wasm
+
+  # read from stdin and write the stripped module to stdout
+  cosign wasm strip-signatures -o - < signed.wasm
+```
+
+### Options
+
+```
+  -h, --help            help for strip-signatures
+  -o, --output string   write the unsigned WebAssembly module to FILE
+```
+
+### Options inherited from parent commands
+
+```
+      --output-file string   log output to a file
+  -t, --timeout duration     timeout for commands (default 3m0s)
+  -d, --verbose              log debug output
+```
+
+### SEE ALSO
+
+* [cosign wasm](cosign_wasm.md)	 - Utilities for working with WebAssembly modules and embedded wasm-cosign signatures
+

--- a/doc/cosign_wasm_verify.md
+++ b/doc/cosign_wasm_verify.md
@@ -1,56 +1,18 @@
-## cosign verify-blob
+## cosign wasm verify
 
-Verify a signature on the supplied blob
-
-### Synopsis
-
-Verify a signature on the supplied blob input using the specified key reference.
-You may specify either a key, a bundle (optionally with trusted root), or a kms reference to verify against.
-	If you use a key, bundle, or trusted root, you must specify the path to them on disk.
-
-The preferred way to provide verification material is via a Sigstore bundle using --bundle,
-which contains the signature, certificate, and transparency log proof.
-The blob may be specified as a path to a file or - for stdin.
+Verify a WebAssembly module with embedded wasm-cosign signatures
 
 ```
-cosign verify-blob [flags]
+cosign wasm verify <module> [flags]
 ```
 
 ### Examples
 
 ```
- cosign verify-blob --bundle <path> --certificate-identity <identity> --certificate-oidc-issuer <issuer> <blob>
+  cosign wasm verify --key cosign.pub module.wasm
 
-  # Verify a signature with a bundle and trusted root
-  cosign verify-blob --bundle artifact.sigstore.json --trusted-root trusted_root.json <blob>
-
-  # Verify a blob (keyless)
-  cosign verify-blob --bundle artifact.sigstore.json --certificate-identity foo@example.com --certificate-oidc-issuer https://accounts.google.com <blob>
-
-  # Verify a blob with an on-disk public key
-  cosign verify-blob --bundle artifact.sigstore.json --key cosign.pub <blob>
-
-  # Verify a blob against Azure Key Vault
-  cosign verify-blob --bundle artifact.sigstore.json --key azurekms://[VAULT_NAME][VAULT_URI]/[KEY] <blob>
-
-  # Verify a blob against AWS KMS
-  cosign verify-blob --bundle artifact.sigstore.json --key awskms://[ENDPOINT]/[ID/ALIAS/ARN] <blob>
-
-  # Verify a blob against Google Cloud KMS
-  cosign verify-blob --bundle artifact.sigstore.json --key gcpkms://projects/[PROJECT ID]/locations/[LOCATION]/keyRings/[KEYRING]/cryptoKeys/[KEY] <blob>
-
-  # Verify a blob against Hashicorp Vault
-  cosign verify-blob --bundle artifact.sigstore.json --key hashivault://[KEY] <blob>
-
-  # Verify a blob against GitLab with project name
-  cosign verify-blob --bundle artifact.sigstore.json --key gitlab://[OWNER]/[PROJECT_NAME] <blob>
-
-  # Verify a blob against GitLab with project id
-  cosign verify-blob --bundle artifact.sigstore.json --key gitlab://[PROJECT_ID] <blob>
-
-  # Verify a WebAssembly module with embedded wasm-cosign Sigstore bundle(s)
-  cosign verify-blob --wasm --key cosign.pub module.wasm
-
+  # verify all embedded wasm-cosign signatures in a module
+  cosign wasm verify --key cosign.pub module.wasm
 ```
 
 ### Options
@@ -67,7 +29,7 @@ cosign verify-blob [flags]
       --certificate-oidc-issuer string                  The OIDC issuer expected in a valid Fulcio certificate, e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth. Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.
       --certificate-oidc-issuer-regexp string           A regular expression alternative to --certificate-oidc-issuer. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.
       --experimental-oci11                              set to true to enable experimental OCI 1.1 behaviour (unrelated to bundle format)
-  -h, --help                                            help for verify-blob
+  -h, --help                                            help for verify
       --insecure-ignore-sct                             when set, verification will not check that a certificate contains an embedded SCT, a proof of inclusion in a certificate transparency log
       --insecure-ignore-tlog                            ignore transparency log verification, to be used when an artifact signature has not been uploaded to the transparency log. Artifacts cannot be publicly verified when not included in a log
       --key string                                      path to the public key file, KMS URI or Kubernetes Secret
@@ -76,7 +38,6 @@ cosign verify-blob [flags]
       --slot string                                     security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)
       --trusted-root string                             Path to a Sigstore TrustedRoot JSON file. Requires --new-bundle-format to be set.
       --use-signed-timestamps                           verify rfc3161 timestamps
-      --wasm                                            treat the blob as a WebAssembly module and verify bytes with wasm-cosign custom sections removed
 ```
 
 ### Options inherited from parent commands
@@ -89,5 +50,5 @@ cosign verify-blob [flags]
 
 ### SEE ALSO
 
-* [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
+* [cosign wasm](cosign_wasm.md)	 - Utilities for working with WebAssembly modules and embedded wasm-cosign signatures
 

--- a/doc/wasm-signatures.md
+++ b/doc/wasm-signatures.md
@@ -1,0 +1,617 @@
+# WebAssembly Module Signing and Signature Management
+
+This document describes cosign's WebAssembly-specific signing commands and the
+embedded signature model used by `cosign wasm`. It is intended for users who
+need a complete module-level signing workflow, similar in spirit to the way PE
+files can carry signatures from one or more publishers while still remaining
+directly executable by the platform loader.
+
+The generated command reference pages under `doc/cosign_wasm*.md` list flags and
+short examples. This document explains the signing format, multi-signature
+semantics, operational workflows, and security considerations in more detail.
+
+## Scope
+
+The WebAssembly command group is designed for `.wasm` modules that should carry
+their own Sigstore verification material inside the module file. The supported
+operations are:
+
+| Operation | Command | Purpose |
+| --- | --- | --- |
+| Sign a module | `cosign wasm sign <module> --wasm-output <file>` | Sign the canonical unsigned module bytes and append a new embedded signature section. |
+| Verify embedded signatures | `cosign wasm verify <module>` | Verify every embedded signature bundle against the canonical unsigned module bytes. |
+| List embedded signatures | `cosign wasm list-signatures <module>` | Show metadata for every embedded `wasm-cosign` section. |
+| Extract embedded signatures | `cosign wasm extract-signatures <module>` | Print the raw embedded Sigstore bundle payloads. |
+| Strip embedded signatures | `cosign wasm strip-signatures <module> -o <file>` | Remove every embedded `wasm-cosign` section and write the unsigned module. |
+
+The lower-level blob commands also support the same WebAssembly payload rules:
+
+| Blob command | WebAssembly-specific behavior |
+| --- | --- |
+| `cosign sign-blob --wasm --wasm-output <file> <module>` | Sign the canonical unsigned module and append the resulting bundle to the output module. |
+| `cosign verify-blob --wasm <module>` | Verify the canonical unsigned module using either embedded bundles or explicitly supplied verification material. |
+
+Use the `cosign wasm` command group for normal module signing workflows. Use
+`sign-blob --wasm` and `verify-blob --wasm` when integrating with existing blob
+signing automation.
+
+## Embedded Signature Format
+
+Cosign stores embedded WebAssembly signatures in a WebAssembly custom section
+named:
+
+```text
+wasm-cosign
+```
+
+The section payload is the Sigstore bundle produced by cosign in the new bundle
+format. WebAssembly runtimes ignore custom sections, so appending a
+`wasm-cosign` custom section does not change the module's execution semantics.
+The signed module remains a valid WebAssembly module and can be passed to a
+runtime without removing the signature sections.
+
+Only custom sections with exactly the name `wasm-cosign` are treated as embedded
+cosign signatures. Other custom sections, such as `name`, `producers`, or
+toolchain-specific metadata sections, are preserved as normal module bytes.
+
+## Canonical Signing Payload
+
+Cosign does not sign the raw `.wasm` file bytes after the signature section has
+been added. That would be self-referential: the signature would need to cover
+the bytes that contain the signature itself. Instead, the WebAssembly-specific
+payload is the module with every embedded cosign signature section removed.
+
+The canonical payload is computed as follows:
+
+1. Read the WebAssembly module.
+2. Validate the WebAssembly magic header and supported version.
+3. Iterate through all module sections in file order.
+4. Remove every custom section whose name is exactly `wasm-cosign`.
+5. Preserve all other bytes exactly as they appeared in the module.
+6. Sign or verify the resulting byte sequence.
+
+Conceptually, this is equivalent to concatenating all byte ranges that are not
+`wasm-cosign` custom sections, in their original order. The implementation may
+materialize those canonical bytes before signing or verifying, but the security
+property is the same: the signature covers the complete module except for the
+embedded signature containers themselves.
+
+This rule has several important consequences:
+
+| Change to the module | Effect on existing embedded signatures |
+| --- | --- |
+| Add another `wasm-cosign` section | Existing signatures remain valid. |
+| Remove one or more `wasm-cosign` sections | Remaining signatures remain valid. |
+| Reorder `wasm-cosign` sections only | Signature payload is unchanged, but section indexes and offsets change. |
+| Add, remove, or modify any non-signature section | Existing signatures fail verification. |
+| Reorder non-signature sections | Existing signatures fail verification. |
+| Change the WebAssembly code, data, imports, exports, or metadata | Existing signatures fail verification. |
+
+This is the same high-level idea used by many embedded-signature file formats:
+the signature storage area is excluded from the digest, while the executable
+content and all non-signature metadata remain protected.
+
+## Multi-Signature Semantics
+
+Cosign supports multiple embedded signatures in one WebAssembly module. A module
+may contain more than one `wasm-cosign` custom section. Those sections may be
+located anywhere a valid WebAssembly custom section can appear, although the
+cosign signing command appends new signatures to the end of the module.
+
+Multi-signature behavior is intentionally additive:
+
+| Action | Behavior |
+| --- | --- |
+| Sign an unsigned module | A new `wasm-cosign` custom section is appended. |
+| Sign an already signed module | Existing `wasm-cosign` sections are preserved and another one is appended. |
+| Verify a module with multiple embedded bundles | Every embedded bundle is verified against the same canonical unsigned payload. |
+| Strip signatures | All `wasm-cosign` sections are removed. |
+| List signatures | Each embedded section is reported with its index, offset, size, and payload digest. |
+| Extract signatures | All embedded bundle payloads are emitted in section order. |
+
+Because all `wasm-cosign` sections are excluded from the canonical payload, a
+signature created by one vendor remains valid when another vendor appends a
+second signature later. This allows workflows such as:
+
+- An upstream language toolchain signs the module it produced.
+- A security scanning service signs the same module after policy checks.
+- A platform vendor signs the module after compatibility testing.
+- An organization signs the module again during internal release promotion.
+
+Each signature is independent verification material over the same protected
+module payload. Cosign verifies cryptographic validity, transparency log
+material, timestamps, certificates, and identity policy according to the flags
+provided by the caller. Deciding which signers are required for a given
+deployment is a policy decision for the verifier or release system.
+
+## Signing Workflows
+
+### Sign with a Local Key
+
+Use `cosign wasm sign` to produce a signed module containing an embedded bundle:
+
+```shell
+cosign wasm sign \
+  --key cosign.key \
+  --wasm-output module.signed.wasm \
+  module.wasm
+```
+
+The command signs the canonical unsigned payload and writes a new module to
+`module.signed.wasm`. The original input file is not modified in place.
+
+The command requires `--wasm-output`. This makes the output path explicit and
+avoids accidentally replacing the input module.
+
+### Sign with Keyless Sigstore Identity
+
+The WebAssembly command reuses the same signing options as `sign-blob`. For a
+keyless signing flow, omit `--key` and use the configured Fulcio/OIDC flow:
+
+```shell
+cosign wasm sign \
+  --wasm-output module.signed.wasm \
+  module.wasm
+```
+
+Depending on the environment, cosign may use ambient identity providers, an
+interactive browser flow, a device flow, or an explicitly supplied identity
+token. See the generated `cosign wasm sign` command reference for the full list
+of OIDC, Fulcio, Rekor, signing-config, timestamp, and trusted-root flags.
+
+### Append a Second Signature
+
+To add a signature without removing existing signatures, sign the already signed
+module and write a new output module:
+
+```shell
+cosign wasm sign \
+  --key vendor-b.key \
+  --wasm-output module.vendor-b.wasm \
+  module.signed.wasm
+```
+
+Cosign signs the canonical payload obtained by removing all existing
+`wasm-cosign` sections, then appends a new `wasm-cosign` section to the original
+input module. The previous embedded signatures remain present in the output.
+
+### Keep a Sidecar Bundle While Embedding
+
+You may also ask cosign to write the bundle to a separate file while embedding
+the same verification material in the module:
+
+```shell
+cosign wasm sign \
+  --key cosign.key \
+  --bundle module.bundle.json \
+  --wasm-output module.signed.wasm \
+  module.wasm
+```
+
+This is useful when a distribution channel wants the module to be self-contained
+but a build system also wants to archive the bundle separately.
+
+### Write the Signed Module to Standard Output
+
+Use `--wasm-output -` to write the signed module bytes to standard output:
+
+```shell
+cosign wasm sign \
+  --key cosign.key \
+  --wasm-output - \
+  module.wasm > module.signed.wasm
+```
+
+When writing binary module bytes to standard output, redirect output to a file or
+pipe it into a tool that expects raw WebAssembly bytes.
+
+### Compatibility Path Through sign-blob
+
+The `sign-blob` command can be used directly with `--wasm`:
+
+```shell
+cosign sign-blob \
+  --wasm \
+  --key cosign.key \
+  --wasm-output module.signed.wasm \
+  module.wasm
+```
+
+When `--wasm-output` is present, `sign-blob` treats the input as a WebAssembly
+module, signs the canonical unsigned payload, and embeds the resulting bundle in
+the output module. This is equivalent to the specialized `cosign wasm sign`
+workflow, but the `cosign wasm` form is clearer for users and documentation.
+
+## Verification Workflows
+
+### Verify All Embedded Signatures with a Public Key
+
+For a module signed with a local key pair, verify embedded bundles with the
+matching public key:
+
+```shell
+cosign wasm verify \
+  --key cosign.pub \
+  module.signed.wasm
+```
+
+If the module contains multiple embedded `wasm-cosign` sections and no explicit
+`--bundle` or `--signature` is provided, cosign verifies every embedded bundle.
+Verification succeeds only if all embedded bundles verify successfully under the
+provided verification options.
+
+### Verify Keyless Signatures
+
+For keyless signatures, specify the expected signing identity and issuer:
+
+```shell
+cosign wasm verify \
+  --certificate-identity "https://github.com/example/project/.github/workflows/release.yml@refs/tags/v1.2.3" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  module.signed.wasm
+```
+
+The identity flags are evaluated for each embedded bundle. In a multi-signature
+module, a single invocation should express the policy that every embedded
+signature is expected to satisfy. If different signatures are expected to come
+from different identities or roots of trust, extract the bundles and verify them
+with separate policy invocations.
+
+### Verify with a Trusted Root
+
+For new-format Sigstore bundles, verification can be pinned to an explicit
+TrustedRoot file:
+
+```shell
+cosign wasm verify \
+  --trusted-root trusted-root.json \
+  --certificate-identity "release@example.com" \
+  --certificate-oidc-issuer "https://oauth2.sigstore.dev/auth" \
+  module.signed.wasm
+```
+
+Use this form for controlled environments that need explicit trust material,
+offline-oriented workflows, or private Sigstore deployments.
+
+### Verify Against an External Bundle
+
+If `--bundle` is supplied, cosign still applies the WebAssembly canonical payload
+rule, but it verifies using the provided bundle instead of the embedded
+`wasm-cosign` sections:
+
+```shell
+cosign wasm verify \
+  --key cosign.pub \
+  --bundle module.bundle.json \
+  module.signed.wasm
+```
+
+This is useful when the module is unsigned, when signatures are distributed as
+sidecar files, or when you want to verify one specific bundle instead of all
+embedded bundles.
+
+The same behavior is available through `verify-blob`:
+
+```shell
+cosign verify-blob \
+  --wasm \
+  --key cosign.pub \
+  --bundle module.bundle.json \
+  module.signed.wasm
+```
+
+### Verify an Unsigned Payload Produced by Stripping
+
+The unsigned payload produced by `strip-signatures` is the same canonical byte
+sequence used for signing and verification:
+
+```shell
+cosign wasm strip-signatures \
+  -o module.unsigned.wasm \
+  module.signed.wasm
+
+cosign verify-blob \
+  --key cosign.pub \
+  --bundle module.bundle.json \
+  module.unsigned.wasm
+```
+
+This can be useful for debugging or for systems that already understand
+sidecar-bundle blob verification but do not yet consume embedded WebAssembly
+signature sections.
+
+## Listing Signatures
+
+Use `list-signatures` to inspect embedded signature sections without verifying
+them:
+
+```shell
+cosign wasm list-signatures module.signed.wasm
+```
+
+Text output includes:
+
+| Field | Meaning |
+| --- | --- |
+| `INDEX` | Zero-based index among embedded `wasm-cosign` sections in file order. |
+| `OFFSET` | Byte offset where the full custom section starts in the module. |
+| `SECTION SIZE` | WebAssembly section payload size, including the custom section name and embedded payload. |
+| `PAYLOAD SIZE` | Size of the embedded Sigstore bundle payload in bytes. |
+| `SHA256` | SHA-256 digest of the embedded bundle payload, not of the WebAssembly module. |
+
+For machine-readable output:
+
+```shell
+cosign wasm list-signatures \
+  --output json \
+  module.signed.wasm
+```
+
+Example JSON shape:
+
+```json
+[
+  {
+    "index": 0,
+    "offset": 128344,
+    "sectionSize": 24391,
+    "payloadSize": 24378,
+    "sha256": "4f8f9d1d9a8d6a0cf7f9e4a6c184e23f8b6c859e5f2e06d8e8e8d6c75c4d4d2a"
+  },
+  {
+    "index": 1,
+    "offset": 152738,
+    "sectionSize": 24106,
+    "payloadSize": 24093,
+    "sha256": "6c8b55cb7f0b02b51bbda13fa8e4e22f2e9dfdceba6bfa6248a54c62f61cf2aa"
+  }
+]
+```
+
+The JSON fields are metadata about the embedded custom sections. They are useful
+for inventory, duplicate detection, auditing, and selecting bundles to extract
+for separate verification policies.
+
+## Extracting Signatures
+
+Use `extract-signatures` to emit the raw embedded bundle payloads:
+
+```shell
+cosign wasm extract-signatures module.signed.wasm > module.bundles.json
+```
+
+If the module contains multiple embedded signatures, payloads are emitted in
+section order with a newline between payloads. For automated workflows that need
+to address individual signatures, first run `list-signatures --output json` to
+determine how many embedded sections are present and to record their payload
+digests.
+
+Extracted bundle payloads are verification material. They are not the unsigned
+WebAssembly module. To obtain the unsigned module bytes, use
+`strip-signatures`.
+
+## Stripping Signatures
+
+Use `strip-signatures` to remove all embedded `wasm-cosign` sections:
+
+```shell
+cosign wasm strip-signatures \
+  -o module.unsigned.wasm \
+  module.signed.wasm
+```
+
+The output module preserves every non-signature byte exactly. This includes all
+standard WebAssembly sections and all custom sections whose name is not
+`wasm-cosign`.
+
+To use standard input and standard output:
+
+```shell
+cosign wasm strip-signatures \
+  -o - \
+  - < module.signed.wasm > module.unsigned.wasm
+```
+
+The stripped module is the canonical payload that cosign signs and verifies.
+Removing signatures does not rewrite, optimize, normalize, or otherwise mutate
+the protected module bytes.
+
+## End-to-End Multi-Vendor Example
+
+The following example signs a module twice and verifies that both embedded
+signatures are valid.
+
+First signer:
+
+```shell
+cosign wasm sign \
+  --key vendor-a.key \
+  --wasm-output module.vendor-a.wasm \
+  module.wasm
+```
+
+Second signer:
+
+```shell
+cosign wasm sign \
+  --key vendor-b.key \
+  --wasm-output module.vendor-a-b.wasm \
+  module.vendor-a.wasm
+```
+
+Inspect the embedded sections:
+
+```shell
+cosign wasm list-signatures \
+  --output json \
+  module.vendor-a-b.wasm
+```
+
+Verify all embedded signatures with one policy:
+
+```shell
+cosign wasm verify \
+  --key shared-release.pub \
+  module.vendor-a-b.wasm
+```
+
+If the two signatures require different trust policies, extract or archive each
+bundle separately and verify each bundle with the appropriate identity, key, or
+trusted root policy.
+
+## Bundle Format Requirements
+
+Embedded WebAssembly signatures use Sigstore bundles as the custom section
+payload. The WebAssembly commands require the new bundle format when writing an
+embedded signed module through `--wasm-output`.
+
+The `--new-bundle-format` flag defaults to true in current cosign behavior and
+is deprecated because it will be the only supported format in future versions.
+The important operational point is that embedded signatures are expected to
+carry the complete verification material needed by modern Sigstore verification
+flows.
+
+When verifying embedded bundles, cosign requires new-format bundle verification.
+If no embedded bundle is present, provide `--bundle` or `--signature` explicitly
+for sidecar verification.
+
+## Trust and Policy Model
+
+An embedded signature proves that a particular signer, key, certificate, or
+identity signed the canonical WebAssembly module payload. It does not by itself
+answer every deployment policy question.
+
+Consumers should decide:
+
+- Which keys, certificates, identities, or issuers are trusted.
+- Whether every embedded signature must pass one shared policy.
+- Whether different signature indexes represent different required roles.
+- Whether a minimum number of valid signatures is required.
+- Whether transparency log inclusion is mandatory.
+- Whether signed timestamps are required.
+- Whether the module must be stripped before storage or execution.
+
+Cosign provides the cryptographic verification mechanism and the CLI primitives
+to list, extract, strip, and verify signatures. Higher-level release gates can
+compose these primitives into organization-specific policies.
+
+## Security Considerations
+
+Treat WebAssembly module signing with the same care as other code signing
+systems:
+
+- Protect private keys and KMS access. A valid embedded signature is only as
+  strong as the controls around the signing identity.
+- Prefer transparency log verification for public artifacts. Avoid
+  `--insecure-ignore-tlog` unless the artifact is intentionally signed in a
+  private or offline workflow.
+- Pin expected identities for keyless verification with
+  `--certificate-identity` or `--certificate-identity-regexp` and
+  `--certificate-oidc-issuer` or `--certificate-oidc-issuer-regexp`.
+- Use `--trusted-root` when verification must be tied to explicit trust
+  material.
+- Remember that custom sections are ignored by runtimes. A runtime executing a
+  module does not automatically enforce signature verification; verification
+  must be performed by the loader, package manager, deployment system, or
+  policy gate.
+- Do not treat `list-signatures` or `extract-signatures` as verification. They
+  are inspection and extraction tools only.
+- Any mutation to protected bytes invalidates existing signatures. Rebuild,
+  optimize, strip non-signature sections, or post-process the module before
+  signing, not after signing.
+
+## Operational Notes
+
+### Input Validation
+
+The WebAssembly helper validates the module header before signing, verifying,
+listing, extracting, or stripping embedded signatures. The module must start
+with the WebAssembly magic header and use the supported version bytes.
+
+If the input is not a valid WebAssembly module, the command fails instead of
+treating it as an arbitrary blob.
+
+### Section Ordering
+
+The signing command appends a new `wasm-cosign` custom section to the end of the
+module. It does not attempt to move existing signatures or normalize section
+ordering.
+
+The stripping and verification logic scans the whole module and removes every
+`wasm-cosign` custom section it finds. This means it supports modules that
+already contain signature sections at different valid custom-section positions.
+
+### Other Custom Sections
+
+Only `wasm-cosign` sections are excluded from the signed payload. Other custom
+sections remain protected by the signature. This is important because custom
+sections may contain meaningful debugging, provenance, producer, or toolchain
+metadata. If that metadata changes after signing, verification should fail.
+
+### In-Place Updates
+
+The CLI writes signed and stripped modules to explicit output paths. It does not
+rewrite the input file in place. This makes signing and stripping easier to use
+in reproducible build pipelines where every step has a named input and output.
+
+### Binary Output
+
+`--wasm-output -` and `strip-signatures -o -` write raw WebAssembly bytes to
+standard output. Redirect them to a file or pipe them only into binary-safe
+tools.
+
+## Troubleshooting
+
+### `wasm module does not contain a "wasm-cosign" custom section`
+
+The module has no embedded cosign signature sections and no explicit `--bundle`
+or `--signature` was provided. Sign the module with `cosign wasm sign`, or verify
+with a sidecar bundle:
+
+```shell
+cosign wasm verify \
+  --key cosign.pub \
+  --bundle module.bundle.json \
+  module.wasm
+```
+
+### Verification Fails After Rebuilding or Optimizing
+
+The signature covers all non-`wasm-cosign` bytes. If a tool rewrites code,
+renumbers sections, changes producers metadata, strips a non-signature custom
+section, or otherwise changes protected bytes, existing signatures no longer
+match. Run those transformations before signing.
+
+### Multiple Embedded Sections Are Present
+
+When no explicit `--bundle` or `--signature` is supplied, cosign verifies all
+embedded `wasm-cosign` sections. If any embedded bundle does not satisfy the
+provided trust policy, verification fails. Use `list-signatures --output json`
+to inspect the embedded sections and `extract-signatures` if separate policy
+handling is required.
+
+### Keyless Verification Requires Identity Flags
+
+For keyless signatures, provide the expected certificate identity and OIDC
+issuer, or their regexp variants. This prevents accepting a valid Sigstore
+certificate from an unexpected identity.
+
+### `unsupported WebAssembly version`
+
+The input has the WebAssembly magic header but does not use the supported
+version bytes. Confirm that the file is a standard `.wasm` module and not a
+component, archive, compressed file, or wrapper format.
+
+## Recommended Release Pattern
+
+A robust release pipeline usually follows this order:
+
+1. Build the WebAssembly module.
+2. Run optimization, metadata generation, and policy checks.
+3. Sign the final module with `cosign wasm sign`.
+4. Optionally append additional signatures for independent approvals.
+5. Verify all required signatures before publishing.
+6. Publish the signed module and, if desired, archive sidecar bundles.
+
+Avoid modifying protected module bytes after step 3. If the module must change,
+produce a new signed module rather than carrying forward old signatures.

--- a/internal/key/svkeypair.go
+++ b/internal/key/svkeypair.go
@@ -49,6 +49,20 @@ func NewSignerVerifierKeypair(sv signature.SignerVerifier, defaultLoadOptions *[
 	if err != nil {
 		return nil, fmt.Errorf("getting public key: %w", err)
 	}
+	algo, err := signature.GetDefaultAlgorithmDetails(pubKey, *cosign.GetDefaultLoadOptions(defaultLoadOptions)...)
+	if err != nil {
+		return nil, fmt.Errorf("getting default algorithm details: %w", err)
+	}
+	return NewSignerVerifierKeypairWithAlgorithm(sv, algo)
+}
+
+// NewSignerVerifierKeypairWithAlgorithm creates a new SignerVerifierKeypair
+// from a SignerVerifier and explicit signature algorithm details.
+func NewSignerVerifierKeypairWithAlgorithm(sv signature.SignerVerifier, algo signature.AlgorithmDetails) (*SignerVerifierKeypair, error) {
+	pubKey, err := sv.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("getting public key: %w", err)
+	}
 	pubKeyBytes, err := x509.MarshalPKIXPublicKey(pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling public key: %w", err)
@@ -66,11 +80,6 @@ func NewSignerVerifierKeypair(sv signature.SignerVerifier, defaultLoadOptions *[
 		keyAlg = "ED25519"
 	default:
 		return nil, errors.New("unsupported key type")
-	}
-
-	algo, err := signature.GetDefaultAlgorithmDetails(pubKey, *cosign.GetDefaultLoadOptions(defaultLoadOptions)...)
-	if err != nil {
-		return nil, fmt.Errorf("getting default algorithm details: %w", err)
 	}
 
 	return &SignerVerifierKeypair{
@@ -125,10 +134,17 @@ func (k *SignerVerifierKeypair) GetPublicKeyPem() (string, error) {
 
 // SignData signs the given data with the SignerVerifier.
 func (k *SignerVerifierKeypair) SignData(ctx context.Context, data []byte) ([]byte, []byte, error) {
-	h := k.sigAlg.GetHashType().New()
-	h.Write(data)
-	digest := h.Sum(nil)
-	sOpts := []signature.SignOption{signatureoptions.WithContext(ctx), signatureoptions.WithDigest(digest)}
+	hashType := k.sigAlg.GetHashType()
+	digest := data
+	if hashType != crypto.Hash(0) {
+		h := hashType.New()
+		h.Write(data)
+		digest = h.Sum(nil)
+	}
+	sOpts := []signature.SignOption{signatureoptions.WithContext(ctx)}
+	if hashType != crypto.Hash(0) {
+		sOpts = append(sOpts, signatureoptions.WithDigest(digest))
+	}
 	sig, err := k.sv.SignMessage(bytes.NewReader(data), sOpts...)
 	if err != nil {
 		return nil, nil, err

--- a/internal/key/svkeypair_test.go
+++ b/internal/key/svkeypair_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
@@ -239,4 +240,73 @@ func TestKMSKeypair_Methods(t *testing.T) {
 			t.Errorf("expected error 'signing failed', got '%s'", err.Error())
 		}
 	})
+}
+
+func TestSignerVerifierKeypairWithExplicitAlgorithm(t *testing.T) {
+	_, ed25519Priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ed25519 key: %v", err)
+	}
+	edSV, err := signature.LoadSignerVerifierFromAlgorithmDetails(ed25519Priv, mustAlgorithmDetails(t, protocommon.PublicKeyDetails_PKIX_ED25519))
+	if err != nil {
+		t.Fatalf("failed to load ed25519 signer verifier: %v", err)
+	}
+	edKP, err := NewSignerVerifierKeypairWithAlgorithm(edSV, mustAlgorithmDetails(t, protocommon.PublicKeyDetails_PKIX_ED25519))
+	if err != nil {
+		t.Fatalf("failed to create ed25519 keypair: %v", err)
+	}
+	data := []byte("some data to sign")
+	sig, digest, err := edKP.SignData(context.Background(), data)
+	if err != nil {
+		t.Fatalf("ed25519 SignData returned an error: %v", err)
+	}
+	if !ed25519.Verify(ed25519Priv.Public().(ed25519.PublicKey), data, sig) {
+		t.Fatal("ed25519 signature did not verify over raw data")
+	}
+	if !bytes.Equal(digest, data) {
+		t.Fatalf("ed25519 digest = %x, want raw data %x", digest, data)
+	}
+	if got, want := edKP.GetHashAlgorithm(), protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED; got != want {
+		t.Fatalf("ed25519 hash algorithm = %v, want %v", got, want)
+	}
+	if got, want := edKP.GetSigningAlgorithm(), protocommon.PublicKeyDetails_PKIX_ED25519; got != want {
+		t.Fatalf("ed25519 signing algorithm = %v, want %v", got, want)
+	}
+
+	edPhAlgo := mustAlgorithmDetails(t, protocommon.PublicKeyDetails_PKIX_ED25519_PH)
+	edPhSV, err := signature.LoadSignerVerifierFromAlgorithmDetails(ed25519Priv, edPhAlgo)
+	if err != nil {
+		t.Fatalf("failed to load ed25519ph signer verifier: %v", err)
+	}
+	edPhKP, err := NewSignerVerifierKeypairWithAlgorithm(edPhSV, edPhAlgo)
+	if err != nil {
+		t.Fatalf("failed to create ed25519ph keypair: %v", err)
+	}
+	sig, digest, err = edPhKP.SignData(context.Background(), data)
+	if err != nil {
+		t.Fatalf("ed25519ph SignData returned an error: %v", err)
+	}
+	digest512 := sha512.Sum512(data)
+	if err := edPhSV.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data)); err != nil {
+		t.Fatalf("ed25519ph signature did not verify: %v", err)
+	}
+	if !bytes.Equal(digest, digest512[:]) {
+		t.Fatalf("ed25519ph digest = %x, want %x", digest, digest512)
+	}
+	if got, want := edPhKP.GetHashAlgorithm(), protocommon.HashAlgorithm_SHA2_512; got != want {
+		t.Fatalf("ed25519ph hash algorithm = %v, want %v", got, want)
+	}
+	if got, want := edPhKP.GetSigningAlgorithm(), protocommon.PublicKeyDetails_PKIX_ED25519_PH; got != want {
+		t.Fatalf("ed25519ph signing algorithm = %v, want %v", got, want)
+	}
+}
+
+func mustAlgorithmDetails(t *testing.T, keyDetails protocommon.PublicKeyDetails) signature.AlgorithmDetails {
+	t.Helper()
+
+	algo, err := signature.GetAlgorithmDetails(keyDetails)
+	if err != nil {
+		t.Fatalf("failed to get algorithm details: %v", err)
+	}
+	return algo
 }

--- a/internal/pkg/cosign/common.go
+++ b/internal/pkg/cosign/common.go
@@ -43,9 +43,18 @@ type HashReader struct {
 	r  io.Reader
 	h  hash.Hash
 	ch crypto.Hash
+	b  *bytesHash
 }
 
 func NewHashReader(r io.Reader, ch crypto.Hash) HashReader {
+	if ch == crypto.Hash(0) {
+		b := &bytesHash{}
+		return HashReader{
+			r:  io.TeeReader(r, b),
+			ch: ch,
+			b:  b,
+		}
+	}
 	h := ch.New()
 	return HashReader{
 		r:  io.TeeReader(r, h),
@@ -58,19 +67,77 @@ func NewHashReader(r io.Reader, ch crypto.Hash) HashReader {
 func (h *HashReader) Read(p []byte) (n int, err error) { return h.r.Read(p) }
 
 // Sum implements hash.Hash.
-func (h *HashReader) Sum(p []byte) []byte { return h.h.Sum(p) }
+func (h *HashReader) Sum(p []byte) []byte {
+	if h.ch == crypto.Hash(0) {
+		if h.b == nil {
+			return append(p, []byte{}...)
+		}
+		return h.b.Sum(p)
+	}
+	return h.h.Sum(p)
+}
 
 // Reset implements hash.Hash.
-func (h *HashReader) Reset() { h.h.Reset() }
+func (h *HashReader) Reset() {
+	if h.ch == crypto.Hash(0) {
+		if h.b == nil {
+			return
+		}
+		h.b.Reset()
+		return
+	}
+	h.h.Reset()
+}
 
 // Size implements hash.Hash.
-func (h *HashReader) Size() int { return h.h.Size() }
+func (h *HashReader) Size() int {
+	if h.ch == crypto.Hash(0) {
+		if h.b == nil {
+			return 0
+		}
+		return h.b.Size()
+	}
+	return h.h.Size()
+}
 
 // BlockSize implements hash.Hash.
-func (h *HashReader) BlockSize() int { return h.h.BlockSize() }
+func (h *HashReader) BlockSize() int {
+	if h.ch == crypto.Hash(0) {
+		if h.b == nil {
+			return 1
+		}
+		return h.b.BlockSize()
+	}
+	return h.h.BlockSize()
+}
 
 // Write implements hash.Hash
 func (h *HashReader) Write(p []byte) (int, error) { return 0, errors.New("not implemented") } //nolint: revive
 
 // HashFunc implements cosign.NamedHash
 func (h *HashReader) HashFunc() crypto.Hash { return h.ch }
+
+type bytesHash struct {
+	buf []byte
+}
+
+func (b *bytesHash) Write(p []byte) (int, error) {
+	b.buf = append(b.buf, p...)
+	return len(p), nil
+}
+
+func (b *bytesHash) Sum(p []byte) []byte {
+	return append(p, b.buf...)
+}
+
+func (b *bytesHash) Reset() {
+	b.buf = nil
+}
+
+func (b *bytesHash) Size() int {
+	return len(b.buf)
+}
+
+func (b *bytesHash) BlockSize() int {
+	return 1
+}

--- a/internal/pkg/cosign/common_test.go
+++ b/internal/pkg/cosign/common_test.go
@@ -72,3 +72,22 @@ func Test_HashReader(t *testing.T) {
 		t.Errorf("Sum returned %s, want %s", gotHash, hash)
 	}
 }
+
+func Test_HashReaderRaw(t *testing.T) {
+	input := []byte("hello world")
+	r := NewHashReader(bytes.NewReader(input), crypto.Hash(0))
+
+	got, err := io.ReadAll(&r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(got, input) {
+		t.Errorf("io.ReadAll returned %s, want %s", got, input)
+	}
+
+	gotRaw := r.Sum(nil)
+	if !bytes.Equal(gotRaw, input) {
+		t.Errorf("Sum returned %s, want %s", gotRaw, input)
+	}
+}

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -16,6 +16,7 @@ package bundle
 
 import (
 	"context"
+	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -25,15 +26,18 @@ import (
 	"time"
 
 	"github.com/sigstore/cosign/v3/internal/ui"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/sign"
 	"github.com/sigstore/sigstore/pkg/signature"
+	signatureoptions "github.com/sigstore/sigstore/pkg/signature/options"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type SignOptions struct {
 	TSAClientTransport  http.RoundTripper
 	CertificateProvider sign.CertificateProvider
+	VerifierOptions     []signature.LoadOption
 }
 
 func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, idToken string, cert []byte, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial, opts SignOptions) ([]byte, error) {
@@ -72,7 +76,7 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		if err != nil {
 			log.Fatal(err)
 		}
-		verifier, err := signature.LoadDefaultVerifier(pubKey)
+		verifier, err := signature.LoadDefaultVerifier(pubKey, opts.VerifierOptions...)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -146,6 +150,21 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		return nil, fmt.Errorf("error signing bundle: %w", err)
 	}
 	return protojson.Marshal(bundle)
+}
+
+func VerifierOptionsForKeypair(keypair sign.Keypair) []signature.LoadOption {
+	opts := []signature.LoadOption{}
+	switch keypair.GetSigningAlgorithm() {
+	case protocommon.PublicKeyDetails_PKIX_ED25519_PH:
+		opts = append(opts, signatureoptions.WithED25519ph())
+	case protocommon.PublicKeyDetails_PKIX_RSA_PSS_2048_SHA256,
+		protocommon.PublicKeyDetails_PKIX_RSA_PSS_3072_SHA256,
+		protocommon.PublicKeyDetails_PKIX_RSA_PSS_4096_SHA256:
+		opts = append(opts, signatureoptions.WithRSAPSS(&rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+		}))
+	}
+	return opts
 }
 
 type verifyTrustedMaterial struct {

--- a/pkg/cosign/bundle/sign_test.go
+++ b/pkg/cosign/bundle/sign_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bundle
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/sign"
+	"github.com/sigstore/sigstore/pkg/signature"
+)
+
+func TestVerifierOptionsForKeypair(t *testing.T) {
+	tests := []struct {
+		name        string
+		algorithm   protocommon.PublicKeyDetails
+		privateKey  crypto.PrivateKey
+		wantType    any
+		expectEmpty bool
+	}{
+		{
+			name:      "ed25519ph",
+			algorithm: protocommon.PublicKeyDetails_PKIX_ED25519_PH,
+			wantType:  &signature.ED25519phVerifier{},
+		},
+		{
+			name:       "rsa-pss",
+			algorithm:  protocommon.PublicKeyDetails_PKIX_RSA_PSS_2048_SHA256,
+			privateKey: mustRSAKey(t),
+			wantType:   &signature.RSAPSSVerifier{},
+		},
+		{
+			name:        "default-ecdsa",
+			algorithm:   protocommon.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+			expectEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keypair, err := sign.NewEphemeralKeypair(&sign.EphemeralKeypairOptions{Algorithm: tt.algorithm})
+			if err != nil {
+				t.Fatal(err)
+			}
+			opts := VerifierOptionsForKeypair(keypair)
+			if tt.expectEmpty {
+				if len(opts) != 0 {
+					t.Fatalf("len(opts) = %d, want 0", len(opts))
+				}
+				return
+			}
+
+			pubKey := keypair.GetPublicKey()
+			if tt.privateKey != nil {
+				pubKey = tt.privateKey.(*rsa.PrivateKey).Public()
+			}
+			verifier, err := signature.LoadDefaultVerifier(pubKey, opts...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch tt.wantType.(type) {
+			case *signature.ED25519phVerifier:
+				if _, ok := verifier.(*signature.ED25519phVerifier); !ok {
+					t.Fatalf("verifier = %T, want *signature.ED25519phVerifier", verifier)
+				}
+			case *signature.RSAPSSVerifier:
+				if _, ok := verifier.(*signature.RSAPSSVerifier); !ok {
+					t.Fatalf("verifier = %T, want *signature.RSAPSSVerifier", verifier)
+				}
+			}
+		})
+	}
+}
+
+func mustRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}

--- a/pkg/cosign/keys.go
+++ b/pkg/cosign/keys.go
@@ -55,12 +55,17 @@ const (
 var SupportedKeyDetails = []v1.PublicKeyDetails{
 	v1.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
 	v1.PublicKeyDetails_PKIX_ECDSA_P384_SHA_384,
+	v1.PublicKeyDetails_PKIX_ECDSA_P384_SHA_256,
 	v1.PublicKeyDetails_PKIX_ECDSA_P521_SHA_512,
+	v1.PublicKeyDetails_PKIX_ECDSA_P521_SHA_256,
+	v1.PublicKeyDetails_PKIX_ED25519,
+	v1.PublicKeyDetails_PKIX_ED25519_PH,
 	v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_2048_SHA256,
 	v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_3072_SHA256,
 	v1.PublicKeyDetails_PKIX_RSA_PKCS1V15_4096_SHA256,
-	// Ed25519ph is not supported by Fulcio, so we don't support it here for now.
-	// v1.PublicKeyDetails_PKIX_ED25519_PH,
+	v1.PublicKeyDetails_PKIX_RSA_PSS_2048_SHA256,
+	v1.PublicKeyDetails_PKIX_RSA_PSS_3072_SHA256,
+	v1.PublicKeyDetails_PKIX_RSA_PSS_4096_SHA256,
 }
 
 // PassFunc is the function to be called to retrieve the signer password. If
@@ -278,7 +283,36 @@ func PemToECDSAKey(pemBytes []byte) (*ecdsa.PublicKey, error) {
 // LoadPrivateKey loads a cosign PEM private key encrypted with the given passphrase,
 // and returns a SignerVerifier instance. The private key must be in the PKCS #8 format.
 func LoadPrivateKey(key []byte, pass []byte, defaultLoadOptions *[]signature.LoadOption) (signature.SignerVerifier, error) {
-	// Decrypt first
+	pk, err := decryptPrivateKey(key, pass)
+	if err != nil {
+		return nil, err
+	}
+	defaultLoadOptions = GetDefaultLoadOptions(defaultLoadOptions)
+	return signature.LoadDefaultSignerVerifier(pk, *defaultLoadOptions...)
+}
+
+// LoadPrivateKeyWithAlgorithm loads a cosign PEM private key encrypted with the
+// given passphrase, and returns a SignerVerifier for the provided algorithm.
+func LoadPrivateKeyWithAlgorithm(key []byte, pass []byte, algo signature.AlgorithmDetails) (signature.SignerVerifier, error) {
+	pk, err := decryptPrivateKey(key, pass)
+	if err != nil {
+		return nil, err
+	}
+	sv, err := signature.LoadSignerVerifierWithOpts(pk, LoadOptionsForAlgorithm(algo)...)
+	if err != nil {
+		return nil, err
+	}
+	pubKey, err := sv.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("getting public key: %w", err)
+	}
+	if err := ValidateAlgorithmForPublicKey(pubKey, algo); err != nil {
+		return nil, err
+	}
+	return sv, nil
+}
+
+func decryptPrivateKey(key []byte, pass []byte) (crypto.PrivateKey, error) {
 	p, _ := pem.Decode(key)
 	if p == nil {
 		return nil, errors.New("invalid pem block")
@@ -295,8 +329,7 @@ func LoadPrivateKey(key []byte, pass []byte, defaultLoadOptions *[]signature.Loa
 	if err != nil {
 		return nil, fmt.Errorf("parsing private key: %w", err)
 	}
-	defaultLoadOptions = GetDefaultLoadOptions(defaultLoadOptions)
-	return signature.LoadDefaultSignerVerifier(pk, *defaultLoadOptions...)
+	return pk, nil
 }
 
 func GetDefaultLoadOptions(defaultLoadOptions *[]signature.LoadOption) *[]signature.LoadOption {
@@ -309,6 +342,37 @@ func GetDefaultLoadOptions(defaultLoadOptions *[]signature.LoadOption) *[]signat
 		return &[]signature.LoadOption{options.WithED25519ph()}
 	}
 	return defaultLoadOptions
+}
+
+func LoadOptionsForAlgorithm(algo signature.AlgorithmDetails) []signature.LoadOption {
+	opts := []signature.LoadOption{options.WithHash(algo.GetHashType())}
+	switch algo.GetSignatureAlgorithm() {
+	case v1.PublicKeyDetails_PKIX_ED25519_PH:
+		opts = append(opts, options.WithED25519ph())
+	case v1.PublicKeyDetails_PKIX_RSA_PSS_2048_SHA256,
+		v1.PublicKeyDetails_PKIX_RSA_PSS_3072_SHA256,
+		v1.PublicKeyDetails_PKIX_RSA_PSS_4096_SHA256:
+		opts = append(opts, options.WithRSAPSS(&rsa.PSSOptions{
+			Hash:       algo.GetHashType(),
+			SaltLength: rsa.PSSSaltLengthAuto,
+		}))
+	}
+	return opts
+}
+
+func ValidateAlgorithmForPublicKey(pubKey crypto.PublicKey, algo signature.AlgorithmDetails) error {
+	registry, err := signature.NewAlgorithmRegistryConfig([]v1.PublicKeyDetails{algo.GetSignatureAlgorithm()})
+	if err != nil {
+		return err
+	}
+	permitted, err := registry.IsAlgorithmPermitted(pubKey, algo.GetHashType())
+	if err != nil {
+		return err
+	}
+	if !permitted {
+		return fmt.Errorf("signing algorithm %s is not compatible with public key", algo.GetSignatureAlgorithm())
+	}
+	return nil
 }
 
 // GetSupportedAlgorithms returns a list of supported algorithms sorted alphabetically.

--- a/pkg/cosign/keys_test.go
+++ b/pkg/cosign/keys_test.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore/pkg/signature"
 	"github.com/stretchr/testify/require"
 )
 
@@ -504,4 +506,57 @@ func TestImportPrivateKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetSupportedAlgorithmsIncludesSigstoreRegistryAlgorithms(t *testing.T) {
+	require.ElementsMatch(t, []string{
+		"ecdsa-sha2-256-nistp256",
+		"ecdsa-sha2-256-nistp384",
+		"ecdsa-sha2-256-nistp521",
+		"ecdsa-sha2-384-nistp384",
+		"ecdsa-sha2-512-nistp521",
+		"ed25519",
+		"ed25519-ph",
+		"rsa-sign-pkcs1-2048-sha256",
+		"rsa-sign-pkcs1-3072-sha256",
+		"rsa-sign-pkcs1-4096-sha256",
+		"rsa-sign-pss-2048-sha256",
+		"rsa-sign-pss-3072-sha256",
+		"rsa-sign-pss-4096-sha256",
+	}, GetSupportedAlgorithms())
+}
+
+func TestLoadPrivateKeyWithAlgorithm(t *testing.T) {
+	keys, err := GenerateKeyPairWithAlgorithm(mustAlgorithmDetails(t, v1.PublicKeyDetails_PKIX_ED25519), pass("hello"))
+	require.NoError(t, err)
+
+	algo := mustAlgorithmDetails(t, v1.PublicKeyDetails_PKIX_ED25519)
+	sv, err := LoadPrivateKeyWithAlgorithm(keys.PrivateBytes, []byte("hello"), *algo)
+	require.NoError(t, err)
+	require.NoError(t, ValidateAlgorithmForPublicKey(mustPublicKey(t, sv), *algo))
+
+	algo = mustAlgorithmDetails(t, v1.PublicKeyDetails_PKIX_ED25519_PH)
+	sv, err = LoadPrivateKeyWithAlgorithm(keys.PrivateBytes, []byte("hello"), *algo)
+	require.NoError(t, err)
+	require.NoError(t, ValidateAlgorithmForPublicKey(mustPublicKey(t, sv), *algo))
+
+	algo = mustAlgorithmDetails(t, v1.PublicKeyDetails_PKIX_RSA_PSS_2048_SHA256)
+	_, err = LoadPrivateKeyWithAlgorithm(keys.PrivateBytes, []byte("hello"), *algo)
+	require.ErrorContains(t, err, "signing algorithm PKIX_RSA_PSS_2048_SHA256 is not compatible with public key")
+}
+
+func mustAlgorithmDetails(t *testing.T, keyDetails v1.PublicKeyDetails) *signature.AlgorithmDetails {
+	t.Helper()
+
+	algo, err := signature.GetAlgorithmDetails(keyDetails)
+	require.NoError(t, err)
+	return &algo
+}
+
+func mustPublicKey(t *testing.T, sv signature.SignerVerifier) any {
+	t.Helper()
+
+	pubKey, err := sv.PublicKey()
+	require.NoError(t, err)
+	return pubKey
 }

--- a/pkg/signature/keys.go
+++ b/pkg/signature/keys.go
@@ -87,6 +87,21 @@ func loadKey(keyPath string, pf cosign.PassFunc, defaultLoadOptions *[]signature
 	return cosign.LoadPrivateKey(kb, pass, defaultLoadOptions)
 }
 
+func loadKeyWithAlgorithm(keyPath string, pf cosign.PassFunc, algo signature.AlgorithmDetails) (signature.SignerVerifier, error) {
+	kb, err := blob.LoadFileOrURL(keyPath)
+	if err != nil {
+		return nil, err
+	}
+	pass := []byte{}
+	if pf != nil {
+		pass, err = pf(false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return cosign.LoadPrivateKeyWithAlgorithm(kb, pass, algo)
+}
+
 // LoadPublicKeyRaw loads a verifier from a PEM-encoded public key
 func LoadPublicKeyRaw(raw []byte, hashAlgorithm crypto.Hash) (signature.Verifier, error) {
 	pub, err := cryptoutils.UnmarshalPEMToPublicKey(raw)
@@ -101,6 +116,14 @@ func SignerFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc) (s
 }
 
 func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc, defaultLoadOptions *[]signature.LoadOption) (signature.SignerVerifier, error) {
+	return signerVerifierFromKeyRef(ctx, keyRef, pf, defaultLoadOptions, nil)
+}
+
+func SignerVerifierFromKeyRefWithAlgorithm(ctx context.Context, keyRef string, pf cosign.PassFunc, algo signature.AlgorithmDetails) (signature.SignerVerifier, error) {
+	return signerVerifierFromKeyRef(ctx, keyRef, pf, nil, &algo)
+}
+
+func signerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.PassFunc, defaultLoadOptions *[]signature.LoadOption, algo *signature.AlgorithmDetails) (signature.SignerVerifier, error) {
 	switch {
 	case strings.HasPrefix(keyRef, pkcs11key.ReferenceScheme):
 		pkcs11UriConfig := pkcs11key.NewPkcs11UriConfig()
@@ -129,6 +152,9 @@ func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.Pass
 		}
 
 		if len(s.Data) > 0 {
+			if algo != nil {
+				return cosign.LoadPrivateKeyWithAlgorithm(s.Data["cosign.key"], s.Data["cosign.password"], *algo)
+			}
 			return cosign.LoadPrivateKey(s.Data["cosign.key"], s.Data["cosign.password"], defaultLoadOptions)
 		}
 	case strings.HasPrefix(keyRef, gitlab.ReferenceScheme):
@@ -150,6 +176,9 @@ func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.Pass
 			return nil, err
 		}
 
+		if algo != nil {
+			return cosign.LoadPrivateKeyWithAlgorithm([]byte(pk), []byte(pass), *algo)
+		}
 		return cosign.LoadPrivateKey([]byte(pk), []byte(pass), defaultLoadOptions)
 	}
 
@@ -165,6 +194,9 @@ func SignerVerifierFromKeyRef(ctx context.Context, keyRef string, pf cosign.Pass
 		// ProviderNotFoundError is okay; loadKey handles other URL schemes
 	}
 
+	if algo != nil {
+		return loadKeyWithAlgorithm(keyRef, pf, *algo)
+	}
 	return loadKey(keyRef, pf, defaultLoadOptions)
 }
 

--- a/pkg/wasm/usign.go
+++ b/pkg/wasm/usign.go
@@ -1,0 +1,231 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+const (
+	// SignatureSectionName is the WebAssembly custom section name used to store
+	// embedded Sigstore verification material.
+	SignatureSectionName = "wasm-cosign"
+
+	customSectionID = byte(0)
+	headerLen       = 8
+)
+
+// SignatureSection describes one embedded wasm-cosign custom section.
+type SignatureSection struct {
+	Index       int
+	Offset      int
+	SectionSize uint32
+	PayloadSize int
+	Payload     []byte
+}
+
+var (
+	wasmMagic   = []byte{0x00, 0x61, 0x73, 0x6d}
+	wasmVersion = []byte{0x01, 0x00, 0x00, 0x00}
+)
+
+// StripSignatureSections returns a copy of module with every custom section
+// named "wasm-cosign" removed. All other bytes are preserved exactly.
+func StripSignatureSections(module []byte) ([]byte, error) {
+	stripped, _, err := StripAndExtractSignatureSections(module)
+	return stripped, err
+}
+
+// ExtractSignatureSections returns the payloads from every "wasm-cosign" custom
+// section without modifying the module.
+func ExtractSignatureSections(module []byte) ([][]byte, error) {
+	_, sections, err := StripAndExtractSignatureSections(module)
+	return sections, err
+}
+
+// InspectSignatureSections returns metadata for every "wasm-cosign" custom
+// section without modifying the module.
+func InspectSignatureSections(module []byte) ([]SignatureSection, error) {
+	_, sections, err := stripInspectSignatureSections(module)
+	return sections, err
+}
+
+// StripAndExtractSignatureSections returns a copy of module with embedded
+// signatures removed, plus the raw payload from every removed signature section.
+func StripAndExtractSignatureSections(module []byte) ([]byte, [][]byte, error) {
+	stripped, sections, err := stripInspectSignatureSections(module)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	payloads := make([][]byte, 0, len(sections))
+	for _, section := range sections {
+		payloads = append(payloads, section.Payload)
+	}
+
+	return stripped, payloads, nil
+}
+
+func stripInspectSignatureSections(module []byte) ([]byte, []SignatureSection, error) {
+	if err := validateHeader(module); err != nil {
+		return nil, nil, err
+	}
+
+	out := append([]byte(nil), module[:headerLen]...)
+	var signatureSections []SignatureSection
+
+	for pos := headerLen; pos < len(module); {
+		sectionStart := pos
+		sectionID := module[pos]
+		pos++
+
+		sectionSize, n, err := readVaruint32(module[pos:])
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading section size at byte %d: %w", pos, err)
+		}
+		pos += n
+
+		if uint64(sectionSize) > uint64(len(module)-pos) {
+			return nil, nil, fmt.Errorf("section at byte %d extends past end of module", sectionStart)
+		}
+		sectionEnd := pos + int(sectionSize)
+		sectionPayload := module[pos:sectionEnd]
+
+		if sectionID == customSectionID {
+			name, payload, err := splitCustomSection(sectionPayload)
+			if err != nil {
+				return nil, nil, fmt.Errorf("reading custom section at byte %d: %w", sectionStart, err)
+			}
+			if name == SignatureSectionName {
+				signatureSections = append(signatureSections, SignatureSection{
+					Index:       len(signatureSections),
+					Offset:      sectionStart,
+					SectionSize: sectionSize,
+					PayloadSize: len(payload),
+					Payload:     append([]byte(nil), payload...),
+				})
+				pos = sectionEnd
+				continue
+			}
+		}
+
+		out = append(out, module[sectionStart:sectionEnd]...)
+		pos = sectionEnd
+	}
+
+	return out, signatureSections, nil
+}
+
+// ReplaceSignatureSection strips any existing "wasm-cosign" custom sections and
+// appends a new one. WebAssembly runtimes ignore custom sections, so appending
+// this section preserves module execution semantics.
+func ReplaceSignatureSection(module, payload []byte) ([]byte, error) {
+	stripped, err := StripSignatureSections(module)
+	if err != nil {
+		return nil, err
+	}
+	return appendCustomSection(stripped, SignatureSectionName, payload)
+}
+
+// AppendSignatureSection appends a new "wasm-cosign" custom section while
+// preserving any existing embedded signatures.
+func AppendSignatureSection(module, payload []byte) ([]byte, error) {
+	if _, _, err := StripAndExtractSignatureSections(module); err != nil {
+		return nil, err
+	}
+	return appendCustomSection(module, SignatureSectionName, payload)
+}
+
+func validateHeader(module []byte) error {
+	if len(module) < headerLen {
+		return errors.New("module is shorter than the WebAssembly header")
+	}
+	if !bytes.Equal(module[:4], wasmMagic) {
+		return errors.New("module does not start with the WebAssembly magic header")
+	}
+	if !bytes.Equal(module[4:headerLen], wasmVersion) {
+		return fmt.Errorf("unsupported WebAssembly version %x", module[4:headerLen])
+	}
+	return nil
+}
+
+func splitCustomSection(sectionPayload []byte) (string, []byte, error) {
+	nameLen, n, err := readVaruint32(sectionPayload)
+	if err != nil {
+		return "", nil, fmt.Errorf("reading custom section name length: %w", err)
+	}
+	if uint64(nameLen) > uint64(len(sectionPayload)-n) {
+		return "", nil, errors.New("custom section name extends past section payload")
+	}
+
+	nameStart := n
+	nameEnd := nameStart + int(nameLen)
+	return string(sectionPayload[nameStart:nameEnd]), sectionPayload[nameEnd:], nil
+}
+
+func appendCustomSection(module []byte, name string, payload []byte) ([]byte, error) {
+	if err := validateHeader(module); err != nil {
+		return nil, err
+	}
+
+	sectionPayload := make([]byte, 0, 5+len(name)+len(payload))
+	sectionPayload = append(sectionPayload, encodeVaruint32(uint32(len(name)))...)
+	sectionPayload = append(sectionPayload, name...)
+	sectionPayload = append(sectionPayload, payload...)
+
+	section := make([]byte, 0, 1+5+len(sectionPayload))
+	section = append(section, customSectionID)
+	section = append(section, encodeVaruint32(uint32(len(sectionPayload)))...)
+	section = append(section, sectionPayload...)
+
+	out := append([]byte(nil), module...)
+	out = append(out, section...)
+	return out, nil
+}
+
+func readVaruint32(data []byte) (uint32, int, error) {
+	var value uint32
+	for i := 0; i < 5; i++ {
+		if i >= len(data) {
+			return 0, 0, errors.New("unexpected end of data")
+		}
+		b := data[i]
+		if i == 4 && b&0xf0 != 0 {
+			return 0, 0, errors.New("varuint32 overflows 32 bits")
+		}
+		value |= uint32(b&0x7f) << uint(7*i)
+		if b&0x80 == 0 {
+			return value, i + 1, nil
+		}
+	}
+	return 0, 0, errors.New("varuint32 is longer than 5 bytes")
+}
+
+func encodeVaruint32(value uint32) []byte {
+	var out []byte
+	for {
+		b := byte(value & 0x7f)
+		value >>= 7
+		if value != 0 {
+			b |= 0x80
+		}
+		out = append(out, b)
+		if value == 0 {
+			return out
+		}
+	}
+}

--- a/pkg/wasm/usign_test.go
+++ b/pkg/wasm/usign_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wasm
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStripAndExtractSignatureSections(t *testing.T) {
+	module := minimalModule(t)
+	module = mustAppendCustomSection(t, module, "producers", []byte("toolchain"))
+	module = mustAppendCustomSection(t, module, SignatureSectionName, []byte("first-bundle"))
+	module = append(module, 1, 1, 0) // type section with an empty vector.
+	module = mustAppendCustomSection(t, module, SignatureSectionName, []byte("second-bundle"))
+
+	stripped, sections, err := StripAndExtractSignatureSections(module)
+	if err != nil {
+		t.Fatalf("StripAndExtractSignatureSections() error = %v", err)
+	}
+
+	if got, want := len(sections), 2; got != want {
+		t.Fatalf("len(sections) = %d, want %d", got, want)
+	}
+	if !bytes.Equal(sections[0], []byte("first-bundle")) {
+		t.Fatalf("sections[0] = %q, want first-bundle", sections[0])
+	}
+	if !bytes.Equal(sections[1], []byte("second-bundle")) {
+		t.Fatalf("sections[1] = %q, want second-bundle", sections[1])
+	}
+	if bytes.Contains(stripped, []byte(SignatureSectionName)) {
+		t.Fatalf("stripped module still contains %q", SignatureSectionName)
+	}
+	if !bytes.Contains(stripped, []byte("producers")) {
+		t.Fatalf("stripped module removed a non-signature custom section")
+	}
+}
+
+func TestAppendSignatureSectionPreservesExistingSections(t *testing.T) {
+	module := minimalModule(t)
+	module = mustAppendCustomSection(t, module, SignatureSectionName, []byte("old-bundle"))
+
+	signed, err := AppendSignatureSection(module, []byte("new-bundle"))
+	if err != nil {
+		t.Fatalf("AppendSignatureSection() error = %v", err)
+	}
+
+	stripped, sections, err := StripAndExtractSignatureSections(signed)
+	if err != nil {
+		t.Fatalf("StripAndExtractSignatureSections() error = %v", err)
+	}
+	if got, want := len(sections), 2; got != want {
+		t.Fatalf("len(sections) = %d, want %d", got, want)
+	}
+	if !bytes.Equal(sections[0], []byte("old-bundle")) {
+		t.Fatalf("sections[0] = %q, want old-bundle", sections[0])
+	}
+	if !bytes.Equal(sections[1], []byte("new-bundle")) {
+		t.Fatalf("sections[1] = %q, want new-bundle", sections[1])
+	}
+	if !bytes.Equal(stripped, minimalModule(t)) {
+		t.Fatalf("stripped signed module = %x, want minimal module", stripped)
+	}
+}
+
+func TestInspectSignatureSections(t *testing.T) {
+	module := minimalModule(t)
+	module = mustAppendCustomSection(t, module, "producers", []byte("toolchain"))
+	firstOffset := len(module)
+	module = mustAppendCustomSection(t, module, SignatureSectionName, []byte("first-bundle"))
+	module = append(module, 1, 1, 0) // type section with an empty vector.
+	secondOffset := len(module)
+	module = mustAppendCustomSection(t, module, SignatureSectionName, []byte("second-bundle"))
+
+	sections, err := InspectSignatureSections(module)
+	if err != nil {
+		t.Fatalf("InspectSignatureSections() error = %v", err)
+	}
+	if got, want := len(sections), 2; got != want {
+		t.Fatalf("len(sections) = %d, want %d", got, want)
+	}
+	if sections[0].Index != 0 || sections[0].Offset != firstOffset || sections[0].PayloadSize != len("first-bundle") {
+		t.Fatalf("sections[0] = %+v, want index 0 offset %d payload size %d", sections[0], firstOffset, len("first-bundle"))
+	}
+	if sections[1].Index != 1 || sections[1].Offset != secondOffset || sections[1].PayloadSize != len("second-bundle") {
+		t.Fatalf("sections[1] = %+v, want index 1 offset %d payload size %d", sections[1], secondOffset, len("second-bundle"))
+	}
+	if !bytes.Equal(sections[0].Payload, []byte("first-bundle")) {
+		t.Fatalf("sections[0].Payload = %q, want first-bundle", sections[0].Payload)
+	}
+	if !bytes.Equal(sections[1].Payload, []byte("second-bundle")) {
+		t.Fatalf("sections[1].Payload = %q, want second-bundle", sections[1].Payload)
+	}
+}
+
+func TestReplaceSignatureSectionReplacesExistingSections(t *testing.T) {
+	module := minimalModule(t)
+	module = mustAppendCustomSection(t, module, SignatureSectionName, []byte("old-bundle"))
+
+	signed, err := ReplaceSignatureSection(module, []byte("new-bundle"))
+	if err != nil {
+		t.Fatalf("ReplaceSignatureSection() error = %v", err)
+	}
+
+	stripped, sections, err := StripAndExtractSignatureSections(signed)
+	if err != nil {
+		t.Fatalf("StripAndExtractSignatureSections() error = %v", err)
+	}
+	if got, want := len(sections), 1; got != want {
+		t.Fatalf("len(sections) = %d, want %d", got, want)
+	}
+	if !bytes.Equal(sections[0], []byte("new-bundle")) {
+		t.Fatalf("sections[0] = %q, want new-bundle", sections[0])
+	}
+	if !bytes.Equal(stripped, minimalModule(t)) {
+		t.Fatalf("stripped signed module = %x, want minimal module", stripped)
+	}
+}
+
+func TestStripRejectsInvalidModule(t *testing.T) {
+	if _, err := StripSignatureSections([]byte("not wasm")); err == nil {
+		t.Fatalf("StripSignatureSections() error = nil, want error")
+	}
+}
+
+func TestAppendRejectsInvalidModule(t *testing.T) {
+	if _, err := AppendSignatureSection([]byte("not wasm"), []byte("bundle")); err == nil {
+		t.Fatalf("AppendSignatureSection() error = nil, want error")
+	}
+}
+
+func minimalModule(t *testing.T) []byte {
+	t.Helper()
+	return []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
+}
+
+func mustAppendCustomSection(t *testing.T, module []byte, name string, payload []byte) []byte {
+	t.Helper()
+	out, err := appendCustomSection(module, name, payload)
+	if err != nil {
+		t.Fatalf("appendCustomSection(%q) error = %v", name, err)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

This PR adds first-class WebAssembly support to cosign so `.wasm` modules can be signed, verified, inspected, stripped, and re-signed as self-contained artifacts.

The new workflow stores Sigstore verification material inside a WebAssembly custom section named `wasm-cosign`, while preserving normal runtime behavior. This makes cosign usable as a module-level signing system for wasm in the same way code-signing tooling is used for PE artifacts.

## What changed

- Added a new `cosign wasm` command group.
- Added subcommands for:
  - `sign`
  - `verify`
  - `list-signatures`
  - `extract-signatures`
  - `strip-signatures`
- Added `--wasm` / `--wasm-output` support to `sign-blob` and `verify-blob`.
- Added a new `pkg/wasm` helper package for parsing, stripping, appending, and inspecting embedded signature sections.
- Added docs for the wasm command group and a detailed manual for the embedded signature model.
- Added tests covering multi-signature behavior, stripping, inspection, verification, and tamper cases.

## How it works

Cosign treats a wasm module as signed by computing the canonical payload from the module with every `wasm-cosign` custom section removed.

That means:

- The signature section itself is excluded from the digest.
- All other wasm bytes remain protected.
- Adding another `wasm-cosign` section does not break existing signatures.
- Any mutation to non-signature sections invalidates verification.

This design supports multiple embedded signatures from different vendors or from the same vendor at different stages of a release pipeline.

## User workflow

Typical usage looks like this:

```bash
cosign wasm sign --key cosign.key --wasm-output signed.wasm module.wasm
cosign wasm verify --key cosign.pub signed.wasm
cosign wasm list-signatures signed.wasm
cosign wasm extract-signatures signed.wasm
cosign wasm strip-signatures -o unsigned.wasm signed.wasm
```

The blob commands also support wasm mode for compatibility with existing automation:

```bash
cosign sign-blob --wasm --wasm-output signed.wasm --key cosign.key module.wasm
cosign verify-blob --wasm --key cosign.pub signed.wasm
```

## Security model

This PR is designed to make wasm signing safe by default:

- Only exact `wasm-cosign` custom sections are treated as embedded signatures.
- Verification strips all embedded signature sections before checking the protected payload.
- Listing and extraction are inspection tools, not trust decisions.
- Non-signature wasm bytes, including custom sections like `producers`, remain covered by the signature.
- Multi-signature modules are verified section-by-section, so tampering with one embedded bundle is detected.

## Validation

I validated the implementation with controlled wasm fixtures generated via `wat2wasm`, including:

- happy-path signing and verification
- multiple embedded signatures
- moving signature sections to different positions
- stripping embedded signatures back to the original module
- tampering with code, exports, and custom sections
- tampering with the embedded `wasm-cosign` payload itself
- malformed wasm and unsupported version handling

## Notes

This work turns cosign into a practical wasm signing system rather than a generic blob signer with a wasm flag. It gives wasm artifacts a complete lifecycle for signing, verification, inspection, and cleanup.
