### PR TITLE
fix: prevent shell completions for various options not taking filenames

### DIFF
--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -107,6 +107,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.TSAServerName, "timestamp-server-name", "",
 		"SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server")
+	_ = cmd.RegisterFlagCompletionFunc("timestamp-server-name", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.TSAServerURL, "timestamp-server-url", "",
 		"url to the Timestamp RFC3161 server, default none. Must be the path to the API to request timestamp responses, e.g. https://freetsa.org/tsr")

--- a/cmd/cosign/cli/options/certificate.go
+++ b/cmd/cosign/cli/options/certificate.go
@@ -51,33 +51,43 @@ func (o *CertVerifyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.CertIdentity, "certificate-identity", "",
 		"The identity expected in a valid Fulcio certificate. Valid values include email address, DNS names, IP addresses, and URIs. Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-identity", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertIdentityRegexp, "certificate-identity-regexp", "",
 		"A regular expression alternative to --certificate-identity. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-identity or --certificate-identity-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-identity-regexp", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertOidcIssuer, "certificate-oidc-issuer", "",
 		"The OIDC issuer expected in a valid Fulcio certificate, e.g. https://token.actions.githubusercontent.com or https://oauth2.sigstore.dev/auth. Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-oidc-issuer", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertOidcIssuerRegexp, "certificate-oidc-issuer-regexp", "",
 		"A regular expression alternative to --certificate-oidc-issuer. Accepts the Go regular expression syntax described at https://golang.org/s/re2syntax. Either --certificate-oidc-issuer or --certificate-oidc-issuer-regexp must be set for keyless flows.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-oidc-issuer-regexp", cobra.NoFileCompletions)
 
 	// -- Cert extensions begin --
 	// Source: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md
 	cmd.Flags().StringVar(&o.CertGithubWorkflowTrigger, "certificate-github-workflow-trigger", "",
 		"contains the event_name claim from the GitHub OIDC Identity token that contains the name of the event that triggered the workflow run")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-trigger", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowSha, "certificate-github-workflow-sha", "",
 		"contains the sha claim from the GitHub OIDC Identity token that contains the commit SHA that the workflow run was based upon.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-sha", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowName, "certificate-github-workflow-name", "",
 		"contains the workflow claim from the GitHub OIDC Identity token that contains the name of the executed workflow.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-name", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowRepository, "certificate-github-workflow-repository", "",
 		"contains the repository claim from the GitHub OIDC Identity token that contains the repository that the workflow run was based upon")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-repository", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.CertGithubWorkflowRef, "certificate-github-workflow-ref", "",
 		"contains the ref claim from the GitHub OIDC Identity token that contains the git ref that the workflow run was based upon.")
+	_ = cmd.RegisterFlagCompletionFunc("certificate-github-workflow-ref", cobra.NoFileCompletions)
 	// -- Cert extensions end --
+
 	cmd.Flags().StringVar(&o.CAIntermediates, "ca-intermediates", "",
 		"path to a file of intermediate CA certificates in PEM format which will be needed "+
 			"when building the certificate chains for the signing certificate. "+

--- a/cmd/cosign/cli/options/copy.go
+++ b/cmd/cosign/cli/options/copy.go
@@ -45,4 +45,5 @@ func (o *CopyOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.Platform, "platform", "",
 		"only copy container image and its signatures for a specific platform image")
+	_ = cmd.RegisterFlagCompletionFunc("platform", cobra.NoFileCompletions)
 }

--- a/cmd/cosign/cli/options/registry.go
+++ b/cmd/cosign/cli/options/registry.go
@@ -71,12 +71,15 @@ func (o *RegistryOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.AuthConfig.Username, "registry-username", "",
 		"registry basic auth username")
+	_ = cmd.RegisterFlagCompletionFunc("registry-username", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.AuthConfig.Password, "registry-password", "",
 		"registry basic auth password")
+	_ = cmd.RegisterFlagCompletionFunc("registry-password", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.AuthConfig.RegistryToken, "registry-token", "",
 		"registry bearer auth token")
+	_ = cmd.RegisterFlagCompletionFunc("registry-token", cobra.NoFileCompletions)
 
 	cmd.Flags().StringVar(&o.RegistryCACert, "registry-cacert", "",
 		"path to the X.509 CA certificate file in PEM format to be used for the connection to the registry")
@@ -92,6 +95,7 @@ func (o *RegistryOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringVar(&o.RegistryServerName, "registry-server-name", "",
 		"SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the registry")
+	_ = cmd.RegisterFlagCompletionFunc("registry-server-name", cobra.NoFileCompletions)
 
 	o.RefOpts.AddFlags(cmd)
 }

--- a/cmd/cosign/cli/options/root.go
+++ b/cmd/cosign/cli/options/root.go
@@ -51,6 +51,7 @@ func (o *RootOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().DurationVarP(&o.Timeout, "timeout", "t", DefaultTimeout,
 		"timeout for commands")
+	_ = cmd.RegisterFlagCompletionFunc("timeout", cobra.NoFileCompletions)
 }
 
 func BindViper(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

SSIA.

This is non-exhaustive, there's surely more to go through. But it's an improvement.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Prevent shell completion for various options that do not take filenames as arguments.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

No