### PR TITLE
docs: add Example fields to env and bundle create commands

### DIFF
--- a/cmd/cosign/cli/bundle.go
+++ b/cmd/cosign/cli/bundle.go
@@ -44,6 +44,11 @@ func bundleCreate() *cobra.Command {
 		Use:   "create",
 		Short: "Create a Sigstore protobuf bundle",
 		Long:  "Create a Sigstore protobuf bundle by supplying signed material",
+		Example: `  # create a bundle from a signature and certificate
+  cosign bundle create --artifact <path> --signature <sig> --certificate <cert> --out bundle.sigstore.json
+
+  # create a bundle from an attestation
+  cosign bundle create --artifact <path> --attestation <att> --out bundle.sigstore.json`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			bundleCreateCmd := &bundle.CreateCmd{
 				Artifact:             o.Artifact,

--- a/cmd/cosign/cli/env.go
+++ b/cmd/cosign/cli/env.go
@@ -32,7 +32,14 @@ func Env() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "env",
 		Short: "Prints Cosign environment variables",
-		Args:  cobra.NoArgs,
+		Example: `  cosign env
+
+  # show environment variables with descriptions
+  cosign env --show-descriptions
+
+  # show environment variables including sensitive values
+  cosign env --show-descriptions --show-sensitive-values`,
+		Args: cobra.NoArgs,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			envVars := env.EnvironmentVariables()
 			printEnv(envVars, getEnv(), getEnviron(), o.ShowDescriptions, o.ShowSensitiveValues)

--- a/doc/cosign_bundle_create.md
+++ b/doc/cosign_bundle_create.md
@@ -10,6 +10,16 @@ Create a Sigstore protobuf bundle by supplying signed material
 cosign bundle create [flags]
 ```
 
+### Examples
+
+```
+  # create a bundle from a signature and certificate
+  cosign bundle create --artifact <path> --signature <sig> --certificate <cert> --out bundle.sigstore.json
+
+  # create a bundle from an attestation
+  cosign bundle create --artifact <path> --attestation <att> --out bundle.sigstore.json
+```
+
 ### Options
 
 ```

--- a/doc/cosign_env.md
+++ b/doc/cosign_env.md
@@ -6,6 +6,18 @@ Prints Cosign environment variables
 cosign env [flags]
 ```
 
+### Examples
+
+```
+  cosign env
+
+  # show environment variables with descriptions
+  cosign env --show-descriptions
+
+  # show environment variables including sensitive values
+  cosign env --show-descriptions --show-sensitive-values
+```
+
 ### Options
 
 ```


### PR DESCRIPTION
Add `Example:` fields to the `env` and `bundle create` cobra commands, which previously had no examples in their help output.

- `cosign env`: show plain invocation plus `--show-descriptions` and `--show-sensitive-values` usage.
- `cosign bundle create`: show signature+certificate bundle creation and attestation bundle creation.

The example style matches other commands in the CLI (backtick string, `  cosign <cmd>` prefix, `# comment` for labels).