### PR TITLE
Deprecate --payload for sign and verify commands

### DIFF
--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -109,6 +109,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.PayloadPath, "payload", "",
 		"path to a payload file to use rather than generating one")
 	// _ = cmd.MarkFlagFilename("payload") // no typical extensions
+	_ = cmd.Flags().MarkDeprecated("payload", "payload will always be generated automatically in future versions")
 
 	cmd.Flags().BoolVarP(&o.Recursive, "recursive", "r", false,
 		"if a multi-arch image is specified, additionally sign each discrete image")

--- a/cmd/cosign/cli/options/verify.go
+++ b/cmd/cosign/cli/options/verify.go
@@ -136,6 +136,7 @@ func (o *VerifyOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&o.PayloadRef, "payload", "",
 		"payload path or remote URL")
 	// _ = cmd.MarkFlagFilename("payload") // no typical extensions
+	_ = cmd.Flags().MarkDeprecated("payload", "payload will always be verified from the bundle in future versions")
 
 	cmd.Flags().BoolVar(&o.LocalImage, "local-image", false,
 		"whether the specified image is a path to an image saved locally via 'cosign save'")

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -38,7 +38,7 @@ Make sure to sign the image by its digest (@sha256:...) rather than by tag
 (:latest) so that you actually sign what you think you're signing! This prevents
 race conditions or (worse) malicious tampering.
 `,
-		Example: `  cosign sign --key <key path>|<kms uri> [--payload <path>] [-a key=value] [--upload=true|false] [-f] [-r] <image digest uri>
+		Example: `  cosign sign --key <key path>|<kms uri> [-a key=value] [--upload=true|false] [-f] [-r] <image digest uri>
 
   # sign a container image with the Sigstore OIDC flow
   cosign sign <IMAGE DIGEST>

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -18,7 +18,7 @@ cosign sign [flags]
 ### Examples
 
 ```
-  cosign sign --key <key path>|<kms uri> [--payload <path>] [-a key=value] [--upload=true|false] [-f] [-r] <image digest uri>
+  cosign sign --key <key path>|<kms uri> [-a key=value] [--upload=true|false] [-f] [-r] <image digest uri>
 
   # sign a container image with the Sigstore OIDC flow
   cosign sign <IMAGE DIGEST>
@@ -85,7 +85,6 @@ cosign sign [flags]
       --oidc-disable-ambient-providers                  Disable ambient OIDC providers. When true, ambient credentials will not be read
       --oidc-provider string                            Specify the provider to get the OIDC token from (Optional). If unset, all options will be tried. Options include: [spiffe, google, github-actions, filesystem, buildkite-agent]
       --oidc-redirect-url string                        OIDC redirect URL (Optional). The default oidc-redirect-url is 'http://localhost:0/auth/callback'.
-      --payload string                                  path to a payload file to use rather than generating one
   -r, --recursive                                       if a multi-arch image is specified, additionally sign each discrete image
       --registry-cacert string                          path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
       --registry-client-cert string                     path to the X.509 certificate file in PEM format to be used for the connection to the registry

--- a/doc/cosign_verify.md
+++ b/doc/cosign_verify.md
@@ -80,7 +80,6 @@ cosign verify [flags]
       --local-image                                     whether the specified image is a path to an image saved locally via 'cosign save'
       --max-workers int                                 the amount of maximum workers for parallel executions (default 10)
   -o, --output string                                   output format for the signing image information (json|text) (default "json")
-      --payload string                                  payload path or remote URL
       --registry-cacert string                          path to the X.509 CA certificate file in PEM format to be used for the connection to the registry
       --registry-client-cert string                     path to the X.509 certificate file in PEM format to be used for the connection to the registry
       --registry-client-key string                      path to the X.509 private key file in PEM format to be used, together with the 'registry-client-cert' value, for the connection to the registry


### PR DESCRIPTION
#### Summary

This change deprecates the `--payload` flag, which will be deprecated  for the `sign` and `verify` commands, as future versions will use the new bundle format exclusively. 