### PR TITLE
fix(load): upload bundle layer blobs before manifest PUT

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -131,10 +131,23 @@ func WriteSignedImageIndexImages(ref name.Reference, sii oci.SignedImageIndex, d
 				}
 			}
 			if predicateType != "" {
-				// Write the empty layer
+				// Write the empty config layer
 				_, _, err := writeEmptyConfigLayer(o)
 				if err != nil {
 					return err
+				}
+
+				// Write bundle layers before the manifest (registries require blobs first)
+				for _, layer := range manifest.Layers {
+					bundlePath := filepath.Join(directory, "blobs", "sha256", layer.Digest.Hex)
+					bundleBytes, err := os.ReadFile(bundlePath)
+					if err != nil {
+						return err
+					}
+					layer := static.NewLayer(bundleBytes, types.MediaType(bundle.BundleV03MediaType))
+					if err := remoteWriteLayer(o.TargetRepository, layer, o.ROpt...); err != nil {
+						return err
+					}
 				}
 
 				// Write the manifest
@@ -145,20 +158,6 @@ func WriteSignedImageIndexImages(ref name.Reference, sii oci.SignedImageIndex, d
 				}
 				if err := remotePut(targetRef, m, o.ROpt...); err != nil {
 					return fmt.Errorf("failed to upload manifest: %w", err)
-				}
-
-				// Write bundle layers
-				for _, layer := range manifest.Layers {
-					bundlePath := filepath.Join(directory, "blobs", "sha256", layer.Digest.Hex)
-					bundleBytes, err := os.ReadFile(bundlePath)
-					if err != nil {
-						return err
-					}
-					layer := static.NewLayer(bundleBytes, types.MediaType(bundle.BundleV03MediaType))
-					err = remoteWriteLayer(o.TargetRepository, layer, o.ROpt...)
-					if err != nil {
-						return err
-					}
 				}
 			}
 		}

--- a/pkg/oci/remote/write_test.go
+++ b/pkg/oci/remote/write_test.go
@@ -16,16 +16,22 @@
 package remote
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
+	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
 	"github.com/sigstore/cosign/v3/pkg/oci/signed"
 	cosignstatic "github.com/sigstore/cosign/v3/pkg/oci/static"
