### PR TITLE
fix(verify): detect local sigstore bundles for saved image indexes

### DIFF
--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1843,10 +1843,11 @@ func getLocalBundleDescriptors(path string) ([]bundleDescriptor, *v1.Hash, error
 		return nil, nil, fmt.Errorf("getting index manifest: %w", err)
 	}
 
-	// Find the target image digest from the index manifest
+	// Find the target image digest from the index manifest. The saved entity
+	// may be a single image or a multi-arch image index, annotated accordingly.
 	var targetDigest v1.Hash
 	for _, m := range manifest.Manifests {
-		if val, ok := m.Annotations["kind"]; ok && val == "dev.cosignproject.cosign/image" {
+		if val, ok := m.Annotations["kind"]; ok && (val == "dev.cosignproject.cosign/image" || val == "dev.cosignproject.cosign/imageIndex") {
 			targetDigest = m.Digest
 			break
 		}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1843,8 +1843,9 @@ func getLocalBundleDescriptors(path string) ([]bundleDescriptor, *v1.Hash, error
 		return nil, nil, fmt.Errorf("getting index manifest: %w", err)
 	}
 
-	// Find the target image digest from the index manifest. The saved entity
-	// may be a single image or a multi-arch image index, annotated accordingly.
+	// Find the target digest from the index manifest. The saved entity may be
+	// a single image (annotated dev.cosignproject.cosign/image) or a
+	// multi-arch image index (annotated dev.cosignproject.cosign/imageIndex).
 	var targetDigest v1.Hash
 	for _, m := range manifest.Manifests {
 		if val, ok := m.Annotations["kind"]; ok && (val == "dev.cosignproject.cosign/image" || val == "dev.cosignproject.cosign/imageIndex") {

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -2410,6 +2410,79 @@ func TestHasLocalSigstoreBundles_OCIReferrers(t *testing.T) {
 	assert.True(t, hasBundles, "expected true for OCI referrers with bundle layers")
 }
 
+func TestHasLocalSigstoreBundles_ImageIndex(t *testing.T) {
+	// Regression test for https://github.com/sigstore/cosign/issues/4937:
+	// a saved multi-arch image index is annotated "dev.cosignproject.cosign/imageIndex"
+	// rather than "dev.cosignproject.cosign/image", and must still be detected as the
+	// referrers' subject.
+	tmp := t.TempDir()
+
+	ii, err := random.Index(100, 3, 2)
+	require.NoError(t, err)
+	sii := signed.ImageIndex(ii)
+
+	if err := layout.WriteSignedImageIndex(tmp, sii); err != nil {
+		t.Fatalf("WriteSignedImageIndex() = %v", err)
+	}
+
+	p, err := ggcrlayout.FromPath(tmp)
+	require.NoError(t, err)
+
+	rootIndex, err := p.ImageIndex()
+	require.NoError(t, err)
+
+	manifest, err := rootIndex.IndexManifest()
+	require.NoError(t, err)
+
+	// Find the target digest, this time annotated as an image index.
+	var targetDigest v1.Hash
+	for _, m := range manifest.Manifests {
+		if m.Annotations["kind"] == "dev.cosignproject.cosign/imageIndex" {
+			targetDigest = m.Digest
+			break
+		}
+	}
+	require.NotEmpty(t, targetDigest.String(), "target digest should be found")
+
+	// Create a referrer manifest with Subject pointing to the target image index.
+	bundleContent := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+	bundleLayer := stream.NewLayer(io.NopCloser(bytes.NewReader(bundleContent)),
+		stream.WithMediaType("application/vnd.dev.sigstore.bundle.v0.3+json"))
+
+	referrerImg := empty.Image
+	referrerImg, err = gcrMutate.AppendLayers(referrerImg, bundleLayer)
+	require.NoError(t, err)
+
+	// Append image to materialize stream layers before calling Manifest()
+	err = p.AppendImage(referrerImg)
+	require.NoError(t, err)
+
+	referrerManifest, err := referrerImg.Manifest()
+	require.NoError(t, err)
+
+	referrerManifest.Subject = &v1.Descriptor{
+		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		Digest:    targetDigest,
+		Size:      0,
+	}
+
+	blobsDir := tmp + "/blobs/sha256"
+	err = os.MkdirAll(blobsDir, 0755)
+	require.NoError(t, err)
+
+	manifestBytes, err := json.Marshal(referrerManifest)
+	require.NoError(t, err)
+
+	manifestHash := v1.Hash{Algorithm: "sha256", Hex: fmt.Sprintf("%x", sha256.Sum256(manifestBytes))}
+	manifestPath := filepath.Join(blobsDir, manifestHash.Hex)
+	err = os.WriteFile(manifestPath, manifestBytes, 0644)
+	require.NoError(t, err)
+
+	hasBundles, err := hasLocalSigstoreBundles(tmp)
+	require.NoError(t, err)
+	assert.True(t, hasBundles, "expected true for OCI referrers on a saved image index")
+}
+
 func TestHasLocalSigstoreBundles_NoBlobsDir(t *testing.T) {
 	// Create a layout without blobs/sha256 directory
 	tmp := t.TempDir()

--- a/pkg/cosign/verify_test.go
+++ b/pkg/cosign/verify_test.go
@@ -2461,7 +2461,7 @@ func TestHasLocalSigstoreBundles_ImageIndex(t *testing.T) {
 	require.NoError(t, err)
 
 	referrerManifest.Subject = &v1.Descriptor{
-		MediaType: "application/vnd.oci.image.manifest.v1+json",
+		MediaType: "application/vnd.oci.image.index.v1+json",
 		Digest:    targetDigest,
 		Size:      0,
 	}


### PR DESCRIPTION
Motivation:
Offline verification of a locally-saved multi-arch image index failed
with "no signatures associated with the image saved in <path>", even
though the same reference verified successfully against the registry
(sigstore/cosign#4937). `cosign save` on an image index writes the root
OCI layout entry annotated `dev.cosignproject.cosign/imageIndex`
(pkg/oci/layout/write.go), but `getLocalBundleDescriptors`
(pkg/cosign/verify.go), which backs `HasLocalBundles` /
`HasLocalAttestationBundles` / `GetLocalBundles`, only recognized the
`dev.cosignproject.cosign/image` annotation used for single images.
As a result, `cosign verify --local-image` on a saved image index never
found the target digest, `HasLocalBundles` reported false, and
verification silently fell back to the legacy v2 signature path, which
has no signature data to find for images signed with the new bundle
format, producing the misleading error above.

Approach:
Extend the annotation check in `getLocalBundleDescriptors` to also
accept `dev.cosignproject.cosign/imageIndex`, matching the annotation
`pkg/oci/layout.WriteSignedImageIndex` already writes for saved image
indexes. The two annotations are mutually exclusive on a given saved
layout's root entry (an entry is either a single image or an image
index, never both), so this cannot introduce ambiguity or select the
wrong digest. This is a detection fix only: it does not change how
found bundles are verified, so it does not weaken verification.

Validation:
- go build ./...
- go test ./pkg/cosign/...  (all pass)
- Added TestHasLocalSigstoreBundles_ImageIndex, which builds a saved
  image-index OCI layout with an OCI 1.1 referrer manifest carrying a
  sigstore bundle layer, and asserts hasLocalSigstoreBundles detects
  it. Verified (via git stash) that this test fails on the pre-fix
  code with the same underlying miss this issue reports, and passes
  with the fix.

Fixes #4937

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
