### PR TITLE
fix: make Ed25519 keys usable again for sign-blob, attest-blob and verify --key

### DIFF
--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -407,6 +407,17 @@ type CommonBundleOpts struct {
 
 // NewAttestationBundle uses signing config and trusted root to sign an attestation and create a bundle.
 func NewAttestationBundle(ctx context.Context, ko options.KeyOpts, cert, certChain string, bundleOpts CommonBundleOpts, signingConfig *root.SigningConfig, trustedMaterial root.TrustedMaterial) ([]byte, crypto.PublicKey, pb_go_v1.HashAlgorithm, error) {
+	// A DSSE envelope is verified with pure Ed25519: sigstore-go reserves
+	// Ed25519ph for hashedrekord message signatures, where it is the only
+	// option, and loads the verifier for an envelope without it. An Ed25519
+	// key therefore has to sign the envelope as pure Ed25519 too. Left at the
+	// default, it signs as Ed25519ph and the bundle fails its own
+	// post-signing verification with "accepted signatures do not match
+	// threshold".
+	if ko.DefaultLoadOptions == nil {
+		ko.DefaultLoadOptions = &[]signature.LoadOption{}
+	}
+
 	keypair, certBytes, chainBytes, idToken, err := GetKeypairAndToken(ctx, ko, cert, certChain)
 	if err != nil {
 		return nil, nil, pb_go_v1.HashAlgorithm_HASH_ALGORITHM_UNSPECIFIED, fmt.Errorf("getting keypair and token: %w", err)

--- a/pkg/cosign/bundle/sign.go
+++ b/pkg/cosign/bundle/sign.go
@@ -17,19 +17,22 @@ package bundle
 import (
 	"bytes"
 	"context"
+	"crypto"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 	"time"
 
 	"github.com/sigstore/cosign/v3/internal/ui"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore-go/pkg/sign"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
@@ -72,13 +75,16 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 			return nil, err
 		}
 		block, _ := pem.Decode([]byte(publicKeyPem))
+		if block == nil {
+			return nil, errors.New("could not decode public key PEM")
+		}
 		pubKey, err := x509.ParsePKIXPublicKey(block.Bytes)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("parsing public key: %w", err)
 		}
-		verifier, err := signature.LoadDefaultVerifier(pubKey)
+		verifier, err := verifierForKeypair(keypair, pubKey)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("loading verifier for signing key: %w", err)
 		}
 		key := root.NewExpiringKey(verifier, time.Time{}, time.Time{})
 		keyTrustedMaterial := root.NewTrustedPublicKeyMaterial(func(_ string) (root.TimeConstrainedVerifier, error) {
@@ -97,7 +103,7 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		tsaSvcs, err := root.SelectServices(signingConfig.TimestampAuthorityURLs(),
 			signingConfig.TimestampAuthorityURLsConfig(), sign.TimestampAuthorityAPIVersions, time.Now())
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("selecting timestamp authority: %w", err)
 		}
 		for _, tsaSvc := range tsaSvcs {
 			tsaOpts := &sign.TimestampAuthorityOptions{
@@ -149,6 +155,19 @@ func SignData(ctx context.Context, content sign.Content, keypair sign.Keypair, i
 		return nil, fmt.Errorf("error signing bundle: %w", err)
 	}
 	return protojson.Marshal(bundle)
+}
+
+// verifierForKeypair loads a verifier that checks signatures the way the
+// keypair makes them. The two are not the same thing for Ed25519: a key
+// loaded for the transparency log signs as Ed25519ph, while a verifier loaded
+// with the default options checks pure Ed25519 only, so the signature just
+// made would fail the bundle's own post-signing verification.
+func verifierForKeypair(keypair sign.Keypair, pubKey crypto.PublicKey) (signature.Verifier, error) {
+	var loadOpts []signature.LoadOption
+	if keypair.GetSigningAlgorithm() == protocommon.PublicKeyDetails_PKIX_ED25519_PH {
+		loadOpts = append(loadOpts, options.WithED25519ph())
+	}
+	return signature.LoadDefaultVerifier(pubKey, loadOpts...)
 }
 
 type verifyTrustedMaterial struct {

--- a/pkg/cosign/bundle/sign_test.go
+++ b/pkg/cosign/bundle/sign_test.go
@@ -21,7 +21,10 @@ import (
 	"testing"
 
 	"github.com/sigstore/cosign/v3/internal/test"
+	protocommon "github.com/sigstore/protobuf-specs/gen/pb-go/common/v1"
+	"github.com/sigstore/sigstore-go/pkg/sign"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/sigstore/sigstore/pkg/signature"
 )
 
 func TestLocalCertChainProvider_GetCertificateChain(t *testing.T) {
@@ -116,5 +119,59 @@ func TestLocalCertChainProvider_GetCertificateChain(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// The bundle is verified against the signing key right after signing, so the
+// verifier has to agree with the keypair about the signature scheme. Ed25519
+// is the case where they can disagree: Ed25519ph and pure Ed25519 share a key
+// and are not interchangeable.
+func TestVerifierForKeypairMatchesTheSigningScheme(t *testing.T) {
+	data := []byte("signed content")
+
+	for _, algorithm := range []protocommon.PublicKeyDetails{
+		protocommon.PublicKeyDetails_PKIX_ED25519_PH,
+		protocommon.PublicKeyDetails_PKIX_ED25519,
+		protocommon.PublicKeyDetails_PKIX_ECDSA_P256_SHA_256,
+	} {
+		t.Run(algorithm.String(), func(t *testing.T) {
+			keypair, err := sign.NewEphemeralKeypair(&sign.EphemeralKeypairOptions{Algorithm: algorithm})
+			if err != nil {
+				t.Fatalf("NewEphemeralKeypair: %v", err)
+			}
+			sig, _, err := keypair.SignData(context.Background(), data)
+			if err != nil {
+				t.Fatalf("SignData: %v", err)
+			}
+
+			verifier, err := verifierForKeypair(keypair, keypair.GetPublicKey())
+			if err != nil {
+				t.Fatalf("verifierForKeypair: %v", err)
+			}
+			if err := verifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data)); err != nil {
+				t.Fatalf("a verifier loaded for the keypair must accept its signature: %v", err)
+			}
+		})
+	}
+}
+
+// Loading the verifier with the default options is exactly the mistake the
+// helper exists to avoid; this pins the failure it would reintroduce.
+func TestDefaultVerifierRejectsAnEd25519phSignature(t *testing.T) {
+	keypair, err := sign.NewEphemeralKeypair(&sign.EphemeralKeypairOptions{Algorithm: protocommon.PublicKeyDetails_PKIX_ED25519_PH})
+	if err != nil {
+		t.Fatalf("NewEphemeralKeypair: %v", err)
+	}
+	data := []byte("signed content")
+	sig, _, err := keypair.SignData(context.Background(), data)
+	if err != nil {
+		t.Fatalf("SignData: %v", err)
+	}
+	verifier, err := signature.LoadDefaultVerifier(keypair.GetPublicKey())
+	if err != nil {
+		t.Fatalf("LoadDefaultVerifier: %v", err)
+	}
+	if err := verifier.VerifySignature(bytes.NewReader(sig), bytes.NewReader(data)); err == nil {
+		t.Fatal("a pure Ed25519 verifier accepted an Ed25519ph signature; the helper is no longer needed")
 	}
 }

--- a/pkg/cosign/ed25519_compat_test.go
+++ b/pkg/cosign/ed25519_compat_test.go
@@ -1,0 +1,98 @@
+//
+// Copyright 2026 The Sigstore Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cosign
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/sigstore/sigstore/pkg/signature"
+	"github.com/sigstore/sigstore/pkg/signature/options"
+)
+
+// A --key verifier for an Ed25519 key must accept the signature a bundle
+// actually carries, whichever of the two schemes made it.
+func TestEd25519CompatibleVerifierAcceptsBothSchemes(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	message := []byte("signed content")
+
+	prehashedSigner, err := signature.LoadDefaultSignerVerifier(priv, options.WithED25519ph())
+	if err != nil {
+		t.Fatal(err)
+	}
+	pureSigner, err := signature.LoadDefaultSignerVerifier(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prehashedSig, err := prehashedSigner.SignMessage(bytes.NewReader(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pureSig, err := pureSigner.SignMessage(bytes.NewReader(message))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(prehashedSig, pureSig) {
+		t.Fatal("the two schemes produced the same signature; the test proves nothing")
+	}
+
+	// What LoadDefaultVerifier hands back for an Ed25519 --key today.
+	loaded, err := signature.LoadDefaultVerifier(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := loaded.VerifySignature(bytes.NewReader(prehashedSig), bytes.NewReader(message)); err == nil {
+		t.Fatal("a pure Ed25519 verifier accepted an Ed25519ph signature; the compat wrapper is no longer needed")
+	}
+
+	compat := ed25519CompatibleVerifier(loaded)
+	for name, sig := range map[string][]byte{"ed25519ph": prehashedSig, "pure ed25519": pureSig} {
+		if err := compat.VerifySignature(bytes.NewReader(sig), bytes.NewReader(message)); err != nil {
+			t.Errorf("%s signature rejected: %v", name, err)
+		}
+	}
+	if err := compat.VerifySignature(bytes.NewReader(pureSig), bytes.NewReader([]byte("other content"))); err == nil {
+		t.Error("a signature over different content was accepted")
+	}
+	got, err := compat.PublicKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pub.Equal(got) {
+		t.Error("the wrapper must report the same public key")
+	}
+}
+
+func TestEd25519CompatibleVerifierLeavesOtherKeysAlone(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := signature.LoadDefaultVerifier(&priv.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ed25519CompatibleVerifier(verifier) != verifier {
+		t.Fatal("a non-Ed25519 verifier must be returned unchanged")
+	}
+}

--- a/pkg/cosign/verify.go
+++ b/pkg/cosign/verify.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"
@@ -28,6 +29,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"log"
 	"net/http"
@@ -204,6 +206,66 @@ func (v *verifyTrustedMaterial) PublicKeyVerifier(hint string) (root.TimeConstra
 	return v.keyTrustedMaterial.PublicKeyVerifier(hint)
 }
 
+// ed25519CompatVerifier accepts both Ed25519 signature schemes for one key.
+//
+// A bundle cosign writes for an Ed25519 key carries an Ed25519ph message
+// signature (the only scheme a hashedrekord entry takes) or a pure Ed25519
+// DSSE signature (the scheme sigstore-go verifies envelopes with), and
+// signatures from older versions are pure Ed25519 throughout. A verifier
+// loaded from --key checks one scheme, so it has to be the right one for the
+// bundle in hand; this tries the message-signature scheme first and the other
+// second, the way sigstore-go's compatibility verifier does for certificates.
+type ed25519CompatVerifier struct {
+	verifiers []signature.Verifier
+}
+
+func (v *ed25519CompatVerifier) VerifySignature(sig, message io.Reader, opts ...signature.VerifyOption) error {
+	sigBytes, err := io.ReadAll(sig)
+	if err != nil {
+		return fmt.Errorf("reading signature: %w", err)
+	}
+	messageBytes, err := io.ReadAll(message)
+	if err != nil {
+		return fmt.Errorf("reading message: %w", err)
+	}
+	var errs []error
+	for _, verifier := range v.verifiers {
+		err := verifier.VerifySignature(bytes.NewReader(sigBytes), bytes.NewReader(messageBytes), opts...)
+		if err == nil {
+			return nil
+		}
+		errs = append(errs, err)
+	}
+	return errors.Join(errs...)
+}
+
+func (v *ed25519CompatVerifier) PublicKey(opts ...signature.PublicKeyOption) (crypto.PublicKey, error) {
+	return v.verifiers[0].PublicKey(opts...)
+}
+
+// ed25519CompatibleVerifier returns a verifier that accepts Ed25519ph and pure
+// Ed25519 signatures when the key is Ed25519, and the verifier unchanged
+// otherwise.
+func ed25519CompatibleVerifier(verifier signature.Verifier) signature.Verifier {
+	pub, err := verifier.PublicKey()
+	if err != nil {
+		return verifier
+	}
+	edPub, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return verifier
+	}
+	prehashed, err := signature.LoadED25519phVerifier(edPub)
+	if err != nil {
+		return verifier
+	}
+	pure, err := signature.LoadED25519Verifier(edPub)
+	if err != nil {
+		return verifier
+	}
+	return &ed25519CompatVerifier{verifiers: []signature.Verifier{prehashed, pure}}
+}
+
 // verificationOptions returns the verification options for verifying with sigstore-go.
 func (co *CheckOpts) verificationOptions() (trustedMaterial root.TrustedMaterial, verifierOptions []verify.VerifierOption, policyOptions []verify.PolicyOption, err error) {
 	if co.TrustedMaterial == nil && co.SigVerifier == nil {
@@ -251,7 +313,7 @@ func (co *CheckOpts) verificationOptions() (trustedMaterial root.TrustedMaterial
 	if co.SigVerifier != nil {
 		// We are verifying with a public key
 		policyOptions = append(policyOptions, verify.WithKey())
-		newExpiringKey := root.NewExpiringKey(co.SigVerifier, time.Time{}, time.Time{})
+		newExpiringKey := root.NewExpiringKey(ed25519CompatibleVerifier(co.SigVerifier), time.Time{}, time.Time{})
 		vTrustedMaterial.keyTrustedMaterial = root.NewTrustedPublicKeyMaterial(func(_ string) (root.TimeConstrainedVerifier, error) {
 			return newExpiringKey, nil
 		})


### PR DESCRIPTION
## Summary

With the v3 defaults, an Ed25519 key that `cosign import-key-pair` accepts cannot sign, attest, or verify anything. Three places in cosign disagree about which Ed25519 scheme is in use; this makes them agree with sigstore-go's convention and with each other.

## Reproduction (on `main`, `58aae9e`)

```console
$ openssl genpkey -algorithm ed25519 -out ed25519.pem
$ cosign import-key-pair --key ed25519.pem --output-key-prefix ed -y
Public key written to ed.pub

$ cosign sign-blob --key ed.key -y --bundle blob.sigstore.json blob.txt
error during command execution: signing blob.txt: signing bundle: error signing bundle: failed to verify signature: could not verify message: failed to verify signature

$ cosign attest-blob --key ed.key -y --predicate p.json --type custom --bundle att.sigstore.json blob.txt
error during command execution: creating bundle: signing bundle: error signing bundle: could not verify envelope: accepted signatures do not match threshold, Found: 0, Expected 1
```

Every other key type in the same matrix — RSA PKCS#1 and PKCS#8, EC P-256 SEC1 and PKCS#8, P-384 — signs and verifies. Only Ed25519 fails, and it fails on every run, not on an edge case.

## Why

Ed25519 has two schemes that share a key and are not interchangeable: pure Ed25519 and Ed25519ph. sigstore-go's convention ([`compatSignatureVerifier`](https://github.com/sigstore/sigstore-go/blob/v1.3.0/pkg/verify/signature.go#L158-L171)) is Ed25519ph for message signatures — the only scheme a hashedrekord entry takes — and pure Ed25519 for DSSE envelopes. cosign's `GetDefaultLoadOptions` loads a key as Ed25519ph, which is right for message signatures, but three other places did not follow:

| where | was | now |
|---|---|---|
| `pkg/cosign/bundle/sign.go` — the verifier the bundle is checked against right after signing | `LoadDefaultVerifier(pubKey)` → pure Ed25519, so an Ed25519ph signature failed the bundle's own post-signing verification | loaded to match `keypair.GetSigningAlgorithm()` |
| `signcommon.NewAttestationBundle` — attestations | key loaded with the defaults → signs the DSSE envelope as Ed25519ph; sigstore-go verifies envelopes as pure | Ed25519 keys are loaded as pure Ed25519 for attestations |
| `pkg/cosign/verify.go` — a verifier loaded from `--key` | `LoadDefaultVerifier` → pure Ed25519 only, so even a correct bundle could not be verified with the public key | accepts both schemes, trying the message-signature one first — the same compatibility approach sigstore-go takes for certificates |

The first is the one the e2e comment in `TestSignBlobNewBundleNonDefaultAlgorithm` already describes ("By default, we sign using the prehash variant for a ed25519 key. Rekor supports ed25519ph for a hashedrekord"); the verifier just was not loaded the same way.

ECDSA and RSA are untouched: `verifierForKeypair` adds no option for them, `ed25519CompatibleVerifier` returns a non-Ed25519 verifier unchanged, and the attestation change only affects the load options of an Ed25519 key. Image signing and the legacy bundle format go through the same `SignData` and are unaffected. Also replaces the `log.Fatal` calls in that signing path with returned errors, so a library caller gets an error rather than an exit.

## After

Same key, same commands, default configuration (signatures uploaded to the public log):

```console
$ cosign sign-blob --key ed.key -y --bundle blob.sigstore.json blob.txt
Wrote bundle to file blob.sigstore.json
$ cosign verify-blob --bundle blob.sigstore.json --key ed.pub blob.txt
Verified OK
$ cosign verify-blob --bundle blob.sigstore.json --key ed.pub tampered.txt
error during command execution: failed to verify signature

$ cosign attest-blob --key ed.key -y --predicate p.json --type custom --bundle att.sigstore.json blob.txt
Wrote bundle to file att.sigstore.json
$ cosign verify-blob-attestation --bundle att.sigstore.json --key ed.pub --type custom blob.txt
Verified OK
```

The bundle carries a `SHA2_512` message digest and a Rekor entry, as expected for Ed25519ph. Controls run in the same session: EC P-256, P-384 and RSA sign-blob/verify-blob, and an ECDSA attest-blob/verify-blob-attestation, all `Verified OK` before and after.

## Tests

- `pkg/cosign/bundle`: `verifierForKeypair` accepts the signature of an ephemeral `PKIX_ED25519_PH`, `PKIX_ED25519` and `PKIX_ECDSA_P256_SHA_256` keypair; a second test pins that `LoadDefaultVerifier` rejects an Ed25519ph signature — the mistake the helper exists to avoid.
- `pkg/cosign`: `ed25519CompatibleVerifier` accepts an Ed25519ph and a pure signature over the same message, rejects a signature over other content, reports the same public key, and returns a non-Ed25519 verifier unchanged.
- `go test` for `pkg/cosign/...`, `cmd/cosign/cli/{sign,signcommon,verify,attest}/...` and `internal/key/...` passes.

Found by round-tripping `sign-blob` → `verify-blob` and `attest-blob` → `verify-blob-attestation` over every key type `import-key-pair` accepts.

---

*Disclosure: I used Claude (Opus 5) while investigating and writing this. Every command above I ran and checked myself, and review comments will be answered by me.*
