### PR TITLE
fix: use correct Rekor URLs to activate privacy warning

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -135,9 +135,12 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 	}
 
 	if c.SigningConfig == nil {
-		c.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(c.KeyOpts, c.TlogUpload)
+		c.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(c.KeyOpts)
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
+		}
+		if !c.TlogUpload {
+			c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
 		}
 	}
 

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -148,9 +148,12 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 
 	if c.SigningConfig == nil {
 		var err error
-		c.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(c.KeyOpts, c.TlogUpload)
+		c.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(c.KeyOpts)
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
+		}
+		if !c.TlogUpload {
+			c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
 		}
 	}
 

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -202,9 +202,12 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 		if err != nil {
 			return fmt.Errorf("should upload to tlog: %w", err)
 		}
-		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko, shouldUpload)
+		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko)
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
+		}
+		if !shouldUpload {
+			ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 		}
 	}
 
@@ -260,9 +263,12 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		if err != nil {
 			return fmt.Errorf("should upload to tlog: %w", err)
 		}
-		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko, shouldUpload)
+		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko)
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
+		}
+		if !shouldUpload {
+			ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 		}
 	}
 

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -198,13 +198,13 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 	}
 
 	if ko.SigningConfig == nil {
-		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-		if err != nil {
-			return fmt.Errorf("should upload to tlog: %w", err)
-		}
 		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko)
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
+		}
+		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
+		if err != nil {
+			return fmt.Errorf("should upload to tlog: %w", err)
 		}
 		if !shouldUpload {
 			ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
@@ -259,13 +259,13 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 	}
 
 	if ko.SigningConfig == nil {
-		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-		if err != nil {
-			return fmt.Errorf("should upload to tlog: %w", err)
-		}
 		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko)
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
+		}
+		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
+		if err != nil {
+			return fmt.Errorf("should upload to tlog: %w", err)
 		}
 		if !shouldUpload {
 			ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -63,13 +63,13 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	var err error
 
 	if ko.SigningConfig == nil {
-		shouldUpload, err = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
-		if err != nil {
-			return nil, fmt.Errorf("upload to tlog: %w", err)
-		}
 		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko)
 		if err != nil {
 			return nil, fmt.Errorf("creating signing config: %w", err)
+		}
+		shouldUpload, err = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
+		if err != nil {
+			return nil, fmt.Errorf("upload to tlog: %w", err)
 		}
 	} else {
 		shouldUpload = len(ko.SigningConfig.RekorLogURLs()) > 0

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -67,7 +67,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		if err != nil {
 			return nil, fmt.Errorf("upload to tlog: %w", err)
 		}
-		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko, shouldUpload)
+		ko.SigningConfig, err = signcommon.NewSigningConfigFromKeyOpts(ko)
 		if err != nil {
 			return nil, fmt.Errorf("creating signing config: %w", err)
 		}
