### PR TITLE
Fix Ed25519ph check to respect custom signing configs in sign-blob

### DIFF
--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -59,14 +59,6 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	ctx, cancel := context.WithTimeout(ctx, ro.Timeout)
 	defer cancel()
 
-	// TODO - this does not take ko.SigningConfig into account
-	if !tlogUpload {
-		// To maintain backwards compatibility with older cosign versions,
-		// we do not use ed25519ph for ed25519 keys when the signatures are not
-		// uploaded to the Tlog.
-		ko.DefaultLoadOptions = &[]signature.LoadOption{}
-	}
-
 	var shouldUpload bool
 	var err error
 
@@ -79,6 +71,15 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		if err != nil {
 			return nil, fmt.Errorf("creating signing config: %w", err)
 		}
+	} else {
+		shouldUpload = len(ko.SigningConfig.RekorLogURLs()) > 0
+	}
+
+	if !shouldUpload {
+		// To maintain backwards compatibility with older cosign versions,
+		// we do not use ed25519ph for ed25519 keys when the signatures are not
+		// uploaded to the Tlog.
+		ko.DefaultLoadOptions = &[]signature.LoadOption{}
 	}
 
 	keypair, certBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)

--- a/cmd/cosign/cli/sign/sign_blob_test.go
+++ b/cmd/cosign/cli/sign/sign_blob_test.go
@@ -15,7 +15,11 @@
 package sign
 
 import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
 	"os"
 	"path/filepath"
