### PR TITLE
check bundle layer size before reading in remote.Bundle

### DIFF
--- a/pkg/oci/remote/signatures.go
+++ b/pkg/oci/remote/signatures.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	payloadsize "github.com/sigstore/cosign/v3/internal/pkg/cosign/payload/size"
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/empty"
 	"github.com/sigstore/cosign/v3/pkg/oci/internal/signature"
@@ -71,6 +72,13 @@ func Bundle(ref name.Reference, opts ...Option) (*sgbundle.Bundle, error) {
 	}
 	if !strings.HasPrefix(string(mediaType), "application/vnd.dev.sigstore.bundle") {
 		return nil, errors.New("expected bundle layer")
+	}
+	size, err := layers[0].Size()
+	if err != nil {
+		return nil, err
+	}
+	if err := payloadsize.CheckSize(uint64(size)); err != nil {
+		return nil, err
 	}
 	layer0, err := layers[0].Uncompressed()
 	if err != nil {

--- a/pkg/oci/remote/signatures_test.go
+++ b/pkg/oci/remote/signatures_test.go
@@ -17,7 +17,9 @@ package remote
 
 import (
 	"errors"
+	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -25,7 +27,50 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/fake"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 )
+
+// oversizeLayer reports a huge Size() but its Uncompressed() must never be
+// reached once Bundle() enforces the size cap.
+type oversizeLayer struct {
+	size int64
+}
+
+func (l *oversizeLayer) Digest() (v1.Hash, error) { return v1.Hash{}, nil }
+func (l *oversizeLayer) DiffID() (v1.Hash, error) { return v1.Hash{}, nil }
+func (l *oversizeLayer) Size() (int64, error)     { return l.size, nil }
+func (l *oversizeLayer) MediaType() (types.MediaType, error) {
+	return "application/vnd.dev.sigstore.bundle+json", nil
+}
+func (l *oversizeLayer) Compressed() (io.ReadCloser, error) {
+	return nil, errors.New("Compressed should not be called")
+}
+func (l *oversizeLayer) Uncompressed() (io.ReadCloser, error) {
+	return nil, errors.New("Uncompressed should not be called once size is capped")
+}
+
+func TestBundleRejectsOversizeLayer(t *testing.T) {
+	ri := remote.Image
+	t.Cleanup(func() {
+		remoteImage = ri
+	})
+
+	remoteImage = func(_ name.Reference, _ ...remote.Option) (v1.Image, error) {
+		return &fake.FakeImage{
+			LayersStub: func() ([]v1.Layer, error) {
+				return []v1.Layer{&oversizeLayer{size: 200 * 1024 * 1024}}, nil
+			},
+		}, nil
+	}
+
+	_, err := Bundle(name.MustParseReference("gcr.io/distroless/static:sha256-deadbeef.sig"))
+	if err == nil {
+		t.Fatal("Bundle() = nil, wanted size limit error")
+	}
+	if !strings.Contains(err.Error(), "exceeded the limit") {
+		t.Fatalf("Bundle() = %v, wanted size limit error", err)
+	}
+}
 
 func TestSignaturesErrors(t *testing.T) {
 	ri := remote.Image

--- a/pkg/oci/remote/signatures_test.go
+++ b/pkg/oci/remote/signatures_test.go
@@ -17,9 +17,7 @@ package remote
 
 import (
 	"errors"
-	"io"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -27,50 +25,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/fake"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
-	"github.com/google/go-containerregistry/pkg/v1/types"
 )
-
-// oversizeLayer reports a huge Size() but its Uncompressed() must never be
-// reached once Bundle() enforces the size cap.
-type oversizeLayer struct {
-	size int64
-}
-
-func (l *oversizeLayer) Digest() (v1.Hash, error) { return v1.Hash{}, nil }
-func (l *oversizeLayer) DiffID() (v1.Hash, error) { return v1.Hash{}, nil }
-func (l *oversizeLayer) Size() (int64, error)     { return l.size, nil }
-func (l *oversizeLayer) MediaType() (types.MediaType, error) {
-	return "application/vnd.dev.sigstore.bundle+json", nil
-}
-func (l *oversizeLayer) Compressed() (io.ReadCloser, error) {
-	return nil, errors.New("Compressed should not be called")
-}
-func (l *oversizeLayer) Uncompressed() (io.ReadCloser, error) {
-	return nil, errors.New("Uncompressed should not be called once size is capped")
-}
-
-func TestBundleRejectsOversizeLayer(t *testing.T) {
-	ri := remote.Image
-	t.Cleanup(func() {
-		remoteImage = ri
-	})
-
-	remoteImage = func(_ name.Reference, _ ...remote.Option) (v1.Image, error) {
-		return &fake.FakeImage{
-			LayersStub: func() ([]v1.Layer, error) {
-				return []v1.Layer{&oversizeLayer{size: 200 * 1024 * 1024}}, nil
-			},
-		}, nil
-	}
-
-	_, err := Bundle(name.MustParseReference("gcr.io/distroless/static:sha256-deadbeef.sig"))
-	if err == nil {
-		t.Fatal("Bundle() = nil, wanted size limit error")
-	}
-	if !strings.Contains(err.Error(), "exceeded the limit") {
-		t.Fatalf("Bundle() = %v, wanted size limit error", err)
-	}
-}
 
 func TestSignaturesErrors(t *testing.T) {
 	ri := remote.Image

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -4082,6 +4082,57 @@ func TestSignDownloadAttachNewBundle(t *testing.T) {
 	must(download.SignatureCmd(ctx, regOpts, img2Name, os.Stdout), t)
 }
 
+func TestBundleLayerSizeCap(t *testing.T) {
+	repo, stop := reg(t)
+	defer stop()
+
+	imgName := path.Join(repo, "bundle-size-cap")
+	_, _, cleanup := mkimage(t, imgName)
+	defer cleanup()
+
+	ctx := context.Background()
+	td := t.TempDir()
+	_, privKeyPath, _ := keypair(t, td)
+	ko := options.KeyOpts{KeyRef: privKeyPath, PassFunc: passFunc}
+	so := options.SignOptions{
+		NewBundleFormat: true,
+		Upload:          true,
+	}
+	must(sign.SignCmd(ctx, ro, ko, so, []string{imgName}), t)
+
+	ref, err := name.ParseReference(imgName)
+	must(err, t)
+	digest, err := ociremote.ResolveDigest(ref)
+	must(err, t)
+	index, err := ociremote.Referrers(digest, "")
+	must(err, t)
+
+	// Find the sigstore bundle referrer; under the default cap it reads back fine.
+	var bundleRef name.Reference
+	for _, m := range index.Manifests {
+		st, err := name.ParseReference(fmt.Sprintf("%s@%s", digest.Repository, m.Digest.String()))
+		must(err, t)
+		if _, err := ociremote.Bundle(st); err == nil {
+			bundleRef = st
+			break
+		}
+	}
+	if bundleRef == nil {
+		t.Fatal("no sigstore bundle referrer found")
+	}
+
+	// Drop the cap below the bundle layer size; Bundle() must reject the layer
+	// before reading it into memory.
+	t.Setenv(env.VariableMaxAttachmentSize.String(), "1")
+	_, err = ociremote.Bundle(bundleRef)
+	if err == nil {
+		t.Fatal("Bundle() = nil, wanted size limit error")
+	}
+	if !strings.Contains(err.Error(), "exceeded the limit") {
+		t.Fatalf("Bundle() = %v, wanted size limit error", err)
+	}
+}
+
 func TestAttachSBOM(t *testing.T) {
 	td := t.TempDir()
 	err := downloadAndSetEnv(t, rekorURL+"/api/v1/log/publicKey", env.VariableSigstoreRekorPublicKey.String(), td)


### PR DESCRIPTION
Repro: point `cosign verify` at an image whose `.sig`-style bundle reference resolves to an image with one `application/vnd.dev.sigstore.bundle` layer that declares (or expands to) a large size. `GetBundles` -> `ociremote.Bundle` reads it before any validation.
Cause: `remote.Bundle` calls `layers[0].Uncompressed()` + `io.ReadAll` with no size cap, while the sibling registry readers (`pkg/oci/internal/signature/layer.go`, `pkg/oci/remote/remote.go`, `pkg/oci/static/file.go`) all gate on `payloadsize.CheckSize` first, so a hostile registry can make cosign allocate unbounded memory on a layer it has not yet trusted.
Fix: apply the same `payloadsize.CheckSize(uint64(layer.Size()))` check before reading, honouring `COSIGN_MAX_ATTACHMENT_SIZE` like the other layers do.

Added a regression test that fails on `main` (the read path is reached) and passes with the cap in place.