### PR TITLE
docs: fix dead TOC anchor in SIGNATURE_SPEC.md

### DIFF
--- a/specs/SIGNATURE_SPEC.md
+++ b/specs/SIGNATURE_SPEC.md
@@ -7,7 +7,7 @@ Container signatures generated with `cosign` should be verifiable in other tools
 This document is broken up into a few parts:
 * [Properties](#properties) details the individual components that are used to create and verify signatures.
 * [Storage](#storage) details how signatures are stored and discovered in an OCI registry.
-* [Payload](#payload) details the format of to-be-signed payloads.
+* [Payload](#payloads) details the format of to-be-signed payloads.
 * [Signature](#signature) details the signature schemes supported.
 
 ## Properties


### PR DESCRIPTION
The table of contents in `specs/SIGNATURE_SPEC.md` links `[Payload](#payload)`, but there is no `Payload` heading. The section is titled `## Payloads` (anchor `#payloads`), so the link currently does not resolve. The other three TOC links resolve correctly; this fixes the one dead anchor.

`[Payload](#payload)` -> `[Payload](#payloads)`