### PR TITLE
Align privacy statement prompt behavior

### DIFF
--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -139,9 +139,13 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
 		}
-		if !c.TlogUpload {
-			c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
-		}
+	}
+	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, digest, c.TlogUpload)
+	if err != nil {
+		return fmt.Errorf("should upload to tlog: %w", err)
+	}
+	if !shouldUpload {
+		c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
 	}
 
 	bundleBytes, pubKey, hashAlgProto, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -140,12 +140,12 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, digest, c.TlogUpload)
-	if err != nil {
-		return fmt.Errorf("should upload to tlog: %w", err)
-	}
+	shouldUpload := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, digest, c.TlogUpload)
 	if !shouldUpload {
 		c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
+	}
+	if err := signcommon.ConfirmPrivacyStatement(ctx, c.KeyOpts, shouldUpload); err != nil {
+		return err
 	}
 
 	bundleBytes, pubKey, hashAlgProto, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)

--- a/cmd/cosign/cli/attest/attest.go
+++ b/cmd/cosign/cli/attest/attest.go
@@ -140,11 +140,11 @@ func (c *AttestCommand) Exec(ctx context.Context, imageRef string) error {
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, digest, c.TlogUpload)
-	if !shouldUpload {
+	uploadToTlog := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, digest, c.TlogUpload)
+	if !uploadToTlog {
 		c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
 	}
-	if err := signcommon.ConfirmPrivacyStatement(ctx, c.KeyOpts, shouldUpload); err != nil {
+	if err := signcommon.ConfirmPrivacyStatement(ctx, c.KeyOpts, uploadToTlog); err != nil {
 		return err
 	}
 

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -153,12 +153,12 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, nil, c.TlogUpload)
-	if err != nil {
-		return fmt.Errorf("should upload to tlog: %w", err)
-	}
+	shouldUpload := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, nil, c.TlogUpload)
 	if !shouldUpload {
 		c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
+	}
+	if err := signcommon.ConfirmPrivacyStatement(ctx, c.KeyOpts, shouldUpload); err != nil {
+		return err
 	}
 
 	bundleBytes, _, _, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -152,9 +152,13 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
 		}
-		if !c.TlogUpload {
-			c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
-		}
+	}
+	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, nil, c.TlogUpload)
+	if err != nil {
+		return fmt.Errorf("should upload to tlog: %w", err)
+	}
+	if !shouldUpload {
+		c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
 	}
 
 	bundleBytes, _, _, err := signcommon.NewAttestationBundle(ctx, c.KeyOpts, c.CertPath, c.CertChainPath, bundleOpts, c.SigningConfig, c.TrustedMaterial)

--- a/cmd/cosign/cli/attest/attest_blob.go
+++ b/cmd/cosign/cli/attest/attest_blob.go
@@ -153,11 +153,11 @@ func (c *AttestBlobCommand) Exec(ctx context.Context, artifactPath string) error
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, nil, c.TlogUpload)
-	if !shouldUpload {
+	uploadToTlog := signcommon.ShouldUploadToTlog(ctx, c.KeyOpts, nil, c.TlogUpload)
+	if !uploadToTlog {
 		c.SigningConfig = c.SigningConfig.WithRekorLogURLs()
 	}
-	if err := signcommon.ConfirmPrivacyStatement(ctx, c.KeyOpts, shouldUpload); err != nil {
+	if err := signcommon.ConfirmPrivacyStatement(ctx, c.KeyOpts, uploadToTlog); err != nil {
 		return err
 	}
 

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -203,12 +203,12 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-	if err != nil {
-		return fmt.Errorf("should upload to tlog: %w", err)
-	}
+	shouldUpload := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
 	if !shouldUpload {
 		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
+	}
+	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, shouldUpload); err != nil {
+		return err
 	}
 
 	bundleBytes, _, _, err := signcommon.NewAttestationBundle(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
@@ -264,12 +264,12 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-	if err != nil {
-		return fmt.Errorf("should upload to tlog: %w", err)
-	}
+	shouldUpload := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
 	if !shouldUpload {
 		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
+	}
+	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, shouldUpload); err != nil {
+		return err
 	}
 
 	keypair, certBytes, chainBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, signOpts.Cert, signOpts.CertChain)

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -202,13 +202,13 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
 		}
-		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-		if err != nil {
-			return fmt.Errorf("should upload to tlog: %w", err)
-		}
-		if !shouldUpload {
-			ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
-		}
+	}
+	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
+	if err != nil {
+		return fmt.Errorf("should upload to tlog: %w", err)
+	}
+	if !shouldUpload {
+		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 	}
 
 	bundleBytes, _, _, err := signcommon.NewAttestationBundle(ctx, ko, signOpts.Cert, signOpts.CertChain, bundleOpts, ko.SigningConfig, ko.TrustedMaterial)