@@ -627,5 +633,113 @@ func TestWriteSignaturesExperimentalOCI(t *testing.T) {
 	}
 	if !strings.Contains(string(manifestBytes), `"artifactType"`) {
 		t.Errorf("Expected manifest JSON to contain artifactType field, got: %s", string(manifestBytes))
+	}
+}
+
+// stubSignedImageIndex is a SignedImageIndex with no image, signatures, or attestations,
+// so WriteSignedImageIndexImages only exercises the bundle-referrer path.
+type stubSignedImageIndex struct{}
+
+func (stubSignedImageIndex) MediaType() (types.MediaType, error) { return empty.Index.MediaType() }
+func (stubSignedImageIndex) Digest() (v1.Hash, error)            { return empty.Index.Digest() }
+func (stubSignedImageIndex) Size() (int64, error)                { return empty.Index.Size() }
+func (stubSignedImageIndex) IndexManifest() (*v1.IndexManifest, error) {
+	return empty.Index.IndexManifest()
+}
+func (stubSignedImageIndex) RawManifest() ([]byte, error)      { return empty.Index.RawManifest() }
+func (stubSignedImageIndex) Image(h v1.Hash) (v1.Image, error) { return empty.Index.Image(h) }
+func (stubSignedImageIndex) ImageIndex(h v1.Hash) (v1.ImageIndex, error) {
+	return empty.Index.ImageIndex(h)
+}
+func (stubSignedImageIndex) SignedImageIndex(v1.Hash) (oci.SignedImageIndex, error) {
+	return nil, nil
+}
+func (stubSignedImageIndex) SignedImage(v1.Hash) (oci.SignedImage, error) { return nil, nil }
+func (stubSignedImageIndex) Signatures() (oci.Signatures, error)          { return nil, nil }
+func (stubSignedImageIndex) Attestations() (oci.Signatures, error)        { return nil, nil }
+func (stubSignedImageIndex) Attachment(string) (oci.File, error)          { return nil, nil }
+
+func TestWriteSignedImageIndexImages_BundleUploadOrder(t *testing.T) {
+	origWriteLayer := remoteWriteLayer
+	origPut := remotePut
+	t.Cleanup(func() {
+		remoteWriteLayer = origWriteLayer
+		remotePut = origPut
+	})
+
+	subjectDigest := v1.Hash{Algorithm: "sha256", Hex: "ef637aabc052029acfd192d8ed6674a5249a8783e551c08db71e321ca11b421d"}
+	bundleBytes := []byte(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+	bundleLayer := static.NewLayer(bundleBytes, types.MediaType(bundle.BundleV03MediaType))
+	layerDigest, err := bundleLayer.Digest()
+	if err != nil {
+		t.Fatalf("bundleLayer.Digest() = %v", err)
+	}
+
+	manifest := &v1.Manifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIManifestSchema1,
+		Config: v1.Descriptor{
+			MediaType: types.MediaType("application/vnd.oci.empty.v1+json"),
+			Digest:    v1.Hash{Algorithm: "sha256", Hex: "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"},
+			Size:      2,
+		},
+		Layers: []v1.Descriptor{{
+			MediaType: types.MediaType(bundle.BundleV03MediaType),
+			Digest:    layerDigest,
+			Size:      int64(len(bundleBytes)),
+		}},
+		Subject: &v1.Descriptor{Digest: subjectDigest},
+		Annotations: map[string]string{
+			BundlePredicateType: "https://sigstore.dev/cosign/sign/v1",
+		},
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("json.Marshal() = %v", err)
+	}
+	manifestDigest, _, err := v1.SHA256(strings.NewReader(string(manifestBytes)))
+	if err != nil {
+		t.Fatalf("v1.SHA256() = %v", err)
+	}
+
+	dir := t.TempDir()
+	blobDir := filepath.Join(dir, "blobs", "sha256")
+	if err := os.MkdirAll(blobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blobDir, layerDigest.Hex), bundleBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(layer) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blobDir, manifestDigest.Hex), manifestBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(manifest) = %v", err)
+	}
+
+	var callOrder []string
+	remoteWriteLayer = func(_ name.Repository, _ v1.Layer, _ ...remote.Option) error {
+		callOrder = append(callOrder, "layer")
+		return nil
+	}
+	remotePut = func(_ name.Reference, _ remote.Taggable, _ ...remote.Option) error {
+		callOrder = append(callOrder, "manifest")
+		return nil
+	}
+
+	ref, err := name.NewDigest("gcr.io/test/image@sha256:ef637aabc052029acfd192d8ed6674a5249a8783e551c08db71e321ca11b421d")
+	if err != nil {
+		t.Fatalf("name.NewDigest() = %v", err)
+	}
+	if err := WriteSignedImageIndexImages(ref, stubSignedImageIndex{}, dir); err != nil {
+		t.Fatalf("WriteSignedImageIndexImages() = %v", err)
+	}
+
+	// Expect config layer + bundle layer, then manifest.
+	want := []string{"layer", "layer", "manifest"}
+	if len(callOrder) != len(want) {
+		t.Fatalf("call order = %v, want %v", callOrder, want)
+	}
+	for i, step := range want {
+		if callOrder[i] != step {
+			t.Fatalf("call order = %v, want %v", callOrder, want)
+		}
 	}
 }

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -43,6 +43,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -50,6 +51,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/stretchr/testify/assert"
 	"github.com/theupdateframework/go-tuf/v2/metadata"
