### PR TITLE
docs: fix Short style and add Example fields to piv-tool subcommands

### DIFF
--- a/cmd/cosign/cli/piv_tool.go
+++ b/cmd/cosign/cli/piv_tool.go
@@ -56,7 +56,15 @@ func pivToolSetManagementKey() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:              "set-management-key",
-		Short:            "sets the management key of a hardware token",
+		Short:            "Set the management key of a hardware token",
+		Example: `  # set a new management key interactively (uses defaults if flags omitted)
+  cosign piv-tool set-management-key
+
+  # set a random management key
+  cosign piv-tool set-management-key --random-management-key
+
+  # set a specific new management key
+  cosign piv-tool set-management-key --old-key <old-key> --new-key <new-key>`,
 		Args:             cobra.ExactArgs(0),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -74,7 +82,12 @@ func pivToolSetPIN() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:              "set-pin",
-		Short:            "sets the PIN on a hardware token",
+		Short:            "Set the PIN on a hardware token",
+		Example: `  # set a new PIN interactively (uses defaults if flags omitted)
+  cosign piv-tool set-pin
+
+  # set a specific PIN
+  cosign piv-tool set-pin --old-pin <old-pin> --new-pin <new-pin>`,
 		Args:             cobra.ExactArgs(0),
 		PersistentPreRun: options.BindViper,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -92,7 +105,12 @@ func pivToolSetPUK() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "set-puk",
