### PR TITLE
fix: restrict bundle signing and attestation to one artifact

### DIFF
--- a/cmd/cosign/cli/attest.go
+++ b/cmd/cosign/cli/attest.go
@@ -68,9 +68,12 @@ func Attest() *cobra.Command {
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
-		PreRunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if o.NewBundleFormat && o.NoUpload && o.BundlePath == "" {
 				return fmt.Errorf("must enable upload to the OCI registry or specify a local --bundle path with --new-bundle-format")
+			}
+			if o.BundlePath != "" && len(args) > 1 {
+				return fmt.Errorf("cannot use --bundle when attesting multiple images")
 			}
 			return nil
 		},

--- a/cmd/cosign/cli/sign.go
+++ b/cmd/cosign/cli/sign.go
@@ -87,9 +87,12 @@ race conditions or (worse) malicious tampering.
 
 		Args:             cobra.MinimumNArgs(1),
 		PersistentPreRun: options.BindViper,
-		PreRunE: func(_ *cobra.Command, _ []string) error {
+		PreRunE: func(_ *cobra.Command, args []string) error {
 			if o.NewBundleFormat && !o.Upload && o.BundlePath == "" {
 				return fmt.Errorf("must enable upload to the OCI registry or specify a local --bundle path with --new-bundle-format")
+			}
+			if o.BundlePath != "" && (len(args) > 1 || o.Recursive) {
+				return fmt.Errorf("cannot use --bundle when signing multiple images or with --recursive")
 			}
 			return nil
 		},

--- a/cmd/cosign/cli/signblob.go
+++ b/cmd/cosign/cli/signblob.go
@@ -55,7 +55,7 @@ func SignBlob() *cobra.Command {
 
   # sign a blob with a key pair stored in Hashicorp Vault
   cosign sign-blob --key hashivault://[KEY] <FILE>`,
-		Args:             cobra.MinimumNArgs(1),
+		Args:             cobra.ExactArgs(1),
 		PersistentPreRun: options.BindViper,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			if options.NOf(o.Key, o.SecurityKey.Use) > 1 {
@@ -122,16 +122,15 @@ func SignBlob() *cobra.Command {
 				return err
 			}
 
-			for _, blob := range args {
-				// TODO: remove when the output flag has been deprecated
-				if o.Output != "" {
-					fmt.Fprintln(os.Stderr, "WARNING: the '--output' flag is deprecated and will be removed in the future. Use '--output-signature'")
-					o.OutputSignature = o.Output
-				}
+			// TODO: remove when the output flag has been deprecated
+			if o.Output != "" {
+				fmt.Fprintln(os.Stderr, "WARNING: the '--output' flag is deprecated and will be removed in the future. Use '--output-signature'")
+				o.OutputSignature = o.Output
+			}
 
-				if _, err := sign.SignBlobCmd(cmd.Context(), ro, ko, blob, o.Cert, o.CertChain, o.Base64Output, o.OutputSignature, o.OutputCertificate, o.TlogUpload); err != nil {
-					return fmt.Errorf("signing %s: %w", blob, err)
-				}
+			blob := args[0]
+			if _, err := sign.SignBlobCmd(cmd.Context(), ro, ko, blob, o.Cert, o.CertChain, o.Base64Output, o.OutputSignature, o.OutputCertificate, o.TlogUpload); err != nil {
+				return fmt.Errorf("signing %s: %w", blob, err)
 			}
 			return nil
 		},


### PR DESCRIPTION
#### Summary

This change restricts signing and attestation to a single artifact (blob or image) when a bundle is requested.

Previously, if a bundle was requested for a single signing or attestation operation over multiple artifacts, the requested bundle was overwritten for each artifact.

For `sign-blob`, this restricts users to a single blob input, and for `sign` and `attest`, this prevents users from providing multiple image inputs when requesting a bundle (as well as `--recursive` for `sign`).

`attest-blob` does not require a change, as inputs are already restricted to a single blob.