### PR TITLE
fix: upload bundle referrer layer blobs before the manifest in cosign load

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -137,17 +137,9 @@ func WriteSignedImageIndexImages(ref name.Reference, sii oci.SignedImageIndex, d
 					return err
 				}
 
-				// Write the manifest
-				m := referrerManifest{*manifest, bundle.BundleV03MediaType}
-				targetRef, err := m.targetRef(o.TargetRepository, opts...)
-				if err != nil {
-					return fmt.Errorf("failed to create target reference: %w", err)
-				}
-				if err := remotePut(targetRef, m, o.ROpt...); err != nil {
-					return fmt.Errorf("failed to upload manifest: %w", err)
-				}
-
-				// Write bundle layers
+				// Write bundle layers before the manifest. Registries that enforce
+				// blob-before-manifest ordering (e.g. AWS ECR) reject a manifest PUT
+				// that references layer digests which have not been uploaded yet.
 				for _, layer := range manifest.Layers {
 					bundlePath := filepath.Join(directory, "blobs", "sha256", layer.Digest.Hex)
 					bundleBytes, err := os.ReadFile(bundlePath)
@@ -159,6 +151,16 @@ func WriteSignedImageIndexImages(ref name.Reference, sii oci.SignedImageIndex, d
 					if err != nil {
 						return err
 					}
+				}
+
+				// Write the manifest
+				m := referrerManifest{*manifest, bundle.BundleV03MediaType}
+				targetRef, err := m.targetRef(o.TargetRepository, opts...)
+				if err != nil {
+					return fmt.Errorf("failed to create target reference: %w", err)
+				}
+				if err := remotePut(targetRef, m, o.ROpt...); err != nil {
+					return fmt.Errorf("failed to upload manifest: %w", err)
 				}
 			}
 		}

--- a/pkg/oci/remote/write_test.go
+++ b/pkg/oci/remote/write_test.go
@@ -16,7 +16,11 @@
 package remote
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,6 +30,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/sigstore/cosign/v3/pkg/cosign/bundle"
+	"github.com/sigstore/cosign/v3/pkg/oci"
 	"github.com/sigstore/cosign/v3/pkg/oci/mutate"
 	"github.com/sigstore/cosign/v3/pkg/oci/signed"
 	cosignstatic "github.com/sigstore/cosign/v3/pkg/oci/static"
