### PR TITLE
Remove xfail from nightly conformance workflow

### DIFF
--- a/.github/workflows/conformance-nightly.yml
+++ b/.github/workflows/conformance-nightly.yml
@@ -49,7 +49,6 @@ jobs:
         with:
           entrypoint: ${{ github.workspace }}/conformance
           environment: ${{ matrix.environment }}
-          xfail: "test_verify*PATH-message-digest-mismatch_fail]"
 
       - name: Create Issue on Failure
         if: failure()


### PR DESCRIPTION
#### Summary

This change removes the `test_verify*PATH-message-digest-mismatch_fail]` xfail from the nightly conformance workflow, as the test now passes due to #4914.