### PR TITLE
fix: allow '=' in annotation values

### DIFF
--- a/cmd/cosign/cli/options/annotations.go
+++ b/cmd/cosign/cli/options/annotations.go
@@ -33,7 +33,7 @@ var _ Interface = (*AnnotationOptions)(nil)
 func (o *AnnotationOptions) AnnotationsMap() (sigs.AnnotationsMap, error) {
 	ann := sigs.AnnotationsMap{}
 	for _, a := range o.Annotations {
-		kv := strings.Split(a, "=")
+		kv := strings.SplitN(a, "=", 2)
 		if len(kv) != 2 {
 			return ann, fmt.Errorf("unable to parse annotation: %s", a)
 		}

--- a/cmd/cosign/cli/options/annotations_test.go
+++ b/cmd/cosign/cli/options/annotations_test.go
@@ -40,6 +40,22 @@ func TestAnnotationOptions_AnnotationsMap(t *testing.T) {
 			},
 		},
 	}, {
+		name:        "value containing equals sign",
+		annotations: []string{"key=a=b"},
+		want: signature.AnnotationsMap{
+			Annotations: map[string]interface{}{
+				"key": "a=b",
+			},
+		},
+	}, {
+		name:        "base64 value with padding",
+		annotations: []string{"sig=aGVsbG8="},
+		want: signature.AnnotationsMap{
+			Annotations: map[string]interface{}{
+				"sig": "aGVsbG8=",
+			},
+		},
+	}, {
 		name:        "invalid key",
 		annotations: []string{"key value"},
 		wantErr:     true,


### PR DESCRIPTION
### Summary

`--annotations key=value` (`-a`) rejects any value that contains `=`.

`AnnotationOptions.AnnotationsMap()` (`cmd/cosign/cli/options/annotations.go`) parses each flag with `strings.Split(a, "=")` and requires exactly 2 parts, so common values fail with `unable to parse annotation`:

- base64 with padding: `-a sig=aGVsbG8=`
- URLs / query strings: `-a url=https://x?a=b`
- chained values: `-a meta=a=b`

Annotation values are free-form, so `=` should be allowed. The repo's own canonical parser (`pkg/signature/annotations.go`) already uses `strings.SplitN(s, "=", 2)`; this aligns the options parser with it. The change flows into `sign`, `verify`, `generate`, `dockerfile`, and `manifest`.

### Fix

`strings.Split(a, "=")` → `strings.SplitN(a, "=", 2)`. The `len != 2` guard still rejects inputs with no `=`.

### Testing

Added cases to `TestAnnotationOptions_AnnotationsMap`: `key=a=b` → `{"key":"a=b"}`, `sig=aGVsbG8=` → `{"sig":"aGVsbG8="}`. Fail before, pass after; the existing `invalid key` negative case still passes. `go test ./cmd/cosign/cli/options/` green.
