### PR TITLE
fix: wire insecure-skip-verify to bundle generation

### DIFF
--- a/cmd/cosign/cli/options/fulcio.go
+++ b/cmd/cosign/cli/options/fulcio.go
@@ -46,6 +46,5 @@ func (o *FulcioOptions) AddFlags(cmd *cobra.Command) {
 		"fulcio interactive oauth2 flow to use for certificate from fulcio. Defaults to determining the flow based on the runtime environment. (options) normal|device|token|client_credentials")
 
 	cmd.Flags().BoolVar(&o.InsecureSkipFulcioVerify, "insecure-skip-verify", false,
-		"skip verifying fulcio published to the SCT (this should only be used for testing).")
-	_ = cmd.Flags().MarkDeprecated("insecure-skip-verify", "SCT verification is no longer performed during signing/attestation.")
+		"skip strict certificate verification, useful for BYOC workflows.")
 }

--- a/cmd/cosign/cli/options/key.go
+++ b/cmd/cosign/cli/options/key.go
@@ -54,9 +54,9 @@ type KeyOpts struct {
 	// for valid values.
 	FulcioAuthFlow string
 
-	// Deprecated: SCT verification is no longer performed during signing/attestation.
 	// Modeled after InsecureSkipVerify in tls.Config, this disables
-	// verifying the SCT.
+	// strict leaf certificate verification, which is necessary for BYOC
+	// (Bring Your Own Certificate) workflows.
 	InsecureSkipFulcioVerify bool
 
 	// TrustedMaterial contains trusted metadata for all Sigstore services. It is exclusive with RekorPubKeys, RootCerts, IntermediateCerts, CTLogPubKeys, and the TSA* cert fields.

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -292,6 +292,7 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	cbundleOpts := cbundle.SignOptions{
 		TSAClientTransport:  tsaClientTransport,
 		CertificateProvider: certProvider,
+		InsecureSkipVerify:  ko.InsecureSkipFulcioVerify,
 	}
 
 	ociSigs := make([]oci.Signature, len(payloads))

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -122,7 +122,11 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 			return nil, fmt.Errorf("getting TSA client transport: %w", err)
 		}
 	}
-	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
+	signOpts := cbundle.SignOptions{
+		TSAClientTransport: tsaClientTransport,
+		InsecureSkipVerify: ko.InsecureSkipFulcioVerify,
+	}
+
 	bundleBytes, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, ko.SigningConfig, ko.TrustedMaterial, signOpts)
 	if err != nil {
 		return nil, fmt.Errorf("signing bundle: %w", err)

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -34,12 +34,14 @@ import (
 type SignOptions struct {
 	TSAClientTransport  http.RoundTripper
 	CertificateProvider sign.CertificateProvider
+	InsecureSkipVerify  bool
 }
 
 func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, idToken string, cert []byte, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial, opts SignOptions) ([]byte, error) {
 	var bundleOpts sign.BundleOptions
 
-	if trustedMaterial != nil {
+	// Do not pass TrustedRoot if we are skipping verification
+	if trustedMaterial != nil && !opts.InsecureSkipVerify {
 		bundleOpts.TrustedRoot = trustedMaterial
 	}
 


### PR DESCRIPTION
Fixes #4865

When the \`--insecure-skip-verify\` flag was marked deprecated due to the removal of SCT verification, it inadvertently broke BYOC (Bring Your Own Certificate) workflows. The bundle generator in v3 strictly verified custom leaf certificates against public roots because the skip flag was dropped.

This commit:
- Un-deprecates the flag and clarifies its requirement for BYOC.
- Adds an InsecureSkipVerify field to bundle.SignOptions.
- Prevents assigning a TrustedRoot in bundle.SignData if skipped.
- Wires the CLI flag down to the bundle options for both blobs and images.

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
**Motivation & Problem:**
When the `--insecure-skip-verify` flag was deprecated in v3 (due to the removal of SCT verification), it inadvertently broke the BYOC (Bring Your Own Certificate) workflow. Enterprise users relying on custom certificates were hitting a `failed to verify leaf certificate` error during bundle generation. The CLI correctly parsed the flag but dropped it before handing off to the bundle builder. As a result, `bundleOpts.TrustedRoot` was being populated unconditionally in `pkg/cosign/bundle/sign.go`, forcing the underlying `sigstore-go` library to strictly verify custom leaf certs against public roots.

This PR fixes this regression by:
1. Un-deprecating the `--insecure-skip-verify` flag and clarifying its requirement for BYOC workflows.
2. Adding an `InsecureSkipVerify` boolean to `bundle.SignOptions`.
3. Updating `bundle.SignData` to block the assignment of `TrustedRoot` if skipped.
4. Wiring the CLI flag down to the bundle options for both blobs and images.

**How reviewers can test:**
1. Generate a local Root CA and Leaf Certificate with `codeSigning` extensions.
2. Attempt to sign a blob or image using `--certificate`, `--key`, and `--certificate-chain` alongside `--insecure-skip-verify=true`.
3. Verify that the bundle signs successfully without triggering the leaf certificate verification crash.

#### Release Note
Fixed a regression where signing with custom certificates (BYOC) failed with a `leaf certificate verification failed` error during bundle generation. Un-deprecated the `--insecure-skip-verify` CLI flag and properly wired it to bypass strict root verification when generating bundles with custom certificates.

#### Documentation
CLI help text and struct documentation for `--insecure-skip-verify` have been updated inline to clarify its active role in bypassing strict verification for BYOC workflows. No external documentation PR is currently linked, but the CLI reference will automatically reflect the un-deprecation.