### PR TITLE
verify: fetch bundles once and reuse them for verification

### DIFF
--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/sign"
@@ -145,6 +146,11 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	}
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 
+	// Bundles fetched while auto-detecting the bundle format, reused to
+	// verify the first image without fetching them again.
+	var bundles []*sgbundle.Bundle
+	var bundlesHash *v1.Hash
+
 	// Auto-detect bundle format for local images
 	if c.LocalImage {
 		hasBundles, err := cosign.HasLocalBundles(images[0])
@@ -155,8 +161,11 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	} else {
 		ref, err := name.ParseReference(images[0], c.NameOptions...)
 		if err == nil && (c.NewBundleFormat || c.CommonVerifyOptions.NewBundleFormat) {
-			newBundles, _, err := cosign.GetBundles(ctx, ref, co.RegistryClientOpts, c.NameOptions...)
-			if len(newBundles) == 0 || err != nil {
+			// The fetched bundles double as the bundle-format probe and as
+			// the verification input for the first image, so the bundle
+			// path downloads everything exactly once.
+			bundles, bundlesHash, err = cosign.GetBundles(ctx, ref, co.RegistryClientOpts, c.NameOptions...)
+			if err != nil || len(bundles) == 0 {
 				co.NewBundleFormat = false
 			}
 		}
@@ -210,7 +219,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 	// was performed so we don't need to use this fragile logic here.
 	fulcioVerified := (co.SigVerifier == nil)
 
-	for _, img := range images {
+	for i, img := range images {
 		var verified []oci.Signature
 		var bundleVerified bool
 
@@ -236,7 +245,12 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 
 			if co.NewBundleFormat {
 				// OCI bundle always contains attestation
-				verified, bundleVerified, err = cosign.VerifyImageAttestations(ctx, ref, co, c.NameOptions...)
+				if i == 0 && bundles != nil {
+					// Reuse the bundles fetched by the format auto-detect.
+					verified, bundleVerified, err = cosign.VerifyImageAttestationsWithBundles(ctx, bundles, bundlesHash, co)
+				} else {
+					verified, bundleVerified, err = cosign.VerifyImageAttestations(ctx, ref, co, c.NameOptions...)
+				}
 				if err != nil {
 					return err
 				}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -245,7 +245,7 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 
 			if co.NewBundleFormat {
 				// OCI bundle always contains attestation
-				if i == 0 && bundles != nil {
+				if i == 0 && len(bundles) > 0 {
 					// Reuse the bundles fetched by the format auto-detect.
 					verified, bundleVerified, err = cosign.VerifyImageAttestationsWithBundles(ctx, bundles, bundlesHash, co)
 				} else {

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
@@ -129,6 +130,11 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	}
 	vOfflineKey := verifyOfflineWithKey(c.KeyRef, c.CertRef, c.Sk, co)
 
+	// Bundles fetched while auto-detecting the bundle format, reused to
+	// verify the first image without fetching them again.
+	var bundles []*sgbundle.Bundle
+	var bundlesHash *v1.Hash
+
 	// Auto-detect bundle format for local images
 	if c.LocalImage {
 		hasBundles, err := cosign.HasLocalAttestationBundles(images[0])
@@ -139,8 +145,11 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	} else {
 		ref, err := name.ParseReference(images[0], c.NameOptions...)
 		if err == nil && c.NewBundleFormat {
-			newBundles, _, err := cosign.GetBundles(ctx, ref, co.RegistryClientOpts, c.NameOptions...)
-			if len(newBundles) == 0 || err != nil {
+			// The fetched bundles double as the bundle-format probe and as
+			// the verification input for the first image, so the bundle
+			// path downloads everything exactly once.
+			bundles, bundlesHash, err = cosign.GetBundles(ctx, ref, co.RegistryClientOpts, c.NameOptions...)
+			if err != nil || len(bundles) == 0 {
 				co.NewBundleFormat = false
 			}
 		}
@@ -189,7 +198,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 	// was performed so we don't need to use this fragile logic here.
 	fulcioVerified := (co.SigVerifier == nil)
 
-	for _, imageRef := range images {
+	for i, imageRef := range images {
 		var verified []oci.Signature
 		var bundleVerified bool
 
@@ -204,7 +213,12 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 				return err
 			}
 
-			verified, bundleVerified, err = cosign.VerifyImageAttestations(ctx, ref, co, c.NameOptions...)
+			if i == 0 && bundles != nil {
+				// Reuse the bundles fetched by the format auto-detect.
+				verified, bundleVerified, err = cosign.VerifyImageAttestationsWithBundles(ctx, bundles, bundlesHash, co)
+			} else {
+				verified, bundleVerified, err = cosign.VerifyImageAttestations(ctx, ref, co, c.NameOptions...)
+			}
 			if err != nil {
 				return err
 			}

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -213,7 +213,7 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 				return err
 			}
 
-			if i == 0 && bundles != nil {
+			if i == 0 && co.NewBundleFormat && len(bundles) > 0 {
 				// Reuse the bundles fetched by the format auto-detect.
 				verified, bundleVerified, err = cosign.VerifyImageAttestationsWithBundles(ctx, bundles, bundlesHash, co)
 			} else {

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1937,6 +1937,9 @@ func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef nam
 // because it fetched them to decide between the bundle and legacy
 // verification paths — can verify without downloading them again.
 func VerifyImageAttestationsWithBundles(ctx context.Context, bundles []*sgbundle.Bundle, hash *v1.Hash, co *CheckOpts) (checkedAttestations []oci.Signature, atLeastOneBundleVerified bool, err error) {
+	if hash == nil {
+		return nil, false, errors.New("image digest hash is required")
+	}
 	digestBytes, err := hex.DecodeString(hash.Hex)
 	if err != nil {
 		return nil, false, err

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -1927,6 +1927,16 @@ func verifyImageAttestationsSigstoreBundle(ctx context.Context, signedImgRef nam
 		return nil, false, err
 	}
 
+	return VerifyImageAttestationsWithBundles(ctx, bundles, hash, co)
+}
+
+// VerifyImageAttestationsWithBundles verifies attestations from
+// already-fetched sigstore bundles (e.g. the result of GetBundles) against
+// the image digest they were fetched for. It performs no registry
+// requests, so a caller that already holds the bundles — for example
+// because it fetched them to decide between the bundle and legacy
+// verification paths — can verify without downloading them again.
+func VerifyImageAttestationsWithBundles(ctx context.Context, bundles []*sgbundle.Bundle, hash *v1.Hash, co *CheckOpts) (checkedAttestations []oci.Signature, atLeastOneBundleVerified bool, err error) {
 	digestBytes, err := hex.DecodeString(hash.Hex)
 	if err != nil {
 		return nil, false, err

--- a/pkg/cosign/verify_oci_test.go
+++ b/pkg/cosign/verify_oci_test.go
@@ -18,8 +18,10 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -85,6 +87,59 @@ func TestGetBundles_Empty(t *testing.T) {
 	assert.ErrorAs(t, err, &noMatchErr)
 	assert.Len(t, bundles, 0)
 	assert.Nil(t, hash)
+}
+
+func TestVerifyImageAttestationsWithBundles_NoRegistryRequests(t *testing.T) {
+	r := registry.New(registry.WithReferrersSupport(true))
+	var requests atomic.Int32
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		requests.Add(1)
+		r.ServeHTTP(w, req)
+	}))
+	defer s.Close()
+
+	u, err := url.Parse(s.URL)
+	assert.NoError(t, err)
+
+	ref, err := name.ParseReference(fmt.Sprintf("%s/repo:tag", u.Host))
+	assert.NoError(t, err)
+	assert.NoError(t, remote.Write(ref, empty.Image))
+
+	desc, err := remote.Head(ref)
+	assert.NoError(t, err)
+	digestRef := ref.Context().Digest(desc.Digest.String())
+
+	// Write valid test attestation
+	err = ociremote.WriteAttestationNewBundleFormat(digestRef, testAttestation, "https://cosign.sigstore.dev/attestation/v1")
+	assert.NoError(t, err)
+
+	// Fetch the bundles once, as the CLI's bundle-format auto-detect does.
+	bundles, hash, err := GetBundles(context.Background(), ref, []ociremote.Option{})
+	assert.NoError(t, err)
+	assert.Len(t, bundles, 1)
+	assert.NotNil(t, hash)
+
+	trustedRoot, err := root.NewTrustedRootFromJSON(testTrustedRootPGI)
+	assert.NoError(t, err)
+
+	co := &CheckOpts{
+		TrustedMaterial: trustedRoot,
+		NewBundleFormat: true,
+		Identities: []Identity{
+			{
+				IssuerRegExp:  ".*",
+				SubjectRegExp: ".*",
+			},
+		},
+	}
+
+	// Verifying already-fetched bundles must not touch the registry.
+	requests.Store(0)
+	atts, bundleVerified, err := VerifyImageAttestationsWithBundles(context.Background(), bundles, hash, co)
+	assert.NoError(t, err)
+	assert.True(t, bundleVerified)
+	assert.Len(t, atts, 1)
+	assert.Equal(t, int32(0), requests.Load())
 }
 
 func TestGetBundles_Valid(t *testing.T) {


### PR DESCRIPTION
The bundle-format auto-detect in `cosign verify` and `cosign verify-attestation` calls `GetBundles` just to learn whether any bundles exist — downloading the referrers index plus every bundle manifest and blob — and throws the result away; verification then calls `GetBundles` again. Every bundle on the image is downloaded twice.

This keeps the bundles the auto-detect fetches and verifies them directly through a new `cosign.VerifyImageAttestationsWithBundles(ctx, bundles, hash, co)` — the tail of the existing bundle verification, split at the `GetBundles` seam. It takes already-fetched bundles and the digest they were fetched for, and performs no registry requests (pinned by an instrumented-registry test). The fallback decision is unchanged: any `GetBundles` error or an empty result selects legacy verification exactly as before. Later images in a multi-image invocation use the fetching path as before, and the `download` commands are untouched.

Measured request counts (all verifications exit 0):

| scenario | before | after |
|---|---|---|
| 5 bundle referrers, live production registry | 36 | 19 |
| 1 bundle referrer (zot v2.1.20; also go-containerregistry's test registry) | 8 | 5 |

Bundle fetches go from 2N to N — everything is downloaded exactly once and reused in-process.

Assisted by Claude Fable 5