### PR TITLE
verify: return TUF errors for new bundle trusted roots

### DIFF
--- a/cmd/cosign/cli/verify/common.go
+++ b/cmd/cosign/cli/verify/common.go
@@ -190,6 +190,9 @@ func SetTrustedMaterial(ctx context.Context, trustedRootPath, certChain, caRoots
 		env.Getenv(env.VariableSigstoreTSACertificateFile) == "" {
 		co.TrustedMaterial, err = cosign.TrustedRoot()
 		if err != nil {
+			if co.NewBundleFormat {
+				return fmt.Errorf("getting trusted root from TUF for new bundle verification: %w", err)
+			}
 			ui.Warnf(ctx, "Could not fetch trusted_root.json from the TUF repository. Continuing with individual targets. Error from TUF: %v", err)
 		}
 	}

--- a/cmd/cosign/cli/verify/common_test.go
+++ b/cmd/cosign/cli/verify/common_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package verify
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sigstore/cosign/v3/internal/ui"
+	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/cosign/v3/pkg/cosign/env"
+)
+
+func TestSetTrustedMaterialNewBundleTUFError(t *testing.T) {
+	setBrokenTrustedRootTUFEnv(t)
+
+	co := &cosign.CheckOpts{NewBundleFormat: true}
+	var err error
+	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+		err = SetTrustedMaterial(ctx, "", "", "", "", "", false, co)
+	})
+
+	if err == nil {
+		t.Fatal("expected trusted root TUF error")
+	}
+	if !strings.Contains(err.Error(), "getting trusted root from TUF for new bundle verification") {
+		t.Fatalf("expected new bundle trusted root error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "error reading root.json given by TUF_ROOT_JSON") {
+		t.Fatalf("expected underlying TUF error, got %v", err)
+	}
+	if co.TrustedMaterial != nil {
+		t.Fatal("expected TrustedMaterial to remain unset")
+	}
+	if stderr != "" {
+		t.Fatalf("expected no warning when returning new bundle error, got %q", stderr)
+	}
+}
+
+func TestSetTrustedMaterialLegacyTUFFallback(t *testing.T) {
+	setBrokenTrustedRootTUFEnv(t)
+
+	co := &cosign.CheckOpts{}
+	var err error
+	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+		err = SetTrustedMaterial(ctx, "", "", "", "", "", false, co)
+	})
+
+	if err != nil {
+		t.Fatalf("expected legacy trusted material fallback, got %v", err)
+	}
+	if co.TrustedMaterial != nil {
+		t.Fatal("expected TrustedMaterial to remain unset")
+	}
+	if !strings.Contains(stderr, "Could not fetch trusted_root.json from the TUF repository") {
+		t.Fatalf("expected legacy fallback warning, got %q", stderr)
+	}
+}
+
+func setBrokenTrustedRootTUFEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(env.VariableTUFRootDir.String(), t.TempDir())
+	t.Setenv(env.VariableTUFMirror.String(), "https://example.com/tuf")
+	t.Setenv(env.VariableTUFRootJSON.String(), filepath.Join(t.TempDir(), "missing-root.json"))
+	t.Setenv(env.VariableSigstoreCTLogPublicKeyFile.String(), "")
+	t.Setenv(env.VariableSigstoreRootFile.String(), "")
+	t.Setenv(env.VariableSigstoreRekorPublicKey.String(), "")
+	t.Setenv(env.VariableSigstoreTSACertificateFile.String(), "")
+}


### PR DESCRIPTION
#### Summary

This change fixes new bundle verification so a failure to load the live trusted root from TUF is returned at the point where it happens. New bundle verification cannot fall back to legacy TUF targets, so returning the wrapped TUF error makes the failure actionable instead of later reporting that trusted material is nil: https://github.com/docker/github-builder/actions/runs/25808830274/job/75819126449?pr=201#step:4:54

```
cosign verify --experimental-oci11 --new-bundle-format --certificate-oidc-issuer https://token.actions.githubusercontent.com/ --certificate-identity-regexp ^https://github.com/docker/github-builder(-experimental)?/.github/workflows/bake.yml.*$ tonistiigi/binfmt@sha256:c7f7f49f896505f3a38e11768b25721a267554b573ad86efa481a8c7e7863a15
  Error: Error: Cosign verify command failed with: error during command execution: trusted root is required when using new bundle format
```

#### Release Note

Fixed new bundle verification to report trusted root loading failures from TUF instead of a later generic missing trusted root error.

#### Documentation

This change does not require documentation updates because it only changes error handling for an existing verification path.

cc @tonistiigi @Hayden-IO