### PR TITLE
fix: strip trailing whitespace from attached signature files/stdin

### DIFF
--- a/cmd/cosign/cli/attach/sig.go
+++ b/cmd/cosign/cli/attach/sig.go
@@ -16,6 +16,7 @@
 package attach
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -147,16 +148,25 @@ const (
 
 func signatureBytes(sigRef string) ([]byte, error) {
 	// sigRef can be "-", a string or a file.
+	var sig []byte
+	var err error
 	switch signatureType(sigRef) {
 	case StdinSignature:
-		return io.ReadAll(os.Stdin)
+		sig, err = io.ReadAll(os.Stdin)
 	case RawSignature:
 		return []byte(sigRef), nil
 	case FileSignature:
-		return os.ReadFile(filepath.Clean(sigRef))
+		sig, err = os.ReadFile(filepath.Clean(sigRef))
 	default:
 		return nil, errors.New("unknown signature arg type")
 	}
+	if err != nil {
+		return nil, err
+	}
+	// Files and stdin commonly carry a trailing newline (e.g. from `jq -r ... >
+	// file` or `echo`). Strip surrounding whitespace so it isn't stored verbatim
+	// as part of the signature annotation value.
+	return bytes.TrimSpace(sig), nil
 }
 
 func signatureType(sigRef string) SignatureArgType {

--- a/cmd/cosign/cli/attach/sig_test.go
+++ b/cmd/cosign/cli/attach/sig_test.go
@@ -1,0 +1,60 @@
+//
+// Copyright 2025 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attach
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSignatureBytesTrimsTrailingWhitespace(t *testing.T) {
+	const want = "MEQCIGnMnU8FiEcNVIgeR6HxNp4Gaqg5q0XLSNhBO5pp+QaNAiB40iDMGGQdthm8U9qQeCAzp6ecLdKCG3R/yq5S2uMa6g=="
+
+	dir := t.TempDir()
+	sigFile := filepath.Join(dir, "signature.sig")
+	// Simulate a signature file produced with `jq -r '.Base64Signature' > signature.sig`,
+	// which appends a trailing newline.
+	if err := os.WriteFile(sigFile, []byte(want+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := signatureBytes(sigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("signatureBytes() = %q, want %q", string(got), want)
+	}
+}
+
+func TestSignatureBytesFileWithoutTrailingWhitespaceUnaffected(t *testing.T) {
+	const want = "MEQCIGnMnU8FiEcNVIgeR6HxNp4Gaqg5q0XLSNhBO5pp+QaNAiB40iDMGGQdthm8U9qQeCAzp6ecLdKCG3R/yq5S2uMa6g=="
+
+	dir := t.TempDir()
+	sigFile := filepath.Join(dir, "signature.sig")
+	if err := os.WriteFile(sigFile, []byte(want), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := signatureBytes(sigFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Errorf("signatureBytes() = %q, want %q", string(got), want)
+	}
+}


### PR DESCRIPTION
Motivation:
The linked report below describes a failure after detaching a
signature with `cosign download signature ... | jq -r
'.Base64Signature' > signature.sig` and later re-attaching it on
another registry with `cosign attach signature --signature
signature.sig ...`. The reporter's own --verbose debug output shows
the OCI manifest annotation dev.cosignproject.cosign/signature on the
re-attached image literally contains the base64 signature value with
a trailing newline embedded in it, unlike the original signing
machine's copy. That newline comes from shell redirection after
`jq -r`; cosign's attach signature command stores whatever bytes it
reads from the --signature file or stdin verbatim, with no trimming.

Storing extraneous whitespace inside a signature annotation is a
real, demonstrated defect regardless of whether it fully explains the
"invalid signature when validating ASN.1 encoded signature" error the
reporter hit: Go's own base64 decoder tolerates embedded \r/\n and
decodes to the same bytes, so this alone would not necessarily
reproduce that exact failure, and the report's repro also mixed up
`cosign download signature`'s JSON envelope for --payload, a separate
issue. This change fixes the annotation-pollution defect on its own
merits; it is not a claim that it resolves the full reported scenario
end-to-end.

Approach:
Trim leading and trailing whitespace from bytes read from a signature
file or stdin in signatureBytes() (cmd/cosign/cli/attach/sig.go)
before they are stored as the signature annotation. Base64 has no
whitespace in its alphabet, so trimming cannot remove meaningful
signature bytes. The literal-argument path is untouched.

Validation:
- go test ./cmd/cosign/cli/attach/... — added
  TestSignatureBytesTrimsTrailingWhitespace, which fails before this
  change (returned bytes include the trailing "\n") and passes after;
  verified this directly by stashing the fix and re-running the test.
  Also added TestSignatureBytesFileWithoutTrailingWhitespaceUnaffected
  confirming clean input is unaffected.
- go build ./... and go vet ./cmd/cosign/cli/attach/... pass.
- go test ./cmd/cosign/... passes (all subpackages).
- golangci-lint run ./cmd/cosign/cli/attach/... (v2.12.2, matching
  this repo's Dockerfile.golangci-lint) reports 0 issues.

Report: https://github.com/sigstore/cosign/issues/4207
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #4207