### PR TITLE
fix: include artifactType in OCI 1.1 signature referrer manifest

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -267,22 +267,15 @@ func WriteSignaturesExperimentalOCI(d name.Digest, se oci.SignedEntity, opts ...
 	artifactType := ociexperimental.ArtifactType("sig")
 	m.Config.MediaType = types.MediaType(artifactType)
 	m.Subject = desc
-	b, err = json.Marshal(&m)
-	if err != nil {
-		return err
-	}
-	digest, _, err := v1.SHA256(bytes.NewReader(b))
-	if err != nil {
-		return err
-	}
-	targetRef, err := name.ParseReference(fmt.Sprintf("%s/%s@%s", d.RegistryStr(), d.RepositoryStr(), digest.String()))
+	rm := referrerManifest{m, artifactType}
+	targetRef, err := rm.targetRef(d.Repository, opts...)
 	if err != nil {
 		return err
 	}
 	// TODO: use ui.Infof
 	fmt.Fprintf(os.Stderr, "Uploading signature for [%s] to [%s] with config.mediaType [%s] layers[0].mediaType [%s].\n",
 		d.String(), targetRef.String(), artifactType, ctypes.SimpleSigningMediaType)
-	return remotePut(targetRef, &taggableManifest{raw: b, mediaType: m.MediaType}, o.ROpt...)
+	return remotePut(targetRef, rm, o.ROpt...)
 }
 
 type taggableManifest struct {

--- a/pkg/oci/remote/write_test.go
+++ b/pkg/oci/remote/write_test.go
@@ -541,3 +541,91 @@ func TestWriteReferrerErrorHandling(t *testing.T) {
 		t.Errorf("Expected error to contain 'remote head failed', got %v", err)
 	}
 }
+
+func TestWriteSignaturesExperimentalOCI(t *testing.T) {
+	// Save original functions
+	origHead := remoteHead
+	origWriteLayer := remoteWriteLayer
+	origPut := remotePut
+	t.Cleanup(func() {
+		remoteHead = origHead
+		remoteWriteLayer = origWriteLayer
+		remotePut = origPut
+	})
+
+	digest := name.MustParseReference("gcr.io/test/image@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef").(name.Digest)
+
+	// Create a test signed entity with signatures
+	i, err := random.Image(300, 1)
+	if err != nil {
+		t.Fatalf("random.Image() = %v", err)
+	}
+	si := signed.Image(i)
+
+	// Add a signature
+	sig, err := cosignstatic.NewSignature(nil, "test-sig")
+	if err != nil {
+		t.Fatalf("static.NewSignature() = %v", err)
+	}
+	si, err = mutate.AttachSignatureToImage(si, sig)
+	if err != nil {
+		t.Fatalf("AttachSignatureToImage() = %v", err)
+	}
+
+	// Mock remoteHead to return a descriptor
+	remoteHead = func(name.Reference, ...remote.Option) (*v1.Descriptor, error) {
+		return &v1.Descriptor{
+			MediaType: types.DockerManifestSchema2,
+			Digest:    v1.Hash{Algorithm: "sha256", Hex: "abcdef1234567890"},
+			Size:      100,
+		}, nil
+	}
+
+	// Mock remoteWriteLayer to succeed
+	remoteWriteLayer = func(name.Repository, v1.Layer, ...remote.Option) error {
+		return nil
+	}
+
+	// Mock remotePut to capture the manifest
+	var capturedManifest remote.Taggable
+	remotePut = func(_ name.Reference, manifest remote.Taggable, _ ...remote.Option) error {
+		capturedManifest = manifest
+		return nil
+	}
+
+	err = WriteSignaturesExperimentalOCI(digest, si)
+	if err != nil {
+		t.Fatalf("WriteSignaturesExperimentalOCI() = %v", err)
+	}
+
+	// Verify that a manifest was uploaded
+	if capturedManifest == nil {
+		t.Fatal("Expected manifest to be uploaded, but none was captured")
+	}
+
+	// Verify it's a referrerManifest (not a taggableManifest)
+	refManifest, ok := capturedManifest.(referrerManifest)
+	if !ok {
+		t.Fatalf("Expected referrerManifest, got %T", capturedManifest)
+	}
+
+	// Verify the top-level artifactType is set to the cosign signature type
+	const wantArtifactType = "application/vnd.dev.cosign.artifact.sig.v1+json"
+	if refManifest.ArtifactType != wantArtifactType {
+		t.Errorf("ArtifactType = %q, want %q", refManifest.ArtifactType, wantArtifactType)
+	}
+
+	// Verify the subject is set
+	if refManifest.Subject == nil {
+		t.Error("Expected Subject to be set")
+	}
+
+	// Verify the manifest JSON serialization includes the top-level artifactType field
+	manifestBytes, err := refManifest.RawManifest()
+	if err != nil {
+		t.Fatalf("RawManifest() = %v", err)
+	}
+	if !strings.Contains(string(manifestBytes), `"artifactType"`) {
+		t.Errorf("Expected manifest JSON to contain artifactType field, got: %s", string(manifestBytes))
+	}
+}


### PR DESCRIPTION
#### Summary

Closes #4995

`WriteSignaturesExperimentalOCI` was constructing the OCI 1.1 referrer manifest by marshalling a plain `v1.Manifest` struct, which does not include the top-level `artifactType` field required by the OCI 1.1 Image Manifest spec. As a result, signature referrer manifests uploaded via the experimental OCI path were missing `artifactType`, making them
non-compliant and difficult to discover by tools that filter referrers by type.

**Fix:** 
Replace the `json.Marshal(&m)` + `taggableManifest` approach with the existing `referrerManifest` wrapper (already used by `WriteReferrer` and `WriteAttestationsReferrer`), which serializes thetop-level `artifactType` field correctly. The value is `application/vnd.dev.cosign.artifact.sig.v1+json`, consistent with what `ociexperimental.ArtifactType("sig")` already computed in the function.

#### Release Note

Fixed `WriteSignaturesExperimentalOCI` to include the top-level `artifactType` field (`application/vnd.dev.cosign.artifact.sig.v1+json`) in OCI 1.1 referrer manifests produced for signatures, aligning with the
OCI 1.1 Image Manifest specification. Previously uploaded signatures are unaffected; new uploads will produce a different manifest digest due to the corrected content.

#### Documentation

No documentation update required. This is a bug fix to an experimental OCI 1.1 code path with no user-facing CLI or API changes.