### PR TITLE
copy annotations by key instead of copying obj

### DIFF
--- a/pkg/oci/remote/write.go
+++ b/pkg/oci/remote/write.go
@@ -362,7 +362,9 @@ func WriteReferrer(d name.Digest, artifactType string, layers []v1.Layer, annota
 			Annotations() (map[string]string, error)
 		}); ok {
 			if ann, err := al.Annotations(); err == nil && len(ann) > 0 {
-				layerDescriptors[i].Annotations = ann
+				for k, v := range ann {
+					layerDescriptors[i].Annotations[k] = v
+				}
 			}
 		}
 	}

--- a/pkg/oci/remote/write_test.go
+++ b/pkg/oci/remote/write_test.go
@@ -457,6 +457,7 @@ func TestWriteAttestationsReferrerPreservesAnnotations(t *testing.T) {
 		"dev.sigstore.cosign/certificate",
 		"dev.sigstore.cosign/chain",
 		"predicateType",
+		"org.opencontainers.image.title",
 	}
 	for _, key := range expectedKeys {
 		if _, exists := layerAnnotations[key]; !exists {


### PR DESCRIPTION
#4498 added the title annotation to layer descriptors, however when preserving per-layer annotations (e.g. from an `oci.Signature` layer returned by `cosignstatic.NewAttestation(...)` which includes signature or certificate metadata), `layerDescriptors[i].Annotations` was directly overwritten