@@ -25,6 +29,7 @@ import (
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/internal/test"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
+	"github.com/sigstore/sigstore-go/pkg/root"
 )
 
 func TestSignBlobCmd(t *testing.T) {
@@ -78,6 +83,73 @@ func TestSignBlobCmd(t *testing.T) {
 	_, err = SignBlobCmd(t.Context(), rootOpts, keyOpts, blobPath, signCertPath, "", false, "", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error %v", err)
+	}
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x509Encoded, err = x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encBytes, err = encrypted.Encrypt(x509Encoded, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes = pem.EncodeToMemory(&pem.Block{
+		Bytes: encBytes,
+		Type:  cosign.SigstorePrivateKeyPemType,
+	})
+
+	// Test signing using Ed25519 key with custom signing config and no transparency log upload
+	edKeyRef := writeFile(t, td, string(pemBytes), "ed_key.pem")
+	keyOpts = options.KeyOpts{KeyRef: edKeyRef, BundlePath: bundlePath}
+	sc, err := root.NewSigningConfig(
+		root.SigningConfigMediaType02,
+		nil,
+		nil,
+		nil,
+		root.ServiceConfiguration{},
+		nil,
+		root.ServiceConfiguration{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyOpts.SigningConfig = sc
+	sigBytes, err := SignBlobCmd(t.Context(), rootOpts, keyOpts, blobPath, "", "", true, "", "", true)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	decodedSig, err := base64.StdEncoding.DecodeString(string(sigBytes))
+	if err != nil {
+		t.Fatalf("failed to decode base64 signature: %v", err)
+	}
+	if !ed25519.Verify(pub, blob, decodedSig) {
+		errString := "expected ed25519 signature"
+		if ed25519.VerifyWithOptions(pub, blob, decodedSig, &ed25519.Options{Hash: crypto.SHA512}) == nil {
+			errString += ", received ed25519ph signature"
+		}
+		t.Fatal("signature verification failed: " + errString)
+	}
+
+	// Test signing using Ed25519 key with default signing config and no transparency log upload
+	keyOpts = options.KeyOpts{KeyRef: edKeyRef, BundlePath: bundlePath}
+	sigBytes, err = SignBlobCmd(t.Context(), rootOpts, keyOpts, blobPath, "", "", true, "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	decodedSig, err = base64.StdEncoding.DecodeString(string(sigBytes))
+	if err != nil {
+		t.Fatalf("failed to decode base64 signature: %v", err)
+	}
+	if !ed25519.Verify(pub, blob, decodedSig) {
+		errString := "expected ed25519 signature"
+		if ed25519.VerifyWithOptions(pub, blob, decodedSig, &ed25519.Options{Hash: crypto.SHA512}) == nil {
+			errString += ", received ed25519ph signature"
+		}
+		t.Fatal("signature verification failed: " + errString)
 	}
 }
 

--- a/internal/key/svkeypair.go
+++ b/internal/key/svkeypair.go
@@ -125,10 +125,17 @@ func (k *SignerVerifierKeypair) GetPublicKeyPem() (string, error) {
 
 // SignData signs the given data with the SignerVerifier.
 func (k *SignerVerifierKeypair) SignData(ctx context.Context, data []byte) ([]byte, []byte, error) {
-	h := k.sigAlg.GetHashType().New()
-	h.Write(data)
-	digest := h.Sum(nil)
-	sOpts := []signature.SignOption{signatureoptions.WithContext(ctx), signatureoptions.WithDigest(digest)}
+	var digest []byte
+	sOpts := []signature.SignOption{signatureoptions.WithContext(ctx)}
+
+	hashType := k.sigAlg.GetHashType()
+	if hashType != 0 {
+		h := hashType.New()
+		h.Write(data)
+		digest = h.Sum(nil)
+		sOpts = append(sOpts, signatureoptions.WithDigest(digest))
+	}
+
 	sig, err := k.sv.SignMessage(bytes.NewReader(data), sOpts...)
 	if err != nil {
 		return nil, nil, err

--- a/internal/key/svkeypair_test.go
+++ b/internal/key/svkeypair_test.go
@@ -141,7 +141,7 @@ func TestNewKMSKeypair(t *testing.T) {
 	}
 }
 
-func TestKMSKeypair_Methods(t *testing.T) {
+func TestKMSKeypair_ECDSA_Methods(t *testing.T) {
 	ecdsaPriv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		t.Fatalf("failed to generate ecdsa key: %v", err)
@@ -237,6 +237,84 @@ func TestKMSKeypair_Methods(t *testing.T) {
 			t.Error("expected an error, but got none")
 		} else if err.Error() != "signing failed" {
 			t.Errorf("expected error 'signing failed', got '%s'", err.Error())
+		}
+	})
+}
+
+func TestKMSKeypair_ED25519_Methods(t *testing.T) {
+	_, ed25519Priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate ed25519 key: %v", err)
+	}
+	sv := &mockSignerVerifier{pubKey: ed25519Priv.Public()}
+	kp, err := NewSignerVerifierKeypair(sv, &[]signature.LoadOption{})
+	if err != nil {
+		t.Fatalf("failed to create KMSKeypair: %v", err)
+	}
+
+	t.Run("GetHashAlgorithm", func(t *testing.T) {
+		if kp.GetHashAlgorithm() != protocommon.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED {
+			t.Errorf("expected HASH_ALGORITHM_UNSPECIFIED, got %v", kp.GetHashAlgorithm())
+		}
+	})
+
+	t.Run("GetSigningAlgorithm", func(t *testing.T) {
+		if kp.GetSigningAlgorithm() != protocommon.PublicKeyDetails_PKIX_ED25519 {
+			t.Errorf("expected PKIX_ED25519, got %v", kp.GetSigningAlgorithm())
+		}
+	})
+
+	t.Run("GetHint", func(t *testing.T) {
+		pubKeyBytes, err := x509.MarshalPKIXPublicKey(ed25519Priv.Public())
+		if err != nil {
+			t.Fatalf("marshalling public key: %v", err)
+		}
+		hashedBytes := sha256.Sum256(pubKeyBytes)
+		expectedHint := base64.StdEncoding.EncodeToString(hashedBytes[:])
+
+		if string(kp.GetHint()) != expectedHint {
+			t.Errorf("expected hint %s, got %s", expectedHint, string(kp.GetHint()))
+		}
+	})
+
+	t.Run("GetKeyAlgorithm", func(t *testing.T) {
+		if kp.GetKeyAlgorithm() != "ED25519" {
+			t.Errorf("expected ED25519, got %s", kp.GetKeyAlgorithm())
+		}
+	})
+
+	t.Run("GetPublicKey", func(t *testing.T) {
+		pub := kp.GetPublicKey()
+		if !pub.(ed25519.PublicKey).Equal(ed25519Priv.Public()) {
+			t.Error("public keys do not match")
+		}
+	})
+
+	t.Run("GetPublicKeyPem", func(t *testing.T) {
+		pem, err := kp.GetPublicKeyPem()
+		if err != nil {
+			t.Fatalf("GetPublicKeyPem returned an error: %v", err)
+		}
+		pub, err := cryptoutils.UnmarshalPEMToPublicKey([]byte(pem))
+		if err != nil {
+			t.Fatalf("failed to unmarshal pem: %v", err)
+		}
+		if !pub.(ed25519.PublicKey).Equal(ed25519Priv.Public()) {
+			t.Error("public keys do not match")
+		}
+	})
+
+	t.Run("SignData", func(t *testing.T) {
+		data := []byte("some data to sign")
+		sig, digest, err := kp.SignData(context.Background(), data)
+		if err != nil {
+			t.Fatalf("SignData returned an error: %v", err)
+		}
+		if string(sig) != "mock-signature" {
+			t.Errorf("expected signature 'mock-signature', got '%s'", string(sig))
+		}
+		if len(digest) != 0 {
+			t.Errorf("expected empty digest, got %x", digest)
 		}
 	})
 }

--- a/internal/pkg/cosign/common.go
+++ b/internal/pkg/cosign/common.go
@@ -46,6 +46,13 @@ type HashReader struct {
 }
 
 func NewHashReader(r io.Reader, ch crypto.Hash) HashReader {
+	if ch == 0 {
+		return HashReader{
+			r:  r,
+			h:  nil,
+			ch: ch,
+		}
+	}
 	h := ch.New()
 	return HashReader{
 		r:  io.TeeReader(r, h),
@@ -58,16 +65,36 @@ func NewHashReader(r io.Reader, ch crypto.Hash) HashReader {
 func (h *HashReader) Read(p []byte) (n int, err error) { return h.r.Read(p) }
 
 // Sum implements hash.Hash.
-func (h *HashReader) Sum(p []byte) []byte { return h.h.Sum(p) }
+func (h *HashReader) Sum(p []byte) []byte {
+	if h.h == nil {
+		return nil
+	}
+	return h.h.Sum(p)
+}
 
 // Reset implements hash.Hash.
-func (h *HashReader) Reset() { h.h.Reset() }
+func (h *HashReader) Reset() {
+	if h.h == nil {
+		return
+	}
+	h.h.Reset()
+}
 
 // Size implements hash.Hash.
-func (h *HashReader) Size() int { return h.h.Size() }
+func (h *HashReader) Size() int {
+	if h.h == nil {
+		return 0
+	}
+	return h.h.Size()
+}
 
 // BlockSize implements hash.Hash.
-func (h *HashReader) BlockSize() int { return h.h.BlockSize() }
+func (h *HashReader) BlockSize() int {
+	if h.h == nil {
+		return 0
+	}
+	return h.h.BlockSize()
+}
 
 // Write implements hash.Hash
 func (h *HashReader) Write(p []byte) (int, error) { return 0, errors.New("not implemented") } //nolint: revive

--- a/internal/pkg/cosign/common_test.go
+++ b/internal/pkg/cosign/common_test.go
@@ -56,19 +56,39 @@ func Test_FileExists(t *testing.T) {
 
 func Test_HashReader(t *testing.T) {
 	input := []byte("hello world")
-	r := NewHashReader(bytes.NewReader(input), crypto.SHA256)
 
-	got, err := io.ReadAll(&r)
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("SHA256", func(t *testing.T) {
+		r := NewHashReader(bytes.NewReader(input), crypto.SHA256)
 
-	if !bytes.Equal(got, input) {
-		t.Errorf("io.ReadAll returned %s, want %s", got, input)
-	}
+		got, err := io.ReadAll(&r)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	gotHash := r.Sum(nil)
-	if hash := sha256.Sum256(input); !bytes.Equal(gotHash, hash[:]) {
-		t.Errorf("Sum returned %s, want %s", gotHash, hash)
-	}
+		if !bytes.Equal(got, input) {
+			t.Errorf("io.ReadAll returned %s, want %s", got, input)
+		}
+
+		gotHash := r.Sum(nil)
+		if hash := sha256.Sum256(input); !bytes.Equal(gotHash, hash[:]) {
+			t.Errorf("Sum returned %s, want %s", gotHash, hash)
+		}
+	})
+
+	t.Run("unspecified hash algorithm", func(t *testing.T) {
+		r := NewHashReader(bytes.NewReader(input), crypto.Hash(0))
+
+		got, err := io.ReadAll(&r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, input) {
+			t.Errorf("io.ReadAll returned %s, want %s", got, input)
+		}
+
+		if gotHash := r.Sum(nil); gotHash != nil {
+			t.Errorf("Sum returned %s, want nil", gotHash)
+		}
+	})
 }


### PR DESCRIPTION
#### Summary

This change updates the logic in `sign-blob` used to determine when Ed25519ph is disabled for Ed25519 keys (i.e., when transparency log upload is disabled) to take into account a user-provided signing config.