### PR TITLE
fix: avoid panic in dockerfile verify when FROM expands to empty

### DIFF
--- a/cmd/cosign/cli/dockerfile/verify.go
+++ b/cmd/cosign/cli/dockerfile/verify.go
@@ -95,6 +95,8 @@ func (fc *finderCache) getImagesFromDockerfile(ctx context.Context, dockerfile i
 		case strings.HasPrefix(lineUpper, "FROM"):
 			image := fc.getImageFromLine(line)
 			switch {
+			case image == "":
+				ui.Infof(ctx, "- unresolved image reference ignored")
 			case image == "scratch":
 				ui.Infof(ctx, "- scratch image ignored")
 			case fc.isStage(image):
@@ -137,6 +139,12 @@ func (fc *finderCache) getImageFromLine(line string) string {
 			fields = fields[:i]
 			break
 		}
+	}
+	if len(fields) == 0 {
+		// The image reference expanded to nothing, e.g. `FROM ${BASE}` where
+		// BASE is a build arg with no default. Static analysis cannot resolve
+		// it, so return empty and let the caller skip it rather than panic.
+		return ""
 	}
 	return fields[len(fields)-1] // The image should be the last portion of the line that remains
 }

--- a/cmd/cosign/cli/dockerfile/verify_test.go
+++ b/cmd/cosign/cli/dockerfile/verify_test.go
@@ -100,6 +100,12 @@ FROM ${IMAGE}`,
 			},
 		},
 		{
+			name: "arg-with-no-default-value",
+			fileContents: `ARG COSIGN_TEST_NO_DEFAULT_BASE
+FROM ${COSIGN_TEST_NO_DEFAULT_BASE}`,
+			expected: nil,
+		},
+		{
 			name:         "image-in-copy",
 			fileContents: `COPY --from=gcr.io/someorg/someimage /var/www/html /app`,
 			expected:     []string{"gcr.io/someorg/someimage"},


### PR DESCRIPTION
`cosign dockerfile verify` panics with an index-out-of-range on a Dockerfile that uses a required build arg with no default:

```dockerfile
ARG BASE_IMAGE
FROM ${BASE_IMAGE}
```

`getImageFromLine` expands the templated vars and then returns `fields[len(fields)-1]`. Static analysis can't know the `--build-arg` value, so `${BASE_IMAGE}` expands to an empty string, `fields` ends up empty, and the slice index goes out of range instead of failing cleanly.

This returns an empty image reference in that case and lets the caller skip it, next to the existing `scratch` and stage-reference skips. Added a test case (`arg-with-no-default-value`) to `TestGetImagesFromDockerfile` that reproduces the panic without the fix.
