### PR TITLE
fix(download): Add predicate type not found error for new bundle format

### DIFF
--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -49,6 +50,7 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 	// Try bundles first
 	newBundles, _, err := cosign.GetBundles(ctx, ref, ociremoteOpts)
 	if err == nil && len(newBundles) > 0 {
+		var found bool
 		for _, eachBundle := range newBundles {
 			if predicateType != "" {
 				envelope, err := eachBundle.Envelope()
@@ -71,6 +73,10 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 			if err != nil {
 				return err
 			}
+			found = true
+		}
+		if predicateType != "" && !found {
+			return fmt.Errorf("no attestations with predicate type '%s' found", predicateType)
 		}
 		return nil
 	}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -2260,6 +2260,46 @@ func TestAttestationDownloadWithBadPredicateType(t *testing.T) {
 	mustErr(download.AttestationCmd(ctx, regOpts, attOpts, imgName, os.Stdout), t)
 }
 
+func TestAttestationDownloadWithBadPredicateTypeNewBundle(t *testing.T) {
+	repo, stop := reg(t)
+	defer stop()
+	td := t.TempDir()
+
+	imgName := path.Join(repo, "cosign-attest-download-bad-type-new-bundle-e2e")
+	_, _, cleanup := mkimage(t, imgName)
+	defer cleanup()
+
+	_, privKeyPath, _ := keypair(t, td)
+	ko := options.KeyOpts{
+		KeyRef:          privKeyPath,
+		PassFunc:        passFunc,
+		NewBundleFormat: true,
+	}
+
+	ctx := context.Background()
+	slsaAttestation := `{ "buildType": "x", "builder": { "id": "2" }, "recipe": {} }`
+	slsaAttestationPath := filepath.Join(td, "attestation.slsa.json")
+	if err := os.WriteFile(slsaAttestationPath, []byte(slsaAttestation), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	regOpts := options.RegistryOptions{}
+	attestCommand := attest.AttestCommand{
+		KeyOpts:        ko,
+		PredicatePath:  slsaAttestationPath,
+		PredicateType:  "slsaprovenance",
+		Timeout:        30 * time.Second,
+		Replace:        true,
+		RekorEntryType: "dsse",
+	}
+	must(attestCommand.Exec(ctx, imgName), t)
+
+	attOpts := options.AttestationDownloadOptions{
+		PredicateType: "vuln",
+	}
+	mustErr(download.AttestationCmd(ctx, regOpts, attOpts, imgName, os.Stdout), t)
+}
+
 func TestAttestationReplaceCreate(t *testing.T) {
 	repo, stop := reg(t)
 	defer stop()


### PR DESCRIPTION
#### Summary

This change adds error handling for when no attestations are found for the given predicate type, when using the new bundle format, to `download attestation`.