### PR TITLE
docs: fix two dead links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Here is how to install and use cosign inside a Dockerfile through the ghcr.io/si
 ```shell
 FROM ghcr.io/sigstore/cosign/cosign:v2.4.1 as cosign-bin
 
-# Source: https://github.com/chainguard-images/static
+# Source: https://github.com/chainguard-images/images/tree/main/images/static
 FROM cgr.dev/chainguard/static:latest
 COPY --from=cosign-bin /ko-app/cosign /usr/local/bin/cosign
 ENTRYPOINT [ "cosign" ]
@@ -420,7 +420,7 @@ That looks like:
 **Note:** This can be generated for an image reference using `cosign generate $IMAGE_URI_DIGEST`.
 
 I'm happy to switch this format to something else if it makes sense.
-See https://github.com/notaryproject/nv2/issues/40 for one option.
+See https://github.com/notaryproject/notation/issues/40 for one option.
 
 #### Registry Details
 


### PR DESCRIPTION
## Summary

Fixes two dead links in README.md found during an external-link sweep of the repo's docs:

| Line | Dead URL | Replacement |
|---|---|---|
| 71 | `https://github.com/chainguard-images/static` (404) | `https://github.com/chainguard-images/images/tree/main/images/static` |
| 423 | `https://github.com/notaryproject/nv2/issues/40` (404) | `https://github.com/notaryproject/notation/issues/40` |

### Verification

- `github.com/chainguard-images/static`: HTTP 404 via curl and GitHub API. The standalone images repos were folded into the [`chainguard-images/images`](https://github.com/chainguard-images/images) monorepo, where `images/static` still tracks the source for `cgr.dev/chainguard/static:latest` — the exact image referenced two lines below in the same snippet.
- `github.com/notaryproject/nv2/issues/40`: HTTP 404; the `nv2` repository no longer resolves. The GitHub API redirects it to `notaryproject/notation`, and issue #40 ("Proposal: Use the OCI Descriptor as a payload format") exists there with the identical title. This is the same discussion the sentence has always pointed at.

All other external links in README.md / doc/ / CLI.md were live-checked and are healthy (the remaining non-200s are bot-blocked 403s on slack.com and intentional placeholders like `ORG/REPO`, left untouched).

Docs-only change; no code paths affected.
