### PR TITLE
Fix panic in dockerfile verify on malformed FROM lines

### DIFF
--- a/cmd/cosign/cli/dockerfile/verify.go
+++ b/cmd/cosign/cli/dockerfile/verify.go
@@ -93,7 +93,10 @@ func (fc *finderCache) getImagesFromDockerfile(ctx context.Context, dockerfile i
 		lineUpper := strings.ToUpper(line)
 		switch {
 		case strings.HasPrefix(lineUpper, "FROM"):
-			image := fc.getImageFromLine(line)
+			image, err := fc.getImageFromLine(line)
+			if err != nil {
+				return nil, err
+			}
 			switch {
 			case image == "scratch":
 				ui.Infof(ctx, "- scratch image ignored")
@@ -116,7 +119,8 @@ func (fc *finderCache) getImagesFromDockerfile(ctx context.Context, dockerfile i
 	return images, nil
 }
 
-func (fc *finderCache) getImageFromLine(line string) string {
+func (fc *finderCache) getImageFromLine(line string) (string, error) {
+	original := line
 	line = strings.TrimPrefix(line, "FROM")          // Remove "FROM" prefix
 	line = os.Expand(line, func(key string) string { // Substitute templated vars
 		if val, ok := fc.Env[key]; ok {
@@ -133,12 +137,18 @@ func (fc *finderCache) getImageFromLine(line string) string {
 	for i := len(fields) - 1; i > 0; i-- {
 		// Remove the "AS" portion of line
 		if strings.EqualFold(fields[i], "AS") {
+			if i == len(fields)-1 {
+				return "", fmt.Errorf("expected stage name after \"AS\" in line %q", original)
+			}
 			fc.Stages = append(fc.Stages, fields[i+1])
 			fields = fields[:i]
 			break
 		}
 	}
-	return fields[len(fields)-1] // The image should be the last portion of the line that remains
+	if len(fields) == 0 {
+		return "", fmt.Errorf("no image found in line %q (is a build arg missing from the environment?)", original)
+	}
+	return fields[len(fields)-1], nil // The image should be the last portion of the line that remains
 }
 
 func (fc *finderCache) getImageFromCopyLine(line string) string {

--- a/cmd/cosign/cli/dockerfile/verify_test.go
+++ b/cmd/cosign/cli/dockerfile/verify_test.go
@@ -160,3 +160,30 @@ CMD bin`,
 		})
 	}
 }
+
+func TestGetImagesFromDockerfileInvalidFromLines(t *testing.T) {
+	testCases := []struct {
+		name         string
+		fileContents string
+	}{
+		{
+			name: "unresolvable-build-arg",
+			fileContents: `ARG BASE_IMAGE
+FROM ${BASE_IMAGE}`,
+		},
+		{
+			name:         "missing-stage-name-after-as",
+			fileContents: `FROM gcr.io/test/image AS`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fc := newFinderCache()
+			ctx := context.Background()
+			got, err := fc.getImagesFromDockerfile(ctx, strings.NewReader(tc.fileContents))
+			if err == nil {
+				t.Errorf("getImagesFromDockerfile returned %v, wanted an error", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`cosign dockerfile verify` panics (`index out of range`) instead of returning an error on two malformed but parseable `FROM` lines. `getImageFromLine` is the culprit.

### Repro 1: unresolvable build arg
```dockerfile
ARG BASE_IMAGE
FROM ${BASE_IMAGE}
```
When `BASE_IMAGE` is not in the environment, `os.Expand` replaces `${BASE_IMAGE}` with an empty string, so after trimming `FROM` the line is blank, `strings.Fields` returns an empty slice, and `fields[len(fields)-1]` indexes `fields[-1]` -> `panic: runtime error: index out of range [-1]`.

### Repro 2: trailing `AS`
```dockerfile
FROM gcr.io/test/image AS
```
The `AS` is the last field, so `fields[i+1]` reads past the slice -> `panic: index out of range [2] with length 2`.

## Change

`getImageFromLine` now returns `(string, error)`:
- errors with `no image found in line %q (is a build arg missing from the environment?)` when no image token remains,
- errors with `expected stage name after "AS" in line %q` when `AS` has no following stage name,

and the caller propagates the error. Fail-closed is intentional: silently skipping an unresolvable base image would weaken a verification command.

## Testing

Adds `TestGetImagesFromDockerfileInvalidFromLines` (both cases). Verified both directions: the test panics/fails on the unpatched code and passes with the fix. `gofmt`, `go vet ./cmd/cosign/cli/dockerfile/...`, and the full package test suite pass; `go build ./cmd/cosign/...` is clean (single call site).

No open issue tracks this crash (the related #434 / #435 are closed and were about ARG *support*, a separate feature).