### PR TITLE
Fix impossible status code checks in GitHub provider PutSecret

### DIFF
--- a/pkg/cosign/git/github/github.go
+++ b/pkg/cosign/git/github/github.go
@@ -87,7 +87,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("could not get repository public key: %w", err)
 	}
 
-	if getPubKeyResp.StatusCode < 200 && getPubKeyResp.StatusCode >= 300 {
+	if getPubKeyResp.StatusCode < 200 || getPubKeyResp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(getPubKeyResp.Body)
 		return fmt.Errorf("%s", bodyBytes)
 	}
@@ -102,7 +102,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("could not create \"COSIGN_PASSWORD\" github actions secret: %w", err)
 	}
 
-	if passwordSecretEnvResp.StatusCode < 200 && passwordSecretEnvResp.StatusCode >= 300 {
+	if passwordSecretEnvResp.StatusCode < 200 || passwordSecretEnvResp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(passwordSecretEnvResp.Body)
 		return fmt.Errorf("%s", bodyBytes)
 	}
@@ -119,7 +119,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("could not create \"COSIGN_PRIVATE_KEY\" github actions secret: %w", err)
 	}
 
-	if privateKeySecretEnvResp.StatusCode < 200 && privateKeySecretEnvResp.StatusCode >= 300 {
+	if privateKeySecretEnvResp.StatusCode < 200 || privateKeySecretEnvResp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(privateKeySecretEnvResp.Body)
 		return fmt.Errorf("%s", bodyBytes)
 	}
@@ -136,7 +136,7 @@ func (g *Gh) PutSecret(ctx context.Context, ref string, pf cosign.PassFunc) erro
 		return fmt.Errorf("could not create \"COSIGN_PUBLIC_KEY\" github actions secret: %w", err)
 	}
 
-	if publicKeySecretEnvResp.StatusCode < 200 && publicKeySecretEnvResp.StatusCode >= 300 {
+	if publicKeySecretEnvResp.StatusCode < 200 || publicKeySecretEnvResp.StatusCode >= 300 {
 		bodyBytes, _ := io.ReadAll(publicKeySecretEnvResp.Body)
 		return fmt.Errorf("%s", bodyBytes)
 	}


### PR DESCRIPTION
## Summary

The HTTP status code checks in `PutSecret` (`pkg/cosign/git/github/github.go`) use `&&` instead of `||`:

```go
if statusCode < 200 && statusCode >= 300 {
```

This condition is always false: no integer is simultaneously less than 200 and greater than or equal to 300. All four checks in `PutSecret` silently pass through, never detecting non-2xx HTTP responses from the GitHub API.

Fix: change `&&` to `||` in all four status code checks.

## Evidence

The GitLab provider (`pkg/cosign/git/gitlab/gitlab.go`) correctly uses `||` for the same check, confirming this is a typo in the GitHub handler, not intentional behavior.

## Bug origin

Introduced in PR #848 by Erkan Zileli on 2021-10-12 ("add github&gitlab reference support to generate-key-pair"). The original PR introduced both the GitHub and GitLab handlers; the GitLab handler was written correctly with `||`, but the GitHub handler used `&&`. The typo was propagated unchanged by PR #3567 (2024-03-21) which renamed variables but preserved the logic.

The bug has been present for ~4.5 years.

## Impact

When the GitHub API returns a non-2xx response (e.g., 403 Forbidden, 404 Not Found, 500 Internal Server Error), `PutSecret` silently continues and eventually returns success. The user sees no error even though their cosign keys were not stored in GitHub Actions secrets. Currently masked by go-github's own error handling, but the status code checks are a defense-in-depth layer that should function correctly.

## Test plan

- `gofmt`, `go vet`, `go build` all clean
- No existing test files for the `git/github` package

Signed-off-by: Sebastien Tardif <sebtardif@ncf.ca>