### PR TITLE
fix(providers): clearer errors when GitHub OIDC token request fails

### DIFF
--- a/pkg/providers/github/github.go
+++ b/pkg/providers/github/github.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -33,10 +34,15 @@ const (
 	RequestTokenEnvKey = env.VariableGitHubRequestToken
 	// Deprecated: use `env.VariableGitHubRequestURL` instead
 	RequestURLEnvKey = env.VariableGitHubRequestURL
+
+	// providerName is the name this provider is registered under.
+	providerName = "github-actions"
+	// maxErrorBodyBytes limits how much of a failed response body is quoted back in the error.
+	maxErrorBodyBytes = 256
 )
 
 func init() {
-	providers.Register("github-actions", &githubActions{})
+	providers.Register(providerName, &githubActions{})
 }
 
 type githubActions struct{}
@@ -93,12 +99,18 @@ func (ga *githubActions) Provide(ctx context.Context, audience string) (string, 
 		}
 		defer resp.Body.Close()
 
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+			return "", fmt.Errorf("identity token request to provider %s failed with status %s: %q",
+				providerName, resp.Status, strings.TrimSpace(string(body)))
+		}
+
 		var payload struct {
 			Value string `json:"value"`
 		}
 		decoder := json.NewDecoder(resp.Body)
 		if err := decoder.Decode(&payload); err != nil {
-			return "", err
+			return "", fmt.Errorf("invalid identity token response from provider %s: %w", providerName, err)
 		}
 		return payload.Value, nil
 	}

--- a/pkg/providers/github/github_test.go
+++ b/pkg/providers/github/github_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -71,5 +72,67 @@ func TestProvide_NoDuplicateAuthHeaders(t *testing.T) {
 	}
 	if got := attempts.Load(); got != 3 {
 		t.Errorf("want 3 attempts, got %d", got)
+	}
+}
+
+func TestProvide_ErrorResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		body    string
+		want    []string
+		notWant []string
+	}{{
+		name:    "non-JSON body on a failing status",
+		status:  http.StatusBadGateway,
+		body:    "upstream connect error or disconnect/reset before headers",
+		want:    []string{"github-actions", "502", "upstream connect error or disconnect/reset before headers"},
+		notWant: []string{"invalid character"},
+	}, {
+		name:    "long error body is truncated",
+		status:  http.StatusInternalServerError,
+		body:    strings.Repeat("x", maxErrorBodyBytes+100),
+		want:    []string{"github-actions", "500"},
+		notWant: []string{strings.Repeat("x", maxErrorBodyBytes+1)},
+	}, {
+		name:   "empty error body",
+		status: http.StatusServiceUnavailable,
+		body:   "",
+		want:   []string{"github-actions", "503"},
+	}, {
+		name:   "malformed JSON body on success",
+		status: http.StatusOK,
+		body:   "not json",
+		want:   []string{"invalid identity token response from provider github-actions"},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				w.Write([]byte(tt.body)) //nolint:errcheck
+			}))
+			defer ts.Close()
+
+			t.Setenv(env.VariableGitHubRequestToken.String(), "fake-token")
+			// The provider appends "&audience=..." so the base URL needs a query param.
+			t.Setenv(env.VariableGitHubRequestURL.String(), ts.URL+"?test=1")
+
+			ga := &githubActions{}
+			_, err := ga.Provide(context.Background(), "sigstore")
+			if err == nil {
+				t.Fatal("Provide: want error, got nil")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("want error containing %q, got %q", want, err)
+				}
+			}
+			for _, notWant := range tt.notWant {
+				if strings.Contains(err.Error(), notWant) {
+					t.Errorf("want error without %q, got %q", notWant, err)
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #4438

## Summary

The GitHub Actions provider decoded the response body without ever checking the status code. When the GitHub OIDC endpoint misbehaves and returns a non-JSON body (for example `upstream connect error or disconnect/reset before headers`, mentioned in the issue), the decoder trips on the first byte and the user sees:

```
error signing scorecard results: getting key from Fulcio: fetching ambient OIDC credentials: invalid character 'u' looking for beginning of value
```

which says nothing about where the failure actually is.

## Changes

- Check `resp.StatusCode` before decoding, and report the status together with the response body. The body is read through an `io.LimitReader` (256 bytes) so a large HTML or proxy error page does not flood the output, and it is formatted with `%q` so an empty body and embedded newlines stay readable on one line.
- Wrap decoder failures with the provider name, as suggested in the issue: `invalid identity token response from provider github-actions`.
- Add a `providerName` constant and use it both in `providers.Register` and in the error messages, so the two cannot drift apart.

The result:

```
fetching ambient OIDC credentials: identity token request to provider github-actions failed with status 502 Bad Gateway: "upstream connect error or disconnect/reset before headers"
```

Retrying on 5xx is deliberately left out: that is a behaviour change rather than a message change, and it belongs in its own PR.

## Tests

Table-driven `TestProvide_ErrorResponse` on top of the existing `httptest` harness, covering a 502 with a non-JSON body, truncation of a long body, an empty body, and malformed JSON on a 200. Each case was confirmed to fail against the unpatched provider.

## Release Note

```release-note
Improve error messages when the GitHub Actions OIDC provider returns a failing status or a malformed identity token response.
```