### PR TITLE
Fix unsafe type assertion in Rego policy evaluation

### DIFF
--- a/pkg/cosign/rego/rego.go
+++ b/pkg/cosign/rego/rego.go
@@ -138,7 +138,10 @@ func ValidateJSONWithModuleInput(jsonBody []byte, moduleInput string) (warnings 
 func evaluateRegoEvalMapResult(query string, response []interface{}) (warning error, retErr error) {
 	retErr = fmt.Errorf("policy is not compliant for query %q", query) //nolint: revive
 	for _, r := range response {
-		rMap := r.(map[string]interface{})
+		rMap, ok := r.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("policy is not compliant for query '%s': unexpected result type %T", query, r)
+		}
 		mapBytes, err := json.Marshal(rMap)
 		if err != nil {
 			return nil, fmt.Errorf("policy is not compliant for query '%s' due to parsing errors: %w", query, err)


### PR DESCRIPTION
`evaluateRegoEvalMapResult` asserts each element in the Rego response array as `map[string]interface{}` without an ok check. If a policy returns a non-map value in the array (e.g., a string or bool), cosign panics instead of returning a policy evaluation error.

## Failure scenario

A Rego policy evaluated via `cosign verify-attestation --policy` can return an `[]interface{}` where individual elements are not maps. The OPA evaluation engine does not constrain element types. When the assertion at `rego.go:141` encounters a non-map element, it panics with:

```
interface conversion: interface {} is string, not map[string]interface {}
```

The caller at line 127 type-switches on the top-level binding (bool vs []interface{}) but never validates the inner element types.

## Fix

Add an ok check to the type assertion and return a descriptive error on type mismatch instead of panicking.

## Bug origin

Introduced in b2cea0c68 (2022-12-28), present for over 3 years.