### PR TITLE
fix(verify): skip identity validation for security keys

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -104,7 +104,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	}
 
 	var identities []cosign.Identity
-	if c.KeyRef == "" {
+	if c.KeyRef == "" && !c.Sk {
 		identities, err = c.Identities()
 		if err != nil {
 			return err

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -92,7 +92,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	}
 
 	var identities []cosign.Identity
-	if c.KeyRef == "" {
+	if c.KeyRef == "" && !c.Sk {
 		identities, err = c.Identities()
 		if err != nil {
 			return err

--- a/cmd/cosign/cli/verify/verify_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_attestation_test.go
@@ -17,6 +17,7 @@ package verify
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
@@ -108,5 +109,20 @@ func TestVerifyAttestationMutuallyExclusiveFlags(t *testing.T) {
 				t.Fatalf("expected %T, got: %T, %v", tt.expectedError, err, err)
 			}
 		})
+	}
+}
+
+func TestVerifyAttestationSkWithoutIdentities(t *testing.T) {
+	ctx := context.Background()
+	verifyAttestation := VerifyAttestationCommand{
+		Sk: true,
+	}
+
+	err := verifyAttestation.Exec(ctx, []string{"foo"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "opening piv token") {
+		t.Fatalf("expected PIV error, got: %v", err)
 	}
 }

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -96,7 +96,7 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 
 	var identities []cosign.Identity
 	var err error
-	if c.KeyRef == "" {
+	if c.KeyRef == "" && !c.Sk {
 		identities, err = c.Identities()
 		if err != nil {
 			return err

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -106,7 +106,7 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 	}
 
 	var identities []cosign.Identity
-	if c.KeyRef == "" {
+	if c.KeyRef == "" && !c.Sk {
 		identities, err = c.Identities()
 		if err != nil {
 			return err

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	ssldsse "github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -573,5 +574,23 @@ func TestParseBlobHashAlgorithm(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestVerifyBlobAttestationSkWithoutIdentities(t *testing.T) {
+	ctx := context.Background()
+	verifyBlobAttestation := VerifyBlobAttestationCommand{
+		KeyOpts: options.KeyOpts{
+			Sk:         true,
+			BundlePath: "bundle.sigstore.json",
+		},
+	}
+
+	err := verifyBlobAttestation.Exec(ctx, "blob")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "opening piv token") {
+		t.Fatalf("expected PIV error, got: %v", err)
 	}
 }

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -748,6 +748,23 @@ func TestVerifyBlobKeyAndCertIdentity(t *testing.T) {
 	}
 }
 
+func TestVerifyBlobSkWithoutIdentities(t *testing.T) {
+	ctx := context.Background()
+	verifyBlob := VerifyBlobCmd{
+		KeyOpts: options.KeyOpts{
+			Sk: true,
+		},
+	}
+
+	err := verifyBlob.Exec(ctx, "blob")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "opening piv token") {
+		t.Fatalf("expected PIV error, got: %v", err)
+	}
+}
+
 func makeRekorEntry(t *testing.T, rekorSigner signature.ECDSASignerVerifier,
 	pyld, sig, svBytes []byte, expiryValid bool) *models.LogEntry {
 	ctx := context.Background()

--- a/cmd/cosign/cli/verify/verify_test.go
+++ b/cmd/cosign/cli/verify/verify_test.go
@@ -32,6 +32,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -449,4 +450,19 @@ func TestTransformOutputSuccess(t *testing.T) {
 	assert.Equal(t, "sha256:deadbeef", sci.Critical.Image.DockerManifestDigest, "digest mismatch")
 	assert.Equal(t, "https://slsa.dev/provenance/v0.2", sci.Critical.Type, "type mismatch")
 	assert.Equal(t, map[string]any{"foo": "bar"}, sci.Optional, "missing annotation")
+}
+
+func TestVerifySkWithoutIdentities(t *testing.T) {
+	ctx := context.Background()
+	verifyCommand := VerifyCommand{
+		Sk: true,
+	}
+
+	err := verifyCommand.Exec(ctx, []string{"foo"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "opening piv token") {
+		t.Fatalf("expected PIV error, got: %v", err)
+	}
 }


### PR DESCRIPTION
#### Summary

This change skips identity validation for security keys.

Identity validation is supposed to be skipped for all key-based signing; however, previously, only providing a public key reference triggered the skip.