### PR TITLE
Deprecate --use-signing-config

### DIFF
--- a/cmd/cosign/cli/options/attest.go
+++ b/cmd/cosign/cli/options/attest.go
@@ -131,6 +131,7 @@ func (o *AttestOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.UseSigningConfig, "use-signing-config", true,
 		"whether to use a TUF-provided signing config for the service URLs")
+	_ = cmd.Flags().MarkDeprecated("use-signing-config", "an offline signing flag will be added in the future; TUF will continue to provide a signing config by default if one is not provided manually")
 
 	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config", "",
 		"path to a signing config file")

--- a/cmd/cosign/cli/options/attest_blob.go
+++ b/cmd/cosign/cli/options/attest_blob.go
@@ -107,6 +107,7 @@ func (o *AttestBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.UseSigningConfig, "use-signing-config", true,
 		"whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format")
+	_ = cmd.Flags().MarkDeprecated("use-signing-config", "an offline signing flag will be added in the future; TUF will continue to provide a signing config by default if one is not provided manually")
 
 	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config", "",
 		"path to a signing config file. Must provide --bundle, which will output verification material in the new format")

--- a/cmd/cosign/cli/options/sign.go
+++ b/cmd/cosign/cli/options/sign.go
@@ -163,6 +163,7 @@ func (o *SignOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.UseSigningConfig, "use-signing-config", true,
 		"whether to use a TUF-provided signing config for the service URLs")
+	_ = cmd.Flags().MarkDeprecated("use-signing-config", "an offline signing flag will be added in the future; TUF will continue to provide a signing config by default if one is not provided manually")
 
 	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config", "",
 		"path to a signing config file")

--- a/cmd/cosign/cli/options/signblob.go
+++ b/cmd/cosign/cli/options/signblob.go
@@ -111,6 +111,7 @@ func (o *SignBlobOptions) AddFlags(cmd *cobra.Command) {
 
 	cmd.Flags().BoolVar(&o.UseSigningConfig, "use-signing-config", true,
 		"whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format")
+	_ = cmd.Flags().MarkDeprecated("use-signing-config", "an offline signing flag will be added in the future; TUF will continue to provide a signing config by default if one is not provided manually")
 
 	cmd.Flags().StringVar(&o.SigningConfigPath, "signing-config", "",
 		"path to a signing config file. Must provide --bundle, which will output verification material in the new format")

--- a/doc/cosign_attest-blob.md
+++ b/doc/cosign_attest-blob.md
@@ -57,7 +57,6 @@ cosign attest-blob [flags]
       --timestamp-server-name string     SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
       --trusted-root string              optional path to a TrustedRoot JSON file to verify a signature after signing
       --type string                      specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
-      --use-signing-config               whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format (default true)
   -y, --yes                              skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_attest.md
+++ b/doc/cosign_attest.md
@@ -82,7 +82,6 @@ cosign attest [flags]
       --timestamp-server-name string     SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
       --trusted-root string              optional path to a TrustedRoot JSON file to verify a signature after signing
       --type string                      specify a predicate type (slsaprovenance|slsaprovenance02|slsaprovenance1|link|spdx|spdxjson|cyclonedx|vuln|openvex|custom) or an URI (default "custom")
-      --use-signing-config               whether to use a TUF-provided signing config for the service URLs (default true)
   -y, --yes                              skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_sign-blob.md
+++ b/doc/cosign_sign-blob.md
@@ -54,7 +54,6 @@ cosign sign-blob [flags]
       --timestamp-client-key string      path to the X.509 private key file in PEM format to be used, together with the 'timestamp-client-cert' value, for the connection to the TSA Server
       --timestamp-server-name string     SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
       --trusted-root string              optional path to a TrustedRoot JSON file to verify a signature after signing
-      --use-signing-config               whether to use a TUF-provided signing config for the service URLs. Must provide --bundle, which will output verification material in the new format (default true)
   -y, --yes                              skip confirmation prompts for non-destructive operations
 ```
 

--- a/doc/cosign_sign.md
+++ b/doc/cosign_sign.md
@@ -103,7 +103,6 @@ cosign sign [flags]
       --timestamp-server-name string                    SAN name to use as the 'ServerName' tls.Config field to verify the mTLS connection to the TSA Server
       --trusted-root string                             optional path to a TrustedRoot JSON file to verify a signature after signing
       --upload                                          whether to upload the signature (default true)
-      --use-signing-config                              whether to use a TUF-provided signing config for the service URLs (default true)
   -y, --yes                                             skip confirmation prompts for non-destructive operations
 ```
 


### PR DESCRIPTION
Partially addresses #5013 

#### Summary

This change deprecates the `--use-signing-config` flag in favor of a future offline signing flag.