-		Short: "sets the PUK on a hardware token",
+		Short: "Set the PUK on a hardware token",
+		Example: `  # set a new PUK interactively (uses defaults if flags omitted)
+  cosign piv-tool set-puk
+
+  # set a specific PUK
+  cosign piv-tool set-puk --old-puk <old-puk> --new-puk <new-puk>`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pivcli.SetPukCmd(cmd.Context(), o.OldPUK, o.NewPUK)
@@ -109,7 +127,9 @@ func pivToolUnblock() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "unblock",
-		Short: "unblocks the hardware token, sets a new PIN",
+		Short: "Unblock a hardware token and set a new PIN",
+		Example: `  # unblock the token using the PUK and set a new PIN
+  cosign piv-tool unblock --puk <puk> --new-PIN <new-pin>`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pivcli.UnblockCmd(cmd.Context(), o.PUK, o.NewPIN)
@@ -126,7 +146,12 @@ func pivToolAttestation() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "attestation",
-		Short: "attestation contains commands to manage a hardware token",
+		Short: "Manage hardware token attestations",
+		Example: `  # print attestation information as text
+  cosign piv-tool attestation --slot 9c
+
+  # print attestation information as JSON
+  cosign piv-tool attestation --slot 9c --output json`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			a, err := pivcli.AttestationCmd(cmd.Context(), o.Slot)
@@ -154,7 +179,12 @@ func pivToolGenerateKey() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "generate-key",
-		Short: "generate-key generates a new signing key on the hardware token",
+		Short: "Generate a new signing key on the hardware token",
+		Example: `  # generate a key with default settings (slot 9c, always-touch policy)
+  cosign piv-tool generate-key
+
+  # generate a key in a specific slot with custom PIN and touch policies
+  cosign piv-tool generate-key --slot 9c --pin-policy once --touch-policy always`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pivcli.GenerateKeyCmd(cmd.Context(), o.ManagementKey, o.RandomKey,
@@ -170,7 +200,8 @@ func pivToolGenerateKey() *cobra.Command {
 func pivToolResetKey() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reset",
-		Short: "reset resets the hardware token completely",
+		Short: "Reset the hardware token completely",
+		Example: `  cosign piv-tool reset`,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pivcli.ResetKeyCmd(cmd.Context())

--- a/doc/cosign_piv-tool.md
+++ b/doc/cosign_piv-tool.md
@@ -20,11 +20,11 @@ Provides utilities for managing a hardware token
 ### SEE ALSO
 
 * [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry
-* [cosign piv-tool attestation](cosign_piv-tool_attestation.md)	 - attestation contains commands to manage a hardware token
-* [cosign piv-tool generate-key](cosign_piv-tool_generate-key.md)	 - generate-key generates a new signing key on the hardware token
-* [cosign piv-tool reset](cosign_piv-tool_reset.md)	 - reset resets the hardware token completely
-* [cosign piv-tool set-management-key](cosign_piv-tool_set-management-key.md)	 - sets the management key of a hardware token
-* [cosign piv-tool set-pin](cosign_piv-tool_set-pin.md)	 - sets the PIN on a hardware token
-* [cosign piv-tool set-puk](cosign_piv-tool_set-puk.md)	 - sets the PUK on a hardware token
-* [cosign piv-tool unblock](cosign_piv-tool_unblock.md)	 - unblocks the hardware token, sets a new PIN
+* [cosign piv-tool attestation](cosign_piv-tool_attestation.md)	 - Manage hardware token attestations
+* [cosign piv-tool generate-key](cosign_piv-tool_generate-key.md)	 - Generate a new signing key on the hardware token
+* [cosign piv-tool reset](cosign_piv-tool_reset.md)	 - Reset the hardware token completely
+* [cosign piv-tool set-management-key](cosign_piv-tool_set-management-key.md)	 - Set the management key of a hardware token
+* [cosign piv-tool set-pin](cosign_piv-tool_set-pin.md)	 - Set the PIN on a hardware token
+* [cosign piv-tool set-puk](cosign_piv-tool_set-puk.md)	 - Set the PUK on a hardware token
+* [cosign piv-tool unblock](cosign_piv-tool_unblock.md)	 - Unblock a hardware token and set a new PIN
 

--- a/doc/cosign_piv-tool_attestation.md
+++ b/doc/cosign_piv-tool_attestation.md
@@ -1,9 +1,19 @@
 ## cosign piv-tool attestation
 
-attestation contains commands to manage a hardware token
+Manage hardware token attestations
 
 ```
 cosign piv-tool attestation [flags]
+```
+
+### Examples
+
+```
+  # print attestation information as text
+  cosign piv-tool attestation --slot 9c
+
+  # print attestation information as JSON
+  cosign piv-tool attestation --slot 9c --output json
 ```
 
 ### Options

--- a/doc/cosign_piv-tool_generate-key.md
+++ b/doc/cosign_piv-tool_generate-key.md
@@ -1,9 +1,19 @@
 ## cosign piv-tool generate-key
 
-generate-key generates a new signing key on the hardware token
+Generate a new signing key on the hardware token
 
 ```
 cosign piv-tool generate-key [flags]
+```
+
+### Examples
+
+```
+  # generate a key with default settings (slot 9c, always-touch policy)
+  cosign piv-tool generate-key
+
+  # generate a key in a specific slot with custom PIN and touch policies
+  cosign piv-tool generate-key --slot 9c --pin-policy once --touch-policy always
 ```
 
 ### Options

--- a/doc/cosign_piv-tool_reset.md
+++ b/doc/cosign_piv-tool_reset.md
@@ -1,9 +1,15 @@
 ## cosign piv-tool reset
 
-reset resets the hardware token completely
+Reset the hardware token completely
 
 ```
 cosign piv-tool reset [flags]
+```
+
+### Examples
+
+```
+  cosign piv-tool reset
 ```
 
 ### Options

--- a/doc/cosign_piv-tool_set-management-key.md
+++ b/doc/cosign_piv-tool_set-management-key.md
@@ -1,9 +1,22 @@
 ## cosign piv-tool set-management-key
 
-sets the management key of a hardware token
+Set the management key of a hardware token
 
 ```
 cosign piv-tool set-management-key [flags]
+```
+
+### Examples
+
+```
+  # set a new management key interactively (uses defaults if flags omitted)
+  cosign piv-tool set-management-key
+
+  # set a random management key
+  cosign piv-tool set-management-key --random-management-key
+
+  # set a specific new management key
+  cosign piv-tool set-management-key --old-key <old-key> --new-key <new-key>
 ```
 
 ### Options

--- a/doc/cosign_piv-tool_set-pin.md
+++ b/doc/cosign_piv-tool_set-pin.md
@@ -1,9 +1,19 @@
 ## cosign piv-tool set-pin
 
-sets the PIN on a hardware token
+Set the PIN on a hardware token
 
 ```
 cosign piv-tool set-pin [flags]
+```
+
+### Examples
+
+```
+  # set a new PIN interactively (uses defaults if flags omitted)
+  cosign piv-tool set-pin
+
+  # set a specific PIN
+  cosign piv-tool set-pin --old-pin <old-pin> --new-pin <new-pin>
 ```
 
 ### Options

--- a/doc/cosign_piv-tool_set-puk.md
+++ b/doc/cosign_piv-tool_set-puk.md
@@ -1,9 +1,19 @@
 ## cosign piv-tool set-puk
 
-sets the PUK on a hardware token
+Set the PUK on a hardware token
 
 ```
 cosign piv-tool set-puk [flags]
+```
+
+### Examples
+
+```
+  # set a new PUK interactively (uses defaults if flags omitted)
+  cosign piv-tool set-puk
+
+  # set a specific PUK
+  cosign piv-tool set-puk --old-puk <old-puk> --new-puk <new-puk>
 ```
 
 ### Options

--- a/doc/cosign_piv-tool_unblock.md
+++ b/doc/cosign_piv-tool_unblock.md
@@ -1,9 +1,16 @@
 ## cosign piv-tool unblock
 
-unblocks the hardware token, sets a new PIN
+Unblock a hardware token and set a new PIN
 
 ```
 cosign piv-tool unblock [flags]
+```
+
+### Examples
+
+```
+  # unblock the token using the PUK and set a new PIN
+  cosign piv-tool unblock --puk <puk> --new-PIN <new-pin>
 ```
 
 ### Options


### PR DESCRIPTION
Fix `Short:` description style and add `Example:` fields to all seven `piv-tool` subcommands.

**Short: fixes (7 commands):** capitalize first letter and remove self-referencing command-name prefix (`generate-key generates...` → `Generate a new signing key...`, `reset resets...` → `Reset the hardware token...`).

**Example: additions (7 commands):** `set-management-key`, `set-pin`, `set-puk`, `unblock`, `attestation`, `generate-key`, `reset` — using the same backtick-string format as other commands in the CLI.

Regenerated `doc/` via `cmd/help/main.go`.