@@ -263,13 +263,13 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 		if err != nil {
 			return fmt.Errorf("creating signing config: %w", err)
 		}
-		shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-		if err != nil {
-			return fmt.Errorf("should upload to tlog: %w", err)
-		}
-		if !shouldUpload {
-			ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
-		}
+	}
+	shouldUpload, err := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
+	if err != nil {
+		return fmt.Errorf("should upload to tlog: %w", err)
+	}
+	if !shouldUpload {
+		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 	}
 
 	keypair, certBytes, chainBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, signOpts.Cert, signOpts.CertChain)

--- a/cmd/cosign/cli/sign/sign.go
+++ b/cmd/cosign/cli/sign/sign.go
@@ -203,11 +203,11 @@ func signDigestBundle(ctx context.Context, digest name.Digest, ko options.KeyOpt
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-	if !shouldUpload {
+	uploadToTlog := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
+	if !uploadToTlog {
 		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 	}
-	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, shouldUpload); err != nil {
+	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, uploadToTlog); err != nil {
 		return err
 	}
 
@@ -264,11 +264,11 @@ func signDigest(ctx context.Context, digest name.Digest, payload []byte, ko opti
 			return fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
-	if !shouldUpload {
+	uploadToTlog := signcommon.ShouldUploadToTlog(ctx, ko, digest, signOpts.TlogUpload)
+	if !uploadToTlog {
 		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 	}
-	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, shouldUpload); err != nil {
+	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, uploadToTlog); err != nil {
 		return err
 	}
 

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -67,12 +67,10 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		if err != nil {
 			return nil, fmt.Errorf("creating signing config: %w", err)
 		}
-		shouldUpload, err = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
-		if err != nil {
-			return nil, fmt.Errorf("upload to tlog: %w", err)
-		}
-	} else {
-		shouldUpload = len(ko.SigningConfig.RekorLogURLs()) > 0
+	}
+	shouldUpload, err = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
+	if err != nil {
+		return nil, fmt.Errorf("upload to tlog: %w", err)
 	}
 
 	if !shouldUpload {

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -68,10 +68,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 			return nil, fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload, err = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
-	if err != nil {
-		return nil, fmt.Errorf("upload to tlog: %w", err)
-	}
+	shouldUpload = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
 
 	if !shouldUpload {
 		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
@@ -79,6 +76,10 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		// we do not use ed25519ph for ed25519 keys when the signatures are not
 		// uploaded to the Tlog.
 		ko.DefaultLoadOptions = &[]signature.LoadOption{}
+	}
+
+	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, shouldUpload); err != nil {
+		return nil, err
 	}
 
 	keypair, certBytes, chainBytes, idToken, err := signcommon.GetKeypairAndToken(ctx, ko, certPath, certChainPath)

--- a/cmd/cosign/cli/sign/sign_blob.go
+++ b/cmd/cosign/cli/sign/sign_blob.go
@@ -59,7 +59,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	ctx, cancel := context.WithTimeout(ctx, ro.Timeout)
 	defer cancel()
 
-	var shouldUpload bool
+	var uploadToTlog bool
 	var err error
 
 	if ko.SigningConfig == nil {
@@ -68,9 +68,9 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 			return nil, fmt.Errorf("creating signing config: %w", err)
 		}
 	}
-	shouldUpload = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
+	uploadToTlog = signcommon.ShouldUploadToTlog(ctx, ko, nil, tlogUpload)
 
