### PR TITLE
download: also emit old-format attestations when a bundle exists (#4573)

### DIFF
--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -28,6 +28,13 @@ import (
 	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 )
 
+// Indirected for testing. These wrap the two registry-touching stages so the
+// command flow (which format(s) to emit) can be exercised without a registry.
+var (
+	writeNewBundles      = writeNewBundlesImpl
+	writeOldAttestations = writeOldAttestationsImpl
+)
+
 func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOptions options.AttestationDownloadOptions, imageRef string, out io.Writer) error {
 	ref, err := name.ParseReference(imageRef, regOpts.NameOptions()...)
 	if err != nil {
@@ -46,35 +53,70 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 		}
 	}
 
-	// Try bundles first
-	newBundles, _, err := cosign.GetBundles(ctx, ref, ociremoteOpts)
-	if err == nil && len(newBundles) > 0 {
-		for _, eachBundle := range newBundles {
-			if predicateType != "" {
-				envelope, err := eachBundle.Envelope()
-				if err != nil || envelope == nil {
-					continue
-				}
-				statement, err := envelope.Statement()
-				if err != nil || statement == nil {
-					continue
-				}
-				if statement.PredicateType != predicateType {
-					continue
-				}
-			}
-			b, err := json.Marshal(eachBundle)
-			if err != nil {
-				return err
-			}
-			_, err = out.Write(append(b, byte('\n')))
-			if err != nil {
-				return err
-			}
-		}
-		return nil
+	// Gather any new-format (sigstore bundle) attestations. Unlike the verify
+	// subcommands, download is an inspection command, so it does not
+	// short-circuit here: an image can carry both new-format bundles and
+	// old-format .att attestations, and download should emit both. GetBundles
+	// returns every bundle referrer (including signature-only bundles), so this
+	// branch may run even when there are no matching attestations.
+	wrote, err := writeNewBundles(ctx, ref, ociremoteOpts, predicateType, out)
+	if err != nil {
+		return err
 	}
 
+	// Also gather any old-format (sha256-<digest>.att) attestations. If at
+	// least one new-format bundle was already written, a missing old-format
+	// entity or an image with no old-format attestations is not fatal: just
+	// return what has been emitted so far. If nothing was written yet, keep the
+	// original behavior and surface the error.
+	if err := writeOldAttestations(ref, ociremoteOpts, attOptions.Platform, predicateType, out); err != nil {
+		if wrote > 0 {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// writeNewBundlesImpl fetches new-format (sigstore bundle) attestation referrers
+// and writes those matching predicateType to out. It returns the number written.
+// A failure to look up bundles is not fatal (the image may only carry old-format
+// attestations), so it returns 0 with no error in that case.
+func writeNewBundlesImpl(ctx context.Context, ref name.Reference, ociremoteOpts []ociremote.Option, predicateType string, out io.Writer) (int, error) {
+	newBundles, _, err := cosign.GetBundles(ctx, ref, ociremoteOpts)
+	if err != nil || len(newBundles) == 0 {
+		return 0, nil
+	}
+	wrote := 0
+	for _, eachBundle := range newBundles {
+		if predicateType != "" {
+			envelope, err := eachBundle.Envelope()
+			if err != nil || envelope == nil {
+				continue
+			}
+			statement, err := envelope.Statement()
+			if err != nil || statement == nil {
+				continue
+			}
+			if statement.PredicateType != predicateType {
+				continue
+			}
+		}
+		b, err := json.Marshal(eachBundle)
+		if err != nil {
+			return wrote, err
+		}
+		if _, err = out.Write(append(b, byte('\n'))); err != nil {
+			return wrote, err
+		}
+		wrote++
+	}
+	return wrote, nil
+}
+
+// writeOldAttestationsImpl fetches old-format (sha256-<digest>.att) attestations
+// for ref and writes those matching predicateType to out.
+func writeOldAttestationsImpl(ref name.Reference, ociremoteOpts []ociremote.Option, plat, predicateType string, out io.Writer) error {
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
 	var entityNotFoundError *ociremote.EntityNotFoundError
 	if err != nil {
@@ -90,7 +132,7 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 		}
 	}
 
-	se, err = platform.SignedEntityForPlatform(se, attOptions.Platform)
+	se, err = platform.SignedEntityForPlatform(se, plat)
 	if err != nil {
 		return err
 	}
@@ -105,8 +147,7 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 		if err != nil {
 			return err
 		}
-		_, err = out.Write(append(b, byte('\n')))
-		if err != nil {
+		if _, err = out.Write(append(b, byte('\n'))); err != nil {
 			return err
 		}
 	}

--- a/cmd/cosign/cli/download/attestation_test.go
+++ b/cmd/cosign/cli/download/attestation_test.go
@@ -1,0 +1,125 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package download
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
+)
+
+// stubSeams replaces the two registry-touching stages of AttestationCmd for the
+// duration of a test and restores the originals afterward, so the command flow
+// can be exercised without contacting a registry.
+func stubSeams(t *testing.T,
+	wnb func(context.Context, name.Reference, []ociremote.Option, string, io.Writer) (int, error),
+	woa func(name.Reference, []ociremote.Option, string, string, io.Writer) error,
+) {
+	t.Helper()
+	origWNB := writeNewBundles
+	origWOA := writeOldAttestations
+	writeNewBundles = wnb
+	writeOldAttestations = woa
+	t.Cleanup(func() {
+		writeNewBundles = origWNB
+		writeOldAttestations = origWOA
+	})
+}
+
+const testDigestRef = "ghcr.io/example/image@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+
+// TestAttestationDownloadEmitsBothFormats covers issue #4573: an image that
+// carries a new-format sigstore bundle referrer (for example a signature-only
+// bundle) must not cause the old-format sha256-<digest>.att attestations to be
+// skipped. download is an inspection command and should emit both formats.
+func TestAttestationDownloadEmitsBothFormats(t *testing.T) {
+	stubSeams(t,
+		func(_ context.Context, _ name.Reference, _ []ociremote.Option, _ string, out io.Writer) (int, error) {
+			_, err := out.Write([]byte("new-bundle-line\n"))
+			return 1, err
+		},
+		func(_ name.Reference, _ []ociremote.Option, _, _ string, out io.Writer) error {
+			_, err := out.Write([]byte("old-format-att-line\n"))
+			return err
+		},
+	)
+
+	var buf bytes.Buffer
+	if err := AttestationCmd(context.Background(), options.RegistryOptions{}, options.AttestationDownloadOptions{}, testDigestRef, &buf); err != nil {
+		t.Fatalf("AttestationCmd returned error: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "new-bundle-line") {
+		t.Errorf("expected new-format bundle in output, got:\n%s", got)
+	}
+	// Regression assertion for #4573: on the unpatched code the command returned
+	// right after the new-format branch, so the old-format .att attestation was
+	// never fetched or written.
+	if !strings.Contains(got, "old-format-att-line") {
+		t.Errorf("old-format attestation was dropped when a new-format bundle was present (issue #4573); output:\n%s", got)
+	}
+}
+
+// TestAttestationDownloadNewFormatOnlyToleratesMissingOldFormat verifies that
+// once a new-format bundle is written, a missing old-format entity (or an image
+// with no old-format attestations) is not fatal.
+func TestAttestationDownloadNewFormatOnlyToleratesMissingOldFormat(t *testing.T) {
+	stubSeams(t,
+		func(_ context.Context, _ name.Reference, _ []ociremote.Option, _ string, out io.Writer) (int, error) {
+			_, err := out.Write([]byte("new-bundle-line\n"))
+			return 1, err
+		},
+		func(_ name.Reference, _ []ociremote.Option, _, _ string, _ io.Writer) error {
+			return errors.New("found no attestations")
+		},
+	)
+
+	var buf bytes.Buffer
+	if err := AttestationCmd(context.Background(), options.RegistryOptions{}, options.AttestationDownloadOptions{}, testDigestRef, &buf); err != nil {
+		t.Fatalf("expected no error when a new-format bundle was written and no old-format attestations exist, got: %v", err)
+	}
+	if !strings.Contains(buf.String(), "new-bundle-line") {
+		t.Errorf("expected new-format bundle in output, got:\n%s", buf.String())
+	}
+}
+
+// TestAttestationDownloadNoNewFormatStillSurfacesError makes sure the fix does
+// not change behavior for an image with no new-format bundles: an old-format
+// lookup that finds nothing must still surface the error.
+func TestAttestationDownloadNoNewFormatStillSurfacesError(t *testing.T) {
+	stubSeams(t,
+		func(_ context.Context, _ name.Reference, _ []ociremote.Option, _ string, _ io.Writer) (int, error) {
+			return 0, nil // no new-format bundles
+		},
+		func(_ name.Reference, _ []ociremote.Option, _, _ string, _ io.Writer) error {
+			return errors.New("found no attestations")
+		},
+	)
+
+	var buf bytes.Buffer
+	err := AttestationCmd(context.Background(), options.RegistryOptions{}, options.AttestationDownloadOptions{}, testDigestRef, &buf)
+	if err == nil {
+		t.Fatalf("expected an error when no attestations of either format exist, got nil (output: %q)", buf.String())
+	}
+}


### PR DESCRIPTION
I work on supply-chain security tooling and ran into this while inspecting an image's attestations.

`cosign attestation download` returns zero old-format `.att` attestations whenever the image also carries a new-bundle-format signature. `GetBundles` returns every bundle referrer (including signature-only ones), so the new-format branch is taken even when there are no matching attestations, and the command then returned before it ever fetched the old-format `sha256-<digest>.att` entries. This is #4573, and @steiza confirmed on that issue that download (unlike verify) should handle both formats.

The fix drops that early return so download writes any new-format bundles and then also fetches the old-format attestations, emitting both. A missing old-format entity is only treated as an error when nothing was written yet, so existing behavior is preserved for old-format-only images. verify paths are untouched, and I've scoped this to inspection-only download semantics so it doesn't conflict with the broader new-bundle work in the draft #4959.

The download package had no tests, so I added the first ones: the main case fails on the old code (old-format attestation dropped) and passes with the fix, plus two cases covering old-format-only errors and tolerating a missing old-format entity. `go test`, `go vet`, and `gofmt` are clean on the package.