### PR TITLE
Verification bypass via public key in legacy bundle (GHSA-fx35-mq7g-6g98)

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -141,7 +141,7 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 		}
 	}
 
-	bundleBytes, pubKey, pubKeyPem, hashAlgProto, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
+	bundleBytes, pubKey, hashAlgProto, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
 	if err != nil {
 		return fmt.Errorf("creating bundle: %w", err)
 	}
@@ -172,7 +172,7 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 		return fmt.Errorf("extracting components from bundle: %w", err)
 	}
 
-	legacyBundleBytes, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents, pubKeyPem)
+	legacyBundleBytes, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents)
 	if err != nil {
 		return fmt.Errorf("creating legacy bundle: %w", err)
 	}

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -154,7 +154,7 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 		}
 	}
 
-	bundleBytes, _, pubKeyPem, _, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
+	bundleBytes, _, _, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)
 	if err != nil {
 		return fmt.Errorf("creating bundle: %w", err)
 	}
@@ -178,7 +178,7 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 	}
 
 	if c.BundlePath != "" {
-		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents, pubKeyPem)
+		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents)
 		if err != nil {
 			return fmt.Errorf("creating legacy bundle: %w", err)
 		}

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -208,7 +208,7 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 		}
 	}
 
-	bundleBytes, _, _, _, err := signcommon.NewAttestationBundle(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
+	bundleBytes, _, _, err := signcommon.NewAttestationBundle(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
 	if err != nil {
 		return err
 	}
@@ -467,8 +467,6 @@ func fetchLocalSignedPayload(sig oci.Signature) (*cosign.LocalSignedPayload, err
 	}
 	if sigCert != nil {
 		signedPayload.Cert = base64.StdEncoding.EncodeToString(sigCert.Raw)
-	} else {
-		signedPayload.Cert = ""
 	}
 
 	signedPayload.Bundle, err = sig.Bundle()

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -147,11 +147,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	if ko.BundlePath != "" {
-		pubKeyPem, err := keypair.GetPublicKeyPem()
-		if err != nil {
-			return nil, fmt.Errorf("getting public key pem: %w", err)
-		}
-		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents, pubKeyPem)
+		contents, err := signcommon.NewLegacyBundleFromProtoBundleComponents(bundleComponents)
 		if err != nil {
 			return nil, fmt.Errorf("creating legacy bundle: %w", err)
 		}

--- a/cmd/cosign/cli/sign/sign_blob_test.go
+++ b/cmd/cosign/cli/sign/sign_blob_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"os"
 	"path/filepath"
@@ -160,4 +161,44 @@ func writeFile(t *testing.T, td string, blob string, name string) string {
 		t.Fatal(err)
 	}
 	return blobPath
+}
+
+func TestSignBlobCmd_LegacyBundleNoCert(t *testing.T) {
+	td := t.TempDir()
+	bundlePath := filepath.Join(td, "legacy-bundle.json")
+
+	keys, _ := cosign.GenerateKeyPair(nil)
+	keyRef := writeFile(t, td, string(keys.PrivateBytes), "key.pem")
+
+	blob := []byte("foo")
+	blobPath := writeFile(t, td, string(blob), "foo.txt")
+
+	rootOpts := &options.RootOptions{}
+	keyOpts := options.KeyOpts{
+		KeyRef:          keyRef,
+		BundlePath:      bundlePath,
+		NewBundleFormat: false,
+	}
+
+	_, err := SignBlobCmd(t.Context(), rootOpts, keyOpts, blobPath, "", "", true, "", "", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	bundleBytes, err := os.ReadFile(bundlePath)
+	if err != nil {
+		t.Fatalf("failed to read written bundle file: %v", err)
+	}
+
+	var payload cosign.LocalSignedPayload
+	if err := json.Unmarshal(bundleBytes, &payload); err != nil {
+		t.Fatalf("failed to unmarshal legacy bundle: %v", err)
+	}
+
+	if payload.Cert != "" {
+		t.Fatalf("expected empty cert field in legacy bundle when signing with a key without certificate, got: %q", payload.Cert)
+	}
+	if payload.Base64Signature == "" {
+		t.Fatal("expected non-empty Base64Signature in legacy bundle")
+	}
 }

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -362,10 +362,10 @@ type CommonBundleOpts struct {
 }
 
 // NewAttestationBundle uses signing config and trusted root to sign an attestation and create a bundle.
-func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) ([]byte, crypto.PublicKey, string, pb_go_v1.HashAlgorithm, error) {
+func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) ([]byte, crypto.PublicKey, pb_go_v1.HashAlgorithm, error) {
 	keypair, certBytes, chainBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
 	if err != nil {
-		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting keypair and token: %w", err)
+		return nil, nil, pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting keypair and token: %w", err)
 	}
 	if closer, ok := keypair.(interface{ Close() }); ok {
 		defer closer.Close()
@@ -380,22 +380,17 @@ func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certCha
 	if ko.TSAClientCACert != "" || (ko.TSAClientCert != "" && ko.TSAClientKey != "") {
 		tsaClientTransport, err = client.GetHTTPTransport(ko.TSAClientCACert, ko.TSAClientCert, ko.TSAClientKey, ko.TSAServerName, 30*time.Second)
 		if err != nil {
-			return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting TSA client transport: %w", err)
+			return nil, nil, pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting TSA client transport: %w", err)
 		}
 	}
 	signOpts := cbundle.SignOptions{TSAClientTransport: tsaClientTransport}
 
 	bundle, err := cbundle.SignData(ctx, content, keypair, idToken, certBytes, chainBytes, signingConfig, trustedMaterial, signOpts)
 	if err != nil {
-		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("signing bundle: %w", err)
+		return nil, nil, pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("signing bundle: %w", err)
 	}
 
-	pubKeyPem, err := keypair.GetPublicKeyPem()
-	if err != nil {
-		return nil, nil, "", pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting public key pem: %w", err)
-	}
-
-	return bundle, keypair.GetPublicKey(), pubKeyPem, keypair.GetHashAlgorithm(), nil
+	return bundle, keypair.GetPublicKey(), keypair.GetHashAlgorithm(), nil
 }
 
 type BundleComponents struct {
@@ -586,7 +581,7 @@ func RekorBundleFromProtoTlogEntry(entry *protorekor.TransparencyLogEntry) *cbun
 }
 
 // NewLegacyBundleFromProtoBundleComponents creates a legacy bundle from a protobuf bundle.
-func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents, pubKeyPem string) ([]byte, error) {
+func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents) ([]byte, error) {
 	signedPayload := cosign.LocalSignedPayload{
 		Base64Signature: base64.StdEncoding.EncodeToString(bc.Signature),
 	}
@@ -594,8 +589,6 @@ func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents, pubKeyPem st
 	if len(bc.Certificates) > 0 {
 		certPem, _ := EncodeCertificatesToPEM(bc.Certificates)
 		signedPayload.Cert = base64.StdEncoding.EncodeToString(certPem)
-	} else if pubKeyPem != "" {
-		signedPayload.Cert = base64.StdEncoding.EncodeToString([]byte(pubKeyPem))
 	}
 
 	if len(bc.RekorEntries) > 0 {

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"os"
 	"reflect"
@@ -28,6 +29,7 @@ import (
 	"github.com/sigstore/cosign/v3/internal/test"
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
+	pb_go_v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -202,4 +204,34 @@ func Test_ParseOCIReference(t *testing.T) {
 			assert.Empty(t, stderr, "expected no warning")
 		}
 	}
+}
+
+func TestNewLegacyBundleFromProtoBundleComponents(t *testing.T) {
+	t.Run("without certificates leaves cert field empty", func(t *testing.T) {
+		bc := &BundleComponents{
+			Signature: []byte("signature"),
+		}
+		bundleBytes, err := NewLegacyBundleFromProtoBundleComponents(bc)
+		assert.NoError(t, err)
+
+		var payload cosign.LocalSignedPayload
+		err = json.Unmarshal(bundleBytes, &payload)
+		assert.NoError(t, err)
+		assert.Empty(t, payload.Cert, "expected empty cert field when BundleComponents has no certificates")
+	})
+
+	t.Run("with certificates populates cert field", func(t *testing.T) {
+		rootCert, _, _ := test.GenerateRootCa()
+		bc := &BundleComponents{
+			Signature:    []byte("signature"),
+			Certificates: []*pb_go_v1.X509Certificate{{RawBytes: rootCert.Raw}},
+		}
+		bundleBytes, err := NewLegacyBundleFromProtoBundleComponents(bc)
+		assert.NoError(t, err)
+
+		var payload cosign.LocalSignedPayload
+		err = json.Unmarshal(bundleBytes, &payload)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, payload.Cert, "expected non-empty cert field when BundleComponents has certificates")
+	})
 }

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -37,7 +37,6 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
-	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	sgverify "github.com/sigstore/sigstore-go/pkg/verify"
 
@@ -191,26 +190,14 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 		if err != nil {
 			return err
 		}
-		// A certificate is required in the bundle unless we specified with
-		//  --key, --sk, or --certificate.
-		if b.Cert == "" && co.SigVerifier == nil && cert == nil {
-			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
-		}
-		// We have to condition on this because sign-blob may not output the signing
-		// key to the bundle when there is no tlog upload.
 		if b.Cert != "" {
-			// b.Cert can either be a certificate or public key
 			certBytes := []byte(b.Cert)
 			if isb64(certBytes) {
 				certBytes, _ = base64.StdEncoding.DecodeString(b.Cert)
 			}
 			bundleCert, err := loadCertFromPEM(certBytes)
 			if err != nil {
-				// check if cert is actually a public key
-				co.SigVerifier, err = sigs.LoadPublicKeyRaw(certBytes, crypto.SHA256)
-				if err != nil {
-					return fmt.Errorf("loading verifier from bundle: %w", err)
-				}
+				return fmt.Errorf("loading verifier certificate from bundle: %w", err)
 			}
 			// if a cert was passed in, make sure it matches the cert in the bundle
 			if cert != nil && !cert.Equal(bundleCert) {
@@ -218,6 +205,12 @@ func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
 			}
 			cert = bundleCert
 		}
+		// A verifier must come either from a certificate from the bundle,
+		// or provided via --key, --sk, or --certificate.
+		if co.SigVerifier == nil && cert == nil {
+			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
+		}
+
 		opts = append(opts, static.WithBundle(b.Bundle))
 	}
 	if c.RFC3161TimestampPath != "" {

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -38,7 +38,6 @@ import (
 	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
 	"github.com/sigstore/cosign/v3/pkg/oci/static"
 	"github.com/sigstore/cosign/v3/pkg/policy"
-	sigs "github.com/sigstore/cosign/v3/pkg/signature"
 	sgbundle "github.com/sigstore/sigstore-go/pkg/bundle"
 	sgverify "github.com/sigstore/sigstore-go/pkg/verify"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
@@ -304,32 +303,25 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		if err != nil {
 			return err
 		}
-		// A certificate is required in the bundle unless we specified with
-		//  --key, --sk, or --certificate.
-		if b.Cert == "" && co.SigVerifier == nil && cert == nil {
-			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
-		}
-		// We have to condition on this because sign-blob may not output the signing
-		// key to the bundle when there is no tlog upload.
 		if b.Cert != "" {
-			// b.Cert can either be a certificate or public key
 			certBytes := []byte(b.Cert)
 			if isb64(certBytes) {
 				certBytes, _ = base64.StdEncoding.DecodeString(b.Cert)
 			}
 			bundleCert, err := loadCertFromPEM(certBytes)
 			if err != nil {
-				// check if cert is actually a public key
-				co.SigVerifier, err = sigs.LoadPublicKeyRaw(certBytes, crypto.SHA256)
-				if err != nil {
-					return fmt.Errorf("loading verifier from bundle: %w", err)
-				}
+				return fmt.Errorf("loading verifier certificate from bundle: %w", err)
 			}
 			// if a cert was passed in, make sure it matches the cert in the bundle
 			if cert != nil && !cert.Equal(bundleCert) {
 				return fmt.Errorf("the cert passed in does not match the cert in the provided bundle")
 			}
 			cert = bundleCert
+		}
+		// A verifier must come either from a certificate from the bundle,
+		// or provided via --key, --sk, or --certificate.
+		if co.SigVerifier == nil && cert == nil {
+			return fmt.Errorf("bundle does not contain cert for verification, please provide public key")
 		}
 
 		encodedSig, err = base64.StdEncoding.DecodeString(b.Base64Signature)

--- a/cmd/cosign/cli/verify/verify_blob_attestation_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation_test.go
@@ -594,3 +594,62 @@ func TestVerifyBlobAttestationSkWithoutIdentities(t *testing.T) {
 		t.Fatalf("expected PIV error, got: %v", err)
 	}
 }
+
+func TestVerifyBlobAttestationLegacyBundlePublicKey(t *testing.T) {
+	ctx := context.Background()
+	td := t.TempDir()
+
+	blobPath := writeBlobFile(t, td, blobContents, "blob")
+	keyRef := writeBlobFile(t, td, pubkey, "cosign.pub")
+
+	t.Run("legacy bundle with public key in cert field fails", func(t *testing.T) {
+		bundleData := map[string]any{
+			"base64Signature": blobSLSAProvenanceSignature,
+			"cert":            pubkey,
+		}
+		bundleBytes, err := json.Marshal(bundleData)
+		if err != nil {
+			t.Fatalf("failed to marshal old bundle: %v", err)
+		}
+		bundleRef := writeBlobFile(t, td, string(bundleBytes), "bundle.json")
+
+		cmd := VerifyBlobAttestationCommand{
+			KeyOpts:       options.KeyOpts{KeyRef: keyRef, BundlePath: bundleRef},
+			IgnoreTlog:    true,
+			CheckClaims:   true,
+			PredicateType: "slsaprovenance",
+		}
+
+		err = cmd.Exec(ctx, blobPath)
+		if err == nil {
+			t.Fatal("expected error when bundle cert field contains a public key, got nil")
+		}
+		if !strings.Contains(err.Error(), "loading verifier certificate from bundle") {
+			t.Fatalf("expected error containing 'loading verifier certificate from bundle', got: %v", err)
+		}
+	})
+
+	t.Run("legacy bundle with empty cert field succeeds when key is provided via KeyRef", func(t *testing.T) {
+		bundleData := map[string]any{
+			"base64Signature": blobSLSAProvenanceSignature,
+			"cert":            "",
+		}
+		bundleBytes, err := json.Marshal(bundleData)
+		if err != nil {
+			t.Fatalf("failed to marshal old bundle: %v", err)
+		}
+		bundleRef := writeBlobFile(t, td, string(bundleBytes), "bundle.json")
+
+		cmd := VerifyBlobAttestationCommand{
+			KeyOpts:       options.KeyOpts{KeyRef: keyRef, BundlePath: bundleRef},
+			IgnoreTlog:    true,
+			CheckClaims:   true,
+			PredicateType: "slsaprovenance",
+		}
+
+		err = cmd.Exec(ctx, blobPath)
+		if err != nil {
+			t.Fatalf("expected success when bundle cert field is empty and key provided via KeyRef, got: %v", err)
+		}
+	})
+}

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -258,6 +258,7 @@ func TestVerifyBlob(t *testing.T) {
 		rekorEntry     []*models.LogEntry
 		skipTlogVerify bool
 		shouldErr      bool
+		expectedErr    string
 		tsPath         string
 		tsChainPath    string
 	}{
@@ -270,15 +271,16 @@ func TestVerifyBlob(t *testing.T) {
 			skipTlogVerify: true,
 		},
 		{
-			name:       "valid signature with public key - experimental no rekor fail",
-			blob:       blobBytes,
-			signature:  blobSignature,
-			key:        pubKeyBytes,
-			rekorEntry: nil,
-			shouldErr:  true,
+			name:        "valid signature with public key - no rekor fail",
+			blob:        blobBytes,
+			signature:   blobSignature,
+			key:         pubKeyBytes,
+			rekorEntry:  nil,
+			shouldErr:   true,
+			expectedErr: "signature not found in transparency log",
 		},
 		{
-			name:      "valid signature with public key - experimental rekor entry success",
+			name:      "valid signature with public key - rekor entry success",
 			blob:      blobBytes,
 			signature: blobSignature,
 			key:       pubKeyBytes,
@@ -287,21 +289,32 @@ func TestVerifyBlob(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:      "valid signature with public key - good bundle provided",
+			name:      "valid signature with public key - good bundle provided fails when public key is in cert",
 			blob:      blobBytes,
 			signature: blobSignature,
 			key:       pubKeyBytes,
 			bundlePath: makeLocalBundle(t, *rekorSigner, blobBytes, []byte(blobSignature),
 				pubKeyBytes, true),
+			shouldErr:   true,
+			expectedErr: "loading verifier certificate from bundle",
+		},
+		{
+			name:      "valid signature with public key - good bundle provided succeeds when key is provided via KeyRef",
+			blob:      blobBytes,
+			signature: blobSignature,
+			key:       pubKeyBytes,
+			bundlePath: makeLocalBundleWithoutCert(t, *rekorSigner, blobBytes, []byte(blobSignature),
+				pubKeyBytes, true),
 			shouldErr: false,
 		},
 		{
-			name:       "valid signature with public key - bundle without rekor bundle fails",
-			blob:       blobBytes,
-			signature:  blobSignature,
-			key:        pubKeyBytes,
-			bundlePath: makeLocalBundleWithoutRekorBundle(t, []byte(blobSignature), pubKeyBytes),
-			shouldErr:  true,
+			name:        "valid signature with public key - bundle without rekor bundle fails",
+			blob:        blobBytes,
+			signature:   blobSignature,
+			key:         pubKeyBytes,
+			bundlePath:  makeLocalBundleWithoutRekorBundle(t, []byte(blobSignature), nil),
+			shouldErr:   true,
+			expectedErr: "signature not found in transparency log",
 		},
 		{
 			name:      "valid signature with public key - bad bundle SET",
@@ -310,7 +323,8 @@ func TestVerifyBlob(t *testing.T) {
 			key:       pubKeyBytes,
 			bundlePath: makeLocalBundle(t, *signer, blobBytes, []byte(blobSignature),
 				unexpiredCertPem, true),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "rekor log public key not found for payload",
 		},
 		{
 			name:      "valid signature with public key - bad bundle cert mismatch",
@@ -319,7 +333,8 @@ func TestVerifyBlob(t *testing.T) {
 			key:       pubKeyBytes,
 			bundlePath: makeLocalBundle(t, *rekorSigner, blobBytes, []byte(unrelatedSignature),
 				unrelatedCertPem, true),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "both public key and certificate were provided but did not match",
 		},
 		{
 			name:      "valid signature with public key and bundle cert derived from public key",
@@ -335,18 +350,20 @@ func TestVerifyBlob(t *testing.T) {
 			blob:      blobBytes,
 			signature: blobSignature,
 			key:       pubKeyBytes,
-			bundlePath: makeLocalBundle(t, *rekorSigner, blobBytes, []byte(makeSignature(blobBytes, signer)),
+			bundlePath: makeLocalBundleWithoutCert(t, *rekorSigner, blobBytes, []byte(makeSignature(blobBytes, signer)),
 				pubKeyBytes, true),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "signature in bundle does not match signature being verified",
 		},
 		{
 			name:      "valid signature with public key - bad bundle msg & signature mismatch",
 			blob:      blobBytes,
 			signature: blobSignature,
 			key:       pubKeyBytes,
-			bundlePath: makeLocalBundle(t, *rekorSigner, otherBytes, []byte(otherSignature),
+			bundlePath: makeLocalBundleWithoutCert(t, *rekorSigner, otherBytes, []byte(otherSignature),
 				pubKeyBytes, true),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "signature in bundle does not match signature being verified",
 		},
 		{
 			name:           "valid signature with public key - new bundle",
@@ -367,27 +384,31 @@ func TestVerifyBlob(t *testing.T) {
 			newBundle:      true,
 			skipTlogVerify: true,
 			shouldErr:      true,
+			expectedErr:    "invalid signature",
 		},
 		{
-			name:      "invalid signature with public key",
-			blob:      blobBytes,
-			signature: otherSignature,
-			key:       pubKeyBytes,
-			shouldErr: true,
+			name:        "invalid signature with public key",
+			blob:        blobBytes,
+			signature:   otherSignature,
+			key:         pubKeyBytes,
+			shouldErr:   true,
+			expectedErr: "signature not found in transparency log",
 		},
 		{
-			name:      "invalid signature with public key - experimental",
-			blob:      blobBytes,
-			signature: otherSignature,
-			key:       pubKeyBytes,
-			shouldErr: true,
+			name:        "invalid signature with public key and no Rekor entry",
+			blob:        blobBytes,
+			signature:   otherSignature,
+			key:         pubKeyBytes,
+			shouldErr:   true,
+			expectedErr: "signature not found in transparency log",
 		},
 		{
-			name:      "valid signature with unexpired certificate - no rekor entry",
-			blob:      blobBytes,
-			signature: blobSignature,
-			cert:      unexpiredLeafCert,
-			shouldErr: true,
+			name:        "valid signature with unexpired certificate - no rekor entry",
+			blob:        blobBytes,
+			signature:   blobSignature,
+			cert:        unexpiredLeafCert,
+			shouldErr:   true,
+			expectedErr: "signature not found in transparency log",
 		},
 		{
 			name:      "valid signature with unexpired certificate - bad bundle signature mismatch",
@@ -396,7 +417,8 @@ func TestVerifyBlob(t *testing.T) {
 			cert:      unexpiredLeafCert,
 			bundlePath: makeLocalBundle(t, *rekorSigner, blobBytes, []byte(makeSignature(blobBytes, signer)),
 				unexpiredCertPem, true),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "signature in bundle does not match signature being verified",
 		},
 		{
 			name:      "valid signature with unexpired certificate - bad bundle msg & signature mismatch",
@@ -405,26 +427,19 @@ func TestVerifyBlob(t *testing.T) {
 			cert:      unexpiredLeafCert,
 			bundlePath: makeLocalBundle(t, *rekorSigner, otherBytes, []byte(otherSignature),
 				unexpiredCertPem, true),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "signature in bundle does not match signature being verified",
 		},
 		{
-			name:      "invalid signature with unexpired certificate",
-			blob:      blobBytes,
-			signature: otherSignature,
-			cert:      unexpiredLeafCert,
-			shouldErr: true,
+			name:        "invalid signature with unexpired certificate and no Rekor entry, expect Rekor",
+			blob:        blobBytes,
+			signature:   otherSignature,
+			cert:        unexpiredLeafCert,
+			shouldErr:   true,
+			expectedErr: "signature not found in transparency log",
 		},
 		{
-			name:      "valid signature with unexpired certificate - experimental",
-			blob:      blobBytes,
-			signature: blobSignature,
-			cert:      unexpiredLeafCert,
-			rekorEntry: []*models.LogEntry{makeRekorEntry(t, *rekorSigner, blobBytes, []byte(blobSignature),
-				unexpiredCertPem, true)},
-			shouldErr: false,
-		},
-		{
-			name:      "valid signature with unexpired certificate - experimental & rekor entry found",
+			name:      "valid signature with unexpired certificate and Rekor proof",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      unexpiredLeafCert,
@@ -433,11 +448,21 @@ func TestVerifyBlob(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:      "valid signature with expired certificate + Rekor",
+			name:      "valid signature with unexpired certificate - rekor entry found",
 			blob:      blobBytes,
 			signature: blobSignature,
-			cert:      expiredLeafCert,
-			shouldErr: true,
+			cert:      unexpiredLeafCert,
+			rekorEntry: []*models.LogEntry{makeRekorEntry(t, *rekorSigner, blobBytes, []byte(blobSignature),
+				unexpiredCertPem, true)},
+			shouldErr: false,
+		},
+		{
+			name:        "valid signature with expired certificate and no proof, expect Rekor",
+			blob:        blobBytes,
+			signature:   blobSignature,
+			cert:        expiredLeafCert,
+			shouldErr:   true,
+			expectedErr: "signature not found in transparency log",
 		},
 		{
 			name:           "valid signature with expired certificate, no Rekor",
@@ -446,9 +471,10 @@ func TestVerifyBlob(t *testing.T) {
 			cert:           expiredLeafCert,
 			skipTlogVerify: true,
 			shouldErr:      true,
+			expectedErr:    "expected a signed timestamp to verify an expired certificate",
 		},
 		{
-			name:      "valid signature with expired certificate - experimental good rekor lookup",
+			name:      "valid signature with expired certificate - good rekor lookup",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      expiredLeafCert,
@@ -457,27 +483,28 @@ func TestVerifyBlob(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:      "valid signature with expired certificate - experimental multiple rekor entries",
+			name:      "valid signature with expired certificate - multiple rekor entries",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      expiredLeafCert,
 			rekorEntry: []*models.LogEntry{makeRekorEntry(t, *rekorSigner, blobBytes, []byte(blobSignature),
 				expiredLeafPem, true), makeRekorEntry(t, *rekorSigner, blobBytes, []byte(blobSignature),
-				expiredLeafPem, false)},
+				expiredLeafPem, true)},
 			shouldErr: false,
 		},
 		{
-			name:      "valid signature with expired certificate - experimental bad rekor integrated time",
+			name:      "valid signature with expired certificate - bad rekor integrated time",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      expiredLeafCert,
 			rekorEntry: []*models.LogEntry{makeRekorEntry(t, *rekorSigner, blobBytes, []byte(blobSignature),
 				expiredLeafPem, false)},
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "certificate expired before observed time",
 		},
 
 		{
-			name:      "valid signature with unexpired certificate - good bundle, nonexperimental",
+			name:      "valid signature with unexpired certificate - good bundle",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      unexpiredLeafCert,
@@ -486,7 +513,7 @@ func TestVerifyBlob(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:      "valid signature with expired certificate - good bundle, nonexperimental",
+			name:      "valid signature with expired certificate - good bundle",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      expiredLeafCert,
@@ -501,7 +528,8 @@ func TestVerifyBlob(t *testing.T) {
 			cert:      expiredLeafCert,
 			bundlePath: makeLocalBundle(t, *rekorSigner, blobBytes, []byte(blobSignature),
 				expiredLeafPem, false),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "certificate expired before observed time",
 		},
 		{
 			name:      "valid signature with expired certificate - bundle with bad SET",
@@ -510,10 +538,11 @@ func TestVerifyBlob(t *testing.T) {
 			cert:      expiredLeafCert,
 			bundlePath: makeLocalBundle(t, *signer, blobBytes, []byte(blobSignature),
 				expiredLeafPem, true),
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "rekor log public key not found for payload",
 		},
 		{
-			name:      "valid signature with expired certificate - experimental good bundle",
+			name:      "valid signature with expired certificate - good bundle",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      expiredLeafCert,
@@ -522,14 +551,15 @@ func TestVerifyBlob(t *testing.T) {
 			shouldErr: false,
 		},
 		{
-			name:      "valid signature with expired certificate - experimental bad rekor entry",
+			name:      "valid signature with expired certificate - bad rekor entry",
 			blob:      blobBytes,
 			signature: blobSignature,
 			cert:      expiredLeafCert,
 			// This is the wrong signer for the SET!
 			rekorEntry: []*models.LogEntry{makeRekorEntry(t, *signer, blobBytes, []byte(blobSignature),
 				expiredLeafPem, true)},
-			shouldErr: true,
+			shouldErr:   true,
+			expectedErr: "rekor log public key not found for payload",
 		},
 		{
 			name:      "valid signature with expired certificate - good bundle, good timestamp",
@@ -561,6 +591,7 @@ func TestVerifyBlob(t *testing.T) {
 			tsChainPath:    expiredTSACertChainPath,
 			skipTlogVerify: true,
 			shouldErr:      true,
+			expectedErr:    "hashed messages don't match",
 		},
 		{
 			name:      "valid signature with unexpired certificate - good bundle, good timestamp",
@@ -643,6 +674,11 @@ func TestVerifyBlob(t *testing.T) {
 			err := cmd.Exec(context.Background(), blobPath)
 			if (err != nil) != tt.shouldErr {
 				t.Fatalf("verifyBlob()= %s, expected shouldErr=%t ", err, tt.shouldErr)
+			}
+			if tt.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("expected error containing %q, got: %v", tt.expectedErr, err)
+				}
 			}
 		})
 	}
@@ -849,6 +885,42 @@ func makeLocalBundle(t *testing.T, rekorSigner signature.ECDSASignerVerifier,
 	b := cosign.LocalSignedPayload{
 		Base64Signature: base64.StdEncoding.EncodeToString(sig),
 		Cert:            string(svBytes),
+		Bundle: &bundle.RekorBundle{
+			Payload: bundle.RekorPayload{
+				Body:           e.Body,
+				IntegratedTime: *e.IntegratedTime,
+				LogIndex:       *e.LogIndex,
+				LogID:          *e.LogID,
+			},
+			SignedEntryTimestamp: e.Verification.SignedEntryTimestamp,
+		},
+	}
+
+	// Write bundle to disk
+	jsonBundle, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundlePath := filepath.Join(td, "bundle.sig")
+	if err := os.WriteFile(bundlePath, jsonBundle, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return bundlePath
+}
+
+func makeLocalBundleWithoutCert(t *testing.T, rekorSigner signature.ECDSASignerVerifier,
+	pyld []byte, sig []byte, svBytes []byte, expiryValid bool) string {
+	td := t.TempDir()
+
+	// Create bundle.
+	entry := makeRekorEntry(t, rekorSigner, pyld, sig, svBytes, expiryValid)
+	var e models.LogEntryAnon
+	for _, v := range *entry {
+		e = v
+	}
+	b := cosign.LocalSignedPayload{
+		Base64Signature: base64.StdEncoding.EncodeToString(sig),
+		Cert:            "",
 		Bundle: &bundle.RekorBundle{
 			Payload: bundle.RekorPayload{
 				Body:           e.Body,


### PR DESCRIPTION
Remove the fallback that loaded a raw public key from a legacy bundle's cert field when X.509 certificate parsing failed. Previously, an attacker could supply a bare public key in b.Cert to populate co.SigVerifier, skipping X.509 certificate chain validation and CheckCertificatePolicy enforcement during keyless verification. This would use the key without any additional checks. The key-as-certificate in the bundle would take priority over a key being provided via --key as well.

This updates the sign-blob and attest-blob code paths to never set a key in the certificate field in the legacy bundle. Before a refactor a few months ago, attest-blob did this. After the refactor, sign-blob did as well. Now, neither code path will persist a key in the bundle.

For verification, verify-blob and verify-blob-attestation have been updated to not fallback to parsing a certificate as a key. If a bundle is supplied that contains a key, it fails with a parsing error.

Note that no change is needed for sign/attest and
verify/verify-attestation, as the container signing path never stored a public key in the certificate field and the container verification path would only load a certificate as a certificate.
