### PR TITLE
docs: fix Short style and add Example fields to pkcs11-tool subcommands

### DIFF
--- a/cmd/cosign/cli/pkcs11_tool.go
+++ b/cmd/cosign/cli/pkcs11_tool.go
@@ -49,8 +49,10 @@ func pkcs11ToolListTokens() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list-tokens",
-		Short: "list-tokens lists all PKCS11 tokens linked to a PKCS11 module",
-		Args:  cobra.ExactArgs(0),
+		Short: "List all PKCS11 tokens linked to a module",
+		Example: `  # list all tokens for a PKCS11 module
+  cosign pkcs11-tool list-tokens --module-path /usr/lib/libp11kit.so`,
+		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pkcs11cli.ListTokensCmd(cmd.Context(), o.ModulePath)
 		},
@@ -66,8 +68,10 @@ func PKCS11ToolListKeysUrisOptions() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "list-keys-uris",
-		Short: "list-keys-uris lists URIs of all keys in a PKCS11 token",
-		Args:  cobra.ExactArgs(0),
+		Short: "List URIs of all keys in a PKCS11 token",
+		Example: `  # list key URIs in a specific PKCS11 token slot
+  cosign pkcs11-tool list-keys-uris --module-path /usr/lib/libp11kit.so --slot-id 0`,
+		Args: cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return pkcs11cli.ListKeysUrisCmd(cmd.Context(), o.ModulePath, o.SlotID, o.Pin)
 		},

--- a/doc/cosign_pkcs11-tool.md
+++ b/doc/cosign_pkcs11-tool.md
@@ -20,6 +20,6 @@ Provides utilities for retrieving information from a PKCS11 token.
 ### SEE ALSO
 
 * [cosign](cosign.md)	 - A tool for Container Signing, Verification and Storage in an OCI registry.
-* [cosign pkcs11-tool list-keys-uris](cosign_pkcs11-tool_list-keys-uris.md)	 - list-keys-uris lists URIs of all keys in a PKCS11 token
-* [cosign pkcs11-tool list-tokens](cosign_pkcs11-tool_list-tokens.md)	 - list-tokens lists all PKCS11 tokens linked to a PKCS11 module
+* [cosign pkcs11-tool list-keys-uris](cosign_pkcs11-tool_list-keys-uris.md)	 - List URIs of all keys in a PKCS11 token
+* [cosign pkcs11-tool list-tokens](cosign_pkcs11-tool_list-tokens.md)	 - List all PKCS11 tokens linked to a module
 

--- a/doc/cosign_pkcs11-tool_list-keys-uris.md
+++ b/doc/cosign_pkcs11-tool_list-keys-uris.md
@@ -1,9 +1,16 @@
 ## cosign pkcs11-tool list-keys-uris
 
-list-keys-uris lists URIs of all keys in a PKCS11 token
+List URIs of all keys in a PKCS11 token
 
 ```
 cosign pkcs11-tool list-keys-uris [flags]
+```
+
+### Examples
+
+```
+  # list key URIs in a specific PKCS11 token slot
+  cosign pkcs11-tool list-keys-uris --module-path /usr/lib/libp11kit.so --slot-id 0
 ```
 
 ### Options

--- a/doc/cosign_pkcs11-tool_list-tokens.md
+++ b/doc/cosign_pkcs11-tool_list-tokens.md
@@ -1,9 +1,16 @@
 ## cosign pkcs11-tool list-tokens
 
-list-tokens lists all PKCS11 tokens linked to a PKCS11 module
+List all PKCS11 tokens linked to a module
 
 ```
 cosign pkcs11-tool list-tokens [flags]
+```
+
+### Examples
+
+```
+  # list all tokens for a PKCS11 module
+  cosign pkcs11-tool list-tokens --module-path /usr/lib/libp11kit.so
 ```
 
 ### Options


### PR DESCRIPTION
Fix `Short:` description style and add `Example:` fields to the two `pkcs11-tool` subcommands, following the same pattern as #4942 (piv-tool).

**Short: fixes:**
- `"list-tokens lists all PKCS11 tokens linked to a PKCS11 module"` → `"List all PKCS11 tokens linked to a module"` (capitalize, remove self-reference)
- `"list-keys-uris lists URIs of all keys in a PKCS11 token"` → `"List URIs of all keys in a PKCS11 token"` (capitalize, remove self-reference)

**Example: additions:** one example per subcommand showing the required `--module-path` flag.

Regenerated `doc/` via `cmd/help/main.go`.