### PR TITLE
Remove new bundle format flag from conformance

### DIFF
--- a/cmd/conformance/main.go
+++ b/cmd/conformance/main.go
@@ -121,7 +121,6 @@ func main() {
 
 	if bundlePath != nil {
 		args = append(args, "--bundle", *bundlePath)
-		args = append(args, "--new-bundle-format")
 	}
 	if identityToken != nil {
 		args = append(args, "--identity-token", *identityToken)


### PR DESCRIPTION
#### Summary

This change removes the deprecated `--new-bundle-format` flag from the conformance test runner.