### PR TITLE
fix: check HTTP status code in LoadFileOrURL

### DIFF
--- a/pkg/blob/load.go
+++ b/pkg/blob/load.go
@@ -50,6 +50,9 @@ func LoadFileOrURL(fileRef string) ([]byte, error) {
 				return nil, err
 			}
 			defer resp.Body.Close()
+			if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+				return nil, fmt.Errorf("loading URL %s: server returned HTTP %d", fileRef, resp.StatusCode)
+			}
 			raw, err = io.ReadAll(resp.Body)
 			if err != nil {
 				return nil, err

--- a/pkg/blob/load_test.go
+++ b/pkg/blob/load_test.go
@@ -99,6 +99,34 @@ func TestLoadURL(t *testing.T) {
 	}
 }
 
+func TestLoadURLNon2xxStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+	}{
+		{"NotFound", http.StatusNotFound},
+		{"InternalServerError", http.StatusInternalServerError},
+		{"Forbidden", http.StatusForbidden},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+				rw.WriteHeader(tc.statusCode)
+				rw.Write([]byte("error page"))
+			}))
+			defer server.Close()
+
+			_, err := LoadFileOrURL(server.URL)
+			if err == nil {
+				t.Fatalf("LoadFileOrURL() with HTTP %d: expected error, got nil", tc.statusCode)
+			}
+			if !strings.Contains(err.Error(), "HTTP") {
+				t.Errorf("error should mention HTTP status, got: %v", err)
+			}
+		})
+	}
+}
+
 func TestLoadURLWithChecksum(t *testing.T) {
 	data := []byte("test")
 


### PR DESCRIPTION
## Problem

`LoadFileOrURL` in `pkg/blob/load.go` calls `http.Get()` but only checks for transport-level errors (DNS failures, connection refused, TLS errors). When a server responds with HTTP 404, 500, or other non-2xx status codes, `err` is `nil` and the HTML error page body is silently returned as valid data.

## Impact

`LoadFileOrURL` is called from 13+ direct call sites (plus `LoadFileOrURLWithChecksum` which delegates to it), loading security-critical data:
- Public keys (`pkg/signature/keys.go`)
- Signatures and payloads (`pkg/cosign/verify.go`)
- Certificate chains (`cmd/cosign/cli/verify/common.go`)
- RFC3161 timestamps (`cmd/cosign/cli/verify/verify_blob.go`, `verify_blob_attestation.go`)
- TUF root files (`cmd/cosign/cli/initialize/init.go`)

A 404 for a key URL silently passes an HTML error page as a "key", producing a confusing PEM/ASN.1 parse error downstream with no indication the actual problem was a broken URL.

## Fix

Add a 3-line status code check between `defer resp.Body.Close()` and `io.ReadAll(resp.Body)` that returns a clear error for non-2xx responses. The existing `defer resp.Body.Close()` ensures the body is properly closed on all return paths.

## Test

Added `TestLoadURLNon2xxStatus` table-driven test covering 404, 500, and 403, using `httptest.NewServer`. Each subtest confirms `LoadFileOrURL` returns a non-nil error containing "HTTP".

## Bug origin

The HTTP code path was added in commit 0c4cf2e9b by Zack Newman on 2022-04-24. The status check was never added; the bug has been present for 4+ years.
