### PR TITLE
Enable initialize command output in conformance

### DIFF
--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -150,6 +150,8 @@ func main() {
 
 	dir := filepath.Dir(os.Args[0])
 	initCmd := exec.Command(filepath.Join(dir, "cosign"), "initialize") // #nosec G204,G702 -- conformance harness invokes the sibling cosign binary
+	initCmd.Stdout = os.Stdout
+	initCmd.Stderr = os.Stderr
 	err := initCmd.Run()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
#### Summary

This change updates the conformance harness so that the output of the `initialize` command is printed, in case a test fails due to an error from the run of `initialize`.