### PR TITLE
Add staging support to conformance testing

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -26,6 +26,9 @@ permissions:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [ production, staging ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -45,6 +48,7 @@ jobs:
       - uses: sigstore/sigstore-conformance@main
         with:
           entrypoint: ${{ github.workspace }}/conformance
+          environment: ${{ matrix.environment }}
           xfail: "test_verify*PATH-message-digest-mismatch_fail]"
 
       - name: Create Issue on Failure
@@ -55,8 +59,8 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const runId = context.runId;
-            const issueTitle = 'Conformance Tests Failed';
-            const issueBody = `The nightly conformance tests have failed. Please check the logs for more details.\n\nWorkflow run: https://github.com/${owner}/${repo}/actions/runs/${runId}\n\ncc @sigstore/security-response-team @sigstore/cosign-codeowners`;
+            const issueTitle = 'Conformance Tests Failed (${{ matrix.environment }})';
+            const issueBody = `The nightly conformance tests have failed on ${{ matrix.environment }}. Please check the logs for more details.\n\nWorkflow run: https://github.com/${owner}/${repo}/actions/runs/${runId}\n\ncc @sigstore/security-response-team @sigstore/cosign-codeowners`;
             const issueLabel = 'bug';
 
             const existingIssues = await github.rest.issues.listForRepo({

--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -28,6 +28,9 @@ permissions:
 jobs:
   conformance:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: [ production, staging ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -47,4 +50,5 @@ jobs:
       - uses: sigstore/sigstore-conformance@e2cc8e51870bb9af4e4ae3342e97cf5f7ea2cdd8 # v0.0.28
         with:
           entrypoint: ${{ github.workspace }}/conformance
+          environment: ${{ matrix.environment }}
           xfail: "test_verify*PATH-message-digest-mismatch_fail]"

--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -33,22 +33,17 @@ var trustedRootPath *string
 var signingConfigPath *string
 var keyPath *string
 var inToto bool
+var staging bool
 
 func usage() {
 	fmt.Println("Usage:")
-	fmt.Printf("\t%s sign-bundle [--in-toto] --identity-token TOKEN [--signing-config FILE] [--trusted-root FILE] --bundle FILE FILE\n", os.Args[0])
-	fmt.Printf("\t%s verify-bundle --bundle FILE [--certificate-identity IDENTITY --certificate-oidc-issuer URL] [--key FILE] [--trusted-root FILE] FILE\n", os.Args[0])
+	fmt.Printf("\t%s sign-bundle [--staging] [--in-toto] --identity-token TOKEN [--signing-config FILE] [--trusted-root FILE] --bundle FILE FILE\n", os.Args[0])
+	fmt.Printf("\t%s verify-bundle [--staging] --bundle FILE [--certificate-identity IDENTITY --certificate-oidc-issuer URL] [--key FILE] [--trusted-root FILE] FILE\n", os.Args[0])
 }
 
 func parseArgs() {
 	for i := 2; i < len(os.Args); {
 		switch os.Args[i] {
-		// TODO: support staging (see https://github.com/sigstore/cosign/issues/2434)
-		//
-		// Today cosign signing does not yet use sigstore-go, and so we would
-		// need to make some clever invocation of `cosign initialize` to
-		// support staging. Instead it might make sense to wait for cosign
-		// signing to use sigstore-go.
 		case "--bundle":
 			bundlePath = &os.Args[i+1]
 			i += 2
@@ -72,6 +67,9 @@ func parseArgs() {
 			i += 2
 		case "--in-toto":
 			inToto = true
+			i++
+		case "--staging":
+			staging = true
 			i++
 		default:
 			i++
@@ -149,7 +147,11 @@ func main() {
 	args = append(args, os.Args[len(os.Args)-1])
 
 	dir := filepath.Dir(os.Args[0])
-	initCmd := exec.Command(filepath.Join(dir, "cosign"), "initialize") // #nosec G204,G702 -- conformance harness invokes the sibling cosign binary
+	initArgs := []string{"initialize"}
+	if staging {
+		initArgs = append(initArgs, "--staging")
+	}
+	initCmd := exec.Command(filepath.Join(dir, "cosign"), initArgs...) // #nosec G204,G702 -- conformance harness invokes the sibling cosign binary
 	initCmd.Stdout = os.Stdout
 	initCmd.Stderr = os.Stderr
 	err := initCmd.Run()


### PR DESCRIPTION
#### Summary

This change updates the conformance testing harness to accept the `--staging` flag from conformance and adds staging runs to the conformance testing workflows.