### PR TITLE
Cap the bundle layer read in ociremote.Bundle

### DIFF
--- a/internal/pkg/cosign/payload/size/size.go
+++ b/internal/pkg/cosign/payload/size/size.go
@@ -21,16 +21,23 @@ import (
 
 const defaultMaxSize = uint64(134217728) // 128MiB
 
-func CheckSize(size uint64) error {
+// MaxSize returns the configured maximum layer size in bytes. Callers that read
+// a decompressed stream need the limit itself, because the size a registry
+// declares is the compressed size and so does not bound what the read produces.
+func MaxSize() uint64 {
 	maxSize := defaultMaxSize
 	maxSizeOverride, exists := env.LookupEnv(env.VariableMaxAttachmentSize)
 	if exists {
-		var err error
-		maxSize, err = humanize.ParseBytes(maxSizeOverride)
-		if err != nil {
-			maxSize = defaultMaxSize
+		parsed, err := humanize.ParseBytes(maxSizeOverride)
+		if err == nil {
+			maxSize = parsed
 		}
 	}
+	return maxSize
+}
+
+func CheckSize(size uint64) error {
+	maxSize := MaxSize()
 	if size > maxSize {
 		return NewMaxLayerSizeExceeded(size, maxSize)
 	}

--- a/pkg/oci/remote/signatures.go
+++ b/pkg/oci/remote/signatures.go
@@ -25,6 +25,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	payloadsize "github.com/sigstore/cosign/v3/internal/pkg/cosign/payload/size"
 	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/empty"
 	"github.com/sigstore/cosign/v3/pkg/oci/internal/signature"
@@ -54,6 +55,23 @@ func Signatures(ref name.Reference, opts ...Option) (oci.Signatures, error) {
 	}, nil
 }
 
+// readCapped reads r fully, refusing to grow past the configured maximum layer
+// size. It exists because a decompressed stream is not bounded by the size a
+// registry declares for the layer, so a small compressed blob can otherwise
+// expand without limit. One byte past the maximum is read so that reaching the
+// limit is distinguishable from a payload that is exactly the maximum size.
+func readCapped(r io.Reader) ([]byte, error) {
+	maxSize := payloadsize.MaxSize()
+	b, err := io.ReadAll(io.LimitReader(r, int64(maxSize)+1))
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(b)) > maxSize {
+		return nil, payloadsize.NewMaxLayerSizeExceeded(uint64(len(b)), maxSize)
+	}
+	return b, nil
+}
+
 func Bundle(ref name.Reference, opts ...Option) (*sgbundle.Bundle, error) {
 	o := makeOptions(ref.Context(), opts...)
 	img, err := remoteImage(ref, o.ROpt...)
@@ -74,12 +92,22 @@ func Bundle(ref name.Reference, opts ...Option) (*sgbundle.Bundle, error) {
 	if !strings.HasPrefix(string(mediaType), "application/vnd.dev.sigstore.bundle") {
 		return nil, errors.New("expected bundle layer")
 	}
+	size, err := layers[0].Size()
+	if err != nil {
+		return nil, err
+	}
+	if err := payloadsize.CheckSize(uint64(size)); err != nil {
+		return nil, err
+	}
 	layer0, err := layers[0].Uncompressed()
 	if err != nil {
 		return nil, err
 	}
 	defer layer0.Close()
-	bundleBytes, err := io.ReadAll(layer0)
+	// The size checked above is the compressed size the registry declares, and this
+	// is the only bundle read that goes through Uncompressed, so that check alone
+	// does not bound the result.
+	bundleBytes, err := readCapped(layer0)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oci/remote/signatures_capped_test.go
+++ b/pkg/oci/remote/signatures_capped_test.go
@@ -1,0 +1,100 @@
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	payloadsize "github.com/sigstore/cosign/v3/internal/pkg/cosign/payload/size"
+	"github.com/sigstore/cosign/v3/pkg/cosign/env"
+)
+
+func TestReadCappedWithinLimit(t *testing.T) {
+	t.Setenv(env.VariableMaxAttachmentSize.String(), "1024")
+
+	got, err := readCapped(strings.NewReader(strings.Repeat("a", 1024)))
+	if err != nil {
+		t.Fatalf("readCapped() returned an unexpected error: %v", err)
+	}
+	if len(got) != 1024 {
+		t.Errorf("readCapped() returned %d bytes, wanted 1024", len(got))
+	}
+}
+
+func TestReadCappedRejectsOversizedPayload(t *testing.T) {
+	t.Setenv(env.VariableMaxAttachmentSize.String(), "1024")
+
+	_, err := readCapped(strings.NewReader(strings.Repeat("a", 1025)))
+	if err == nil {
+		t.Fatal("readCapped() accepted a payload one byte over the limit")
+	}
+	var sizeErr *payloadsize.MaxLayerSizeExceeded
+	if !errors.As(err, &sizeErr) {
+		t.Errorf("readCapped() returned %T, wanted *payloadsize.MaxLayerSizeExceeded", err)
+	}
+}
+
+// A bundle layer is read through Uncompressed, so the size a registry declares
+// for the layer does not bound the result. This is the case the declared-size
+// check on its own cannot catch: a small compressed blob that inflates well
+// past the maximum.
+func TestReadCappedRejectsDecompressionBomb(t *testing.T) {
+	t.Setenv(env.VariableMaxAttachmentSize.String(), "1M")
+
+	const uncompressed = 64 << 20 // 64MiB of zeroes, comfortably over the 1MiB cap
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	if _, err := io.Copy(zw, io.LimitReader(zeroReader{}, uncompressed)); err != nil {
+		t.Fatalf("building the gzip stream failed: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("closing the gzip writer failed: %v", err)
+	}
+
+	compressedSize := buf.Len()
+	if uint64(compressedSize) > payloadsize.MaxSize() {
+		t.Fatalf("the compressed stream is %d bytes, which the declared-size check would already reject; this test needs it under the cap", compressedSize)
+	}
+
+	zr, err := gzip.NewReader(&buf)
+	if err != nil {
+		t.Fatalf("opening the gzip stream failed: %v", err)
+	}
+	defer zr.Close()
+
+	_, err = readCapped(zr)
+	if err == nil {
+		t.Fatalf("readCapped() consumed a stream inflating from %d bytes to %d", compressedSize, uncompressed)
+	}
+	var sizeErr *payloadsize.MaxLayerSizeExceeded
+	if !errors.As(err, &sizeErr) {
+		t.Errorf("readCapped() returned %T, wanted *payloadsize.MaxLayerSizeExceeded", err)
+	}
+}
+
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
+}


### PR DESCRIPTION
## Summary

Adds a size cap to the bundle layer read in `ociremote.Bundle()`. Follow-up to the private report on `GHSA-cq2j-v5qh-cjqh`, which @Hayden-IO closed with the note that DoS vectors do not need an advisory and that a patch adding a sensible limit would be welcome. This is that patch.

`Bundle()` decompressed the new-bundle-format attestation layer and read all of it into memory with no check, while the three sibling read sinks in `pkg/oci` all call `payloadsize.CheckSize` first: `pkg/oci/internal/signature/layer.go`, `pkg/oci/static/file.go` and `pkg/oci/remote/remote.go`.

## Why the declared size alone is not enough

The three siblings read through `Compressed()`, so the size the registry declares genuinely bounds what they read. `Bundle()` is the one that goes through `Uncompressed()`, so the declared size does not bound the result and a small compressed blob can inflate past any limit.

So this does both:

- checks the declared size first, so an oversized layer is rejected before anything is read, which keeps it consistent with the siblings
- bounds the decompressed stream by the same limit, which is the part the declared size cannot cover

This matters more than a single read suggests. `GetBundles` in `pkg/cosign/verify.go` calls `Bundle()` for every manifest in a referrers index and swallows the error with `continue`, because non-Sigstore referrers are expected there. Without the second check, each oversized layer in an index was read in full before its error was reached.

## Changes

`internal/pkg/cosign/payload/size`: exports `MaxSize()`, and `CheckSize` now calls it. A caller reading a decompressed stream needs the limit itself rather than a yes or no answer about a size it already knows. Behaviour is unchanged, including the fallback to the default when `COSIGN_MAX_ATTACHMENT_SIZE` fails to parse.

`pkg/oci/remote/signatures.go`: the declared-size check, plus a `readCapped` helper that reads one byte past the maximum so that hitting the limit is distinguishable from a payload that is exactly the maximum size.

## Tests

`pkg/oci/remote/signatures_capped_test.go`, three cases: a payload at exactly the limit is accepted, one byte over is rejected, and a gzip stream inflating from roughly 64KiB to 64MiB is rejected against a 1MiB cap. That third one is the case the declared-size check cannot catch, and it asserts the compressed size is under the cap so the test cannot pass for the wrong reason.

With the cap removed, the two rejection tests fail:

```
--- FAIL: TestReadCappedRejectsOversizedPayload (0.00s)
--- FAIL: TestReadCappedRejectsDecompressionBomb (0.21s)
```

With it in place, `./pkg/oci/...` and `./internal/pkg/cosign/payload/size/...` are green, and `go build ./...` and `go vet` are clean.

## A note on the original report

I verified the code paths by reading them at `v3.1.3` and I said so in the report: I did not stand up a crafted registry, so I had no measured RSS figure. The decompression behaviour is now covered by the test above rather than by reasoning.
