### PR TITLE
Fix stale version comment on pinned actions/checkout

### DIFF
--- a/.github/workflows/donotsubmit.yaml
+++ b/.github/workflows/donotsubmit.yaml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v2.4.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
         with:
           persist-credentials: false
 


### PR DESCRIPTION
### Summary

`.github/workflows/donotsubmit.yaml` pins `actions/checkout` to `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` with the comment `#v2.4.0`. That commit is **v7.0.0**. The SHA is not changed here — only the comment, so there is no behavioural difference.

### Why it is worth fixing

The comment is the only human-readable signal of which release a pin refers to, and nothing validates it. Here it is five majors behind the pinned commit, so anyone auditing this workflow would reasonably conclude it is running a 2021-era checkout when it is in fact current.

### Verification

```bash
# what tags does the pinned commit carry?
gh api repos/actions/checkout/tags --paginate \
  --jq '.[] | select(.commit.sha=="9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0") | .name'
# -> v7.0.0

# where does the claimed tag actually point?
gh api repos/actions/checkout/git/ref/tags/v2.4.0 --jq '.object.sha'
# -> ec3a7ce113134d7a93b817d10a8272cb61118579   (a different commit)
```

Every pinned action across `.github/workflows/` was checked (71 pins). This was the only provable mismatch.

I kept the file's existing `#vX.Y.Z` spacing rather than normalising it, so the diff is one token.

### Out of scope

Several `github/codeql-action` pins in this repo are commented `v2.16.1` while the commit carries `codeql-bundle-v2.16.1`. That is upstream's tag-naming change rather than a wrong claim, so I left those alone.
