### PR TITLE
fix(ci): Pass --insecure-registry to ko publish

### DIFF
--- a/.github/workflows/kind-verify-attestation.yaml
+++ b/.github/workflows/kind-verify-attestation.yaml
@@ -94,7 +94,7 @@ jobs:
           fmt.Println("hello world")
         }
         EOF
-        demoimage=`ko publish -B example.com/demo`
+        demoimage=$(ko publish --insecure-registry -B example.com/demo)
         echo "demoimage=$demoimage" >> $GITHUB_ENV
         echo Created image $demoimage
         popd


### PR DESCRIPTION
#### Summary

This change passes the `--insecure-registry` flag to `ko publish` in the `kind-verify-attestation` workflow, as `go-containerregistry` no longer automatically treats `*.local` as an insecure HTTP registry hostname (google/go-containerregistry#2281).