### PR TITLE
[release-2.6] Allow attestation download to handle both bundle types (#4996)

### DIFF
--- a/cmd/cosign/cli/download/attestation.go
+++ b/cmd/cosign/cli/download/attestation.go
@@ -46,6 +46,31 @@ func AttestationCmd(ctx context.Context, regOpts options.RegistryOptions, attOpt
 		}
 	}
 
+	// Try bundles first
+	newBundles, _, err := cosign.GetBundles(ctx, ref, &cosign.CheckOpts{RegistryClientOpts: ociremoteOpts})
+	if err == nil && len(newBundles) > 0 {
+		for _, eachBundle := range newBundles {
+			if predicateType != "" {
+				envelope, err := eachBundle.Envelope()
+				if err != nil || envelope == nil {
+					continue
+				}
+				statement, err := envelope.Statement()
+				if err != nil || statement == nil {
+					continue
+				}
+				if statement.PredicateType != predicateType {
+					continue
+				}
+			}
+			b, err := json.Marshal(eachBundle)
+			if err != nil {
+				return err
+			}
+			fmt.Println(string(b))
+		}
+	}
+
 	se, err := ociremote.SignedEntity(ref, ociremoteOpts...)
 	var entityNotFoundError *ociremote.EntityNotFoundError
 	if err != nil {

--- a/pkg/cosign/fetch.go
+++ b/pkg/cosign/fetch.go
@@ -154,15 +154,15 @@ func FetchAttestations(se oci.SignedEntity, predicateType string) ([]Attestation
 	if err != nil {
 		return nil, fmt.Errorf("fetching attestations: %w", err)
 	}
+	attestations := make([]AttestationPayload, 0, len(l))
 	if len(l) == 0 {
-		return nil, errors.New("found no attestations")
+		return attestations, nil
 	}
 	if len(l) > maxAllowedSigsOrAtts {
 		errMsg := fmt.Sprintf("maximum number of attestations on an image is %d, found %d", maxAllowedSigsOrAtts, len(l))
 		return nil, errors.New(errMsg)
 	}
 
-	attestations := make([]AttestationPayload, 0, len(l))
 	var attMu sync.Mutex
 
 	var g errgroup.Group


### PR DESCRIPTION
Backport of #4996 to release-2.6.

#### Summary
As suggested on #4573

`cosign download attestation` now includes both protobuf bundles (new sigstore bundle format stored as OCI referrers) as well as the old `.att` tag-based bundles.

#### Release Note
- `cosign download attestation` includes both protobuf bundles as well as the old `.att` bundles

#### Documentation
NA

### Adaptation for release-2.6

Two adaptations were required when cherry-picking from main:

1. **`GetBundles` API**: On main, `GetBundles` accepts `[]remote.Option` directly. On release-2.6, it accepts `*CheckOpts`. Changed to `&cosign.CheckOpts{RegistryClientOpts: ociremoteOpts}`.

2. **Output**: On main, `AttestationCmd` takes an `out *bytes.Buffer` parameter. On release-2.6, it writes directly with `fmt.Println`. Adapted accordingly.

3. **e2e test**: The new `TestAttestDownloadAttachNewBundle` test from main uses the updated `AttestationCmd` signature with `out *bytes.Buffer` which does not exist on release-2.6. This test is excluded from the backport.

Cherry-picked from: sigstore/cosign@c0edaac0