### PR TITLE
docs: fix duplicated word in test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -36,7 +36,7 @@ should include the following:
 - Steps to do whatever other custom configuration the scenario needs
 - A step to run the test with `go test -tags=e2e,<your tag> -v ./test/...`
 
-To run these kinds of tests tests locally, you'll have to [setup
+To run these kinds of tests locally, you'll have to [setup
 scaffolding](https://github.com/sigstore/scaffolding/blob/main/getting-started.md)
 and do the other setup steps manually.
 


### PR DESCRIPTION
## Summary
Remove a duplicated word in `test/README.md`: "these kinds of tests tests locally" now reads "these kinds of tests locally".

## Why this matters
The sentence in the "Running the tests" section of `test/README.md` accidentally repeats the word "tests", which reads as a typo for contributors following the e2e setup steps. Dropping the duplicate keeps the docs clean without changing meaning.