-	if !shouldUpload {
+	if !uploadToTlog {
 		ko.SigningConfig = ko.SigningConfig.WithRekorLogURLs()
 		// To maintain backwards compatibility with older cosign versions,
 		// we do not use ed25519ph for ed25519 keys when the signatures are not
@@ -78,7 +78,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 		ko.DefaultLoadOptions = &[]signature.LoadOption{}
 	}
 
-	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, shouldUpload); err != nil {
+	if err := signcommon.ConfirmPrivacyStatement(ctx, ko, uploadToTlog); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +97,7 @@ func SignBlobCmd(ctx context.Context, ro *options.RootOptions, ko options.KeyOpt
 	}
 	defer closePayload()
 
-	if hashFunction != crypto.SHA256 && !ko.NewBundleFormat && (shouldUpload || (!ko.Sk && ko.KeyRef == "")) {
+	if hashFunction != crypto.SHA256 && !ko.NewBundleFormat && (uploadToTlog || (!ko.Sk && ko.KeyRef == "")) {
 		ui.Infof(ctx, "Non SHA256 hash function is not supported for old bundle format. Use --new-bundle-format to use the new bundle format or use different signing key/algorithm.")
 		if !ko.SkipConfirmation {
 			if err := ui.ConfirmContinue(ctx); err != nil {

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -183,6 +183,10 @@ func shouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 		return false
 	}
 
+	if ko.SigningConfig != nil && len(ko.SigningConfig.RekorLogURLs()) == 0 {
+		return false
+	}
+
 	if ko.SkipConfirmation {
 		return true
 	}

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -102,7 +102,6 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 			DisableProviders: ko.OIDCDisableProviders,
 			Provider:         ko.OIDCProvider,
 			AuthFlow:         ko.FulcioAuthFlow,
-			SkipConfirm:      ko.SkipConfirmation,
 			OIDCServices:     ko.SigningConfig.OIDCProviderURLs(),
 			ClientID:         ko.OIDCClientID,
 			ClientSecret:     ko.OIDCClientSecret,
@@ -149,9 +148,13 @@ func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 }
 
 // ConfirmPrivacyStatement prompts the user with the Sigstore privacy statement
-// if the operation will record data to the public Rekor transparency log.
+// if the operation will record data to a public transparency log.
 func ConfirmPrivacyStatement(ctx context.Context, ko options.KeyOpts, uploadToRekor bool) error {
-	if uploadToRekor && hasPublicGoodRekorURL(ko.SigningConfig) {
+	isKeyless := (ko.KeyRef == "" && !ko.Sk) || ko.IssueCertificateForExistingKey
+	// The privacy statement applies when publishing to the public Rekor
+	// transparency log or the public Fulcio Certificate Transparency (CT) log.
+	if (uploadToRekor && hasPublicGoodRekorURL(ko.SigningConfig)) ||
+		(isKeyless && hasPublicGoodFulcioURL(ko.SigningConfig)) {
 		var statementErr error
 		privacy.StatementOnce.Do(func() {
 			ui.Infof(ctx, privacy.Statement)

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -167,39 +167,53 @@ func ConfirmPrivacyStatement(ctx context.Context, ko options.KeyOpts, uploadToRe
 	return nil
 }
 
-// publicGoodRekorHostSuffixes are the hostname suffixes of Rekor instances operated
-// as part of the sigstore public good instance (production and staging). A literal
-// comparison against options.DefaultRekorURL is not sufficient because the public
-// good instance is served from multiple region- and year-specific hostnames.
-var publicGoodRekorHostSuffixes = []string{".sigstore.dev", ".sigstage.dev"}
+// publicGoodHostSuffixes are the hostname suffixes of services operated as part
+// of the sigstore public good instance (production and staging). A literal
+// comparison against options.DefaultRekorURL or options.DefaultFulcioURL is not
+// sufficient because the public good instance is served from multiple region-
+// and year-specific hostnames.
+var publicGoodHostSuffixes = []string{".sigstore.dev", ".sigstage.dev"}
 
 // hasPublicGoodRekorURL reports whether a signing config contains a rekor URL that
-// points at the sigstore public good instance (production or staging), which is the
-// only case where the data-retention privacy statement applies.
+// points at the sigstore public good instance (production or staging).
 func hasPublicGoodRekorURL(sc *root.SigningConfig) bool {
 	if sc == nil {
 		return false
 	}
 	for _, s := range sc.RekorLogURLs() {
-		if isPublicGoodRekorURL(s.URL) {
+		if isPublicGoodURL(s.URL) {
 			return true
 		}
 	}
 	return false
 }
 
-// isPublicGoodRekorURL reports whether a rekor URL points at the sigstore public good
-// instance (production or staging).
-func isPublicGoodRekorURL(rekorURL string) bool {
-	if rekorURL == "" {
+// hasPublicGoodFulcioURL reports whether a signing config contains a fulcio URL that
+// points at the sigstore public good instance (production or staging).
+func hasPublicGoodFulcioURL(sc *root.SigningConfig) bool {
+	if sc == nil {
 		return false
 	}
-	parsed, err := url.Parse(rekorURL)
+	for _, s := range sc.FulcioCertificateAuthorityURLs() {
+		if isPublicGoodURL(s.URL) {
+			return true
+		}
+	}
+	return false
+}
+
+// isPublicGoodURL reports whether a URL points at the sigstore public good
+// instance (production or staging).
+func isPublicGoodURL(rawURL string) bool {
+	if rawURL == "" {
+		return false
+	}
+	parsed, err := url.Parse(rawURL)
 	if err != nil || parsed.Hostname() == "" {
 		return false
 	}
 	host := strings.ToLower(parsed.Hostname())
-	for _, suffix := range publicGoodRekorHostSuffixes {
+	for _, suffix := range publicGoodHostSuffixes {
 		if host == suffix[1:] || strings.HasSuffix(host, suffix) {
 			return true
 		}

--- a/cmd/cosign/cli/signcommon/common.go
+++ b/cmd/cosign/cli/signcommon/common.go
@@ -118,12 +118,41 @@ func GetKeypairAndToken(ctx context.Context, ko options.KeyOpts, cert, certChain
 }
 
 // ShouldUploadToTlog determines whether the user wants to upload the entry to Rekor.
-func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Reference, tlogUpload bool) (bool, error) {
-	upload := shouldUploadToTlog(ctx, ko, ref, tlogUpload)
-	var statementErr error
-	// Only warn about the public good instance's data retention policy when
-	// actually uploading to it
-	if upload && hasPublicGoodRekorURL(ko.SigningConfig) {
+func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Reference, tlogUpload bool) bool {
+	// return false if not uploading to the tlog has been requested
+	if !tlogUpload {
+		return false
+	}
+
+	if ko.SigningConfig != nil && len(ko.SigningConfig.RekorLogURLs()) == 0 {
+		return false
+	}
+
+	if ko.SkipConfirmation {
+		return true
+	}
+
+	// We don't need to validate the ref, just return true
+	if ref == nil {
+		return true
+	}
+
+	// Check if the image is public (no auth in Get)
+	if _, err := remote.Get(ref, remote.WithContext(ctx)); err != nil {
+		ui.Warnf(ctx, "%q appears to be a private repository, please confirm uploading to the transparency log at %q", ref.Context().String(), ko.RekorURL)
+		if ui.ConfirmContinue(ctx) != nil {
+			ui.Infof(ctx, "not uploading to transparency log")
+			return false
+		}
+	}
+	return true
+}
+
+// ConfirmPrivacyStatement prompts the user with the Sigstore privacy statement
+// if the operation will record data to the public Rekor transparency log.
+func ConfirmPrivacyStatement(ctx context.Context, ko options.KeyOpts, uploadToRekor bool) error {
+	if uploadToRekor && hasPublicGoodRekorURL(ko.SigningConfig) {
+		var statementErr error
 		privacy.StatementOnce.Do(func() {
 			ui.Infof(ctx, privacy.Statement)
 			ui.Infof(ctx, privacy.StatementConfirmation)
@@ -133,8 +162,9 @@ func ShouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Refere
 				}
 			}
 		})
+		return statementErr
 	}
-	return upload, statementErr
+	return nil
 }
 
 // publicGoodRekorHostSuffixes are the hostname suffixes of Rekor instances operated
@@ -175,36 +205,6 @@ func isPublicGoodRekorURL(rekorURL string) bool {
 		}
 	}
 	return false
-}
-
-func shouldUploadToTlog(ctx context.Context, ko options.KeyOpts, ref name.Reference, tlogUpload bool) bool {
-	// return false if not uploading to the tlog has been requested
-	if !tlogUpload {
-		return false
-	}
-
-	if ko.SigningConfig != nil && len(ko.SigningConfig.RekorLogURLs()) == 0 {
-		return false
-	}
-
-	if ko.SkipConfirmation {
-		return true
-	}
-
-	// We don't need to validate the ref, just return true
-	if ref == nil {
-		return true
-	}
-
-	// Check if the image is public (no auth in Get)
-	if _, err := remote.Get(ref, remote.WithContext(ctx)); err != nil {
-		ui.Warnf(ctx, "%q appears to be a private repository, please confirm uploading to the transparency log at %q", ref.Context().String(), ko.RekorURL)
-		if ui.ConfirmContinue(ctx) != nil {
-			ui.Infof(ctx, "not uploading to transparency log")
-			return false
-		}
-	}
-	return true
 }
 
 func signerFromKeyOpts(ctx context.Context, certPath string, certChainPath string, ko options.KeyOpts) (*SignerVerifier, bool, error) {

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -219,7 +219,7 @@ func mustSigningConfig(t *testing.T, rekorURL string) *root.SigningConfig {
 	return sc
 }
 
-func TestShouldUploadToTlog_PublicInstanceStatement(t *testing.T) {
+func TestConfirmPrivacyStatement(t *testing.T) {
 	tests := []struct {
 		name          string
 		signingConfig *root.SigningConfig
@@ -237,13 +237,11 @@ func TestShouldUploadToTlog_PublicInstanceStatement(t *testing.T) {
 				SigningConfig:    tt.signingConfig,
 				SkipConfirmation: true,
 			}
-			var upload bool
 			var err error
 			stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
-				upload, err = ShouldUploadToTlog(ctx, ko, nil, true)
+				err = ConfirmPrivacyStatement(ctx, ko, true)
 			})
 			assert.NoError(t, err)
-			assert.True(t, upload)
 			if tt.wantWarning {
 				assert.Contains(t, stderr, "hosted by sigstore", "should warn about the public good instance's data retention policy")
 			} else {
@@ -291,8 +289,7 @@ func TestShouldUploadToTlog(t *testing.T) {
 				SigningConfig:    tt.signingConfig,
 				SkipConfirmation: true,
 			}
-			upload, err := ShouldUploadToTlog(context.Background(), ko, nil, tt.tlogUpload)
-			assert.NoError(t, err)
+			upload := ShouldUploadToTlog(context.Background(), ko, nil, tt.tlogUpload)
 			assert.Equal(t, tt.wantUpload, upload)
 		})
 	}

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -232,23 +232,83 @@ func TestConfirmPrivacyStatement(t *testing.T) {
 	tests := []struct {
 		name          string
 		signingConfig *root.SigningConfig
+		keyRef        string
+		sk            bool
+		uploadToRekor bool
 		wantWarning   bool
 	}{
-		{"custom Rekor URL skips public instance statement", mustSigningConfigWithRekor(t, "http://localhost:3000"), false},
-		{"region-specific public good URL shows public instance statement", mustSigningConfigWithRekor(t, "https://rekor.us-central1.sigstore.dev"), true},
-		{"staging public good signing config shows public instance statement", mustSigningConfigWithRekor(t, "https://rekor.sigstage.dev"), true},
-		{"nil signing config skips public instance statement", nil, false},
+		{
+			name:          "custom Rekor URL with key skips public instance statement",
+			signingConfig: mustSigningConfigWithRekor(t, "http://localhost:3000"),
+			keyRef:        "cosign.key",
+			uploadToRekor: true,
+			wantWarning:   false,
+		},
+		{
+			name:          "region-specific public good Rekor URL shows public instance statement",
+			signingConfig: mustSigningConfigWithRekor(t, "https://rekor.us-central1.sigstore.dev"),
+			keyRef:        "cosign.key",
+			uploadToRekor: true,
+			wantWarning:   true,
+		},
+		{
+			name:          "staging public good Rekor URL shows public instance statement",
+			signingConfig: mustSigningConfigWithRekor(t, "https://rekor.sigstage.dev"),
+			keyRef:        "cosign.key",
+			uploadToRekor: true,
+			wantWarning:   true,
+		},
+		{
+			name:          "public good Rekor URL without tlog upload and with key skips statement",
+			signingConfig: mustSigningConfigWithRekor(t, options.DefaultRekorURL),
+			keyRef:        "cosign.key",
+			uploadToRekor: false,
+			wantWarning:   false,
+		},
+		{
+			name:          "keyless with public good Fulcio URL shows public instance statement",
+			signingConfig: mustSigningConfigWithFulcio(t, options.DefaultFulcioURL),
+			uploadToRekor: false,
+			wantWarning:   true,
+		},
+		{
+			name:          "keyless with staging public good Fulcio URL shows public instance statement",
+			signingConfig: mustSigningConfigWithFulcio(t, "https://fulcio.sigstage.dev"),
+			uploadToRekor: false,
+			wantWarning:   true,
+		},
+		{
+			name:          "keyless with custom Fulcio URL skips public instance statement",
+			signingConfig: mustSigningConfigWithFulcio(t, "http://localhost:5555"),
+			uploadToRekor: false,
+			wantWarning:   false,
+		},
+		{
+			name:          "public good Fulcio URL with key and without tlog upload skips statement",
+			signingConfig: mustSigningConfigWithFulcio(t, options.DefaultFulcioURL),
+			keyRef:        "cosign.key",
+			uploadToRekor: false,
+			wantWarning:   false,
+		},
+		{
+			name:          "nil signing config skips public instance statement",
+			signingConfig: nil,
+			uploadToRekor: true,
+			wantWarning:   false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			privacy.StatementOnce = sync.Once{}
 			ko := options.KeyOpts{
+				KeyRef:           tt.keyRef,
+				Sk:               tt.sk,
 				SigningConfig:    tt.signingConfig,
 				SkipConfirmation: true,
 			}
 			var err error
 			stderr := ui.RunWithTestCtx(func(ctx context.Context, _ ui.WriteFunc) {
-				err = ConfirmPrivacyStatement(ctx, ko, true)
+				err = ConfirmPrivacyStatement(ctx, ko, tt.uploadToRekor)
 			})
 			assert.NoError(t, err)
 			if tt.wantWarning {

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -210,9 +210,18 @@ func Test_ParseOCIReference(t *testing.T) {
 	}
 }
 
-func mustSigningConfig(t *testing.T, rekorURL string) *root.SigningConfig {
+func mustSigningConfigWithRekor(t *testing.T, rekorURL string) *root.SigningConfig {
 	t.Helper()
 	sc, err := NewSigningConfigFromKeyOpts(options.KeyOpts{RekorURL: rekorURL})
+	if err != nil {
+		t.Fatalf("creating signing config: %v", err)
+	}
+	return sc
+}
+
+func mustSigningConfigWithFulcio(t *testing.T, fulcioURL string) *root.SigningConfig {
+	t.Helper()
+	sc, err := NewSigningConfigFromKeyOpts(options.KeyOpts{FulcioURL: fulcioURL})
 	if err != nil {
 		t.Fatalf("creating signing config: %v", err)
 	}
@@ -225,9 +234,9 @@ func TestConfirmPrivacyStatement(t *testing.T) {
 		signingConfig *root.SigningConfig
 		wantWarning   bool
 	}{
-		{"custom Rekor URL skips public instance statement", mustSigningConfig(t, "http://localhost:3000"), false},
-		{"region-specific public good URL shows public instance statement", mustSigningConfig(t, "https://rekor.us-central1.sigstore.dev"), true},
-		{"staging public good signing config shows public instance statement", mustSigningConfig(t, "https://rekor.sigstage.dev"), true},
+		{"custom Rekor URL skips public instance statement", mustSigningConfigWithRekor(t, "http://localhost:3000"), false},
+		{"region-specific public good URL shows public instance statement", mustSigningConfigWithRekor(t, "https://rekor.us-central1.sigstore.dev"), true},
+		{"staging public good signing config shows public instance statement", mustSigningConfigWithRekor(t, "https://rekor.sigstage.dev"), true},
 		{"nil signing config skips public instance statement", nil, false},
 	}
 	for _, tt := range tests {
@@ -260,19 +269,19 @@ func TestShouldUploadToTlog(t *testing.T) {
 	}{
 		{
 			name:          "tlogUpload false returns false",
-			signingConfig: mustSigningConfig(t, options.DefaultRekorURL),
+			signingConfig: mustSigningConfigWithRekor(t, options.DefaultRekorURL),
 			tlogUpload:    false,
 			wantUpload:    false,
 		},
 		{
 			name:          "signing config with no Rekor URLs returns false",
-			signingConfig: mustSigningConfig(t, options.DefaultRekorURL).WithRekorLogURLs(),
+			signingConfig: mustSigningConfigWithRekor(t, options.DefaultRekorURL).WithRekorLogURLs(),
 			tlogUpload:    true,
 			wantUpload:    false,
 		},
 		{
 			name:          "tlogUpload true with Rekor URL returns true",
-			signingConfig: mustSigningConfig(t, "http://localhost:3000"),
+			signingConfig: mustSigningConfigWithRekor(t, "http://localhost:3000"),
 			tlogUpload:    true,
 			wantUpload:    true,
 		},
@@ -302,10 +311,10 @@ func TestHasPublicGoodRekorURL(t *testing.T) {
 		want          bool
 	}{
 		{"nil signing config returns false", nil, false},
-		{"empty signing config returns false", mustSigningConfig(t, ""), false},
-		{"custom Rekor URL returns false", mustSigningConfig(t, "http://localhost:3000"), false},
-		{"public good Rekor URL returns true", mustSigningConfig(t, options.DefaultRekorURL), true},
-		{"signing config with cleared Rekor URLs returns false", mustSigningConfig(t, options.DefaultRekorURL).WithRekorLogURLs(), false},
+		{"empty signing config returns false", mustSigningConfigWithRekor(t, ""), false},
+		{"custom Rekor URL returns false", mustSigningConfigWithRekor(t, "http://localhost:3000"), false},
+		{"public good Rekor URL returns true", mustSigningConfigWithRekor(t, options.DefaultRekorURL), true},
+		{"signing config with cleared Rekor URLs returns false", mustSigningConfigWithRekor(t, options.DefaultRekorURL).WithRekorLogURLs(), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -314,16 +323,38 @@ func TestHasPublicGoodRekorURL(t *testing.T) {
 	}
 }
 
-func TestIsPublicGoodRekorURL(t *testing.T) {
+func TestHasPublicGoodFulcioURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		rekorURL string
-		want     bool
+		name          string
+		signingConfig *root.SigningConfig
+		want          bool
+	}{
+		{"nil signing config returns false", nil, false},
+		{"empty signing config returns false", mustSigningConfigWithFulcio(t, ""), false},
+		{"custom Fulcio URL returns false", mustSigningConfigWithFulcio(t, "http://localhost:5555"), false},
+		{"public good Fulcio URL returns true", mustSigningConfigWithFulcio(t, options.DefaultFulcioURL), true},
+		{"staging public good Fulcio URL returns true", mustSigningConfigWithFulcio(t, "https://fulcio.sigstage.dev"), true},
+		{"signing config with cleared Fulcio URLs returns false", mustSigningConfigWithFulcio(t, options.DefaultFulcioURL).WithFulcioCertificateAuthorityURLs(), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasPublicGoodFulcioURL(tt.signingConfig))
+		})
+	}
+}
+
+func TestIsPublicGoodURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
 	}{
 		{"empty is not public good", "", false},
-		{"default production URL", options.DefaultRekorURL, true},
+		{"default Rekor production URL", options.DefaultRekorURL, true},
+		{"default Fulcio production URL", options.DefaultFulcioURL, true},
 		{"region-specific production URL", "https://rekor.us-central1.sigstore.dev", true},
-		{"staging URL", "https://rekor.sigstage.dev", true},
+		{"staging Rekor URL", "https://rekor.sigstage.dev", true},
+		{"staging Fulcio URL", "https://fulcio.sigstage.dev", true},
 		{"region-specific staging URL", "https://rekor.us-central1.sigstage.dev", true},
 		{"custom self-hosted URL", "http://localhost:3000", false},
 		{"uppercase hostname is still public good", "https://REKOR.SIGSTORE.DEV", true},
@@ -333,7 +364,7 @@ func TestIsPublicGoodRekorURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isPublicGoodRekorURL(tt.rekorURL))
+			assert.Equal(t, tt.want, isPublicGoodURL(tt.url))
 		})
 	}
 }

--- a/cmd/cosign/cli/signcommon/common_test.go
+++ b/cmd/cosign/cli/signcommon/common_test.go
@@ -253,6 +253,51 @@ func TestShouldUploadToTlog_PublicInstanceStatement(t *testing.T) {
 	}
 }
 
+func TestShouldUploadToTlog(t *testing.T) {
+	tests := []struct {
+		name          string
+		signingConfig *root.SigningConfig
+		tlogUpload    bool
+		wantUpload    bool
+	}{
+		{
+			name:          "tlogUpload false returns false",
+			signingConfig: mustSigningConfig(t, options.DefaultRekorURL),
+			tlogUpload:    false,
+			wantUpload:    false,
+		},
+		{
+			name:          "signing config with no Rekor URLs returns false",
+			signingConfig: mustSigningConfig(t, options.DefaultRekorURL).WithRekorLogURLs(),
+			tlogUpload:    true,
+			wantUpload:    false,
+		},
+		{
+			name:          "tlogUpload true with Rekor URL returns true",
+			signingConfig: mustSigningConfig(t, "http://localhost:3000"),
+			tlogUpload:    true,
+			wantUpload:    true,
+		},
+		{
+			name:          "nil signing config with tlogUpload true returns true",
+			signingConfig: nil,
+			tlogUpload:    true,
+			wantUpload:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ko := options.KeyOpts{
+				SigningConfig:    tt.signingConfig,
+				SkipConfirmation: true,
+			}
+			upload, err := ShouldUploadToTlog(context.Background(), ko, nil, tt.tlogUpload)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantUpload, upload)
+		})
+	}
+}
+
 func TestHasPublicGoodRekorURL(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
-	"github.com/sigstore/cosign/v3/cmd/cosign/cli/sign/privacy"
-	"github.com/sigstore/cosign/v3/internal/ui"
 	"github.com/sigstore/cosign/v3/pkg/providers"
 	"github.com/sigstore/sigstore-go/pkg/root"
 	"github.com/sigstore/sigstore/pkg/oauthflow"
@@ -44,7 +42,6 @@ type IDTokenConfig struct {
 	DisableProviders bool
 	Provider         string
 	AuthFlow         string
-	SkipConfirm      bool
 	OIDCServices     []root.Service
 	ClientID         string
 	ClientSecret     string
@@ -64,7 +61,7 @@ func RetrieveIDToken(ctx context.Context, c IDTokenConfig) (string, error) {
 	if idToken != "" {
 		return idToken, nil
 	}
-	flow, err := GetOAuthFlow(ctx, c.AuthFlow, idToken, c.SkipConfirm)
+	flow, err := GetOAuthFlow(c.AuthFlow, idToken)
 	if err != nil {
 		return "", fmt.Errorf("setting auth flow: %w", err)
 	}
@@ -105,7 +102,7 @@ func ReadIDToken(ctx context.Context, tokOrPath string, disableProviders bool, o
 }
 
 // GetOAuthFlow returns authentication flow that the client will initiate
-func GetOAuthFlow(ctx context.Context, authFlow, idToken string, skipConfirm bool) (string, error) {
+func GetOAuthFlow(authFlow, idToken string) (string, error) {
 	var flow string
 	switch {
 	case authFlow != "":
@@ -117,19 +114,6 @@ func GetOAuthFlow(ctx context.Context, authFlow, idToken string, skipConfirm boo
 		fmt.Fprintln(os.Stderr, "Non-interactive mode detected, using device flow.")
 		flow = flowDevice
 	default:
-		var statementErr error
-		privacy.StatementOnce.Do(func() {
-			ui.Infof(ctx, privacy.Statement)
-			ui.Infof(ctx, privacy.StatementConfirmation)
-			if !skipConfirm {
-				if err := ui.ConfirmContinue(ctx); err != nil {
-					statementErr = err
-				}
-			}
-		})
-		if statementErr != nil {
-			return "", statementErr
-		}
 		flow = flowNormal
 	}
 	return flow, nil

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -180,7 +180,7 @@ func TestGetOAuthFlow(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetOAuthFlow(context.Background(), tt.authFlow, tt.idToken, false)
+			got, err := GetOAuthFlow(tt.authFlow, tt.idToken)
 
 			if err != nil {
 				t.Errorf("GetOAuthFlow() error = %v", err)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1200,6 +1200,7 @@ func TestSignVerifyContainerWithSigningConfigWithCertificate(t *testing.T) {
 		},
 		NewBundleFormat: true,
 		IgnoreSCT:       true,
+		IgnoreTlog:      true,
 	}
 	args := []string{imgName}
 	must(cmd.Exec(ctx, args), t)
@@ -1301,6 +1302,7 @@ func TestSignVerifyContainerWithCertificateChain(t *testing.T) {
 						AllowCertificateChain: tc.allowChain,
 					},
 					IgnoreSCT:     true,
+					IgnoreTlog:    true,
 					PredicateType: predicateType,
 					CheckClaims:   true,
 				}).Exec(ctx, []string{imgName})
@@ -1321,7 +1323,8 @@ func TestSignVerifyContainerWithCertificateChain(t *testing.T) {
 						NewBundleFormat:       true,
 						AllowCertificateChain: tc.allowChain,
 					},
-					IgnoreSCT: true,
+					IgnoreSCT:  true,
+					IgnoreTlog: true,
 				}).Exec(ctx, []string{imgName})
 			}
 
@@ -1427,6 +1430,7 @@ func TestSignVerifyBlobWithCertificateChain(t *testing.T) {
 					KeyOpts:               options.KeyOpts{NewBundleFormat: true, BundlePath: bundlePath},
 					CertVerifyOptions:     certVerify,
 					IgnoreSCT:             true,
+					IgnoreTlog:            true,
 					CheckClaims:           true,
 					PredicateType:         "something",
 					Digest:                "7e9b6e7ba2842c91cf49f3e214d04a7a496f8214356f41d81a6e6dcad11f11e3",
@@ -1441,6 +1445,7 @@ func TestSignVerifyBlobWithCertificateChain(t *testing.T) {
 					KeyOpts:               options.KeyOpts{NewBundleFormat: true, BundlePath: bundlePath},
 					CertVerifyOptions:     certVerify,
 					IgnoreSCT:             true,
+					IgnoreTlog:            true,
 					AllowCertificateChain: tc.allowChain,
 				}).Exec(ctx, bp)
 			}


### PR DESCRIPTION
Closes #5015

#### Summary

This change aligns the appearance of the Sigstore public good privacy statement so that all signers using a Sigstore public good transparency log (i.e., Rekor or Fulcio's CT log) are prompted to confirm.

To achieve this:
* The determination of whether a Rekor upload will occur (via `ShouldUploadToTlog`) is expanded to all signers, not just those not using a signing config.
    * **Note:** `attest` and `attest-blob` did not call `ShouldUploadToTlog` due to a regression in #4618 but now do.
* The privacy statement logic for Rekor is extracted from `ShouldUploadToTlog` into a new function `ConfirmPrivacyStatement`, which is called universally after `ShouldUploadToTlog`.
* The privacy statement logic for Fulcio's CT log, called by `GetOAuthFlow` erroneously for all keyless signers, is removed in favor of a public good Fulcio check for keyless signers in `ConfirmPrivacyStatement`.

#### Release Note

* Privacy statement prompt behavior aligned such that **ALL** signers using a public good Rekor or Fulcio service are required to confirm the Sigstore public good privacy statement