### PR TITLE
fix(oci): Honor target COSIGN_REPOSITORY for legacy-bundle OCI 1.1 signatures

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -211,8 +211,8 @@ func WriteAttestations(repo name.Repository, se oci.SignedEntity, opts ...Option
 	return remoteWrite(tag, atts, o.ROpt...)
 }
 
-// WriteSignaturesExperimentalOCI publishes the signatures attached to the given entity
-// into the provided repository (using OCI 1.1 methods).
+// WriteSignaturesExperimentalOCI reads the subject from the supplied digest and publishes
+// the attached signatures to the configured target repository using OCI 1.1 methods.
 func WriteSignaturesExperimentalOCI(d name.Digest, se oci.SignedEntity, opts ...Option) error {
 	o := makeOptions(d.Repository, opts...)
 	signTarget := d.String()
@@ -235,7 +235,7 @@ func WriteSignaturesExperimentalOCI(d name.Digest, se oci.SignedEntity, opts ...
 		return err
 	}
 	for _, v := range s {
-		if err := remoteWriteLayer(d.Repository, v, o.ROpt...); err != nil {
+		if err := remoteWriteLayer(o.TargetRepository, v, o.ROpt...); err != nil {
 			return err
 		}
 	}
@@ -250,7 +250,7 @@ func WriteSignaturesExperimentalOCI(d name.Digest, se oci.SignedEntity, opts ...
 		return err
 	}
 	configLayer := static.NewLayer(configBytes, configDesc.MediaType)
-	if err := remoteWriteLayer(d.Repository, configLayer, o.ROpt...); err != nil {
+	if err := remoteWriteLayer(o.TargetRepository, configLayer, o.ROpt...); err != nil {
 		return err
 	}
 
@@ -268,7 +268,7 @@ func WriteSignaturesExperimentalOCI(d name.Digest, se oci.SignedEntity, opts ...
 	m.Config.MediaType = types.MediaType(artifactType)
 	m.Subject = desc
 	rm := referrerManifest{m, artifactType}
-	targetRef, err := rm.targetRef(d.Repository, opts...)
+	targetRef, err := rm.targetRef(o.TargetRepository, opts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/oci/remote/write_test.go
+++ b/pkg/oci/remote/write_test.go
@@ -17,11 +17,15 @@ package remote
 
 import (
 	"fmt"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/static"
@@ -581,14 +585,18 @@ func TestWriteSignaturesExperimentalOCI(t *testing.T) {
 		}, nil
 	}
 
-	// Mock remoteWriteLayer to succeed
-	remoteWriteLayer = func(name.Repository, v1.Layer, ...remote.Option) error {
+	// Mock remoteWriteLayer to capture the destination repository
+	var capturedRepositories []name.Repository
+	remoteWriteLayer = func(repo name.Repository, _ v1.Layer, _ ...remote.Option) error {
+		capturedRepositories = append(capturedRepositories, repo)
 		return nil
 	}
 
 	// Mock remotePut to capture the manifest
+	var capturedReference name.Reference
 	var capturedManifest remote.Taggable
-	remotePut = func(_ name.Reference, manifest remote.Taggable, _ ...remote.Option) error {
+	remotePut = func(ref name.Reference, manifest remote.Taggable, _ ...remote.Option) error {
+		capturedReference = ref
 		capturedManifest = manifest
 		return nil
 	}
@@ -601,6 +609,17 @@ func TestWriteSignaturesExperimentalOCI(t *testing.T) {
 	// Verify that a manifest was uploaded
 	if capturedManifest == nil {
 		t.Fatal("Expected manifest to be uploaded, but none was captured")
+	}
+	if got := len(capturedRepositories); got != 2 {
+		t.Fatalf("layer writes = %d, want 2", got)
+	}
+	for _, repo := range capturedRepositories {
+		if repo.String() != digest.Repository.String() {
+			t.Errorf("layer repository = %q, want %q", repo, digest.Repository)
+		}
+	}
+	if capturedReference.Context().String() != digest.Repository.String() {
+		t.Errorf("manifest repository = %q, want %q", capturedReference.Context(), digest.Repository)
 	}
 
 	// Verify it's a referrerManifest (not a taggableManifest)
@@ -627,5 +646,90 @@ func TestWriteSignaturesExperimentalOCI(t *testing.T) {
 	}
 	if !strings.Contains(string(manifestBytes), `"artifactType"`) {
 		t.Errorf("Expected manifest JSON to contain artifactType field, got: %s", string(manifestBytes))
+	}
+
+	targetRepository := name.MustParseReference("gcr.io/target/image").Context()
+	capturedRepositories = nil
+	capturedReference = nil
+	if err := WriteSignaturesExperimentalOCI(digest, si, WithTargetRepository(targetRepository)); err != nil {
+		t.Fatalf("WriteSignaturesExperimentalOCI() with target repository = %v", err)
+	}
+	if got := len(capturedRepositories); got != 2 {
+		t.Fatalf("layer writes = %d, want 2", got)
+	}
+	for _, repo := range capturedRepositories {
+		if repo.String() != targetRepository.String() {
+			t.Errorf("layer repository = %q, want %q", repo, targetRepository)
+		}
+	}
+	if capturedReference.Context().String() != targetRepository.String() {
+		t.Errorf("manifest repository = %q, want %q", capturedReference.Context(), targetRepository)
+	}
+}
+
+func TestWriteSignaturesExperimentalOCIWithTargetRepository(t *testing.T) {
+	r := registry.New(registry.WithReferrersSupport(true))
+	s := httptest.NewServer(r)
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		t.Fatalf("url.Parse() = %v", err)
+	}
+	sourceRef, err := name.ParseReference(fmt.Sprintf("%s/source-repo:tag", u.Host))
+	if err != nil {
+		t.Fatalf("name.ParseReference(source) = %v", err)
+	}
+	targetRef, err := name.ParseReference(fmt.Sprintf("%s/target-repo", u.Host))
+	if err != nil {
+		t.Fatalf("name.ParseReference(target) = %v", err)
+	}
+	targetRepo := targetRef.Context()
+	if err := remote.Write(sourceRef, empty.Image); err != nil {
+		t.Fatalf("remote.Write() = %v", err)
+	}
+	desc, err := remote.Head(sourceRef)
+	if err != nil {
+		t.Fatalf("remote.Head() = %v", err)
+	}
+	sourceDigest := sourceRef.Context().Digest(desc.Digest.String())
+
+	si := signed.Image(empty.Image)
+	sig, err := cosignstatic.NewSignature(nil, "test-sig")
+	if err != nil {
+		t.Fatalf("static.NewSignature() = %v", err)
+	}
+	si, err = mutate.AttachSignatureToImage(si, sig)
+	if err != nil {
+		t.Fatalf("AttachSignatureToImage() = %v", err)
+	}
+
+	if err := WriteSignaturesExperimentalOCI(sourceDigest, si, WithTargetRepository(targetRepo)); err != nil {
+		t.Fatalf("WriteSignaturesExperimentalOCI() = %v", err)
+	}
+
+	targetDigest := targetRepo.Digest(desc.Digest.String())
+	targetReferrers, err := remote.Referrers(targetDigest)
+	if err != nil {
+		t.Fatalf("remote.Referrers(target) = %v", err)
+	}
+	targetManifest, err := targetReferrers.IndexManifest()
+	if err != nil {
+		t.Fatalf("targetReferrers.IndexManifest() = %v", err)
+	}
+	if got := len(targetManifest.Manifests); got != 1 {
+		t.Fatalf("target referrers = %d, want 1", got)
+	}
+
+	sourceReferrers, err := remote.Referrers(sourceDigest)
+	if err != nil {
+		t.Fatalf("remote.Referrers(source) = %v", err)
+	}
+	sourceManifest, err := sourceReferrers.IndexManifest()
+	if err != nil {
+		t.Fatalf("sourceReferrers.IndexManifest() = %v", err)
+	}
+	if got := len(sourceManifest.Manifests); got != 0 {
+		t.Fatalf("source referrers = %d, want 0", got)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Closes #5033.

##### What

- Publish legacy-bundle OCI 1.1 signature artifacts to the configured target `COSIGN_REPOSITORY`.
- Keep subject resolution in the original repository and preserve existing remote options.
- Test redirected and default placement with unit and in-process registry coverage.

##### Why

The legacy-bundle command exited successfully and announced the target `COSIGN_REPOSITORY`, but its OCI 1.1 writer uploaded the signature artifacts to the source repository.

##### Reproduction

```console
$ COSIGN_PASSWORD=repro COSIGN_EXPERIMENTAL=1 COSIGN_REPOSITORY=127.0.0.1:5007/target \
    ./cosign sign --yes --key cosign.key --signing-config signing-config.json --bundle repro.bundle --registry-referrers-mode=oci-1-1 \
    --new-bundle-format=false --allow-insecure-registry 127.0.0.1:5007/source@sha256:e7a1a92a5bfeee40966aea60f0796b0e7917cc35591542701834f03a68fa3d18
Signing artifact...
Wrote bundle to file repro.bundle
Pushing signature to: 127.0.0.1:5007/target
Uploading signature for [127.0.0.1:5007/source@sha256:e7a1a92a5bfeee40966aea60f0796b0e7917cc35591542701834f03a68fa3d18] to [127.0.0.1:5007/source@sha256:<signature-manifest-digest>] ...
```

The first destination message uses `COSIGN_REPOSITORY`, but the OCI 1.1 writer's upload message shows the artifact going to `127.0.0.1:5007/source`.

##### Verification

- `go test ./pkg/oci/remote -run TestWriteSignaturesExperimentalOCI -count=1`

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Fixed legacy-bundle OCI 1.1 signature publication to honor `COSIGN_REPOSITORY`.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

No documentation update is required. This fixes the existing documented `COSIGN_REPOSITORY` behavior without changing the CLI or API.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>