### PR TITLE
Fix Makefile: fall back to "unknown" version info when built outside a git repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,20 @@ endif
 PROJECT_ID ?= projectsigstore
 RUNTIME_IMAGE ?= gcr.io/distroless/static
 GIT_TAG ?= dirty-tag
-GIT_VERSION ?= $(shell git describe --tags --always --dirty)
-GIT_HASH ?= $(shell git rev-parse HEAD)
+IS_GIT_REPO := $(shell git rev-parse --is-inside-work-tree 2>/dev/null)
+GIT_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown")
+GIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null || echo "unknown")
 DATE_FMT = +%Y-%m-%dT%H:%M:%SZ
-SOURCE_DATE_EPOCH ?= $(shell git log -1 --no-show-signature --pretty=%ct)
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --no-show-signature --pretty=%ct 2>/dev/null)
 ifdef SOURCE_DATE_EPOCH
     BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
 else
     BUILD_DATE ?= $(shell date "$(DATE_FMT)")
 endif
 GIT_TREESTATE = "clean"
+ifeq ($(IS_GIT_REPO),)
+    GIT_TREESTATE = "unknown"
+endif
 DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
 ifeq ($(DIFF), 1)
     GIT_TREESTATE = "dirty"


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #4999.

`GIT_VERSION`/`GIT_HASH` in the `Makefile` are computed by shelling out to `git describe`/`git rev-parse`. When the source tree has no `.git` directory (e.g. a downstream packager building from a release tarball rather than `git clone`), those commands fail, `$(shell ...)` swallows the failure, and the variables silently resolve to empty strings — which then get baked into the binary via `-ldflags -X ...=`. `GIT_TREESTATE` also stays at its `"clean"` default in this case, since the `git diff` check fails the same way.

The result is a binary that reports:
```
GitVersion:
GitCommit:
GitTreeState:  clean
```
instead of clearly signaling that build provenance couldn't be determined. This was observed downstream in GitLab's CNG container build (see [MR discussion](https://gitlab.com/gitlab-org/build/CNG/-/merge_requests/3009#note_3542976316)), which builds cosign from a GitLab API repository-archive tarball rather than a git clone.

## What this PR changes

- `GIT_VERSION`/`GIT_HASH` fall back to `"unknown"` when the git commands fail, instead of an empty string.
- `GIT_TREESTATE` is set to `"unknown"` when not building inside a git work tree (detected via `git rev-parse --is-inside-work-tree`), instead of defaulting to `"clean"`.
- No change to behavior when building from a normal git checkout (verified below).

## Verification

Built from a `v3.1.1` release tarball (no `.git`):
```
GitVersion:    unknown
GitCommit:     unknown
GitTreeState:  unknown
```

Built from a normal git checkout (unchanged behavior):
```
GitVersion:    v3.1.2-0.20260708212140-a8642c7b8611+dirty
GitCommit:     a8642c7b8611d557b4a592e6b94b188bd9427d7c
GitTreeState:  dirty
```
