### PR TITLE
Fix unsafe DefaultTransport type assertions

### DIFF
--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -154,7 +154,12 @@ func (o *RegistryOptions) GetRegistryClientOpts(ctx context.Context) []remote.Op
 
 	tlsConfig, err := o.getTLSConfig()
 	if err == nil {
-		tr := http.DefaultTransport.(*http.Transport).Clone()
+		var tr *http.Transport
+		if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+			tr = dt.Clone()
+		} else {
+			tr = &http.Transport{}
+		}
 		tr.TLSClientConfig = tlsConfig
 		opts = append(opts, remote.WithTransport(tr))
 	}

--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -79,7 +79,12 @@ func (ga *githubActions) Provide(ctx context.Context, audience string) (string, 
 			// DefaultClient will fail because it will just use HTTP2 again.
 			// I don't know why go doesn't do this for us.
 			if strings.Contains(err.Error(), "HTTP_1_1_REQUIRED") {
-				http1transport := http.DefaultTransport.(*http.Transport).Clone()
+				var http1transport *http.Transport
+				if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+					http1transport = dt.Clone()
+				} else {
+					http1transport = &http.Transport{}
+				}
 				http1transport.ForceAttemptHTTP2 = false
 
 				client = &http.Client{


### PR DESCRIPTION
Two call sites assert `http.DefaultTransport` as `*http.Transport` without an ok check, panicking if `DefaultTransport` has been replaced by tracing, proxy, or other middleware wrappers:

- `cmd/cosign/cli/options/registry.go:157` -- registry TLS config path
- `pkg/providers/github/github.go:82` -- HTTP/1.1 fallback on OIDC token fetch

## Failure scenario

Any middleware that wraps `http.DefaultTransport` with a non-`*http.Transport` type (e.g., OpenTelemetry instrumentation, corporate proxy wrappers, or test harnesses) causes a panic:

```
interface conversion: http.RoundTripper is *otelhttp.Transport, not *http.Transport
```

The registry path (`registry.go:157`) is hit whenever a custom CA cert or TLS client cert is configured. The GitHub OIDC path (`github.go:82`) is hit when a GitHub Actions runner encounters an HTTP/2 protocol error.

## Fix

Use a guarded type assertion with a fallback to a fresh `http.Transport` when the cast fails. This preserves the existing behavior when `DefaultTransport` is the standard type, and avoids a panic when it has been wrapped.

## Bug origins

- `registry.go`: introduced in d01988ed7 (2025-01-13)
- `github.go`: introduced in c049cef04 (2023-08-09)

## Related

This is the same class of bug as kubernetes/kubernetes `DefaultTransport` assertions ([F015 in k8s audit](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/server/egressselector/egress_selector.go#L46)).