### PR TITLE
Guard against empty certificate PEM in mutate.Signature (attach path)

### DIFF
--- a/pkg/oci/mutate/signature.go
+++ b/pkg/oci/mutate/signature.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 
@@ -189,6 +190,9 @@ func Signature(original oci.Signature, opts ...SignatureOption) (oci.Signature, 
 		certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(so.cert))
 		if err != nil {
 			return nil, err
+		}
+		if len(certs) == 0 {
+			return nil, errors.New("no certificates found in the provided certificate PEM")
 		}
 		newAnn[static.CertificateAnnotationKey] = string(so.cert)
 		cert = certs[0]

--- a/pkg/oci/mutate/signature_test.go
+++ b/pkg/oci/mutate/signature_test.go
@@ -445,3 +445,15 @@ func TestSignatureWithEverythingTSA(t *testing.T) {
 
 	assertSignaturesEqual(t, expectedSig, newSig)
 }
+
+func TestSignatureWithEmptyCertChain(t *testing.T) {
+	payload := "this is the TestSignatureWithEmptyCertChain content!"
+	b64sig := "b64 content=="
+	originalSig := mustCreateSignature(t, []byte(payload), b64sig)
+
+	// An empty or whitespace-only certificate PEM loads to zero certs without
+	// error; the signer must return an error instead of panicking on certs[0].
+	if _, err := Signature(originalSig, WithCertChain([]byte(" \n"), nil)); err == nil {
+		t.Error("Signature(WithCertChain(emptyCert)) returned nil error, want error")
+	}
+}


### PR DESCRIPTION
`cryptoutils.LoadCertificatesFromPEM` returns `(nil, nil)` for an empty or whitespace-only PEM (it only errors when `pem.Decode` fails on non-empty input). `mutate.Signature` does not check for that before indexing:

```go
certs, err := cryptoutils.LoadCertificatesFromPEM(bytes.NewReader(so.cert))
if err != nil {
    return nil, err
}
newAnn[static.CertificateAnnotationKey] = string(so.cert)
cert = certs[0]   // panics on an empty cert PEM
```

So `cosign attach signature --signature sig.b64 --certificate empty.pem <image>` panics with `index out of range [0] with length 0` instead of returning an error.

This is the same failure mode that #4760 fixed on the read path (`pkg/oci/internal/signature/layer.go`, which now has a `len(certs) == 0` guard). This PR applies the same guard to the write/attach path in `pkg/oci/mutate/signature.go`.

Added `TestSignatureWithEmptyCertChain`; I ran `go test ./pkg/oci/mutate/` locally (the new test and the existing `TestSignatureWithCertChain` pass; the new test panics without the guard).

Thanks!