@@ -76,6 +76,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 
 	if !shouldUpload {
+		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 		// To maintain backwards compatibility with older cosign versions,
 		// we do not use ed25519ph for ed25519 keys when the signatures are not
 		// uploaded to the Tlog.

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -122,8 +122,8 @@ func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 	upload := shouldUploadToTlog(ctx, ko, ref, tlogUpload)
 	var statementErr error
 	// Only warn about the public good instance's data retention policy when
-	// actually uploading to it; a custom --rekor-url points elsewhere.
-	if upload && isPublicGoodRekorURL(ko.RekorURL) {
+	// actually uploading to it
+	if upload && hasPublicGoodRekorURL(ko.SigningConfig) {
 		privacy.StatementOnce.Do(func() {
 			ui.Infof(ctx, privacy.Statement)
 			ui.Infof(ctx, privacy.StatementConfirmation)
@@ -143,10 +143,23 @@ func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 // good instance is served from multiple region- and year-specific hostnames.
 var publicGoodRekorHostSuffixes = []string{".sigstore.dev", ".sigstage.dev"}
 
-// isPublicGoodRekorURL reports whether rekorURL points at the sigstore public good
-// instance (production or staging), which is the only case where the data-retention
-// privacy statement applies. An empty rekorURL means no Rekor service is configured
-// for upload (see NewSigningConfigFromKeyOpts), so it is not treated as public good.
+// hasPublicGoodRekorURL reports whether a signing config contains a rekor URL that
+// points at the sigstore public good instance (production or staging), which is the
+// only case where the data-retention privacy statement applies.
+func hasPublicGoodRekorURL(sc *root.SigningConfig) bool {
+	if sc == nil {
+		return false
+	}
+	for _, s := range sc.RekorLogURLs() {
+		if isPublicGoodRekorURL(s.URL) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPublicGoodRekorURL reports whether a rekor URL points at the sigstore public good
+// instance (production or staging).
 func isPublicGoodRekorURL(rekorURL string) bool {
 	if rekorURL == "" {
 		return false

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -631,7 +631,7 @@ func NewLegacyBundleFromProtoBundleComponents(bc *BundleComponents) ([]byte, err
 
 // NewSigningConfigFromKeyOpts creates a signing config from key options.
 // This only supports Rekor v1. Rekor v2 requires a user-provided signing config.
-func NewSigningConfigFromKeyOpts(ko options.KeyOpts, tlogUpload bool) (*root.SigningConfig, error) {
+func NewSigningConfigFromKeyOpts(ko options.KeyOpts) (*root.SigningConfig, error) {
 	var fulcioServices []root.Service
 	if ko.FulcioURL != "" {
 		fulcioServices = append(fulcioServices, root.Service{
@@ -652,7 +652,7 @@ func NewSigningConfigFromKeyOpts(ko options.KeyOpts, tlogUpload bool) (*root.Sig
 
 	var rekorServices []root.Service
 	var rekorConfig root.ServiceConfiguration
-	if ko.RekorURL != "" && tlogUpload {
+	if ko.RekorURL != "" {
 		rekorServices = append(rekorServices, root.Service{
 			URL:                 ko.RekorURL,
 			MajorAPIVersion:     1,

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -23,14 +23,17 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/secure-systems-lab/go-securesystemslib/encrypted"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
+	"github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/privacy"
 	"github.com/sigstore/cosign/v3/internal/test"
 	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/cosign"
 	pb_go_v1 "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -207,19 +210,31 @@ func Test_ParseOCIReference(t *testing.T) {
 	}
 }
 
+func mustSigningConfig(t *testing.T, rekorURL string) *root.SigningConfig {
+	t.Helper()
+	sc, err := NewSigningConfigFromKeyOpts(options.KeyOpts{RekorURL: rekorURL})
+	if err != nil {
+		t.Fatalf("creating signing config: %v", err)
+	}
+	return sc
+}
+
 func TestShouldUploadToTlog_PublicInstanceStatement(t *testing.T) {
 	tests := []struct {
-		name        string
-		rekorURL    string
-		wantWarning bool
+		name          string
+		signingConfig *root.SigningConfig
+		wantWarning   bool
 	}{
-		{"custom Rekor URL skips public instance statement", "http://localhost:3000", false},
-		{"region-specific public good URL shows public instance statement", "https://rekor.us-central1.sigstore.dev", true},
+		{"custom Rekor URL skips public instance statement", mustSigningConfig(t, "http://localhost:3000"), false},
+		{"region-specific public good URL shows public instance statement", mustSigningConfig(t, "https://rekor.us-central1.sigstore.dev"), true},
+		{"staging public good signing config shows public instance statement", mustSigningConfig(t, "https://rekor.sigstage.dev"), true},
+		{"nil signing config skips public instance statement", nil, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			privacy.StatementOnce = sync.Once{}
 			ko := options.KeyOpts{
-				RekorURL:         tt.rekorURL,
+				SigningConfig:    tt.signingConfig,
 				SkipConfirmation: true,
 			}
 			var upload bool
@@ -234,6 +249,25 @@ func TestShouldUploadToTlog_PublicInstanceStatement(t *testing.T) {
 			} else {
 				assert.NotContains(t, stderr, "hosted by sigstore", "should not warn about the public good instance's data retention policy")
 			}
+		})
+	}
+}
+
+func TestHasPublicGoodRekorURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		signingConfig *root.SigningConfig
+		want          bool
+	}{
+		{"nil signing config returns false", nil, false},
+		{"empty signing config returns false", mustSigningConfig(t, ""), false},
+		{"custom Rekor URL returns false", mustSigningConfig(t, "http://localhost:3000"), false},
+		{"public good Rekor URL returns true", mustSigningConfig(t, options.DefaultRekorURL), true},
+		{"signing config with cleared Rekor URLs returns false", mustSigningConfig(t, options.DefaultRekorURL).WithRekorLogURLs(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasPublicGoodRekorURL(tt.signingConfig))
 		})
 	}
 }


### PR DESCRIPTION
#### Summary

This change updates the Rekor public good instance privacy warning for `sign` and `sign-blob` to appear only when the Rekor public good instance is to be used.

Previously, `ShouldUploadToTlog` only checked `KeyOpts.RekorURL`, despite the fact that  `KeyOpts.RekorURL` defaults to the public good Rekor URL even when a signing config is provided containing a different transparency log URL. Now, `ShouldUploadToTlog` instead checks the signing config created for users that do not provide one manually. 

To make this work, the following refactors occur:
1. The constructed signing config no longer omits `ko.RekorURL` when `--tlog-upload=false`. `NewSigningConfigFromKeyOpts` no longer has a `tlogUpload` input, and the relevant logic has been extracted for after `ShouldUploadToTlog` is called.
2. That signing config is now constructed before (instead of after) `ShouldUploadToTlog` is called.