### PR TITLE
ci(vault): Undo SKIP_SETCAP and add IPC_LOCK capability

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -83,8 +83,8 @@ jobs:
         image: hashicorp/vault:latest
         env:
           VAULT_DEV_ROOT_TOKEN_ID: root
-          SKIP_SETCAP: "true"
         options: >-
+          --cap-add=IPC_LOCK
           --health-cmd "VAULT_ADDR=http://127.0.0.1:8200 vault status"
           --health-interval 1s
           --health-timeout 5s


### PR DESCRIPTION
#### Summary

This change undoes #4824 and adds the `IPC_LOCK` capability, as Vault v2.0.1 fixes the breaking `SETCAP` issue but requires this capability.