@@ -4087,6 +4089,141 @@ func TestSaveLoad(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSaveLoadCrossRegistry verifies that cosign load uploads bundle layer blobs
+// before manifest PUT when loading to a registry that does not already contain them.
+// This reproduces sigstore/cosign#5030, which is masked when save and load use the
+// same registry (bundle blobs already exist from signing).
+//
+// The destination uses a wrapper around registry.New() that rejects manifest PUTs
+// referencing missing blobs (like AWS ECR), since the stock fake registry does not.
+func TestSaveLoadCrossRegistry(t *testing.T) {
+	if os.Getenv("COSIGN_TEST_REPO") != "" { //nolint: forbidigo
+		t.Skip("cross-registry test requires isolated fake registries")
+	}
+
+	keysDir := t.TempDir()
+	_, privKeyPath, pubKeyPath := keypair(t, keysDir)
+
+	src := httptest.NewServer(registry.New())
+	defer src.Close()
+	dst := httptest.NewServer(blobEnforcingRegistry(registry.New()))
+	defer dst.Close()
+
+	srcURL, err := url.Parse(src.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dstURL, err := url.Parse(dst.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srcRepo := path.Join(srcURL.Host, "cross-registry-src")
+	dstRepo := path.Join(dstURL.Host, "cross-registry-dst")
+	imgName := path.Join(srcRepo, "image")
+
+	_, _, cleanup := mkimage(t, imgName)
+	defer cleanup()
+
+	ctx := context.Background()
+	ko := options.KeyOpts{
+		KeyRef:           privKeyPath,
+		PassFunc:         passFunc,
+		RekorURL:         rekorURL,
+		SkipConfirmation: true,
+	}
+	so := options.SignOptions{
+		Upload:          true,
+		TlogUpload:      false,
+		NewBundleFormat: true,
+	}
+	must(sign.SignCmd(ctx, ro, ko, so, []string{imgName}), t)
+
+	imageDir := t.TempDir()
+	must(cli.SaveCmd(ctx, options.SaveOptions{Directory: imageDir}, imgName), t)
+
+	imgName2 := path.Join(dstRepo, "image")
+	must(cli.LoadCmd(ctx, options.LoadOptions{Directory: imageDir}, imgName2), t)
+
+	// Key-based verify without tlog/Fulcio — LoadCmd succeeding is the #5030 regression
+	// guard; verify confirms the loaded bundle is usable.
+	cmd := cliverify.VerifyCommand{
+		KeyRef:          pubKeyPath,
+		NewBundleFormat: true,
+		IgnoreTlog:      true,
+	}
+	must(cmd.Exec(ctx, []string{imgName2}), t)
+}
+
+// blobEnforcingRegistry wraps a registry handler and rejects manifest PUTs that
+// reference blobs that have not been uploaded yet (BLOB_UPLOAD_UNKNOWN).
+func blobEnforcingRegistry(next http.Handler) http.Handler {
+	var blobs sync.Map // digest string -> struct{}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/blobs/uploads/") {
+			digest := r.URL.Query().Get("digest")
+			rw := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(rw, r)
+			if digest != "" && rw.status >= 200 && rw.status < 300 {
+				blobs.Store(digest, struct{}{})
+			}
+			return
+		}
+
+		if r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/manifests/") {
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			r.Body = io.NopCloser(bytes.NewReader(body))
+
+			var mf struct {
+				Config *struct {
+					Digest string `json:"digest"`
+				} `json:"config"`
+				Layers []struct {
+					Digest string `json:"digest"`
+				} `json:"layers"`
+			}
+			if err := json.Unmarshal(body, &mf); err == nil && mf.Config != nil {
+				var missing []string
+				if _, ok := blobs.Load(mf.Config.Digest); !ok && mf.Config.Digest != "" {
+					missing = append(missing, mf.Config.Digest)
+				}
+				for _, layer := range mf.Layers {
+					if _, ok := blobs.Load(layer.Digest); !ok && layer.Digest != "" {
+						missing = append(missing, layer.Digest)
+					}
+				}
+				if len(missing) > 0 {
+					w.WriteHeader(http.StatusNotFound)
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"errors": []map[string]string{{
+							"code":    "BLOB_UPLOAD_UNKNOWN",
+							"message": fmt.Sprintf("Layers with digests '%v' do not exist", missing),
+						}},
+					})
+					return
+				}
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	r.status = status
+	r.ResponseWriter.WriteHeader(status)
 }
 
 // TestSaveLoadAutoDetectFormat verifies that local image verification auto-detects


### PR DESCRIPTION
## Summary
- Fix `cosign load` uploading v3 Sigstore bundle manifests before their layer blobs, which caused `BLOB_UPLOAD_UNKNOWN` on registries that require blob-before-manifest ordering (e.g. AWS ECR).
- Reorder the bundle path in `WriteSignedImageIndexImages` to upload config + layer blobs first, then PUT the manifest (matching `WriteReferrer`).
- Add a unit test asserting upload order and a cross-registry e2e that signs on one registry, saves, and loads to a fresh registry that rejects references to missing blobs

Fixes #5030