### PR TITLE
fix(release): restore signing-step auth and fail on image signing errors

### DIFF
--- a/release/cloudbuild.yaml
+++ b/release/cloudbuild.yaml
@@ -90,8 +90,9 @@ steps:
     args:
       - '-c'
       - |
-        echo $$GITHUB_TOKEN | docker login ghcr.io -u $$GITHUB_USER --password-stdin \
-        && make sign-release-images || true
+        gcloud auth configure-docker --quiet \
+        && echo $$GITHUB_TOKEN | docker login ghcr.io -u $$GITHUB_USER --password-stdin \
+        && make sign-release-images
 
   - name: 'ghcr.io/oras-project/oras:v1.3.2@sha256:46c55ba0eac848ade573594ef23fa5b1784227f151dab6eac38de2afd0b9c382'
     env:
@@ -162,4 +163,3 @@ substitutions:
   _KEY_LOCATION: 'global'
   _GITHUB_USER: 'placeholder'
   _GHCR_PREFIX: 'ghcr.io/sigstore/cosign'
-


### PR DESCRIPTION
Closes #4973

#### Summary

This PR fixes a release-pipeline failure mode where `cosign` image signing could fail without failing the release.

The immediate user-visible symptom is that `cosign verify` fails for `ghcr.io/sigstore/cosign/cosign:v3.1.1` with `no signatures found`. The same verification failure is observable against `gcr.io/projectsigstore/cosign:v3.1.1`, which suggests this is not only a GHCR mirroring issue.

During investigation, the current registry state showed:

- `v3.1.1` resolves to the same top-level multi-arch digest in both registries:
  - `sha256:6bbe0d281d955c79f85b325f0f7e651c1bcab5a4fa4ad4903d74955178a3b2eb`
- the expected legacy detached signature artifact for that digest is not discoverable:
  - missing `sha256-6bbe0d281d955c79f85b325f0f7e651c1bcab5a4fa4ad4903d74955178a3b2eb.sig`
- `cosign tree` also does not show signature referrers for that digest
- in GCR, image manifests and SBOM artifacts for `v3.1.1` are present, but signature artifacts are not currently visible
- older releases such as `v3.0.2` still verify successfully, and their graphs include detached `.sig` artifacts such as `sha256-3db384ac964445d8fc521d9284d7a59e2c54796870b9eaa69ea4cff7d06a4ff2.sig` for the `linux/amd64` image manifest

This PR makes two release-pipeline changes:

- restores registry auth configuration in the signing step before `make sign-release-images`
- removes the `|| true` from that signing step so image-signing failures become release-blocking

Local validation:

- `make test`
- `make lint`
- YAML parsing of `release/cloudbuild.yaml`

#### Release Note

Fixed a release pipeline issue where `cosign` container image signing failures could be silently ignored, which could allow unsigned release images to be published.

#### Documentation

NONE
