### PR TITLE
fix: ignore build stage references in dockerfile verify

### DIFF
--- a/cmd/cosign/cli/dockerfile/verify.go
+++ b/cmd/cosign/cli/dockerfile/verify.go
@@ -93,9 +93,12 @@ func (fc *finderCache) getImagesFromDockerfile(ctx context.Context, dockerfile i
 		lineUpper := strings.ToUpper(line)
 		switch {
 		case strings.HasPrefix(lineUpper, "FROM"):
-			switch image := fc.getImageFromLine(line); image {
-			case "scratch":
+			image := fc.getImageFromLine(line)
+			switch {
+			case image == "scratch":
 				ui.Infof(ctx, "- scratch image ignored")
+			case fc.isStage(image):
+				ui.Infof(ctx, "- stage reference ignored: %s", image)
 			default:
 				images = append(images, image)
 			}

--- a/cmd/cosign/cli/dockerfile/verify_test.go
+++ b/cmd/cosign/cli/dockerfile/verify_test.go
@@ -118,6 +118,13 @@ COPY --from=prepare /app /app`,
 			expected: []string{"gcr.io/someorg/coolimage", "gcr.io/someorg/someimage"},
 		},
 		{
+			name: "from-references-previous-stage",
+			fileContents: `FROM gcr.io/someorg/baseimage AS base_image
+			RUN customize
+			FROM base_image`,
+			expected: []string{"gcr.io/someorg/baseimage"},
+		},
+		{
 			name: "gauntlet",
 			fileContents: `FROM gcr.io/${TEST_IMAGE_REPO_PATH}/one AS one
 RUN script1


### PR DESCRIPTION
## Summary

`cosign dockerfile verify` fails on multi-stage Dockerfiles where a `FROM` instruction references a previously declared build stage instead of an image:

```dockerfile
FROM cgr.dev/chainguard/static:latest AS base_image
FROM base_image
```

The extractor treated `base_image` as a real image and tried to pull it, producing:

```
Error: GET https://index.docker.io/v2/library/base_image/manifests/latest: UNAUTHORIZED: authentication required
```

## Fix

`getImagesFromDockerfile` already records stage names (`AS <name>`) and skips them for `COPY --from=<stage>`. This applies the same check to `FROM` instructions, so references to a known stage are ignored rather than verified.

## Testing

Added a `from-references-previous-stage` case to `TestGetImagesFromDockerfile` reproducing the issue.

Fixes #3880