### PR TITLE
Fix crash verifying timestamps when no timestamp was verified

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1403,6 +1403,9 @@ func VerifyRFC3161Timestamp(sig oci.Signature, co *CheckOpts) (*timestamp.Timest
 		if len(verifyErrs) > 0 {
 			log.Printf("Warning: subset of signed timestamps failed to verify: %v", verifyErrs)
 		}
+		if len(verifiedTimestamps) == 0 {
+			return nil, fmt.Errorf("expected at least one verified timestamp")
+		}
 		return &timestamp.Timestamp{Time: verifiedTimestamps[0].Time}, nil
 	}
 

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -1841,6 +1841,18 @@ func TestVerifyRFC3161Timestamp(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "no TSA root certificate(s) provided to verify timestamp") {
 		t.Fatalf("expected error verifying without a root certificate, got: %v", err)
 	}
+
+	// failure with empty TrustedRoot
+	emptyTrustedRoot, err := root.NewTrustedRoot(root.TrustedRootMediaType01, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error creating empty trusted root: %v", err)
+	}
+	_, err = VerifyRFC3161Timestamp(ociSig, &CheckOpts{
+		TrustedMaterial: emptyTrustedRoot,
+	})
+	if err == nil || !strings.Contains(err.Error(), "expected at least one verified timestamp") {
+		t.Fatalf("expected error verifying with empty trusted root, got: %v", err)
+	}
 }
 
 // This test verifies that artifact verification rejects signatures


### PR DESCRIPTION
If no TSA chain in the trust root can verify a signed timestamp, then a crash would occur when Cosign tries to read one of the verified timestamps. We now throw an error if no timestamp was verified.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
