### PR TITLE
refactor: extract signing flag validation

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -80,7 +80,7 @@ func Attest() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := signcommon.ValidateSigningOptions(cmd.Context(), o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL,
-				o.TlogUpload, o.NewBundleFormat, "",
+				o.TlogUpload, o.NewBundleFormat, o.BundlePath,
 				"", "", "", "", "", ""); err != nil {
 				return err
 			}

--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -78,6 +78,13 @@ func Attest() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := signcommon.ValidateSigningOptions(cmd.Context(), o.UseSigningConfig, o.SigningConfigPath,
+				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL,
+				o.TlogUpload, o.NewBundleFormat, "",
+				"", "", "", "", "", ""); err != nil {
+				return err
+			}
+
 			oidcClientSecret, err := o.OIDC.ClientSecret()
 			if err != nil {
 				return err
@@ -109,10 +116,7 @@ func Attest() *cobra.Command {
 				BundlePath:                     o.BundlePath,
 				NewBundleFormat:                o.NewBundleFormat,
 			}
-			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
-				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, "", o.Key, o.IssueCertificate,
-				"", "", "", "", "", ""); err != nil {
+			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath, o.TrustedRootPath); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/attest_blob.go
+++ b/cmd/cosign/cli/attest_blob.go
@@ -58,6 +58,13 @@ func AttestBlob() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := signcommon.ValidateSigningOptions(cmd.Context(), o.UseSigningConfig, o.SigningConfigPath,
+				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL,
+				o.TlogUpload, o.NewBundleFormat, o.BundlePath,
+				"", o.OutputAttestation, o.OutputCertificate, "", o.OutputSignature, o.RFC3161TimestampPath); err != nil {
+				return err
+			}
+
 			if o.Predicate.Statement == "" && len(args) != 1 {
 				return cobra.ExactArgs(1)(cmd, args)
 			}
@@ -93,10 +100,7 @@ func AttestBlob() *cobra.Command {
 				BundlePath:                     o.BundlePath,
 				NewBundleFormat:                o.NewBundleFormat,
 			}
-			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
-				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate,
-				"", o.OutputAttestation, o.OutputCertificate, "", o.OutputSignature, o.RFC3161TimestampPath); err != nil {
+			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath, o.TrustedRootPath); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -99,7 +99,7 @@ race conditions or (worse) malicious tampering.
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := signcommon.ValidateSigningOptions(cmd.Context(), o.UseSigningConfig, o.SigningConfigPath,
 				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL,
-				o.TlogUpload, o.NewBundleFormat, "",
+				o.TlogUpload, o.NewBundleFormat, o.BundlePath,
 				o.Output, "", o.OutputCertificate, o.OutputPayload, o.OutputSignature, ""); err != nil {
 				return err
 			}

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -97,6 +97,13 @@ race conditions or (worse) malicious tampering.
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := signcommon.ValidateSigningOptions(cmd.Context(), o.UseSigningConfig, o.SigningConfigPath,
+				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL,
+				o.TlogUpload, o.NewBundleFormat, "",
+				o.Output, "", o.OutputCertificate, o.OutputPayload, o.OutputSignature, ""); err != nil {
+				return err
+			}
+
 			switch o.Attachment {
 			case "sbom":
 				fmt.Fprintln(os.Stderr, options.SBOMAttachmentDeprecation)
@@ -135,9 +142,7 @@ race conditions or (worse) malicious tampering.
 				IssueCertificateForExistingKey: o.IssueCertificate,
 				NewBundleFormat:                o.NewBundleFormat,
 			}