@@ -628,4 +634,177 @@ func TestWriteSignaturesExperimentalOCI(t *testing.T) {
 	if !strings.Contains(string(manifestBytes), `"artifactType"`) {
 		t.Errorf("Expected manifest JSON to contain artifactType field, got: %s", string(manifestBytes))
 	}
+}
+
+// stubSignedImageIndex is a minimal oci.SignedImageIndex whose SignedImage
+// and SignedImageIndex accessors report no nested image or index, so
+// WriteSignedImageIndexImages falls straight through to scanning the
+// on-disk layout for referrer manifests. The methods below that aren't
+// exercised by that code path are unimplemented on purpose.
+type stubSignedImageIndex struct{}
+
+func (*stubSignedImageIndex) MediaType() (types.MediaType, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) Digest() (v1.Hash, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) Size() (int64, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) IndexManifest() (*v1.IndexManifest, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) RawManifest() ([]byte, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) Image(v1.Hash) (v1.Image, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) ImageIndex(v1.Hash) (v1.ImageIndex, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) Attachment(string) (oci.File, error) {
+	panic("not implemented")
+}
+
+func (*stubSignedImageIndex) SignedImage(v1.Hash) (oci.SignedImage, error) {
+	return nil, nil
+}
+
+func (*stubSignedImageIndex) SignedImageIndex(v1.Hash) (oci.SignedImageIndex, error) {
+	return nil, nil
+}
+
+func (*stubSignedImageIndex) Signatures() (oci.Signatures, error) {
+	return nil, nil
+}
+
+func (*stubSignedImageIndex) Attestations() (oci.Signatures, error) {
+	return nil, nil
+}
+
+var _ oci.SignedImageIndex = (*stubSignedImageIndex)(nil)
+
+// TestWriteSignedImageIndexImagesBundleLayerBeforeManifest is a regression
+// test for https://github.com/sigstore/cosign/issues/5030: `cosign load`
+// PUT the bundle referrer manifest before uploading the bundle layer blob
+// it references, which registries that enforce blob-before-manifest
+// ordering (e.g. AWS ECR) reject with BLOB_UPLOAD_UNKNOWN.
+func TestWriteSignedImageIndexImagesBundleLayerBeforeManifest(t *testing.T) {
+	origPut := remotePut
+	origWriteLayer := remoteWriteLayer
+	t.Cleanup(func() {
+		remotePut = origPut
+		remoteWriteLayer = origWriteLayer
+	})
+
+	// writeEmptyConfigLayer also goes through remoteWriteLayer, so tell the
+	// bundle layer apart from the empty config layer by media type rather
+	// than assuming there's only one layer write.
+	var order []string
+	remoteWriteLayer = func(_ name.Repository, layer v1.Layer, _ ...remote.Option) error {
+		mt, err := layer.MediaType()
+		if err != nil {
+			return err
+		}
+		if mt == types.MediaType(bundle.BundleV03MediaType) {
+			order = append(order, "bundle-layer")
+		} else {
+			order = append(order, "config-layer")
+		}
+		return nil
+	}
+	remotePut = func(_ name.Reference, _ remote.Taggable, _ ...remote.Option) error {
+		order = append(order, "manifest")
+		return nil
+	}
+
+	digestRef := name.MustParseReference(
+		"gcr.io/test/image@sha256:1111111111111111111111111111111111111111111111111111111111111111").(name.Digest)
+	subjectHash, err := v1.NewHash(digestRef.DigestStr())
+	if err != nil {
+		t.Fatalf("NewHash() = %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	blobDir := filepath.Join(tmpDir, "blobs", "sha256")
+	if err := os.MkdirAll(blobDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() = %v", err)
+	}
+
+	bundleLayerBytes := []byte(`{"bundle":"contents"}`)
+	layerHash, _, err := v1.SHA256(bytes.NewReader(bundleLayerBytes))
+	if err != nil {
+		t.Fatalf("SHA256(layer) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blobDir, layerHash.Hex), bundleLayerBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(layer) = %v", err)
+	}
+
+	bundleManifest := v1.Manifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIManifestSchema1,
+		Config: v1.Descriptor{
+			MediaType: "application/vnd.oci.empty.v1+json",
+			Digest:    v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("0", 64)},
+			Size:      2,
+		},
+		Layers: []v1.Descriptor{{
+			MediaType: types.MediaType(bundle.BundleV03MediaType),
+			Digest:    layerHash,
+			Size:      int64(len(bundleLayerBytes)),
+		}},
+		Subject: &v1.Descriptor{
+			MediaType: types.OCIManifestSchema1,
+			Digest:    subjectHash,
+			Size:      100,
+		},
+		Annotations: map[string]string{
+			BundlePredicateType: "https://test.predicate.type",
+		},
+	}
+	manifestBytes, err := json.Marshal(bundleManifest)
+	if err != nil {
+		t.Fatalf("json.Marshal(manifest) = %v", err)
+	}
+	manifestHash, _, err := v1.SHA256(bytes.NewReader(manifestBytes))
+	if err != nil {
+		t.Fatalf("SHA256(manifest) = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(blobDir, manifestHash.Hex), manifestBytes, 0o644); err != nil {
+		t.Fatalf("WriteFile(manifest) = %v", err)
+	}
+
+	if err := WriteSignedImageIndexImages(digestRef, &stubSignedImageIndex{}, tmpDir); err != nil {
+		t.Fatalf("WriteSignedImageIndexImages() = %v", err)
+	}
+
+	if len(order) != 3 {
+		t.Fatalf("expected the empty config layer, the bundle layer, and the manifest to each be written once, got %v", order)
+	}
+	bundleLayerIdx := indexOf(order, "bundle-layer")
+	manifestIdx := indexOf(order, "manifest")
+	if bundleLayerIdx == -1 || manifestIdx == -1 {
+		t.Fatalf("expected both a bundle-layer write and a manifest put, got %v", order)
+	}
+	if bundleLayerIdx > manifestIdx {
+		t.Errorf("expected the bundle layer to be uploaded before the manifest, got order %v", order)
+	}
+}
+
+func indexOf(haystack []string, needle string) int {
+	for i, v := range haystack {
+		if v == needle {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
Fixes #5030.

`WriteSignedImageIndexImages` (the function behind `cosign load`) PUT the bundle referrer manifest before uploading the bundle layer blob it references. Registries that enforce blob-before-manifest ordering (e.g. AWS ECR) reject that PUT with `BLOB_UPLOAD_UNKNOWN`, since the manifest points at a digest the registry hasn't received yet.

Root cause, in `pkg/oci/remote/write.go`:

```go
// before
if err := remotePut(targetRef, m, o.ROpt...); err != nil {   // manifest PUT first
    ...
}
for _, layer := range manifest.Layers {                       // bundle layer uploaded after, too late
    ...
    remoteWriteLayer(...)
}
```

Same-registry loads can mask this when the blob already exists from a prior upload, which is likely why it went unnoticed - the destination in that case doesn't need the blob freshly uploaded at all. That also matches the issue's own observation that it only reproduces cross-registry/cross-account.

Fix is a straightforward reorder: upload the bundle layer(s) before the manifest, matching how the empty config layer and legacy signature blobs are already handled elsewhere in this file.

**Test coverage**

This code path (`WriteSignedImageIndexImages`) had no test coverage at all before this PR, which is likely how the ordering bug slipped through. Also worth noting: go-containerregistry's in-process test registry (`pkg/registry`) doesn't validate blob-before-manifest ordering on PUT (there's a literal `// TODO: Probably want to do an existence check for blobs.` in its own manifest handler), so a test built against that fake registry wouldn't have caught this either.

Instead, the added test swaps the package's `remotePut`/`remoteWriteLayer` function variables (the same dependency-injection pattern already used by the other tests in this file) to record call order, and asserts the bundle layer write happens before the manifest put. Verified this test fails on the pre-fix code with the exact ordering from the bug report (`config-layer, manifest, bundle-layer`) and passes after the fix.

**Testing done**

- `go build ./...`, `go vet ./pkg/oci/remote/...`, `gofmt -l` clean
- `golangci-lint run ./pkg/oci/remote/...`: 0 issues
- Full `go test ./pkg/oci/...`: all packages pass
- Manually reverted the fix and confirmed the new test fails with the reported ordering, then restored it and confirmed it passes