### PR TITLE
feat: --slot option argument shell completion

### DIFF
--- a/cmd/cosign/cli/options/bundle.go
+++ b/cmd/cosign/cli/options/bundle.go
@@ -16,6 +16,7 @@
 package options
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -82,11 +83,9 @@ func (o *BundleCreateOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Sk, "sk", false,
 		"whether to use a hardware security key")
 
-	slots := []string{"authentication", "signature", "card-authentication", "key-management"}
 	cmd.Flags().StringVar(&o.Slot, "slot", "signature",
-		"security key slot to use for generated key ("+
-			strings.Join(slots, "|")+")")
-	_ = cmd.RegisterFlagCompletionFunc("slot", cobra.FixedCompletions(slots, cobra.ShellCompDirectiveNoFileComp))
+		fmt.Sprintf("security key slot to use for generated key (%s)", strings.Join(securityKeySlots, "|")))
+	_ = cmd.RegisterFlagCompletionFunc("slot", cobra.FixedCompletions(securityKeySlots, cobra.ShellCompDirectiveNoFileComp))
 
 	cmd.MarkFlagsMutuallyExclusive("bundle", "certificate")
 	cmd.MarkFlagsMutuallyExclusive("bundle", "signature")

--- a/cmd/cosign/cli/options/options.go
+++ b/cmd/cosign/cli/options/options.go
@@ -60,3 +60,10 @@ var rekorEntryTypes = []string{
 	"dsse", // first one is the default
 	"intoto",
 }
+
+var securityKeySlots = []string{
+	"authentication",
+	"signature",
+	"card-authentication",
+	"key-management",
+}

--- a/cmd/cosign/cli/options/piv_tool.go
+++ b/cmd/cosign/cli/options/piv_tool.go
@@ -16,6 +16,9 @@
 package options
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
@@ -105,7 +108,8 @@ func (o *PIVToolAttestationOptions) AddFlags(cmd *cobra.Command) {
 		"format to output attestation information in. (text|json)")
 
 	cmd.Flags().StringVar(&o.Slot, "slot", "",
-		"Slot to use for generated key (authentication|signature|card-authentication|key-management)")
+		fmt.Sprintf("Slot to use for generated key (%s)", strings.Join(securityKeySlots, "|")))
+	_ = cmd.RegisterFlagCompletionFunc("slot", cobra.FixedCompletions(securityKeySlots, cobra.ShellCompDirectiveNoFileComp))
 }
 
 // PIVToolGenerateKeyOptions is the wrapper for `piv-tool generate-key` related options.
@@ -128,7 +132,8 @@ func (o *PIVToolGenerateKeyOptions) AddFlags(cmd *cobra.Command) {
 		"if set to true, generates a new random management key and deletes it after")
 
 	cmd.Flags().StringVar(&o.Slot, "slot", "",
-		"Slot to use for generated key (authentication|signature|card-authentication|key-management)")
+		fmt.Sprintf("Slot to use for generated key (%s)", strings.Join(securityKeySlots, "|")))
+	_ = cmd.RegisterFlagCompletionFunc("slot", cobra.FixedCompletions(securityKeySlots, cobra.ShellCompDirectiveNoFileComp))
 
 	cmd.Flags().StringVar(&o.PINPolicy, "pin-policy", "",
 		"PIN policy for slot (never|once|always)")

--- a/cmd/cosign/cli/options/security_key.go
+++ b/cmd/cosign/cli/options/security_key.go
@@ -16,6 +16,9 @@
 package options
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/spf13/cobra"
 )
 
@@ -33,5 +36,6 @@ func (o *SecurityKeyOptions) AddFlags(cmd *cobra.Command) {
 		"whether to use a hardware security key")
 
 	cmd.Flags().StringVar(&o.Slot, "slot", "",
-		"security key slot to use for generated key (default: signature) (authentication|signature|card-authentication|key-management)")
+		fmt.Sprintf("security key slot to use for generated key (default: signature) (%s)", strings.Join(securityKeySlots, "|")))
+	_ = cmd.RegisterFlagCompletionFunc("slot", cobra.FixedCompletions(securityKeySlots, cobra.ShellCompDirectiveNoFileComp))
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Please do not just delete this text.  The three fields below are mandatory.

Please remember to:
- This PR requires an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficient time for discussions to take place. Please use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!

Thank you :)
-->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?
-->

Improve `--slot <TAB>` shell completion.

#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

Improved --slot argument shell completion.

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->

N/A