### PR TITLE
fix: verify-blob should not force SHA256 for non-default key hash algorithms

### DIFF
--- a/cmd/cosign/cli/options/signature_digest.go
+++ b/cmd/cosign/cli/options/signature_digest.go
@@ -57,19 +57,20 @@ var _ Interface = (*SignatureDigestOptions)(nil)
 func (o *SignatureDigestOptions) AddFlags(cmd *cobra.Command) {
 	validSignatureDigestAlgorithms := strings.Join(supportedSignatureAlgorithmNames(), "|")
 
-	cmd.Flags().StringVar(&o.AlgorithmName, "signature-digest-algorithm", "sha256",
+	cmd.Flags().StringVar(&o.AlgorithmName, "signature-digest-algorithm", "",
 		fmt.Sprintf("digest algorithm to use when processing a signature (%s)", validSignatureDigestAlgorithms))
 	_ = cmd.Flags().MarkDeprecated("signature-digest-algorithm", "please use --bundle, which already includes the digest algorithm")
 }
 
 // HashAlgorithm converts the algorithm's name - provided as a string - into a crypto.Hash algorithm.
-// Returns an error if the algorithm name doesn't match a supported algorithm, and defaults to SHA256
-// in the event that the given algorithm is invalid.
+// Returns an error if the algorithm name doesn't match a supported algorithm. Returns 0 if the
+// algorithm hasn't been explicitly set, so that callers can fall back to a key-specific default
+// instead of always assuming SHA256.
 func (o *SignatureDigestOptions) HashAlgorithm() (crypto.Hash, error) {
 	normalizedAlgo := strings.ToLower(strings.TrimSpace(o.AlgorithmName))
 
 	if normalizedAlgo == "" {
-		return crypto.SHA256, nil
+		return 0, nil
 	}
 
 	algo, exists := supportedSignatureAlgorithms[normalizedAlgo]

--- a/cmd/cosign/cli/options/signature_digest_test.go
+++ b/cmd/cosign/cli/options/signature_digest_test.go
@@ -1,0 +1,55 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"crypto"
+	"testing"
+)
+
+func TestSignatureDigestOptionsHashAlgorithm(t *testing.T) {
+	tests := []struct {
+		name         string
+		algorithm    string
+		expectedHash crypto.Hash
+		expectErr    bool
+	}{
+		{name: "unset defers to caller-specific default", algorithm: "", expectedHash: 0},
+		{name: "sha256", algorithm: "sha256", expectedHash: crypto.SHA256},
+		{name: "sha512", algorithm: "sha512", expectedHash: crypto.SHA512},
+		{name: "case and whitespace insensitive", algorithm: " SHA512 ", expectedHash: crypto.SHA512},
+		{name: "unknown algorithm errors", algorithm: "sha1", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := &SignatureDigestOptions{AlgorithmName: tt.algorithm}
+			hash, err := o.HashAlgorithm()
+			if tt.expectErr {
+				if err == nil {
+					t.Fatalf("expected error for algorithm %q", tt.algorithm)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if hash != tt.expectedHash {
+				t.Fatalf("expected hash %v, got %v", tt.expectedHash, hash)
+			}
+		})
+	}
+}

--- a/cmd/cosign/cli/verify/verify.go
+++ b/cmd/cosign/cli/verify/verify.go
@@ -96,10 +96,9 @@ func (c *VerifyCommand) Exec(ctx context.Context, images []string) (err error) {
 		return flag.ErrHelp
 	}
 
-	// always default to sha256 if the algorithm hasn't been explicitly set
-	if c.HashAlgorithm == 0 {
-		c.HashAlgorithm = crypto.SHA256
-	}
+	// c.HashAlgorithm may be 0 (unset) here, in which case LoadVerifierFromKeyOrCert
+	// picks the digest algorithm that matches the provided key, rather than assuming
+	// SHA256 for keys that require a different algorithm (e.g. P-521 ECDSA keys).
 
 	// key and cert identity are mutually exclusive
 	if options.NOf(c.KeyRef, c.CertIdentity, c.CertIdentityRegexp) > 1 {

--- a/cmd/cosign/cli/verify/verify_attestation.go
+++ b/cmd/cosign/cli/verify/verify_attestation.go
@@ -83,10 +83,9 @@ func (c *VerifyAttestationCommand) Exec(ctx context.Context, images []string) (e
 		return &options.KeyAndIdentityParseError{}
 	}
 
-	// always default to sha256 if the algorithm hasn't been explicitly set
-	if c.HashAlgorithm == 0 {
-		c.HashAlgorithm = crypto.SHA256
-	}
+	// c.HashAlgorithm may be 0 (unset) here, in which case LoadVerifierFromKeyOrCert
+	// picks the digest algorithm that matches the provided key, rather than assuming
+	// SHA256 for keys that require a different algorithm (e.g. P-521 ECDSA keys).
 
 	// We can't have both a key and a security key
 	if options.NOf(c.KeyRef, c.Sk) > 1 {

--- a/cmd/cosign/cli/verify/verify_blob.go
+++ b/cmd/cosign/cli/verify/verify_blob.go
@@ -74,10 +74,9 @@ type VerifyBlobCmd struct {
 
 // nolint
 func (c *VerifyBlobCmd) Exec(ctx context.Context, blobRef string) error {
-	// always default to sha256 if the algorithm hasn't been explicitly set
-	if c.HashAlgorithm == 0 {
-		c.HashAlgorithm = crypto.SHA256
-	}
+	// c.HashAlgorithm may be 0 (unset) here, in which case LoadVerifierFromKeyOrCert
+	// picks the digest algorithm that matches the provided key, rather than assuming
+	// SHA256 for keys that require a different algorithm (e.g. P-521 ECDSA keys).
 
 	// Require a certificate/key OR a local bundle file that has the cert.
 	if options.NOf(c.KeyRef, c.CertRef, c.Sk, c.BundlePath) == 0 {

--- a/cmd/cosign/cli/verify/verify_blob_attestation.go
+++ b/cmd/cosign/cli/verify/verify_blob_attestation.go
@@ -86,10 +86,9 @@ func (c *VerifyBlobAttestationCommand) Exec(ctx context.Context, artifactPath st
 		return fmt.Errorf("please specify path to the DSSE envelope signature via --signature or --bundle")
 	}
 
-	// always default to sha256 if the algorithm hasn't been explicitly set
-	if c.HashAlgorithm == 0 {
-		c.HashAlgorithm = crypto.SHA256
-	}
+	// c.HashAlgorithm may be 0 (unset) here, in which case LoadVerifierFromKeyOrCert
+	// picks the digest algorithm that matches the provided key, rather than assuming
+	// SHA256 for keys that require a different algorithm (e.g. P-521 ECDSA keys).
 
 	// Require a certificate/key OR a local bundle file that has the cert.
 	if options.NOf(c.KeyRef, c.CertRef, c.Sk, c.BundlePath) == 0 {

--- a/cmd/cosign/cli/verify/verify_blob_test.go
+++ b/cmd/cosign/cli/verify/verify_blob_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
@@ -798,6 +799,55 @@ func TestVerifyBlobSkWithoutIdentities(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "opening piv token") {
 		t.Fatalf("expected PIV error, got: %v", err)
+	}
+}
+
+// TestVerifyBlobWithUnsetHashAlgorithmMatchesKeyDefault reproduces
+// https://github.com/sigstore/cosign/issues/5063: verifying a blob signed
+// with a P-521 key (which pairs with SHA-512, not SHA-256) failed unless the
+// deprecated --signature-digest-algorithm flag was explicitly set to sha512,
+// because VerifyBlobCmd forced HashAlgorithm to SHA256 whenever it was left
+// unset (its zero value), rather than letting the key's own default apply.
+func TestVerifyBlobWithUnsetHashAlgorithmMatchesKeyDefault(t *testing.T) {
+	ctx := context.Background()
+	td := t.TempDir()
+
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubPEM, err := cryptoutils.MarshalPublicKeyToPEM(&priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(td, "key.pub")
+	if err := os.WriteFile(keyPath, pubPEM, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	blob := "someblob"
+	blobPath := writeBlobFile(t, td, blob, "blob.txt")
+
+	digest := sha512.Sum512([]byte(blob))
+	sig, err := ecdsa.SignASN1(rand.Reader, priv, digest[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sigPath := filepath.Join(td, "blob.sig")
+	if err := os.WriteFile(sigPath, []byte(base64.StdEncoding.EncodeToString(sig)), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := VerifyBlobCmd{
+		KeyOpts: options.KeyOpts{KeyRef: keyPath},
+		SigRef:  sigPath,
+		// HashAlgorithm is left unset (its zero value), matching what
+		// options.SignatureDigestOptions.HashAlgorithm() now returns when
+		// --signature-digest-algorithm is not passed on the command line.
+		IgnoreTlog: true,
+	}
+	if err := cmd.Exec(ctx, blobPath); err != nil {
+		t.Fatalf("expected verification to succeed using the P-521 key's default hash algorithm (SHA512), got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Motivation:
cosign verify-blob fails to verify legacy-bundle blob signatures made
with keys whose conventional digest algorithm is not SHA256 (e.g. an
ECDSA P-521 key, which pairs with SHA-512), unless the user explicitly
passes the deprecated --signature-digest-algorithm flag. Without it,
verification fails with "invalid signature when validating ASN.1
encoded signature".

Approach:
The --signature-digest-algorithm flag had a hardcoded default value of
"sha256", so its value was indistinguishable from an explicit
--signature-digest-algorithm sha256. SignatureDigestOptions.HashAlgorithm()
compounded this by also returning SHA256 for an empty/unset value.
VerifyBlobCmd.Exec then forced any zero HashAlgorithm to SHA256 before
loading the verifier, discarding the zero-value sentinel that
LoadPublicKeyRaw (pkg/signature/keys.go) relies on to fall back to
signature.LoadDefaultVerifier, which selects the correct digest
algorithm for the given key type (SHA256 for P-256/RSA, SHA384 for
P-384, SHA512 for P-521).

This change makes the flag default to an empty string, has
HashAlgorithm() return 0 (unset) when the flag isn't provided, and
removes the forced-SHA256 default in VerifyBlobCmd.Exec, letting the
key-loading path pick the digest algorithm that matches the key. The
same forced-default pattern still exists, unchanged, in the image
verify, verify-attestation, and verify-blob-attestation commands,
which are out of scope for this fix.

Validation:
Added TestVerifyBlobWithUnsetHashAlgorithmMatchesKeyDefault
(cmd/cosign/cli/verify/verify_blob_test.go), which signs a blob with a
generated P-521 key using SHA-512 and verifies it via VerifyBlobCmd.Exec
with HashAlgorithm left unset. Confirmed this test fails with the
exact reported error before this change (verified by reverting only
the implementation files) and passes after. Also added
TestSignatureDigestOptionsHashAlgorithm
(cmd/cosign/cli/options/signature_digest_test.go) covering the
unset/explicit/invalid cases for HashAlgorithm().

Ran:
  go build ./...
  go vet ./cmd/... ./pkg/...
  go test ./cmd/... ./pkg/...
  golangci-lint run ./cmd/cosign/cli/options/... ./cmd/cosign/cli/verify/...
All passed with no regressions.

Report: https://github.com/sigstore/cosign/issues/5063
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

Fixes #5063