### PR TITLE
Allow attestation download to handle both bundle types

### DIFF
--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -72,7 +72,6 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 				return err
 			}
 		}
-		return nil
 	}
 
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -154,15 +154,15 @@ func FetchAttestations(se oci.SignedEntity, predicateType string) ([]Attestation
 	if err != nil {
 		return nil, fmt.Errorf("fetching attestations: %w", err)
 	}
+	attestations := make([]AttestationPayload, 0, len(l))
 	if len(l) == 0 {
-		return nil, errors.New("found no attestations")
+		return attestations, nil
 	}
 	if len(l) > maxAllowedSigsOrAtts {
 		errMsg := fmt.Sprintf("maximum number of attestations on an image is %d, found %d", maxAllowedSigsOrAtts, len(l))
 		return nil, errors.New(errMsg)
 	}
 
-	attestations := make([]AttestationPayload, 0, len(l))
 	var attMu sync.Mutex
 
 	var g errgroup.Group

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -3996,7 +3996,9 @@ func TestAttestDownloadAttachNewBundle(t *testing.T) {
 	ctx := context.Background()
 	regOpts := options.RegistryOptions{}
 	attOpts := options.AttestationDownloadOptions{}
-	mustErr(download.AttestationCmd(ctx, regOpts, attOpts, imgName, os.Stdout), t)
+	out := bytes.Buffer{}
+	must(download.AttestationCmd(ctx, regOpts, attOpts, imgName, &out), t)
+	assert.Len(t, out.Bytes(), 0, "expected empty output")
 
 	// Attest first image
 	td := t.TempDir()
@@ -4019,8 +4021,9 @@ func TestAttestDownloadAttachNewBundle(t *testing.T) {
 	must(attestCommand.Exec(ctx, imgName), t)
 
 	// Download should now succeed - redirect stdout to use with attach
-	out := bytes.Buffer{}
+	out = bytes.Buffer{}
 	must(download.AttestationCmd(ctx, regOpts, attOpts, imgName, &out), t)
+	assert.True(t, len(out.Bytes()) > 0)
 
 	// Create a new image to attach to
 	img2Name := path.Join(repo, "attest-new-bundle-2")
@@ -4035,7 +4038,9 @@ func TestAttestDownloadAttachNewBundle(t *testing.T) {
 	must(attach.AttestationCmd(ctx, regOpts, []string{bundlePath}, img2Name), t)
 
 	// Download should succeed on second image
-	must(download.AttestationCmd(ctx, regOpts, attOpts, img2Name, os.Stdout), t)
+	out = bytes.Buffer{}
+	must(download.AttestationCmd(ctx, regOpts, attOpts, img2Name, &out), t)
+	assert.True(t, len(out.Bytes()) > 0)
 }
 
 func TestSignDownloadAttachNewBundle(t *testing.T) {


### PR DESCRIPTION
As suggested on https://github.com/sigstore/cosign/issues/4573

<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

As suggested on https://github.com/sigstore/cosign/issues/4573


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->
* `cosign download attestation` includes both protobuf bundles as well as the old `.att` bundles

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
N/A