### PR TITLE
fix: report certificate and timestamp verification checks

### DIFF
--- a/cmd/cosign/cli/verify/common.go
+++ b/cmd/cosign/cli/verify/common.go
@@ -200,7 +200,7 @@ func SetTrustedMaterial(ctx context.Context, trustedRootPath, certChain, caRoots
 }
 
 // PrintVerificationHeader prints boilerplate information after successful verification.
-func PrintVerificationHeader(ctx context.Context, imgRef string, co *cosign.CheckOpts, bundleVerified, fulcioVerified bool) {
+func PrintVerificationHeader(ctx context.Context, imgRef string, co *cosign.CheckOpts, bundleVerified, fulcioVerified, certVerified bool) {
 	ui.Infof(ctx, "\nVerification for %s --", imgRef)
 	ui.Infof(ctx, "The following checks were performed on each of these signatures:")
 	if co.ClaimVerifier != nil {
@@ -217,6 +217,12 @@ func PrintVerificationHeader(ctx context.Context, imgRef string, co *cosign.Chec
 	}
 	if co.SigVerifier != nil {
 		ui.Infof(ctx, "  - The signatures were verified against the specified public key")
+	}
+	if certVerified {
+		ui.Infof(ctx, "  - The signing certificate was verified using trusted certificate authority certificates")
+	}
+	if co.UseSignedTimestamps {
+		ui.Infof(ctx, "  - The RFC3161 timestamp was verified using trusted timestamp authority certificates")
 	}
 	if fulcioVerified {
 		ui.Infof(ctx, "  - The code-signing certificate was verified using trusted certificate authority certificates")

--- a/cmd/cosign/cli/verify/common_test.go
+++ b/cmd/cosign/cli/verify/common_test.go
@@ -70,6 +70,29 @@ func TestSetTrustedMaterialLegacyTUFFallback(t *testing.T) {
 	}
 }
 
+func TestPrintVerificationHeaderIncludesCertificateAndTimestampChecks(t *testing.T) {
+	co := &cosign.CheckOpts{
+		ClaimVerifier:       cosign.SimpleClaimVerifier,
+		UseSignedTimestamps: true,
+	}
+
+	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+		PrintVerificationHeader(ctx, "example.com/repo/image:tag", co, false, false, true)
+	})
+
+	for _, want := range []string{
+		"Verification for example.com/repo/image:tag --",
+		"The following checks were performed on each of these signatures:",
+		"  - The cosign claims were validated",
+		"  - The signing certificate was verified using trusted certificate authority certificates",
+		"  - The RFC3161 timestamp was verified using trusted timestamp authority certificates",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Fatalf("expected header to contain %q, got %q", want, stderr)
+		}
+	}
+}
+
 func setBrokenTrustedRootTUFEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv(env.VariableTUFRootDir.String(), t.TempDir())

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -221,7 +221,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 					return err
 				}
 			}
-			PrintVerificationHeader(ctx, img, co, bundleVerified, fulcioVerified)
+			PrintVerificationHeader(ctx, img, co, bundleVerified, fulcioVerified, c.CertRef != "")
 			PrintVerification(ctx, verified, c.Output)
 		} else {
 			ref, err := name.ParseReference(img, c.NameOptions...)
@@ -252,7 +252,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 				}
 			}
 
-			PrintVerificationHeader(ctx, ref.Name(), co, bundleVerified, fulcioVerified)
+			PrintVerificationHeader(ctx, ref.Name(), co, bundleVerified, fulcioVerified, c.CertRef != "")
 			PrintVerification(ctx, verified, c.Output)
 		}
 	}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -269,7 +269,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		}
 
 		// TODO: add CUE validation report to `PrintVerificationHeader`.
-		PrintVerificationHeader(ctx, imageRef, co, bundleVerified, fulcioVerified)
+		PrintVerificationHeader(ctx, imageRef, co, bundleVerified, fulcioVerified, c.CertRef != "")
 		// The attestations are always JSON, so use the raw "text" mode for outputting them instead of conversion
 		PrintVerification(ctx, checked, "text")
 	}


### PR DESCRIPTION
## Summary
- report certificate-chain verification in `cosign verify` output when verification used a supplied certificate
- report RFC3161 timestamp verification in the success header when signed timestamp verification was enabled
- cover the new success lines with a focused header-output test

This addresses the output-precision parts of #4817. Custom CT log support is intentionally left out of scope.

## Testing
- `PATH=/tmp/go1.26.3/bin:$PATH go test ./cmd/cosign/cli/verify -run TestPrintVerificationHeaderIncludesCertificateAndTimestampChecks -count=1`
- `PATH=/tmp/go1.26.3/bin:$PATH go test ./cmd/cosign/cli/verify -count=1`
- `git diff --check`