### PR TITLE
fix: include annotations in implied payload for offline verify

### DIFF
--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -55,7 +55,7 @@ func SignatureCmd(ctx context.Context, regOpts options.RegistryOptions, sigRef, 
 
 	var payload []byte
 	if payloadRef == "" {
-		payload, err = cosign.ObsoletePayload(ctx, digest)
+		payload, err = cosign.ObsoletePayload(ctx, digest, nil)
 	} else {
 		payload, err = os.ReadFile(filepath.Clean(payloadRef))
 	}

--- a/pkg/cosign/obsolete.go
+++ b/pkg/cosign/obsolete.go
@@ -26,8 +26,8 @@ import (
 // ObsoletePayload returns the implied payload that some commands expect to match
 // the signature if no payload is provided by the user.
 // DO NOT ADD ANY NEW CALLERS OF THIS.
-func ObsoletePayload(ctx context.Context, digestedImage name.Digest) ([]byte, error) {
-	blob, err := (&payload.Cosign{Image: digestedImage}).MarshalJSON()
+func ObsoletePayload(ctx context.Context, digestedImage name.Digest, annotations map[string]interface{}) ([]byte, error) {
+	blob, err := (&payload.Cosign{Image: digestedImage, Annotations: annotations}).MarshalJSON()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cosign/obsolete_test.go
+++ b/pkg/cosign/obsolete_test.go
@@ -32,10 +32,26 @@ func TestObsoletePayload(t *testing.T) {
 	require.NoError(t, err)
 	var res []byte
 	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
-		r, err := ObsoletePayload(ctx, digestedImg)
+		r, err := ObsoletePayload(ctx, digestedImg, nil)
 		require.NoError(t, err)
 		res = r
 	})
 	assert.Contains(t, stderr, "obsolete implied signature payload")
 	assert.Equal(t, []byte(`{"critical":{"identity":{"docker-reference":"index.docker.io/namespace/image"},"image":{"docker-manifest-digest":"sha256:4aa3054270f7a70b4528f2064ee90961788e1e1518703592ae4463de3b889dec"},"type":"cosign container image signature"},"optional":null}`), res)
+}
+
+func TestObsoletePayloadWithAnnotations(t *testing.T) {
+	// The implied payload must include annotations passed by the caller so it matches
+	// the payload generated when signing with annotations (cmd/cosign/cli/generate).
+	digestedImg, err := name.NewDigest("docker.io/namespace/image@sha256:4aa3054270f7a70b4528f2064ee90961788e1e1518703592ae4463de3b889dec")
+	require.NoError(t, err)
+	annotations := map[string]interface{}{"appname": "myapp"}
+	var res []byte
+	stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+		r, err := ObsoletePayload(ctx, digestedImg, annotations)
+		require.NoError(t, err)
+		res = r
+	})
+	assert.Contains(t, stderr, "obsolete implied signature payload")
+	assert.Equal(t, []byte(`{"critical":{"identity":{"docker-reference":"index.docker.io/namespace/image"},"image":{"docker-manifest-digest":"sha256:4aa3054270f7a70b4528f2064ee90961788e1e1518703592ae4463de3b889dec"},"type":"cosign container image signature"},"optional":{"appname":"myapp"}}`), res)
 }

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1040,7 +1040,7 @@ func loadSignatureFromFile(ctx context.Context, sigRef string, signedImgRef name
 		if err != nil {
 			return nil, err
 		}
-		payload, err = ObsoletePayload(ctx, digest)
+		payload, err = ObsoletePayload(ctx, digest, co.Annotations)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Motivation:
When signing with `cosign sign --upload=false -a key=value
--output-signature=sig.file`, cosign builds the signed payload from
payload.Cosign{Image, ClaimedIdentity, Annotations} including the
annotations (cmd/cosign/cli/sign/sign.go). When later verifying
offline with `cosign verify -a key=value --signature sig.file` and no
explicit `--payload`, cosign reconstructs an "implied" payload via
ObsoletePayload to compare against the signature, but that
reconstruction dropped annotations entirely. The reconstructed payload
therefore never matched the payload that was actually signed, so
verification always failed with "crypto/rsa: verification error" (or
equivalent) any time annotations were used with offline signing.

Approach:
Thread the caller-supplied annotations through ObsoletePayload so the
implied payload it builds matches what was used at signing time. The
verify call site (pkg/cosign/verify.go) now passes co.Annotations,
which is populated from the `-a` flag. The attach-signature call site
(cmd/cosign/cli/attach/sig.go) has no annotations flag, so it passes
nil, preserving its existing behavior exactly.

This is a pure payload-construction/serialization fix with no
dependency on registry, network, or transparency-log state: the
default (no-annotations) case is byte-for-byte unchanged.

Validation:
- go build ./...
- go test ./pkg/cosign/... ./cmd/cosign/cli/attach/... ./cmd/cosign/cli/verify/...
- go test $(go list ./... | grep -v third_party/)
  All pass. Added TestObsoletePayloadWithAnnotations in
  pkg/cosign/obsolete_test.go, which fails to compile against the
  pre-fix ObsoletePayload signature and asserts the annotation now
  appears in the marshaled payload's "optional" field once the fix is
  applied; confirmed by temporarily reverting the source changes and
  observing the test target fail to build.

Report: https://github.com/sigstore/cosign/issues/4024
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #4024