### PR TITLE
fix(verify): copy CheckOpts inside VerifyNewBundle to fix data race

### DIFF
--- a/pkg/cosign/verify_bundle.go
+++ b/pkg/cosign/verify_bundle.go
@@ -23,10 +23,15 @@ import (
 
 // VerifyNewBundle verifies a Sigstore bundle with the given parameters
 func VerifyNewBundle(_ context.Context, co *CheckOpts, artifactPolicyOption verify.ArtifactPolicyOption, bundle verify.SignedEntity) (*verify.VerificationResult, error) {
-	if err := rekorV2Bundle(bundle, co); err != nil {
+	// Copy co so rekorV2Bundle's UseSignedTimestamps write stays per-call and
+	// doesn't race a *CheckOpts shared across goroutines.
+	// TODO(cody)(cosign v4): Consider changing function signature to take a
+	// non-pointer CheckOpts and avoid this copy.
+	coCopy := *co
+	if err := rekorV2Bundle(bundle, &coCopy); err != nil {
 		return nil, err
 	}
-	trustedMaterial, verifierOptions, policyOptions, err := co.verificationOptions()
+	trustedMaterial, verifierOptions, policyOptions, err := coCopy.verificationOptions()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/verify_bundle_test.go
+++ b/pkg/cosign/verify_bundle_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"sync"
 	"testing"
 
 	protobundle "github.com/sigstore/protobuf-specs/gen/pb-go/bundle/v1"
@@ -453,6 +454,67 @@ func makeTlogEntry(t *testing.T, integratedTime int64) *tlog.Entry {
 		t.Fatal(err)
 	}
 	return entry
+}
+
+// rekorV2Entity wraps a real SignedEntity but reports caller-supplied tlog
+// entries, letting a test force the Rekor v2 code path (an entry with no
+// integrated time) that makes rekorV2Bundle write co.UseSignedTimestamps.
+type rekorV2Entity struct {
+	verify.SignedEntity
+	entries []*tlog.Entry
+}
+
+func (e *rekorV2Entity) TlogEntries() ([]*tlog.Entry, error) {
+	return e.entries, nil
+}
+
+// TestVerifyNewBundleConcurrentNoDataRace guards against the data race where the
+// attestation verification fan-out shares one *CheckOpts across goroutines:
+// VerifyNewBundle -> rekorV2Bundle writes co.UseSignedTimestamps for a Rekor v2
+// bundle while sibling goroutines read it in co.verificationOptions(). Run with
+// -race; without VerifyNewBundle copying co, the detector fires.
+func TestVerifyNewBundleConcurrentNoDataRace(t *testing.T) {
+	virtualSigstore, err := ca.NewVirtualSigstore()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	artifact := []byte("artifact")
+	digest := sha256.Sum256(artifact)
+	digestHex := hex.EncodeToString(digest[:])
+	statement := []byte(fmt.Sprintf(`{"_type":"https://in-toto.io/Statement/v0.1","predicateType":"https://example.com/predicateType","subject":[{"name":"subject","digest":{"sha256":"%s"}}],"predicate":{}}`, digestHex))
+	attestation, err := virtualSigstore.Attest("foo@example.com", "example issuer", statement)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Report a single Rekor v2 entry (zero integrated time, no v1 entry) so
+	// rekorV2Bundle sets co.UseSignedTimestamps during verification.
+	bundle := &rekorV2Entity{SignedEntity: attestation, entries: []*tlog.Entry{makeTlogEntry(t, 0)}}
+
+	// One *CheckOpts shared across goroutines, exactly as verifyImageAttestationsSigstoreBundle shares it.
+	co := &CheckOpts{
+		Identities:      []Identity{{Issuer: "example issuer", Subject: "foo@example.com"}},
+		IgnoreSCT:       true,
+		TrustedMaterial: virtualSigstore,
+	}
+	artifactPolicyOption := verify.WithArtifact(bytes.NewReader(artifact))
+
+	const goroutines = 50
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start // release all goroutines together to widen the race window
+			// Verification against the synthetic tlog entry is expected to fail;
+			// the test only asserts the concurrent calls don't race on co.
+			_, _ = VerifyNewBundle(context.Background(), co, artifactPolicyOption, bundle)
+		}()
+	}
+	close(start)
+	wg.Wait()
 }
 
 func TestRekorV2Bundle(t *testing.T) {


### PR DESCRIPTION
## Summary

`verifyImageAttestationsSigstoreBundle` fans out one goroutine per bundle, all sharing a single `*CheckOpts`. Inside each goroutine, `VerifyNewBundle -> rekorV2Bundle` writes `co.UseSignedTimestamps` when it sees a Rekor v2 entry, which races sibling goroutines reading `co` via `co.verificationOptions()`.

This fixes the race at the chokepoint every caller funnels through: `VerifyNewBundle` now copies `co` once and verifies against the copy, so the opportunistic write can't escape to a shared `*CheckOpts`. A shallow copy suffices — `rekorV2Bundle` only writes `UseSignedTimestamps` (a `bool`), and no other path under `VerifyNewBundle` mutates `co`'s pointer/map fields.

## Test

Adds `TestVerifyNewBundleConcurrentNoDataRace`, which fans out concurrent verifications of a Rekor v2 bundle against one shared `CheckOpts`. It passes normally and fails under `-race` if the per-call copy is removed.