### PR TITLE
fix: clarify COSIGN_REPOSITORY error when repository path is missing

### DIFF
--- a/pkg/oci/remote/options.go
+++ b/pkg/oci/remote/options.go
@@ -17,6 +17,7 @@ package remote
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -136,6 +137,16 @@ func GetEnvTargetRepository() (name.Repository, error) {
 	if ro := env.Getenv(env.VariableRepository); ro != "" {
 		repo, err := name.NewRepository(ro)
 		if err != nil {
+			// A bare registry (e.g. "registry.example.com:5000", with no
+			// repository path) has no '/' to split on, so name.NewRepository
+			// treats the whole value as a repository name and rejects it for
+			// containing '.'/':' characters. That error is misleading: the
+			// real problem is that COSIGN_REPOSITORY must be a full
+			// repository, not just a registry.
+			if !strings.Contains(ro, "/") && (strings.Contains(ro, ".") || strings.Contains(ro, ":")) {
+				return name.Repository{}, fmt.Errorf("parsing $"+RepoOverrideEnvKey+": %q looks like a registry, but "+
+					RepoOverrideEnvKey+" must be a full repository (registry plus path), e.g. %q: %w", ro, ro+"/my-repo", err)
+			}
 			return name.Repository{}, fmt.Errorf("parsing $"+RepoOverrideEnvKey+": %w", err)
 		}
 		return repo, nil

--- a/pkg/oci/remote/options_test.go
+++ b/pkg/oci/remote/options_test.go
@@ -162,6 +162,12 @@ func TestGetEnvTargetRepository(t *testing.T) {
 			envVal: "",
 			want:   name.Repository{},
 		},
+		{
+			desc: "registry without repository path",
+
+			envVal:  "registry.example.com:5000",
+			wantErr: errors.New(`parsing $COSIGN_REPOSITORY: "registry.example.com:5000" looks like a registry, but COSIGN_REPOSITORY must be a full repository (registry plus path), e.g. "registry.example.com:5000/my-repo": repository can only contain the characters ` + "`abcdefghijklmnopqrstuvwxyz0123456789_-./`" + `: registry.example.com:5000`),
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

`COSIGN_REPOSITORY` must be set to a full repository (registry + path), not just a registry. When it's set to a bare registry, e.g. `COSIGN_REPOSITORY=registry.example.com:5000`, `name.NewRepository()` has no `/` to split on, so it treats the entire value as a repository name and rejects it with:

```
repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`
```

which looks like a parsing/port bug rather than what it actually is: a missing repository path. This was discussed in #3029, where both the reporter's follow-up investigation and another user confirmed that port parsing itself works fine, and that the real issue is this misleading error message.

This PR detects that specific case (no `/` in the value, but it looks like a registry host because it contains `.` or `:`) and returns a clearer, actionable error pointing out that `COSIGN_REPOSITORY` needs a repository path, with an example.

Before:
```
Error: parsing $COSIGN_REPOSITORY: repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`: registry.example.com:5000
```

After:
```
Error: parsing $COSIGN_REPOSITORY: "registry.example.com:5000" looks like a registry, but COSIGN_REPOSITORY must be a full repository (registry plus path), e.g. "registry.example.com:5000/my-repo": repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`
```

## Testing

Added a test case to `TestGetEnvTargetRepository` in `pkg/oci/remote/options_test.go` covering a bare registry with a port and no repository path. Ran:

```
go test ./pkg/oci/remote/...
```

All tests pass, including the pre-existing cases (a genuinely invalid repo name, e.g. `bad$repo`, is unaffected since it contains neither `.` nor `:`).

Fixes #3029