-			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
-				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, "", o.Key, o.IssueCertificate, o.Output, "", o.OutputCertificate, o.OutputPayload, o.OutputSignature, ""); err != nil {
+			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath, o.TrustedRootPath); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -83,6 +83,13 @@ func SignBlob() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := signcommon.ValidateSigningOptions(cmd.Context(), o.UseSigningConfig, o.SigningConfigPath,
+				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL,
+				o.TlogUpload, o.NewBundleFormat, o.BundlePath,
+				o.Output, "", o.OutputCertificate, "", o.OutputSignature, o.RFC3161TimestampPath); err != nil {
+				return err
+			}
+
 			oidcClientSecret, err := o.OIDC.ClientSecret()
 			if err != nil {
 				return err
@@ -116,10 +123,7 @@ func SignBlob() *cobra.Command {
 				IssueCertificateForExistingKey: o.IssueCertificate,
 				SigningAlgorithm:               o.SigningAlgorithm,
 			}
-			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath,
-				o.Rekor.URL, o.Fulcio.URL, o.OIDC.Issuer, o.TSAServerURL, o.TrustedRootPath, o.TlogUpload,
-				o.NewBundleFormat, o.BundlePath, o.Key, o.IssueCertificate,
-				o.Output, "", o.OutputCertificate, "", o.OutputSignature, o.RFC3161TimestampPath); err != nil {
+			if err := signcommon.LoadTrustedMaterialAndSigningConfig(cmd.Context(), &ko, o.UseSigningConfig, o.SigningConfigPath, o.TrustedRootPath); err != nil {
 				return err
 			}
 

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -467,12 +467,31 @@ func ParseSignatureAlgorithmFlag(signingAlgorithm string) (pb_go_v1.PublicKeyDet
 	return signature.ParseSignatureAlgorithmFlag(signingAlgorithm)
 }
 
-// LoadTrustedMaterialAndSigningConfig loads the trusted material and signing config from the given options.
-func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpts, useSigningConfig bool, signingConfigPath string,
-	rekorURL, fulcioURL, oidcIssuer, tsaServerURL, trustedRootPath string,
-	tlogUpload bool, newBundleFormat bool, bundlePath string, keyRef string, issueCertificate bool,
+// ValidateSigningOptions checks signing option compatibility and emits deprecation warnings.
+func ValidateSigningOptions(ctx context.Context, useSigningConfig bool, signingConfigPath string,
+	rekorURL, fulcioURL, oidcIssuer, tsaServerURL string,
+	tlogUpload bool, newBundleFormat bool, bundlePath string,
 	output, outputAttestation, outputCertificate, outputPayload, outputSignature, outputTimestamp string) error {
-	var err error
+	// TODO: Remove deprecated output flags warning in a future release (when flags are removed)
+	if newBundleFormat && outputSignature != "" {
+		ui.Warnf(ctx, "--output-signature is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputAttestation != "" {
+		ui.Warnf(ctx, "--output-attestation is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputCertificate != "" {
+		ui.Warnf(ctx, "--output-certificate is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputPayload != "" {
+		ui.Warnf(ctx, "--output-payload is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && outputTimestamp != "" {
+		ui.Warnf(ctx, "--rfc3161-timestamp is deprecated when using --new-bundle-format and will be ignored")
+	}
+	if newBundleFormat && output != "" {
+		ui.Warnf(ctx, "--output is deprecated when using --new-bundle-format and will be ignored")
+	}
+
 	// If a signing config is used, then service URLs cannot be specified
 	if (useSigningConfig || signingConfigPath != "") &&
 		((rekorURL != "" && rekorURL != options.DefaultRekorURL) ||
@@ -488,10 +507,17 @@ func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpt
 	if (useSigningConfig || signingConfigPath != "") && !newBundleFormat && bundlePath == "" {
 		return fmt.Errorf("must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config")
 	}
+
+	return nil
+}
+
+// LoadTrustedMaterialAndSigningConfig loads the trusted material and signing config from the given options.
+func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpts, useSigningConfig bool, signingConfigPath, trustedRootPath string) error {
+	var err error
 	// Fetch a trusted root when:
 	// * requesting a certificate and no CT log key is provided to verify an SCT
 	// * using a signing config
-	if ((keyRef == "" || issueCertificate) && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "") ||
+	if ((ko.KeyRef == "" || ko.IssueCertificateForExistingKey) && env.Getenv(env.VariableSigstoreCTLogPublicKeyFile) == "") ||
 		(useSigningConfig || signingConfigPath != "") {
 		if trustedRootPath != "" {
 			ko.TrustedMaterial, err = root.NewTrustedRootFromPath(trustedRootPath)
@@ -515,26 +541,6 @@ func LoadTrustedMaterialAndSigningConfig(ctx context.Context, ko *options.KeyOpt
 		if err != nil {
 			return fmt.Errorf("error getting signing config from TUF: %w", err)
 		}
-	}
-
-	// TODO: Remove deprecated output flags warning in a future release (when flags are removed)
-	if newBundleFormat && outputSignature != "" {
-		ui.Warnf(context.Background(), "--output-signature is deprecated when using --new-bundle-format and will be ignored")
-	}
-	if newBundleFormat && outputAttestation != "" {
-		ui.Warnf(context.Background(), "--output-attestation is deprecated when using --new-bundle-format and will be ignored")
-	}
-	if newBundleFormat && outputCertificate != "" {
-		ui.Warnf(context.Background(), "--output-certificate is deprecated when using --new-bundle-format and will be ignored")
-	}
-	if newBundleFormat && outputPayload != "" {
-		ui.Warnf(context.Background(), "--output-payload is deprecated when using --new-bundle-format and will be ignored")
-	}
-	if newBundleFormat && outputTimestamp != "" {
-		ui.Warnf(context.Background(), "--rfc3161-timestamp is deprecated when using --new-bundle-format and will be ignored")
-	}
-	if newBundleFormat && output != "" {
-		ui.Warnf(context.Background(), "--output is deprecated when using --new-bundle-format and will be ignored")
 	}
 
 	return nil

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -325,3 +325,243 @@ func TestNewLegacyBundleFromProtoBundleComponents(t *testing.T) {
 		assert.NotEmpty(t, payload.Cert, "expected non-empty cert field when BundleComponents has certificates")
 	})
 }
+
+func TestValidateSigningOptions(t *testing.T) {
+	tests := []struct {
+		name              string
+		useSigningConfig  bool
+		signingConfigPath string
+		rekorURL          string
+		fulcioURL         string
+		oidcIssuer        string
+		tsaServerURL      string
+		tlogUpload        bool
+		newBundleFormat   bool
+		bundlePath        string
+		output            string
+		outputAttestation string
+		outputCertificate string
+		outputPayload     string
+		outputSignature   string
+		outputTimestamp   string
+		wantErr           bool
+		wantErrSubstr     string
+		wantWarningSubstr string
+	}{
+		{
+			name:            "valid default online signing flags",
+			rekorURL:        options.DefaultRekorURL,
+			fulcioURL:       options.DefaultFulcioURL,
+			oidcIssuer:      options.DefaultOIDCIssuerURL,
+			tlogUpload:      true,
+			newBundleFormat: true,
+			wantErr:         false,
+		},
+		{
+			name:             "valid signing config from TUF",
+			useSigningConfig: true,
+			rekorURL:         options.DefaultRekorURL,
+			fulcioURL:        options.DefaultFulcioURL,
+			oidcIssuer:       options.DefaultOIDCIssuerURL,
+			tlogUpload:       true,
+			newBundleFormat:  true,
+			wantErr:          false,
+		},
+		{
+			name:              "valid signing config from file",
+			signingConfigPath: "/path/to/signing_config.json",
+			rekorURL:          options.DefaultRekorURL,
+			fulcioURL:         options.DefaultFulcioURL,
+			oidcIssuer:        options.DefaultOIDCIssuerURL,
+			tlogUpload:        true,
+			newBundleFormat:   true,
+			wantErr:           false,
+		},
+		{
+			name:             "use signing config with custom rekor URL",
+			useSigningConfig: true,
+			rekorURL:         "http://localhost:3000",
+			tlogUpload:       true,
+			wantErr:          true,
+			wantErrSubstr:    "cannot specify service URLs and use signing config",
+		},
+		{
+			name:             "use signing config with custom fulcio URL",
+			useSigningConfig: true,
+			fulcioURL:        "http://localhost:5555",
+			tlogUpload:       true,
+			wantErr:          true,
+			wantErrSubstr:    "cannot specify service URLs and use signing config",
+		},
+		{
+			name:             "use signing config with custom OIDC issuer",
+			useSigningConfig: true,
+			oidcIssuer:       "http://localhost:8080",
+			tlogUpload:       true,
+			wantErr:          true,
+			wantErrSubstr:    "cannot specify service URLs and use signing config",
+		},
+		{
+			name:             "use signing config with custom TSA server URL",
+			useSigningConfig: true,
+			tsaServerURL:     "http://localhost:3001",
+			tlogUpload:       true,
+			wantErr:          true,
+			wantErrSubstr:    "cannot specify service URLs and use signing config",
+		},
+		{
+			name:              "signing config path with custom service URLs",
+			signingConfigPath: "/path/to/signing_config.json",
+			rekorURL:          "http://localhost:3000",
+			tlogUpload:        true,
+			wantErr:           true,
+			wantErrSubstr:     "cannot specify service URLs and use signing config",
+		},
+		{
+			name:             "use signing config with tlog upload false",
+			useSigningConfig: true,
+			rekorURL:         options.DefaultRekorURL,
+			fulcioURL:        options.DefaultFulcioURL,
+			oidcIssuer:       options.DefaultOIDCIssuerURL,
+			tlogUpload:       false,
+			newBundleFormat:  true,
+			wantErr:          true,
+			wantErrSubstr:    "--tlog-upload=false is not supported with --signing-config or --use-signing-config",
+		},
+		{
+			name:              "signing config path with tlog upload false",
+			signingConfigPath: "/path/to/signing_config.json",
+			rekorURL:          options.DefaultRekorURL,
+			fulcioURL:         options.DefaultFulcioURL,
+			oidcIssuer:        options.DefaultOIDCIssuerURL,
+			tlogUpload:        false,
+			newBundleFormat:   true,
+			wantErr:           true,
+			wantErrSubstr:     "--tlog-upload=false is not supported with --signing-config or --use-signing-config",
+		},
+		{
+			name:             "missing bundle output with use signing config",
+			useSigningConfig: true,
+			rekorURL:         options.DefaultRekorURL,
+			fulcioURL:        options.DefaultFulcioURL,
+			oidcIssuer:       options.DefaultOIDCIssuerURL,
+			tlogUpload:       true,
+			newBundleFormat:  false,
+			bundlePath:       "",
+			wantErr:          true,
+			wantErrSubstr:    "must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config",
+		},
+		{
+			name:              "missing bundle output with signing config path",
+			signingConfigPath: "/path/to/signing_config.json",
+			rekorURL:          options.DefaultRekorURL,
+			fulcioURL:         options.DefaultFulcioURL,
+			oidcIssuer:        options.DefaultOIDCIssuerURL,
+			tlogUpload:        true,
+			newBundleFormat:   false,
+			bundlePath:        "",
+			wantErr:           true,
+			wantErrSubstr:     "must provide --new-bundle-format or --bundle where applicable with --signing-config or --use-signing-config",
+		},
+		{
+			name:             "legacy bundle format with explicit bundle path is valid with use signing config",
+			useSigningConfig: true,
+			rekorURL:         options.DefaultRekorURL,
+			fulcioURL:        options.DefaultFulcioURL,
+			oidcIssuer:       options.DefaultOIDCIssuerURL,
+			tlogUpload:       true,
+			newBundleFormat:  false,
+			bundlePath:       "/tmp/bundle.json",
+			wantErr:          false,
+		},
+		{
+			name:              "legacy bundle format with explicit bundle path is valid with signing config path",
+			signingConfigPath: "/path/to/signing_config.json",
+			rekorURL:          options.DefaultRekorURL,
+			fulcioURL:         options.DefaultFulcioURL,
+			oidcIssuer:        options.DefaultOIDCIssuerURL,
+			tlogUpload:        true,
+			newBundleFormat:   false,
+			bundlePath:        "/tmp/bundle.json",
+			wantErr:           false,
+		},
+		{
+			name:            "custom service URLs without signing config is valid",
+			rekorURL:        "http://localhost:3000",
+			tlogUpload:      true,
+			newBundleFormat: true,
+			wantErr:         false,
+		},
+		{
+			name:            "tlog upload false without signing config is valid",
+			tlogUpload:      false,
+			newBundleFormat: true,
+			wantErr:         false,
+		},
+		{
+			name:              "deprecated output-signature warning with new bundle format",
+			newBundleFormat:   true,
+			tlogUpload:        true,
+			outputSignature:   "sig.sig",
+			wantWarningSubstr: "--output-signature is deprecated when using --new-bundle-format",
+		},
+		{
+			name:              "deprecated output-attestation warning with new bundle format",
+			newBundleFormat:   true,
+			tlogUpload:        true,
+			outputAttestation: "att.att",
+			wantWarningSubstr: "--output-attestation is deprecated when using --new-bundle-format",
+		},
+		{
+			name:              "deprecated output-certificate warning with new bundle format",
+			newBundleFormat:   true,
+			tlogUpload:        true,
+			outputCertificate: "cert.crt",
+			wantWarningSubstr: "--output-certificate is deprecated when using --new-bundle-format",
+		},
+		{
+			name:              "deprecated output-payload warning with new bundle format",
+			newBundleFormat:   true,
+			tlogUpload:        true,
+			outputPayload:     "payload.json",
+			wantWarningSubstr: "--output-payload is deprecated when using --new-bundle-format",
+		},
+		{
+			name:              "deprecated rfc3161-timestamp warning with new bundle format",
+			newBundleFormat:   true,
+			tlogUpload:        true,
+			outputTimestamp:   "ts.tsr",
+			wantWarningSubstr: "--rfc3161-timestamp is deprecated when using --new-bundle-format",
+		},
+		{
+			name:              "deprecated output warning with new bundle format",
+			newBundleFormat:   true,
+			tlogUpload:        true,
+			output:            "out.sig",
+			wantWarningSubstr: "--output is deprecated when using --new-bundle-format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
+				err = ValidateSigningOptions(ctx, tt.useSigningConfig, tt.signingConfigPath,
+					tt.rekorURL, tt.fulcioURL, tt.oidcIssuer, tt.tsaServerURL,
+					tt.tlogUpload, tt.newBundleFormat, tt.bundlePath,
+					tt.output, tt.outputAttestation, tt.outputCertificate, tt.outputPayload, tt.outputSignature, tt.outputTimestamp)
+			})
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.wantErrSubstr != "" {
+					assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.wantWarningSubstr != "" {
+				assert.Contains(t, stderr, tt.wantWarningSubstr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

This change simplifies `LoadTrustedMaterialAndSigningConfig` by extracting its signing flag validation logic and relevant inputs into a new function `ValidateSigningOptions`.