### PR TITLE
fix(blob): compare file checksums case-insensitively

### DIFF
--- a/pkg/blob/load.go
+++ b/pkg/blob/load.go
@@ -15,6 +15,7 @@
 package blob
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
@@ -103,11 +104,13 @@ func LoadFileOrURLWithChecksum(fileRef string, checksum string) ([]byte, error) 
 	}
 
 	checksumAlgo.Write(fileContent)
-	computedChecksum := hex.EncodeToString(checksumAlgo.Sum(nil))
-	// Hex is case-insensitive and checksums are commonly published in upper case,
-	// so compare without regard to case rather than rejecting a correct digest.
-	if !strings.EqualFold(computedChecksum, checksumValue) {
-		return nil, fmt.Errorf("incorrect checksum for file %s: expected %s but got %s", fileRef, checksumValue, computedChecksum)
+	computedChecksum := checksumAlgo.Sum(nil)
+	// Compare the digests rather than their hex spellings: hex is case-insensitive
+	// and checksums are frequently published in upper case, which a plain string
+	// comparison would reject. A value that is not valid hex cannot match either.
+	expectedChecksum, err := hex.DecodeString(checksumValue)
+	if err != nil || !bytes.Equal(computedChecksum, expectedChecksum) {
+		return nil, fmt.Errorf("incorrect checksum for file %s: expected %s but got %s", fileRef, checksumValue, hex.EncodeToString(computedChecksum))
 	}
 
 	return fileContent, nil

--- a/pkg/blob/load.go
+++ b/pkg/blob/load.go
@@ -104,7 +104,9 @@ func LoadFileOrURLWithChecksum(fileRef string, checksum string) ([]byte, error) 
 
 	checksumAlgo.Write(fileContent)
 	computedChecksum := hex.EncodeToString(checksumAlgo.Sum(nil))
-	if computedChecksum != checksumValue {
+	// Hex is case-insensitive and checksums are commonly published in upper case,
+	// so compare without regard to case rather than rejecting a correct digest.
+	if !strings.EqualFold(computedChecksum, checksumValue) {
 		return nil, fmt.Errorf("incorrect checksum for file %s: expected %s but got %s", fileRef, checksumValue, computedChecksum)
 	}
 

--- a/pkg/blob/load_test.go
+++ b/pkg/blob/load_test.go
@@ -157,6 +157,29 @@ func TestLoadURLWithChecksum(t *testing.T) {
 		t.Errorf("LoadFileOrURL(HTTP) = '%s'; want '%s'", actual, data)
 	}
 
+	// an upper-case digest is the same digest: hex is case-insensitive, and
+	// checksums are frequently published in upper case
+	actual, err = LoadFileOrURLWithChecksum(
+		server.URL,
+		"9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08",
+	)
+	if err != nil {
+		t.Errorf("Upper-case checksum rejected: %v", err)
+	} else if !bytes.Equal(actual, data) {
+		t.Errorf("LoadFileOrURL(HTTP) = '%s'; want '%s'", actual, data)
+	}
+
+	// same for the prefixed form
+	actual, err = LoadFileOrURLWithChecksum(
+		server.URL,
+		"sha512:EE26B0DD4AF7E749AA1A8EE3C10AE9923F618980772E473F8819A5D4940E0DB27AC185F8A0E1D5F84F88BC887FD67B143732C304CC5FA9AD8E6F57F50028A8FF",
+	)
+	if err != nil {
+		t.Errorf("Upper-case sha512 checksum rejected: %v", err)
+	} else if !bytes.Equal(actual, data) {
+		t.Errorf("LoadFileOrURL(HTTP) = '%s'; want '%s'", actual, data)
+	}
+
 	// ensure it fails with the wrong checksum
 	_, err = LoadFileOrURLWithChecksum(
 		server.URL,


### PR DESCRIPTION
## Summary

`cosign initialize --root-checksum` rejects a correct checksum when it is written in upper case.

`hex.EncodeToString` always emits lower case, and `pkg/blob/load.go:107` compares it to the user-supplied value with `!=`. Hex is case-insensitive, and plenty of sources publish digests in upper case, so a user holding a perfectly good checksum is told it is wrong.

Reproducer against the real sigstore root:

```console
$ curl -sO https://tuf-repo-cdn.sigstore.dev/12.root.json
$ shasum -a 256 12.root.json | awk '{print toupper($1)}'
5FE1E509A47277183A004745942C0A116379297DA9F1CCA529774320F1A5DFAB

$ cosign initialize --root 12.root.json \
    --root-checksum 5FE1E509A47277183A004745942C0A116379297DA9F1CCA529774320F1A5DFAB
Error: incorrect checksum for file 12.root.json: expected 5FE1E509A47277183A004745942C0A116379297DA9F1CCA529774320F1A5DFAB but got 5fe1e509a47277183a004745942c0a116379297da9f1cca529774320f1a5dfab
```

The error message gives it away: expected and got are the same digest.

## Why this is more than cosmetic

`LoadFileOrURLWithChecksum` has exactly one caller, `cmd/cosign/cli/initialize/init.go:59`, and that is the TUF root of trust. So the person who hits this is doing the right thing: pinning a root they fetched out of band. What the tool tells them is that the root does not match. The nearest way out is `--force-skip-checksum-validation`, which is exactly the habit this flag exists to prevent.

## Change

`strings.EqualFold` instead of `!=`. Wrong checksums stay wrong: a `DEADBEEF`-prefixed digest is still rejected, and the prefixed forms (`sha256:`, `sha512:`) behave the same as before apart from case.

## Testing

Added upper-case sha256 and sha512 cases to the existing `TestLoadURLWithChecksum`. They fail on main and pass with the fix; the existing cases are untouched. `go vet ./pkg/blob/`, `gofmt` and `go build ./...` are clean.

Also ran both binaries end to end against sigstore's `12.root.json`:

| build | checksum | exit |
|---|---|---|
| main | lower case | 0 |
| main | UPPER CASE | 1 |
| fix | UPPER CASE | 0, initialization completes |
| fix | `sha256:` + UPPER CASE | 0 |
| fix | `DEADBEEF...` | 1, still rejected |

## Release Note

`cosign initialize --root-checksum` now accepts upper-case and mixed-case hex digests.

## Documentation

NA
