### PR TITLE
fix: only show public-instance privacy statement for the default Rekor URL

### DIFF
--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -119,7 +119,9 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Reference, tlogUpload bool) (bool, error) {
 	upload := shouldUploadToTlog(ctx, ko, ref, tlogUpload)
 	var statementErr error
-	if upload {
+	// Only warn about the public good instance's data retention policy when
+	// actually uploading to it; a custom --rekor-url points elsewhere.
+	if upload && (ko.RekorURL == "" || ko.RekorURL == options.DefaultRekorURL) {
 		privacy.StatementOnce.Do(func() {
 			ui.Infof(ctx, privacy.Statement)
 			ui.Infof(ctx, privacy.StatementConfirmation)

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -25,7 +25,9 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"net/http"
 	"time"
@@ -121,7 +123,7 @@ func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 	var statementErr error
 	// Only warn about the public good instance's data retention policy when
 	// actually uploading to it; a custom --rekor-url points elsewhere.
-	if upload && (ko.RekorURL == "" || ko.RekorURL == options.DefaultRekorURL) {
+	if upload && isPublicGoodRekorURL(ko.RekorURL) {
 		privacy.StatementOnce.Do(func() {
 			ui.Infof(ctx, privacy.Statement)
 			ui.Infof(ctx, privacy.StatementConfirmation)
@@ -133,6 +135,33 @@ func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 		})
 	}
 	return upload, statementErr
+}
+
+// publicGoodRekorHostSuffixes are the hostname suffixes of Rekor instances operated
+// as part of the sigstore public good instance (production and staging). A literal
+// comparison against options.DefaultRekorURL is not sufficient because the public
+// good instance is served from multiple region- and year-specific hostnames.
+var publicGoodRekorHostSuffixes = []string{".sigstore.dev", ".sigstage.dev"}
+
+// isPublicGoodRekorURL reports whether rekorURL points at the sigstore public good
+// instance (production or staging), which is the only case where the data-retention
+// privacy statement applies. An empty rekorURL is treated as the default public
+// instance.
+func isPublicGoodRekorURL(rekorURL string) bool {
+	if rekorURL == "" {
+		return true
+	}
+	parsed, err := url.Parse(rekorURL)
+	if err != nil || parsed.Hostname() == "" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	for _, suffix := range publicGoodRekorHostSuffixes {
+		if host == suffix[1:] || strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func shouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Reference, tlogUpload bool) bool {

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -145,11 +145,11 @@ var publicGoodRekorHostSuffixes = []string{".sigstore.dev", ".sigstage.dev"}
 
 // isPublicGoodRekorURL reports whether rekorURL points at the sigstore public good
 // instance (production or staging), which is the only case where the data-retention
-// privacy statement applies. An empty rekorURL is treated as the default public
-// instance.
+// privacy statement applies. An empty rekorURL means no Rekor service is configured
+// for upload (see NewSigningConfigFromKeyOpts), so it is not treated as public good.
 func isPublicGoodRekorURL(rekorURL string) bool {
 	if rekorURL == "" {
-		return true
+		return false
 	}
 	parsed, err := url.Parse(rekorURL)
 	if err != nil || parsed.Hostname() == "" {

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -244,7 +244,7 @@ func TestIsPublicGoodRekorURL(t *testing.T) {
 		rekorURL string
 		want     bool
 	}{
-		{"empty defaults to public good", "", true},
+		{"empty is not public good", "", false},
 		{"default production URL", options.DefaultRekorURL, true},
 		{"region-specific production URL", "https://rekor.us-central1.sigstore.dev", true},
 		{"staging URL", "https://rekor.sigstage.dev", true},

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -207,34 +207,35 @@ func Test_ParseOCIReference(t *testing.T) {
 	}
 }
 
-func TestShouldUploadToTlog_CustomRekorURLSkipsPublicInstanceStatement(t *testing.T) {
-	ko := options.KeyOpts{
-		RekorURL:         "http://localhost:3000",
-		SkipConfirmation: true,
+func TestShouldUploadToTlog_PublicInstanceStatement(t *testing.T) {
+	tests := []struct {
+		name        string
+		rekorURL    string
+		wantWarning bool
+	}{
+		{"custom Rekor URL skips public instance statement", "http://localhost:3000", false},
+		{"region-specific public good URL shows public instance statement", "https://rekor.us-central1.sigstore.dev", true},
 	}
-	var upload bool
-	var err error
-	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
-		upload, err = ShouldUploadToTlog(ctx, ko, nil, true)
-	})
-	assert.NoError(t, err)
-	assert.True(t, upload)
-	assert.NotContains(t, stderr, "hosted by sigstore", "should not warn about the public good instance's data retention policy when uploading to a custom Rekor URL")
-}
-
-func TestShouldUploadToTlog_RegionSpecificPublicGoodRekorURLShowsPublicInstanceStatement(t *testing.T) {
-	ko := options.KeyOpts{
-		RekorURL:         "https://rekor.us-central1.sigstore.dev",
-		SkipConfirmation: true,
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ko := options.KeyOpts{
+				RekorURL:         tt.rekorURL,
+				SkipConfirmation: true,
+			}
+			var upload bool
+			var err error
+			stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+				upload, err = ShouldUploadToTlog(ctx, ko, nil, true)
+			})
+			assert.NoError(t, err)
+			assert.True(t, upload)
+			if tt.wantWarning {
+				assert.Contains(t, stderr, "hosted by sigstore", "should warn about the public good instance's data retention policy")
+			} else {
+				assert.NotContains(t, stderr, "hosted by sigstore", "should not warn about the public good instance's data retention policy")
+			}
+		})
 	}
-	var upload bool
-	var err error
-	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
-		upload, err = ShouldUploadToTlog(ctx, ko, nil, true)
-	})
-	assert.NoError(t, err)
-	assert.True(t, upload)
-	assert.Contains(t, stderr, "hosted by sigstore", "should warn about the public good instance's data retention policy for a region-specific sigstore.dev Rekor URL")
 }
 
 func TestIsPublicGoodRekorURL(t *testing.T) {

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -222,6 +222,45 @@ func TestShouldUploadToTlog_CustomRekorURLSkipsPublicInstanceStatement(t *testin
 	assert.NotContains(t, stderr, "hosted by sigstore", "should not warn about the public good instance's data retention policy when uploading to a custom Rekor URL")
 }
 
+func TestShouldUploadToTlog_RegionSpecificPublicGoodRekorURLShowsPublicInstanceStatement(t *testing.T) {
+	ko := options.KeyOpts{
+		RekorURL:         "https://rekor.us-central1.sigstore.dev",
+		SkipConfirmation: true,
+	}
+	var upload bool
+	var err error
+	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+		upload, err = ShouldUploadToTlog(ctx, ko, nil, true)
+	})
+	assert.NoError(t, err)
+	assert.True(t, upload)
+	assert.Contains(t, stderr, "hosted by sigstore", "should warn about the public good instance's data retention policy for a region-specific sigstore.dev Rekor URL")
+}
+
+func TestIsPublicGoodRekorURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		rekorURL string
+		want     bool
+	}{
+		{"empty defaults to public good", "", true},
+		{"default production URL", options.DefaultRekorURL, true},
+		{"region-specific production URL", "https://rekor.us-central1.sigstore.dev", true},
+		{"staging URL", "https://rekor.sigstage.dev", true},
+		{"region-specific staging URL", "https://rekor.us-central1.sigstage.dev", true},
+		{"custom self-hosted URL", "http://localhost:3000", false},
+		{"uppercase hostname is still public good", "https://REKOR.SIGSTORE.DEV", true},
+		{"lookalike domain is not public good", "https://sigstore.dev.evil.example.com", false},
+		{"lookalike suffix without dot boundary is not public good", "https://notsigstore.dev", false},
+		{"unparseable URL", "://bad-url", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isPublicGoodRekorURL(tt.rekorURL))
+		})
+	}
+}
+
 func TestNewLegacyBundleFromProtoBundleComponents(t *testing.T) {
 	t.Run("without certificates leaves cert field empty", func(t *testing.T) {
 		bc := &BundleComponents{

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/internal/test"
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
@@ -204,6 +205,21 @@ func Test_ParseOCIReference(t *testing.T) {
 			assert.Empty(t, stderr, "expected no warning")
 		}
 	}
+}
+
+func TestShouldUploadToTlog_CustomRekorURLSkipsPublicInstanceStatement(t *testing.T) {
+	ko := options.KeyOpts{
+		RekorURL:         "http://localhost:3000",
+		SkipConfirmation: true,
+	}
+	var upload bool
+	var err error
+	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+		upload, err = ShouldUploadToTlog(ctx, ko, nil, true)
+	})
+	assert.NoError(t, err)
+	assert.True(t, upload)
+	assert.NotContains(t, stderr, "hosted by sigstore", "should not warn about the public good instance's data retention policy when uploading to a custom Rekor URL")
 }
 
 func TestNewLegacyBundleFromProtoBundleComponents(t *testing.T) {


### PR DESCRIPTION
Motivation:
When uploading to a transparency log, cosign always printed the
"hosted by sigstore a Series of LF Projects, LLC" privacy statement
and confirmation prompt, even when the user pointed --rekor-url at
their own local or self-hosted Rekor instance. The upload itself
correctly went to the custom instance, but the displayed text
described the public sigstore.dev data-retention/Terms of Use policy,
which is misleading and confusing for anyone running their own Rekor
server (e.g. via the rekor docker-compose setup).

This is a UX/cosmetic issue only: no upload destination or signing
behavior changes, only the confirmation text shown to the user.

Approach:
In ShouldUploadToTlog (cmd/cosign/cli/signcommon/common.go), only show
the public-instance privacy statement when the configured Rekor URL is
empty (unset) or equal to options.DefaultRekorURL
(https://rekor.sigstore.dev). A custom --rekor-url no longer triggers
the public-instance notice.

Validation:
- go build ./...
- go test $(go list ./... | grep -v third_party/) (equivalent to `make test`) — all packages pass
- make lint — 0 issues
- Added TestShouldUploadToTlog_CustomRekorURLSkipsPublicInstanceStatement
  in cmd/cosign/cli/signcommon/common_test.go, which calls
  ShouldUploadToTlog with a custom RekorURL and asserts the public-instance
  statement is not printed. Manually reverted the guard and reran the test
  to confirm it fails without the fix and passes with it restored.

Report: https://github.com/sigstore/cosign/issues/4400
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #4400