### PR TITLE
fix: pass NewBundleFormat to KeyOpts in sign command

### DIFF
--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -130,6 +130,7 @@ race conditions or (worse) malicious tampering.
 				TSAServerName:                  o.TSAServerName,
 				TSAServerURL:                   o.TSAServerURL,
 				IssueCertificateForExistingKey: o.IssueCertificate,
+				NewBundleFormat:                o.NewBundleFormat,
 			}
 			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,


### PR DESCRIPTION
`NewBundleFormat` is parsed from the CLI flag but never copied to `KeyOpts` in `sign.go`,
causing TSA signing to fail with:

    "expected either new bundle or an rfc3161-timestamp path when using a TSA server"

This only affects the manual flags path (`--use-signing-config=false` with explicit
`--timestamp-server-url`). The default signing config path is unaffected as it sources
TSA and bundle format settings from the trusted root / signing config, bypassing `KeyOpts`.

Fix: add the missing `NewBundleFormat: o.NewBundleFormat` to the `KeyOpts` struct initialization.

Fixes: https://github.com/sigstore/cosign/issues/4980