### PR TITLE
fix: don't warn about tag usage for cosign-generated references

### DIFF
--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 
 	"net/http"
 	"time"
@@ -496,13 +497,29 @@ type BundleComponents struct {
 	RFC3161Timestamps []*pb_go_v1.RFC3161SignedTimestamp
 }
 
+// cosignGeneratedTagPattern matches the tags cosign derives from an image
+// digest to store signatures, attestations and SBOMs (for example
+// "sha256-<hex>.att", as produced by `cosign triangulate`).
+var cosignGeneratedTagPattern = regexp.MustCompile(`^[a-z0-9]+-[0-9a-f]+\.(` +
+	ociremote.SignatureTagSuffix + `|` +
+	ociremote.AttestationTagSuffix + `|` +
+	ociremote.SBOMTagSuffix + `)$`)
+
+// isCosignGeneratedTag reports whether tag is one of the discovery tags cosign
+// derives from an image digest (the "sha256-<digest>.sig|.att|.sbom" form).
+// These tags are already pinned to a digest, so the "use a digest" warning is
+// misleading when signing them directly.
+func isCosignGeneratedTag(tag string) bool {
+	return cosignGeneratedTagPattern.MatchString(tag)
+}
+
 // ParseOCIReference parses a string reference to an OCI image into a reference, warning if the reference did not include a digest.
 func ParseOCIReference(ctx context.Context, refStr string, opts ...name.Option) (name.Reference, error) {
 	ref, err := name.ParseReference(refStr, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("parsing reference: %w", err)
 	}
-	if _, ok := ref.(name.Digest); !ok {
+	if t, ok := ref.(name.Tag); ok && !isCosignGeneratedTag(t.TagStr()) {
 		ui.Warnf(ctx, ui.TagReferenceMessage, refStr)
 	}
 	return ref, nil

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -191,6 +191,14 @@ func Test_ParseOCIReference(t *testing.T) {
 		{"image:bytag", "WARNING: Image reference image:bytag uses a tag, not a digest"},
 		{"image:bytag@sha256:abcdef", ""},
 		{"image:@sha256:abcdef", ""},
+		// cosign-generated discovery tags are derived from a digest, so they
+		// must not trigger the "use a digest" warning (issue #3995).
+		{"image:sha256-" + strings.Repeat("a", 64) + ".sig", ""},
+		{"image:sha256-" + strings.Repeat("a", 64) + ".att", ""},
+		{"image:sha256-" + strings.Repeat("a", 64) + ".sbom", ""},
+		// A tag that merely ends in a cosign suffix but is not digest-derived
+		// should still warn.
+		{"image:latest.att", "WARNING: Image reference image:latest.att uses a tag, not a digest"},
 	}
 	for _, tt := range tests {
 		stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {


### PR DESCRIPTION
## Summary

Fixes #3995.

When signing a cosign-generated discovery tag — e.g. the `sha256-<digest>.att` reference returned by `cosign triangulate ... --type attestation` — `ParseOCIReference` printed:

```
WARNING: Image reference <repo>:sha256-abc123.att uses a tag, not a digest, to identify the image to sign.
    ...
```

That warning is misleading here: these tags are *derived from an image digest*, so they already pin to specific content, and the user is deliberately signing the attestation/signature/SBOM artifact rather than a mutable image tag.

## Changes

- `ParseOCIReference` now skips the tag warning when the reference is one of cosign's own digest-derived discovery tags (`sha256-<digest>.sig`, `.att`, `.sbom`). Ordinary mutable tags still warn as before, and digest references continue to be silent.
- The suffix set reuses the existing `ociremote.{Signature,Attestation,SBOM}TagSuffix` constants so it stays in sync with cosign's tag scheme.
- Extended `Test_ParseOCIReference` with cases for each generated suffix (no warning) and a look-alike tag `latest.att` (still warns).

## Notes

CHANGELOG.md is release-generated, so it is intentionally left untouched. No Go toolchain was available locally; relied on CI for `go test`/lint.